### PR TITLE
Bugfix: Avoid numeric overflow when validating transaction value

### DIFF
--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -19,11 +19,18 @@ proc validateTransaction*(vmState: BaseVMState, tx: Transaction,
       addition=tx.gasLimit
     return
 
-  let totalCost = tx.gasLimit.u256 * tx.gasPrice.u256 + tx.value
-  if totalCost > balance:
-    debug "invalid tx: not enough cash",
+  let gasCost = tx.gasLimit.u256 * tx.gasPrice.u256
+  if gasCost > balance:
+    debug "invalid tx: not enough cash for gas",
       available=balance,
-      require=totalCost
+      require=gasCost
+    return
+
+  if tx.value > balance - gasCost:
+    debug "invalid tx: not enough cash to send",
+      available=balance,
+      availableMinusGas=balance-gasCost,
+      require=tx.value
     return
 
   if tx.gasLimit < tx.intrinsicGas(fork):


### PR DESCRIPTION
It's possible for `tx.value` in the transaction to have a deliberately constructed large 256-bit value, such that adding `gasLimit * gasPrice` to it overflows to a small value.

Prior to this patch, the code would allow such a transaction to pass validation, even though such a large transfer cannot be valid.
