### PR TITLE
CI: Skip GitHub actions for `hive_integration` files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: nimbus-eth1 CI
 on:
   push:
-    paths-ignore: ['doc/**', 'docs/**', '**/*.md']
+    paths-ignore: ['doc/**', 'docs/**', '**/*.md', 'hive_integration/**']
   pull_request:
-    paths-ignore: ['doc/**', 'docs/**', '**/*.md']
+    paths-ignore: ['doc/**', 'docs/**', '**/*.md', 'hive_integration/**']
 
 jobs:
   build:


### PR DESCRIPTION
Files underneath `hive_integration` are not used to build anything, so don't trigger CI when these files change.

Most of them are manually copied into Hive `hive/clients/nimbus`.
The rest are instructions and a standalone helper program not used by CI.
