### PR TITLE
add '--nat:0.0.0.0' flag to hive_integration/nimbus/nimbus.sh

### DIFF
--- a/hive_integration/README.md
+++ b/hive_integration/README.md
@@ -88,7 +88,7 @@ These Hive suites/simulators don't work with `nimbus-eth1` currently:
 The number of passes and fails output at the time of writing (2021-04-26) is:
 
     ethereum/consensus:  16556 pass, 11643 fail, 28199 total
-    ethereum/graphql:       31 pass,    15 fail,    46 total
+    ethereum/graphql:       34 pass,    12 fail,    46 total
     devp2p/discv4:           0 pass,    14 fail,    14 total
     devp2p/eth:              0 pass,     1 fail,     1 total
     ethereum/rpc:            0 pass,     1 fail,     1 total

--- a/hive_integration/nimbus/nimbus.sh
+++ b/hive_integration/nimbus/nimbus.sh
@@ -47,7 +47,7 @@
 set -e
 
 nimbus=/usr/bin/nimbus
-FLAGS="--prune:archive"
+FLAGS="--prune:archive --nat:0.0.0.0"
 
 if [ "$HIVE_LOGLEVEL" != "" ]; then
   FLAGS="$FLAGS --log-level:DEBUG"


### PR DESCRIPTION
trying Jacek suggestion in #591, I added nat setting to
nimbus-eth1 hive shell script. visible difference after adding
this flag is the nat library not complaining about
"the gateway does not support nat-pmp" anymore.

but the slow startup time described in #591 is yet to be measured
again, although I already see improvement when executing
ethereum/consensus category in hive.