### PR TITLE
RPC: Don't export rpcSetupComputation

### DIFF
--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -23,8 +23,8 @@ type
     data*: seq[byte]
     contractCreation*: bool
 
-proc rpcSetupComputation*(vmState: BaseVMState, call: RpcCallData,
-                          fork: Fork, gasLimit: GasInt): Computation =
+proc rpcSetupComputation(vmState: BaseVMState, call: RpcCallData,
+                         fork: Fork, gasLimit: GasInt): Computation =
   vmState.setupTxContext(
     origin = call.source,
     gasPrice = call.gasPrice,


### PR DESCRIPTION
The point of the `call_vm` exercise is to allow `Computation` to become an
internal type of the EVM, not used as API by the rest of the program.  So
`rpcSetupComputation` should be private.  It was left exported by mistake.