### PR TITLE
Fix blockchain tests

### DIFF
--- a/newBlockchainTests.md
+++ b/newBlockchainTests.md
@@ -1,6 +1,6 @@
 newBlockchainTests
 ===
-## BlockChainTests
+## BlockchainTests
 ```diff
 + randomStatetest391.json                                         OK
 ```

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -760,7 +760,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus, debugMode = fal
 proc blockchainJsonMain*(debugMode = false) =
   const
     legacyFolder = "eth_tests" / "LegacyTests" / "Constantinople" / "BlockchainTests"
-    newFolder = "eth_tests" / "BlockChainTests"
+    newFolder = "eth_tests" / "BlockchainTests"
 
   let config = test_config.getConfiguration()
   if config.testSubject == "" or not debugMode:

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -91,6 +91,8 @@ proc jsonTestImpl*(inputFolder, outputName: string, handler, skipTest: NimNode):
       if `skipTest`(last, name):
         continue
       filenames.add(filename)
+
+    doAssert(filenames.len > 0)
     for fname in filenames:
       test fname:
         {.gcsafe.}:


### PR DESCRIPTION
Tests: Rename incorrect case `newBlockChainTests.md` file in repo

...This meant, on Linux, both files were created, test differences didn't make themselves visible in `git diff`, and the repo would not get updates with changed test output.  On Mac and Windows it worked.

---
Bugfix: Tests: It was skipping 4654 of the blockchain tests

...The "new block chain json tests" were being skipped on Linux, but silently so that CI didn't notice.  These are a significant part of the Ethereum test suite.  See the missing output from `make test`, also visible in CI logs for Linux targets (prior to this commit):

    [Suite] new block chain json tests
            <-- nothing here