### PR TITLE
EVMC: Small stacks when using EVMC, closes #575 (segfaults)

### DIFF
--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -31,7 +31,15 @@ proc buildBinary(name: string, srcDir = "./", params = "", lang = "c") =
 
 proc test(name: string, lang = "c") =
   buildBinary name, "tests/", "-d:chronicles_log_level=ERROR"
-  exec "build/" & name
+  when not defined(windows):
+    # Verify stack usage is kept low by setting 1024k stack limit in tests.
+    exec "ulimit -s 1024 && build/" & name
+  else:
+    # Don't enforce stack limit in Windows, as we can't control it with these tools.
+    # See https://public-inbox.org/git/alpine.DEB.2.21.1.1709131448390.4132@virtualbox/
+    # When set by ulimit -s` in Bash, it's ignored.  Also, the command passed to
+    # NimScript `exec` on Windows is not a shell script.
+    exec "build/" & name
 
 task test, "Run tests":
   test "all_tests"

--- a/nimbus/vm/interpreter_dispatch.nim
+++ b/nimbus/vm/interpreter_dispatch.nim
@@ -387,6 +387,7 @@ proc executeOpcodes(c: Computation) =
 
   block:
     if not c.continuation.isNil:
+      (c.continuation)()
       c.continuation = nil
     elif c.execPrecompiles(fork):
       break

--- a/nimbus/vm/types.nim
+++ b/nimbus/vm/types.nim
@@ -20,6 +20,11 @@ when defined(evmc_enabled):
   import
     ./evmc_api
 
+# Select between small-stack recursion and no recursion.  Both are good, fast,
+# low resource using methods.  Keep both here because true EVMC API requires
+# the small-stack method, but Chronos `async` is better without recursion.
+const vm_use_recursion* = defined(evmc_enabled)
+
 type
   VMFlag* = enum
     ExecutionOK
@@ -85,7 +90,11 @@ type
     savePoint*:             SavePoint
     instr*:                 Op
     opIndex*:               int
-    parent*, child*:        Computation
+    when defined(evmc_enabled):
+      child*:               ref nimbus_message
+      res*:                 nimbus_result
+    else:
+      parent*, child*:      Computation
     continuation*:          proc() {.gcsafe.}
 
   Error* = ref object


### PR DESCRIPTION
This patch reduces stack space used with EVM in ENABLE_EVMC=1 mode, from 13 MB worst case to 550 kB, a 24x reduction.

This completes fixing the "stack problem" and closes #575 (`EVM: Different segmentation faults when running the test suite with EVMC`)

It also closes #256 (`recursive EVM call trigger unrecoverable stack overflow`).

After this patch, it is possible to re-enable the CI targets which had to be disabled due to #575.

This change is also a required precursor for switching over to "nearly EVMC" as the clean and focused Nimbus-internal API between EVM and sync/database processes, and is also key to the use of Chronos `async` in those processes when calling the EVM.

(The motivation is the internal interface has to be substantially changed _anyway_ for the parallel sync and database processes, and EVMC turns out to be well-designed and well-suited for this.  It provides good separation between modules, and suits our needs better than our other current interface.  Might as well use a good one designed by someone else.  EVMC is 98% done in Nimbus thanks to great work done before by @jangko, and we can use Nimbus-specific extensions where we need flexibility, including for performance.  Being aligned with the ecosystem is a useful bonus feature.)

All tests below were run on Ubuntu 20.04 LTS server, x86-64.  This matches one of the targets that has been disabled for a while in CI in EVMC mode due to stack overflow crashing the tests, so it's a good choice.

Measurements before
===================

Testing commit `e76e0144 2021-04-22 11:29:42 +0700 add submodules: graphql and toml-serialization`.

    $ rm -f build/all_tests && make ENABLE_EVMC=1 test
    $ ulimit -S -s 16384 # Requires larger stack than default to avoid crash.
    $ ./build/all_tests 9 | tee tlog
    [Suite] persist block json tests
    ...
    Stack range 38416 depthHigh 3
    ...
    Stack range 13074720 depthHigh 1024
    [OK] tests/fixtures/PersistBlockTests/block1431916.json

These tests use 13.07 MB of stack to run, and so crash with the default stack limit on Ubuntu Server 20.04 (8MB).  Exactly 12768 bytes per EVM call stack frame.

    $ rm -f build/all_tests && make ENABLE_EVMC=1 test
    $ ulimit -S -s 16384 # Requires larger stack than default.
    $ ./build/all_tests 7 | tee tlog
    [Suite] new generalstate json tests
        ...
    Stack range 14384 depthHigh 2
        ...
    Stack range 3495456 depthHigh 457
    [OK] tests/fixtures/eth_tests/GeneralStateTests/stRandom2/randomStatetest639.json
    ...
    Stack range 3709600 depthHigh 485
    [OK] tests/fixtures/eth_tests/GeneralStateTests/stRandom2/randomStatetest458.json
        ...
    Stack range 7831600 depthHigh 1024
    [OK] tests/fixtures/eth_tests/GeneralStateTests/stCreate2/Create2OnDepth1024.json

These tests use 7.83MB of stack to run.  About 7648 bytes per EVM call stack frame.  It _only just_ avoids crashing with the default Ubuntu Server stack limit of 8 MB.  However, it still crashes on Windows x86-64, which is why the Windows CI EVMC target is currently disabled.

On Linux where this passes, this is so borderline that it affects work and testing of the complex storage code, because that's called from the EVM.

Also, this greatly exceeds the default thread stack size.

Measurements after
==================

    $ rm -f build/all_tests && make ENABLE_EVMC=1 test
    $ ulimit -S -s 600 # Because we can!  600k stack.
    $ ./build/all_tests 9 | tee tlog
    [Suite] persist block json tests
    ...
    Stack range 1936 depthHigh 3
    ...
        Stack range 556272 depthHigh 1022
        Stack range 556512 depthHigh 1023
        Stack range 556816 depthHigh 1023
        Stack range 557056 depthHigh 1024
        Stack range 557360 depthHigh 1024
        [OK] tests/fixtures/PersistBlockTests/block1431916.json

    $ rm -f build/all_tests && make ENABLE_EVMC=1 test
    $ ulimit -S -s 600 # Because we can!  600k stack.
    $ ./build/all_tests 7 | tee tlog
    [Suite] new generalstate json tests
        ...
    Stack range 1392 depthHigh 2
        ...
    Stack range 248912 depthHigh 457
    [OK] tests/fixtures/eth_tests/GeneralStateTests/stRandom2/randomStatetest639.json
    ...
    Stack range 264144 depthHigh 485
    [OK] tests/fixtures/eth_tests/GeneralStateTests/stRandom2/randomStatetest458.json
        ...
        Stack range 557360 depthHigh 1024
    [OK] tests/fixtures/eth_tests/GeneralStateTests/stStaticCall/static_CallRecursiveBombPreCall.json

For both tests, a satisfying *544 bytes* per EVM call stack frame, and EVM takes less than 600 kB total.  With other overheads, both tests run in 600 kB stack total at maximum EVM depth.

We must add some headroom on this for database activity called from the EVM, and different compile targets.  But it means the EVM itself is no longer a stack burden.

This is much smaller than the default thread stack size on Linux (2MB), with plenty of margin.  (Just fyi, it isn't smaller than a _small_ thread stack on Linux from a long time ago (128kB), and some small embedded C targets.)

This size is well suited to running EVMs in threads.

Further reduction
=================

This patch solves the stack problem.  Windows and Linux 64-bit EVMC CI targets can be re-enabled, and there is no longer a problem with stack usage.

We can reduce further to ~340 bytes per frame and 350 kB total, while still complying with EVMC.  But as this involves changing how errors are handled to comply fully with EVMC, and removing `dispose` calls, it's not worth doing now while there are other EVMC changes in progress that will have the same effect.

A Nimbus-specific extension will allow us to avoid recursion with EVMC anyway, bringing bytes per frame to zero.  We need the extension anyway, to support Chronos `async` which parallel transaction processing is built around.

Interop with non-Nimbus over EVMC won't let us avoid recursion, but then we can't control the stack frame size either.  To prevent stack overflow in interop I anticipate using (this method in Aleth)
[https://github.com/ethereum/aleth/blob/6e96ce34e3f131e2d42f3cb00741b54e05ab029d/libethereum/ExtVM.cpp#L61].

Smoke test other versions of GCC and Clang/LLVM
===============================================

As all builds including Windows use GCC or Apple's Clang/LLVM, this is just to verify we're in the right ballpark on all targets. I've only checked `x86_64` though, not 32-bit, and not ARM.

It's interesting to see GCC 10 uses less stack.  This is because it optimises `struct` returns better, sometimes skipping an intermediate copy.  Here it benefits the EVMC API, but I found GCC 10 also improves the larger stack usage of the rest of `nimbus-eth1` as well.

Apple clang 12.0.0 (clang-1200.0.26.2) on MacOS 10.15:

- 544 bytes per EVM call stack frame

GCC 10.3.0 (Ubuntu 10.3.0-1ubuntu1) on Ubuntu 21.04:

- 464 bytes per EVM call stack frame

GCC 10.2.0 (Ubuntu 10.2.0-5ubuntu1~20.04) on Ubuntu 20.04 LTS:

- 464 bytes per EVM call stack frame

GCC 11.0.1 20210417 (experimental; Ubuntu 11-20210417-1ubuntu1) on Ubuntu 21.04:

- 8 bytes per EVM call stack frame

GCC 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04) on Ubuntu 20.04 LTS:

- 544 bytes per EVM call stack frame

GCC 8.4.0 (Ubuntu 8.4.0-3ubuntu2) on Ubuntu 20.04 LTS:

- 544 bytes per EVM call stack frame

GCC 7.5.0 (Ubuntu 7.5.0-6ubuntu2) on Ubuntu 20.04 LTS:

- 544 bytes per EVM call stack frame

GCC 9.2.1 20191008 (Ubuntu 9.2.1-9ubuntu2) on Ubuntu 19.10:

- 528 bytes per EVM call stack frame