### PR TITLE
Assembler: Prepare asmSetupComputation to support asmCallEvm

### DIFF
--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -23,8 +23,8 @@ type
     data*: seq[byte]
     contractCreation*: bool
 
-proc rpcSetupComputation*(vmState: BaseVMState, call: RpcCallData,
-                          fork: Fork, gasLimit: GasInt): Computation =
+proc rpcSetupComputation(vmState: BaseVMState, call: RpcCallData,
+                         fork: Fork, gasLimit: GasInt): Computation =
   vmState.setupTxContext(
     origin = call.source,
     gasPrice = call.gasPrice,

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -211,25 +211,8 @@ proc initDatabase*(): (Uint256, BaseChainDB) =
 
   result = (blockNumber, newBaseChainDB(memoryDB, false))
 
-proc initComputation(blockNumber: Uint256, chainDB: BaseChainDB, code, data: seq[byte], fork: Fork): Computation =
-  let
-    parentNumber = blockNumber - 1
-    parent = chainDB.getBlockHeader(parentNumber)
-    header = chainDB.getBlockHeader(blockNumber)
-    headerHash = header.blockHash
-    body = chainDB.getBlockBody(headerHash)
-    vmState = newBaseVMState(parent.stateRoot, header, chainDB)
-
-  var
-    tx = body.transactions[0]
-    sender = transaction.getSender(tx)
-
-  tx.payload = code
-  tx.gasLimit = 500000000
-  asmSetupComputation(tx, sender, vmState, data, some(fork))
-
 proc runVM*(blockNumber: Uint256, chainDB: BaseChainDB, boa: Assembler): bool =
-  var computation = initComputation(blockNumber, chainDB, boa.code, boa.data, boa.fork)
+  var computation = asmSetupComputation(blockNumber, chainDB, boa.code, boa.data, boa.fork)
 
   let gas = computation.gasMeter.gasRemaining
   execComputation(computation)


### PR DESCRIPTION
In the `macro_assembler` test code, `initComputation` is another variant of `rpcSetupComputation` and `txSetupComputation` with slightly different paremeters.  The similarity is obvious.  It is a special setup for testing, though, as it requires a contract-creation transaction for parameters, but sets up a `CALL` execution not `CREATE`.
Move this and its sibling function (same name) to `call_evm` like their `rpc...` and `tx...` counterparts.