### PR TITLE
EVM: Make continuation exceptions behave as they did before

### DIFF
--- a/nimbus/vm/interpreter_dispatch.nim
+++ b/nimbus/vm/interpreter_dispatch.nim
@@ -386,13 +386,13 @@ proc executeOpcodes(c: Computation) =
   let fork = c.fork
 
   block:
-    if not c.continuation.isNil:
-      (c.continuation)()
-      c.continuation = nil
-    elif c.execPrecompiles(fork):
+    if c.continuation.isNil and c.execPrecompiles(fork):
       break
 
     try:
+      if not c.continuation.isNil:
+        (c.continuation)()
+        c.continuation = nil
       c.selectVM(fork)
     except CatchableError as e:
       c.setError(&"Opcode Dispatch Error msg={e.msg}, depth={c.msg.depth}", true)


### PR DESCRIPTION
The account database code is not supposed to raise exceptions in the EVM, and the behaviour is not well defined if it does.  It isn't compliant with EVMC spec either.  But that will be dealt with properly when the account state-cache is dealt with, as there is some work to be done on it.

Meanwhile, if it raises in code under `chainTo` and then `(continuation)()`, the behaviour was changed slightly by the stack-shrink patches.

Before those patches, an exception after the recursion-point was converted to `c.setError` "Opcode Dispatch Error" in `executeOpcodes.  After, it would propagate out, a different behaviour.  (It still correctly walked the chain of `c.dispose()` calls to clean up.)

It's easy to restore the original behaviour just by moving the continuation call, so let's do that.