### PR TITLE
[WIP] parallelise tests using unittest2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -111,6 +111,12 @@
 [submodule "vendor/news"]
   path = vendor/news
   url = https://github.com/tormund/news
+  ignore = dirty
+  branch = master
+[submodule "vendor/nim-unittest2"]
+  path = vendor/nim-unittest2
+  url = https://github.com/stefantalpalaru/nim-unittest2.git
+  ignore = dirty
   branch = master
 [submodule "vendor/nim-metrics"]
   path = vendor/nim-metrics

--- a/nim.cfg
+++ b/nim.cfg
@@ -11,6 +11,10 @@
   --passL:"-Wl,--stack,8388608"
   # https://github.com/nim-lang/Nim/issues/4057
   --tlsEmulation:off
+  @if i386:
+    # set the IMAGE_FILE_LARGE_ADDRESS_AWARE flag so we can use PAE, if enabled, and access more than 2 GiB of RAM
+    --passL:"-Wl,--large-address-aware"
+  @end
 @end
 
 --threads:on

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -5,7 +5,11 @@
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import macros, strutils, os, unittest, osproc
+import macros, strutils, os, unittest2, osproc
+import threadpool
+
+# AppVeyor may go out of memory with the default of 4
+setMinPoolSize(2)
 
 proc executeMyself(numModules: int): int =
   let appName = getAppFilename()

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -1,5 +1,5 @@
 import
-  macrocache, strutils, unittest,
+  macrocache, strutils, unittest2,
   stew/byteutils, chronicles, stew/ranges, eth/common,
   ../nimbus/vm/interpreter/opcode_values,
   stew/shims/macros
@@ -185,7 +185,8 @@ proc generateVMProxy(boa: Assembler): NimNode =
       proc `vmProxy`(): bool =
         let boa = `body`
         runVM(`blockNumber`, `chainDB`, boa)
-      check `vmProxy`()
+      {.gcsafe.}:
+        check `vmProxy`()
 
   when defined(macro_assembler_debug):
     echo result.toStrLit.strVal

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,3 +1,5 @@
 -d:chronicles_line_numbers
 -d:"chronicles_sinks=textblocks"
+# comment this out, to run the tests in a serial manner:
+#-d:nimtestParallel
 

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, json, os, tables, strutils, sets, strformat, times,
+  unittest2, json, os, tables, strutils, sets, strformat, times,
   options,
   eth/[common, rlp, bloom], eth/trie/[db, trie_defs],
   ethash, stew/endians2, nimcrypto,

--- a/tests/test_code_stream.nim
+++ b/tests/test_code_stream.nim
@@ -5,7 +5,7 @@
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import  unittest, strutils, sequtils,
+import  unittest2, strutils, sequtils,
         ../nimbus/vm/interpreter
 
 proc codeStreamMain*() =
@@ -15,11 +15,11 @@ proc codeStreamMain*() =
       check(codeStream.len == 1)
 
 
-  # quicktest
-  # @pytest.mark.parametrize("code_bytes", (1010, '1010', True, bytearray(32)))
-  # def test_codeStream_rejects_invalid_code_byte_values(code_bytes):
-  #     with pytest.raises(ValidationError):
-  #         CodeStream(code_bytes)
+    # quicktest
+    # @pytest.mark.parametrize("code_bytes", (1010, '1010', True, bytearray(32)))
+    # def test_codeStream_rejects_invalid_code_byte_values(code_bytes):
+    #     with pytest.raises(ValidationError):
+    #         CodeStream(code_bytes)
 
     test "next returns the correct opcode":
       var codeStream = newCodeStream("\x01\x02\x30")

--- a/tests/test_difficulty.nim
+++ b/tests/test_difficulty.nim
@@ -1,4 +1,4 @@
-import unittest, strutils, tables, ospaths, json,
+import unittest2, strutils, tables, ospaths, json,
   ../nimbus/utils/difficulty, stint, times,
   eth/common, test_helpers, stew/byteutils
 
@@ -41,16 +41,16 @@ proc parseTests(name: string, hex: static[bool]): Tests =
     result[title] = t
 
 template runTests(name: string, hex: bool, calculator: typed) =
-  let data = parseTests(name, hex)
-  for title, t in data:
-    var p = BlockHeader(
-      difficulty: t.parentDifficulty,
-      timestamp: times.fromUnix(t.parentTimestamp),
-      blockNumber: t.currentBlockNumber - 1,
-      ommersHash: t.parentUncles)
+  test name:
+    let data = parseTests(name, hex)
+    for title, t in data:
+      var p = BlockHeader(
+        difficulty: t.parentDifficulty,
+        timestamp: times.fromUnix(t.parentTimestamp),
+        blockNumber: t.currentBlockNumber - 1,
+        ommersHash: t.parentUncles)
 
-    let diff = calculator(times.fromUnix(t.currentTimeStamp), p)
-    test name & " " & title:
+      let diff = calculator(times.fromUnix(t.currentTimeStamp), p)
       check diff == t.currentDifficulty
 
 proc difficultyMain*() =

--- a/tests/test_gas_meter.nim
+++ b/tests/test_gas_meter.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, macros, strformat,
+  unittest2, macros, strformat,
   eth/common/eth_types,
   ../nimbus/[vm_types, errors, vm/interpreter]
 

--- a/tests/test_generalstate_failing.nim
+++ b/tests/test_generalstate_failing.nim
@@ -53,4 +53,10 @@ func allowedFailingGeneralStateTest*(folder, name: string): bool =
     #"randomStatetest613BC.json",
     #"randomStatetest623BC.json",
   ]
+  # let allowedFailingPersistBlockTests = [
+    # # stack overflow
+    # "block1431916.json",
+  # ]
+  # result = name in allowedFailingGeneralStateTests or name in allowedFailingPersistBlockTests
   result = name in allowedFailingGeneralStateTests
+

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, strformat, strutils, tables, json, ospaths, times, os,
+  unittest2, strformat, strutils, tables, json, ospaths, times, os,
   stew/byteutils, stew/ranges/typedranges, nimcrypto, options,
   eth/[rlp, common], eth/trie/[db, trie_defs], chronicles,
   ./test_helpers, ../nimbus/p2p/executor, test_config,

--- a/tests/test_genesis.nim
+++ b/tests/test_genesis.nim
@@ -1,4 +1,4 @@
-import unittest, ../nimbus/[genesis, config], eth/common, nimcrypto/hash
+import unittest2, ../nimbus/[genesis, config], eth/common, nimcrypto/hash
 
 proc genesisMain*() =
   suite "Genesis":

--- a/tests/test_memory.nim
+++ b/tests/test_memory.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, sequtils,
+  unittest2, sequtils,
   eth/common/eth_types,
   ../nimbus/[constants, errors, vm/memory]
 

--- a/tests/test_op_arith.nim
+++ b/tests/test_op_arith.nim
@@ -1,8 +1,9 @@
-import macro_assembler, unittest
+import macro_assembler, unittest2
 
 proc opArithMain*() =
   suite "Arithmetic Opcodes":
-    let (blockNumber, chainDB) = initDatabase()
+    setup:
+      let (blockNumber, chainDB) = initDatabase()
 
     assembler:
       title: "ADD_1"

--- a/tests/test_op_bit.nim
+++ b/tests/test_op_bit.nim
@@ -1,8 +1,9 @@
-import macro_assembler, unittest
+import macro_assembler, unittest2
 
 proc opBitMain*() =
   suite "Bitwise Opcodes":
-    let (blockNumber, chainDB) = initDatabase()
+    setup:
+      let (blockNumber, chainDB) = initDatabase()
 
     assembler: # AND OP
       title: "AND_1"

--- a/tests/test_op_custom.nim
+++ b/tests/test_op_custom.nim
@@ -1,11 +1,12 @@
 import
-  macro_assembler, unittest, macros, strutils,
+  macro_assembler, unittest2, macros, strutils,
   stew/byteutils, eth/common, ../nimbus/db/state_db,
   ../nimbus/db/db_chain, stew/ranges
 
 proc opCustomMain*() =
   suite "Custom Opcodes Test":
-    let (blockNumber, chainDB) = initDatabase()
+    setup:
+      let (blockNumber, chainDB) = initDatabase()
 
     assembler: # CALLDATASIZE OP
       title: "CALLDATASIZE_1"

--- a/tests/test_op_env.nim
+++ b/tests/test_op_env.nim
@@ -1,11 +1,12 @@
 import
-  macro_assembler, unittest, macros, strutils,
+  macro_assembler, unittest2, macros, strutils,
   stew/byteutils, eth/common, ../nimbus/db/state_db,
   ../nimbus/db/db_chain, stew/ranges
 
 proc opEnvMain*() =
   suite "Environmental Information Opcodes":
-    let (blockNumber, chainDB) = initDatabase()
+    setup:
+      let (blockNumber, chainDB) = initDatabase()
 
     assembler: # CODECOPY OP
       title: "CODECOPY_1"
@@ -176,20 +177,23 @@ proc opEnvMain*() =
         "0x5e"
         "0x07"
 
-    var acc: EthAddress
-    hexToByteArray("0xfbe0afcd7658ba86be41922059dd879c192d4c73", acc)
-    var
-      parent = chainDB.getBlockHeader(blockNumber - 1)
-      stateDB = newAccountStateDB(chainDB.db, parent.stateRoot, false)
-      code = hexToSeqByte("0x0102030405060708090A0B0C0D0E0F" &
-        "611234600054615566602054603E6000602073471FD3AD3E9EEADEEC4608B92D" &
-        "16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b" &
-        "51602001600a5254516040016014525451606001601e52545160800160285254" &
-        "60a052546016604860003960166000f26000603f556103e756600054600053602002351234")
+  suite "Environmental Information Opcodes 2":
+    setup:
+      let (blockNumber, chainDB) = initDatabase()
+      var acc: EthAddress
+      hexToByteArray("0xfbe0afcd7658ba86be41922059dd879c192d4c73", acc)
+      var
+        parent = chainDB.getBlockHeader(blockNumber - 1)
+        stateDB = newAccountStateDB(chainDB.db, parent.stateRoot, false)
+        code = hexToSeqByte("0x0102030405060708090A0B0C0D0E0F" &
+          "611234600054615566602054603E6000602073471FD3AD3E9EEADEEC4608B92D" &
+          "16CE6B500704CC3C6000605f556014600054601e60205463abcddcba6040545b" &
+          "51602001600a5254516040016014525451606001601e52545160800160285254" &
+          "60a052546016604860003960166000f26000603f556103e756600054600053602002351234")
 
-    stateDB.setCode(acc, code.toRange)
-    parent.stateRoot = stateDB.rootHash
-    chainDB.setHead(parent, true)
+      stateDB.setCode(acc, code.toRange)
+      parent.stateRoot = stateDB.rootHash
+      chainDB.setHead(parent, true)
 
     assembler: # EXTCODECOPY OP
       title: "EXTCODECOPY_1"

--- a/tests/test_op_memory.nim
+++ b/tests/test_op_memory.nim
@@ -1,8 +1,9 @@
-import macro_assembler, unittest, macros, strutils
+import macro_assembler, unittest2, macros, strutils
 
 proc opMemoryMain*() =
   suite "Memory Opcodes":
-    let (blockNumber, chainDB) = initDatabase()
+    setup:
+      let (blockNumber, chainDB) = initDatabase()
 
     assembler: # PUSH1 OP
       title: "PUSH1"

--- a/tests/test_op_misc.nim
+++ b/tests/test_op_misc.nim
@@ -1,11 +1,12 @@
 import
-  macro_assembler, unittest, macros, strutils,
+  macro_assembler, unittest2, macros, strutils,
   stew/byteutils, eth/common, ../nimbus/db/state_db,
   ../nimbus/db/db_chain, stew/ranges
 
 proc opMiscMain*() =
   suite "Misc Opcodes":
-    let (blockNumber, chainDB) = initDatabase()
+    setup:
+      let (blockNumber, chainDB) = initDatabase()
 
     assembler: # LOG0 OP
       title: "Log0"

--- a/tests/test_persistblock_json.nim
+++ b/tests/test_persistblock_json.nim
@@ -6,16 +6,10 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, json, os, tables, strformat, strutils,
+  unittest2, json, os, tables, strformat, strutils,
   eth/[common, rlp], stew/byteutils, eth/trie/db,
   ./test_helpers, ../nimbus/db/[db_chain, storage_types], ../nimbus/[tracer, vm_types],
   ../nimbus/p2p/chain
-
-proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus)
-
-proc persistBlockJsonMain*() =
-  suite "persist block json tests":
-    jsonTest("PersistBlockTests", testFixture)
 
 # use tracerTestGen.nim to generate additional test data
 proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus) =
@@ -43,3 +37,8 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus) =
   chainDB.setHead(parent, true)
   let validationResult = chain.persistBlocks(headers, bodies)
   check validationResult == ValidationResult.OK
+
+proc persistBlockJsonMain*() =
+  suite "persist block json tests":
+    jsonTest("PersistBlockTests", testFixture)
+

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, ../nimbus/vm/precompiles, json, stew/byteutils, test_helpers, ospaths, tables,
+  unittest2, ../nimbus/vm/precompiles, json, stew/byteutils, test_helpers, ospaths, tables,
   strformat, strutils, eth/trie/db, eth/common, ../nimbus/db/[db_chain, state_db],
   ../nimbus/[constants, vm_types, vm_state], ../nimbus/vm/[computation, message], macros
 

--- a/tests/test_stack.nim
+++ b/tests/test_stack.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest,
+  unittest2,
   eth/common/eth_types,
   ../nimbus/[constants, errors, vm/interpreter]
 

--- a/tests/test_state_db.nim
+++ b/tests/test_state_db.nim
@@ -5,19 +5,20 @@
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import  unittest, strutils, eth/trie/[hexary, db],
+import  unittest2, strutils, eth/trie/[hexary, db],
         ../nimbus/db/state_db, stew/byteutils, eth/common,
         stew/ranges
 
 proc stateDBMain*() =
   suite "Account State DB":
-    var
-      memDB = newMemoryDB()
-      trie = initHexaryTrie(memDB)
-      stateDB = newAccountStateDB(memDB, trie.rootHash, true)
-      address: EthAddress
+    setup:
+      var
+        memDB = newMemoryDB()
+        trie = initHexaryTrie(memDB)
+        stateDB = newAccountStateDB(memDB, trie.rootHash, true)
+        address: EthAddress
 
-    hexToByteArray("0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6", address)
+      hexToByteArray("0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6", address)
 
     test "accountExists and isDeadAccount":
       check stateDB.accountExists(address) == false

--- a/tests/test_tracer_json.nim
+++ b/tests/test_tracer_json.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, json, os, tables, strformat, strutils,
+  unittest2, json, os, tables, strformat, strutils,
   eth/common, stew/byteutils, eth/trie/db,
   ./test_helpers, ../nimbus/db/db_chain, ../nimbus/[tracer, vm_types]
 

--- a/tests/test_transaction_json.nim
+++ b/tests/test_transaction_json.nim
@@ -1,5 +1,5 @@
 import
-  unittest, json, os, tables, strformat, strutils,
+  unittest2, json, os, tables, strformat, strutils,
   eth/[common, rlp],
   ./test_helpers, ../nimbus/[transaction, utils, errors]
 

--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, strformat, strutils, sequtils, tables, json, ospaths, times,
+  unittest2, strformat, strutils, sequtils, tables, json, ospaths, times,
   stew/byteutils, stew/ranges/typedranges, eth/[rlp, common], eth/trie/db,
   ./test_helpers, ../nimbus/vm/interpreter,
   ../nimbus/[constants, errors, vm_state, vm_types, utils],


### PR DESCRIPTION
## the good

`time build/all_tests`:

before | after
---------|-------
5.39s | 2.46s

Relevant gains, right? Too bad that most of the time is taken by compilation, not the actual test running.

`rm -rf nimcache; time make test`:

before | after
---------|-------
2m 12s | 1m 49s

Why the 23s difference when only test suites imported in "all_tests.nim" where parallelised and the runtime difference there is a little under 3s? My guess is that some changes in "test_helpers.nim" made the code faster to compile.

## the bad

There's an occasional deadlock in unittest2's wrapper for threadpool's sync(). I hope it will be solved by the two commits I made to Nim's devel branch, but I need them to reach a public release before I can refactor unittest2 to depend on those fixes.

Until that's sorted out, this PR is in limbo.

## the ugly

Adding one extra proc to the general state test runner was enough to bring back VM-related call-stack overflow issues. It's unfortunate that we're regressing on 17 JSON test files, but it's good to know that the workarounds in place were not something we could rely on in the long term.

I wasn't able to parallelise "test_rpc.nim" and "test_rpc_whisper.nim", due to a strange `'yield' only allowed in an iterator` error when `await` appeared inside a test. Maybe it's something simple like an error inside compiler checks. Maybe it's something complex emerging from mixing async and threads.

## the weird

~~After changing the `jsonTest()` logic, more test results appear in the corresponding \*.md log files, and it's not just the newly added explicit skips. Hundreds of new, successfully run JSON test fixtures appear in those logs. I think it was a logic bug preventing this logging that was inadvertently fixed by changes meant to ensure GC-safety inside tests.~~