### PR TITLE
Gather EVM-calling functions to one place

### DIFF
--- a/nimbus/graphql/ethapi.nim
+++ b/nimbus/graphql/ethapi.nim
@@ -778,7 +778,7 @@ proc blockEstimateGas(ud: RootRef, params: Args, parent: Node): RespResult {.api
   let param = params[0].val
   try:
     let (callData, gasLimit) = toCallData(param)
-    let gasUsed = estimateGas(callData, h.header, ctx.chainDB, gasLimit)
+    let gasUsed = rpcEstimateGas(callData, h.header, ctx.chainDB, gasLimit)
     longNode(gasUsed)
   except Exception as em:
     err("estimateGas error: " & em.msg)

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -15,7 +15,8 @@ import
   ../transaction, ../config, ../vm_state, ../constants, ../vm_types,
   ../utils, ../db/[db_chain, state_db],
   rpc_types, rpc_utils, ../vm_message, ../vm_computation,
-  ../vm_types2
+  ../vm_types2,
+  ../transaction/call_evm
 
 #[
   Note:
@@ -261,7 +262,7 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB , server: RpcServer) =
     let
       header   = headerFromTag(chain, quantityTag)
       callData = callData(call, true, chain)
-    result = doCall(callData, header, chain)
+    result = rpcDoCall(callData, header, chain)
 
   server.rpc("eth_estimateGas") do(call: EthCall, quantityTag: string) -> HexQuantityStr:
     ## Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -275,7 +275,7 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB , server: RpcServer) =
     let
       header   = chain.headerFromTag(quantityTag)
       callData = callData(call, false, chain)
-      gasUsed  = estimateGas(callData, header, chain, call.gas.isSome)
+      gasUsed  = rpcEstimateGas(callData, header, chain, call.gas.isSome)
     result = encodeQuantity(gasUsed.uint64)
 
   server.rpc("eth_getBlockByHash") do(data: EthHashStr, fullTransactions: bool) -> Option[BlockObject]:

--- a/nimbus/rpc/rpc_utils.nim
+++ b/nimbus/rpc/rpc_utils.nim
@@ -180,28 +180,6 @@ proc callData*(call: EthCall, callMode: bool = true, chain: BaseChainDB): RpcCal
   if call.data.isSome:
     result.data = hexToSeqByte(call.data.get.string)
 
-proc estimateGas*(call: RpcCallData, header: BlockHeader, chain: BaseChainDB, haveGasLimit: bool): GasInt =
-  var
-    # we use current header stateRoot, unlike block validation
-    # which use previous block stateRoot
-    vmState = newBaseVMState(header.stateRoot, header, chain)
-    fork    = toFork(chain.config, header.blockNumber)
-    tx      = Transaction(
-      accountNonce: vmState.accountdb.getNonce(call.source),
-      gasPrice: call.gasPrice,
-      gasLimit: if haveGasLimit: call.gas else: header.gasLimit - vmState.cumulativeGasUsed,
-      to      : call.to,
-      value   : call.value,
-      payload : call.data,
-      isContractCreation:  call.contractCreation
-    )
-
-  var dbTx = chain.db.beginTransaction()
-  defer: dbTx.dispose()
-  result = processTransaction(tx, call.source, vmState, fork)
-  dbTx.dispose()
-  # TODO: handle revert and error
-
 proc populateTransactionObject*(tx: Transaction, header: BlockHeader, txIndex: int): TransactionObject =
   result.blockHash = some(header.hash)
   result.blockNumber = some(encodeQuantity(header.blockNumber))

--- a/nimbus/rpc/rpc_utils.nim
+++ b/nimbus/rpc/rpc_utils.nim
@@ -180,19 +180,6 @@ proc callData*(call: EthCall, callMode: bool = true, chain: BaseChainDB): RpcCal
   if call.data.isSome:
     result.data = hexToSeqByte(call.data.get.string)
 
-proc doCall*(call: RpcCallData, header: BlockHeader, chain: BaseChainDB): HexDataStr =
-  var
-    # we use current header stateRoot, unlike block validation
-    # which use previous block stateRoot
-    vmState = newBaseVMState(header.stateRoot, header, chain)
-    fork    = toFork(chain.config, header.blockNumber)
-    comp    = rpcSetupComputation(vmState, call, fork)
-
-  comp.execComputation()
-  result = hexDataStr(comp.output)
-  # TODO: handle revert and error
-  # TODO: handle contract ABI
-
 proc estimateGas*(call: RpcCallData, header: BlockHeader, chain: BaseChainDB, haveGasLimit: bool): GasInt =
   var
     # we use current header stateRoot, unlike block validation

--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -1,0 +1,41 @@
+# Nimbus - Various ways of calling the EVM
+#
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  eth/common/eth_types, stint, options,
+  ".."/[vm_types, vm_types2, vm_state, vm_computation]
+
+type
+  RpcCallData* = object
+    source*: EthAddress
+    to*: EthAddress
+    gas*: GasInt
+    gasPrice*: GasInt
+    value*: UInt256
+    data*: seq[byte]
+    contractCreation*: bool
+
+proc rpcSetupComputation*(vmState: BaseVMState, call: RpcCallData, fork: Fork): Computation =
+  vmState.setupTxContext(
+    origin = call.source,
+    gasPrice = call.gasPrice,
+    forkOverride = some(fork)
+  )
+
+  let msg = Message(
+    kind: evmcCall,
+    depth: 0,
+    gas: call.gas,
+    sender: call.source,
+    contractAddress: call.to,
+    codeAddress: call.to,
+    value: call.value,
+    data: call.data
+    )
+
+  return newComputation(vmState, msg)


### PR DESCRIPTION
Start gathering the functions that call the EVM into one place, `transaction/call_evm.nim`.

This is a series of changes to gather all ways the EVM is called to one place.  Duplicate, slightly different setup functions have accumulated over time, each with some knowledge of EVM internals.  When they are brought together, these methods will be changed to use a single entry point to the EVM, allowing the entry point to be refactored, EVMC to be completed, and async concurrency to be implemented on top.  This also simplifies the callers.
