### PR TITLE
fixes `validateFixedLenHex` in graphql/ethapi.nim

### DIFF
--- a/nimbus/graphql/ethapi.nim
+++ b/nimbus/graphql/ethapi.nim
@@ -350,6 +350,9 @@ proc validateFixedLenHex(x: Node, minLen: int, kind: string, padding = false): N
         [kind, $expectedLen, $x.stringVal.len])
     else:
       padBytes(x, prefixLen, minLen * 2)
+  elif x.stringVal.len > expectedLen:
+    return err("$1 len is too long: expect $2 got $3" %
+      [kind, $expectedLen, $x.stringVal.len])
 
   for i in prefixLen..<x.stringVal.len:
     if x.stringVal[i] notin HexDigits:

--- a/tests/graphql/queries.toml
+++ b/tests/graphql/queries.toml
@@ -521,3 +521,14 @@ mutation {
 """
   errors = ["[2, 1]: Fatal: Instrument Error: query complexity exceed max(200), got 204: @[]"]
   result = """null"""
+
+[[units]]
+  name = "hex address is too long"
+  errors = ["[2, 11]: Error: 'address' got '\"0x095e7baea6a6c7c4c2dfeb977efac326af552d8700\"': Address len is too long: expect 42 got 44"]
+  code = """
+{
+  account(address: "0x095e7baea6a6c7c4c2dfeb977efac326af552d8700") {
+    balance
+  }
+}
+"""


### PR DESCRIPTION
now it can detect too long hex besides padding too short hex