### PR TITLE
Precompiles: Change precompile tests to use fixtureCallEvm

### DIFF
--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -302,7 +302,7 @@ type
   FixtureResult* = object
     isError*:         bool
     error*:           Error
-    gasRemaining*:    GasInt
+    gasUsed*:         GasInt
     output*:          seq[byte]
     vmState*:         BaseVMState
     logEntries*:      seq[Log]
@@ -310,6 +310,7 @@ type
 proc fixtureCallEvm*(vmState: BaseVMState, call: RpcCallData,
                      origin: EthAddress, forkOverride = none(Fork)): FixtureResult =
   var c = fixtureSetupComputation(vmState, call, origin, forkOverride)
+  let gas = c.gasMeter.gasRemaining
 
   # Next line differs from all the other EVM calls.  With `execComputation`,
   # most "vm json tests" fail with either `balanceDiff` or `nonceDiff` errors.
@@ -319,7 +320,7 @@ proc fixtureCallEvm*(vmState: BaseVMState, call: RpcCallData,
   # computation doesn't return.  We'll have to obtain them outside EVMC.
   result.isError         = c.isError
   result.error           = c.error
-  result.gasRemaining    = c.gasMeter.gasRemaining
+  result.gasUsed         = gas - c.gasMeter.gasRemaining
   result.output          = c.output
   result.vmState         = c.vmState
   shallowCopy(result.logEntries, c.logEntries)

--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -80,7 +80,7 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
     check(fixtureResult.output.bytesToHex == expectedOutput)
 
     let expectedGasRemaining = fixture{"gas"}.getHexadecimalInt
-    let actualGasRemaining = fixtureResult.gasRemaining
+    let actualGasRemaining = call.gas - fixtureResult.gasUsed
     checkpoint(&"Remaining: {actualGasRemaining} - Expected: {expectedGasRemaining}")
     check(actualGasRemaining == expectedGasRemaining)
 


### PR DESCRIPTION
Move the EVM setup and call in precompile tests to `fixtureCallEvm` in `call_evm`.  Extra return values needed for testing are returned specially, and the convention for reporting gas used is changed to match `asmCallEvm`.

Although the precompile tests used `execPrecompiles` before, `executeOpcodes` does perfectly well as a substitute, allowing `fixtureCallEvm` to be shared.

_Significantly, this patch also makes `Computation` more or less an internal type of the EVM now._

Nothing outside the EVM (except `call_evm`) needs access any more to `Computation`, `execComputation`, `executeOpcodes` or `execPrecompiles`. Many imports can be trimmed, some files removed, and EVMC is much closer.

(As a bonus, the functions in `call_evm` reveal what capabilities parts of the program have needed over time, makes certain bugs and inconsistencies clearer, and suggests how to refactor into a more useful shared entry point.)
