### PR TITLE
CI: Skip GitHub actions for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: nimbus-eth1 CI
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore: ['doc/**', 'docs/**', '**/*.md']
+  pull_request:
+    paths-ignore: ['doc/**', 'docs/**', '**/*.md']
 
 jobs:
   build:


### PR DESCRIPTION
The CI takes a long time (sometimes hours) and shouldn't hold up documentation-only commits.  We may also find CI for other changes starts faster, if we're not using up as many credits.  When we process documentation into something nicer (like `nimbus.guide`) we'll need to revisit this.

Syntax from [example ignoring paths](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-ignoring-paths).