### PR TITLE
Transaction: Prepare txSetupComputation and txRefundGas to support txCallEvm

### DIFF
--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -72,7 +72,7 @@ proc processTransaction*(tx: Transaction, sender: EthAddress, vmState: BaseVMSta
 
     result = tx.gasLimit
     if not c.shouldBurnGas:
-      c.refundGas(tx, sender)
+      txRefundGas(tx, sender, c)
       result -= c.gasMeter.gasRemaining
 
   vmState.cumulativeGasUsed += result

--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -5,7 +5,8 @@ import options, sets,
   ../vm_state, ../vm_types, ../vm_state_transactions,
   ../vm_computation, ../vm_message, ../vm_precompiles,
   ../vm_types2,
-  ./dao, ../config
+  ./dao, ../config,
+  ../transaction/call_evm
 
 proc validateTransaction*(vmState: BaseVMState, tx: Transaction,
                           sender: EthAddress, fork: Fork): bool =
@@ -64,7 +65,7 @@ proc processTransaction*(tx: Transaction, sender: EthAddress, vmState: BaseVMSta
         db.accessList(c)
 
   if validateTransaction(vmState, tx, sender, fork):
-    var c = setupComputation(vmState, tx, sender, fork)
+    var c = txSetupComputation(tx, sender, vmState, fork)
     vmState.mutateStateDB:
       db.subBalance(sender, tx.gasLimit.u256 * tx.gasPrice.u256)
     execComputation(c)

--- a/nimbus/vm/state_transactions.nim
+++ b/nimbus/vm/state_transactions.nim
@@ -25,9 +25,3 @@ proc execComputation*(c: Computation) =
     c.vmState.touchedAccounts.incl c.touchedAccounts
 
   c.vmstate.status = c.isSuccess
-
-proc refundGas*(c: Computation, tx: Transaction, sender: EthAddress) =
-  let maxRefund = (tx.gasLimit - c.gasMeter.gasRemaining) div 2
-  c.gasMeter.returnGas min(c.getGasRefund(), maxRefund)
-  c.vmState.mutateStateDB:
-    db.addBalance(sender, c.gasMeter.gasRemaining.u256 * tx.gasPrice.u256)

--- a/nimbus/vm/state_transactions.nim
+++ b/nimbus/vm/state_transactions.nim
@@ -11,30 +11,6 @@ import
   ../transaction,
   ./computation, ./interpreter, ./state, ./types
 
-proc setupComputation*(vmState: BaseVMState, tx: Transaction, sender: EthAddress, fork: Fork) : Computation =
-  var gas = tx.gasLimit - tx.intrinsicGas(fork)
-  assert gas >= 0
-
-  vmState.setupTxContext(
-    origin = sender,
-    gasPrice = tx.gasPrice,
-    forkOverride = some(fork)
-  )
-
-  let msg = Message(
-    kind: if tx.isContractCreation: evmcCreate else: evmcCall,
-    depth: 0,
-    gas: gas,
-    sender: sender,
-    contractAddress: tx.getRecipient(),
-    codeAddress: tx.to,
-    value: tx.value,
-    data: tx.payload
-    )
-
-  result = newComputation(vmState, msg)
-  doAssert result.isOriginComputation
-
 proc execComputation*(c: Computation) =
   if not c.msg.isCreate:
     c.vmState.mutateStateDB:

--- a/nimbus/vm_state_transactions.nim
+++ b/nimbus/vm_state_transactions.nim
@@ -17,7 +17,6 @@ else:
 
 export
   vmx.execComputation,
-  vmx.refundGas,
-  vmx.setupComputation
+  vmx.refundGas
 
 # End

--- a/nimbus/vm_state_transactions.nim
+++ b/nimbus/vm_state_transactions.nim
@@ -16,7 +16,6 @@ else:
     vm2/state_transactions as vmx
 
 export
-  vmx.execComputation,
-  vmx.refundGas
+  vmx.execComputation
 
 # End


### PR DESCRIPTION
After recent changes, there's only one call left to `setupComputation`, and it's just a variant like `rpcSetupComputation` but for transaction processing. The similarity to `rpcSetupComputation` is obvious.
Same with `refundGas(Transaction, ...)`, and the similarity of that to the tail of `rpcEstimateGas` is obvious.
Move these to `call_evm`, and name them like their `rpc...` counterparts.