### PR TITLE
Fixtures: Make fixture "vm json tests" use new function fixtureCallEvm

### DIFF
--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -282,3 +282,23 @@ proc asmCallEvm*(blockNumber: Uint256, chainDB: BaseChainDB, code, data: seq[byt
   result.memory          = c.memory
   result.vmState         = c.vmState
   result.contractAddress = c.msg.contractAddress
+
+proc fixtureSetupComputation*(vmState: BaseVMState, call: RpcCallData, origin: EthAddress): Computation =
+  vmState.setupTxContext(
+    origin = origin,          # Differs from `rpcSetupComputation`
+    gasPrice = call.gasPrice,
+    # fork is not set.
+  )
+
+  var msg = Message(
+    kind: if call.contractCreation: evmcCreate else: evmcCall,
+    depth: 0,
+    gas: call.gas,            # Differs from `rpcSetupComputation`
+    sender: call.source,
+    contractAddress: call.to, # Differs from `rpcSetupComputation`
+    codeAddress: call.to,
+    value: call.value,
+    data: call.data
+  )
+
+  return newComputation(vmState, msg)


### PR DESCRIPTION
Move the EVM setup and call in fixtures "vm json tests" to new function `fixtureCallEvm` in `call_evm`.  Extra return values needed for testing are returned specially.  This entry point is different from all other `..CallEvm` type functions, because it uses `executeOpcodes` instead of `execComputation`, so it doesn't update the account balance or nonce on entry and exit from the EVM.