### PR TITLE
Limit stack size on Windows like other targets

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -6,8 +6,9 @@ else:
 if defined(windows):
   # disable timestamps in Windows PE headers - https://wiki.debian.org/ReproducibleBuilds/TimestampsInPEBinaries
   switch("passL", "-Wl,--no-insert-timestamp")
-  # increase stack size
-  switch("passL", "-Wl,--stack,8388608")
+  # increase stack size, unless something else is setting the stack size
+  if not defined(windowsNoSetStack):
+    switch("passL", "-Wl,--stack,8388608")
   # https://github.com/nim-lang/Nim/issues/4057
   --tlsEmulation:off
   if defined(i386):


### PR DESCRIPTION
We can't use `ulimit -s` to limit stack size on Windows.  Even though Bash accepts `ulimit -s` and the numbers change it has no effect and is not passed to child processes.

(See https://public-inbox.org/git/alpine.DEB.2.21.1.1709131448390.4132@virtualbox/)

Instead, set it when building the test executable, following, a suggestion from @stefantalpalaru.
https://github.com/status-im/nimbus-eth1/pull/598#discussion_r621107128

To ensure no conflict with `config.nims`, `-d:windowsNoSetStack` is used.  This proved unnecessary in practice because the command-line option is passed to the linker after the config file option.  But given we don't have an automated test to verify linker behaviour, it's best not to rely on the option order, neither how the linker treats it, or whether Nim will always send them in that order.

Testing:

This has been verified by using a smaller limit.  At 200k, all `ENABLE_EVMC=0` OS targets passed as expected, and all `ENABLE_EVMC=1` OS targets failed with expected kinds of errors due to stack overflow, including Windows.
(400k wasn't small enough; 32-bit x86 Windows passed on that).