### PR TITLE
Fixtures: Prepare fixtureSetupComputation to support fixtureCallEvm

### DIFF
--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -282,3 +282,23 @@ proc asmCallEvm*(blockNumber: Uint256, chainDB: BaseChainDB, code, data: seq[byt
   result.memory          = c.memory
   result.vmState         = c.vmState
   result.contractAddress = c.msg.contractAddress
+
+proc fixtureSetupComputation*(vmState: BaseVMState, call: RpcCallData, origin: EthAddress): Computation =
+  vmState.setupTxContext(
+    origin = origin,          # Differs from `rpcSetupComputation`
+    gasPrice = call.gasPrice,
+    # fork is not set.
+  )
+
+  var msg = Message(
+    kind: if call.contractCreation: evmcCreate else: evmcCall,
+    depth: 0,
+    gas: call.gas,            # Differs from `rpcSetupComputation`
+    sender: call.source,
+    contractAddress: call.to, # Differs from `rpcSetupComputation`
+    codeAddress: call.to,
+    value: call.value,
+    data: call.data
+  )
+
+  return newComputation(vmState, msg)


### PR DESCRIPTION
In the `text_vm_json` ("fixtures") test code, there is another variant of `rpcSetupComputation` and `txSetupComputation` with slightly different paremeters.  The similarity is obvious.

It's a special setup for testing, though, as it requires slightly different parameters.
