### PR TITLE
Fix wrong chainid usage

### DIFF
--- a/nimbus/db/db_chain.nim
+++ b/nimbus/db/db_chain.nim
@@ -17,6 +17,7 @@ type
     db*       : TrieDatabaseRef
     pruneTrie*: bool
     config*   : ChainConfig
+    networkId*: PublicNetwork
 
     # startingBlock, currentBlock, and highestBlock
     # are progress indicator
@@ -33,6 +34,7 @@ proc newBaseChainDB*(db: TrieDatabaseRef, pruneTrie: bool = true, id: PublicNetw
   result.db = db
   result.pruneTrie = pruneTrie
   result.config = publicChainConfig(id)
+  result.networkId = id
 
 proc `$`*(db: BaseChainDB): string =
   result = "BaseChainDB"

--- a/nimbus/genesis.nim
+++ b/nimbus/genesis.nim
@@ -97,6 +97,7 @@ proc defaultGenesisBlockForNetwork*(id: PublicNetwork): Genesis =
   of CustomNet:
     let genesis = getConfiguration().customGenesis
     var alloc = new GenesisAlloc
+    assert(genesis.prealloc.isNil.not, "genesis prealloc should not nil")
     if genesis.prealloc != parseJson("{}"):
       alloc = customNetPrealloc(genesis.prealloc)
     Genesis(

--- a/nimbus/p2p/chain.nim
+++ b/nimbus/p2p/chain.nim
@@ -93,8 +93,7 @@ proc newChain*(db: BaseChainDB): Chain =
 
   if not db.config.daoForkSupport:
     db.config.daoForkBlock = db.config.homesteadBlock
-  let chainId = PublicNetwork(db.config.chainId)
-  let g = defaultGenesisBlockForNetwork(chainId)
+  let g = defaultGenesisBlockForNetwork(db.networkId)
   result.blockZeroHash = g.toBlock.blockHash
   let genesisCRC = crc32(0, result.blockZeroHash.data)
   result.forkIds = calculateForkIds(db.config, genesisCRC)

--- a/nimbus/tracer.nim
+++ b/nimbus/tracer.nim
@@ -87,7 +87,7 @@ proc traceTransaction*(chainDB: BaseChainDB, header: BlockHeader,
     memoryDB = newMemoryDB()
     captureDB = newCaptureDB(chainDB.db, memoryDB)
     captureTrieDB = trieDB captureDB
-    captureChainDB = newBaseChainDB(captureTrieDB, false, PublicNetWork(chainDB.config.chainId)) # prune or not prune?
+    captureChainDB = newBaseChainDB(captureTrieDB, false, chainDB.networkId) # prune or not prune?
     vmState = newBaseVMState(parent.stateRoot, header, captureChainDB, tracerFlags + {EnableAccount})
 
   var stateDb = vmState.accountDb
@@ -155,7 +155,7 @@ proc dumpBlockState*(db: BaseChainDB, header: BlockHeader, body: BlockBody, dump
     memoryDB = newMemoryDB()
     captureDB = newCaptureDB(db.db, memoryDB)
     captureTrieDB = trieDB captureDB
-    captureChainDB = newBaseChainDB(captureTrieDB, false, PublicNetWork(db.config.chainId))
+    captureChainDB = newBaseChainDB(captureTrieDB, false, db.networkId)
     # we only need stack dump if we want to scan for internal transaction address
     vmState = newBaseVMState(parent.stateRoot, header, captureChainDB, {EnableTracing, DisableMemory, DisableStorage, EnableAccount})
     miner = vmState.coinbase()
@@ -212,7 +212,7 @@ proc traceBlock*(chainDB: BaseChainDB, header: BlockHeader, body: BlockBody, tra
     memoryDB = newMemoryDB()
     captureDB = newCaptureDB(chainDB.db, memoryDB)
     captureTrieDB = trieDB captureDB
-    captureChainDB = newBaseChainDB(captureTrieDB, false, PublicNetWork(chainDB.config.chainId))
+    captureChainDB = newBaseChainDB(captureTrieDB, false, chainDB.networkId)
     vmState = newBaseVMState(parent.stateRoot, header, captureChainDB, tracerFlags + {EnableTracing})
 
   if header.txRoot == BLANK_ROOT_HASH: return newJNull()
@@ -246,7 +246,7 @@ proc dumpDebuggingMetaData*(chainDB: BaseChainDB, header: BlockHeader,
     memoryDB = newMemoryDB()
     captureDB = newCaptureDB(chainDB.db, memoryDB)
     captureTrieDB = trieDB captureDB
-    captureChainDB = newBaseChainDB(captureTrieDB, false, PublicNetWork(chainDB.config.chainId))
+    captureChainDB = newBaseChainDB(captureTrieDB, false, chainDB.networkId)
     bloom = createBloom(vmState.receipts)
 
   let blockSummary = %{

--- a/nimbus/vm/state.nim
+++ b/nimbus/vm/state.nim
@@ -69,9 +69,9 @@ proc setupTxContext*(vmState: BaseVMState, origin: EthAddress, gasPrice: GasInt,
   vmState.gasCosts = vmState.fork.forkToSchedule
 
 proc consensusEnginePoA*(vmState: BaseVMState): bool =
-  let chainId = PublicNetwork(vmState.chainDB.config.chainId)
+  let networkId = vmState.chainDB.networkId
   # PoA consensus engine have no reward for miner
-  result = chainId in {GoerliNet, RinkebyNet, KovanNet}
+  result = networkId in {GoerliNet, RinkebyNet, KovanNet}
 
 proc getSignature(bytes: openArray[byte], output: var Signature): bool =
   let sig = Signature.fromRaw(bytes)

--- a/nimbus/vm2/state.nim
+++ b/nimbus/vm2/state.nim
@@ -57,9 +57,9 @@ proc newBaseVMState*(prevStateRoot: Hash256,
   result.init(prevStateRoot, header, chainDB, tracerFlags)
 
 proc consensusEnginePoA*(vmState: BaseVMState): bool =
-  let chainId = PublicNetwork(vmState.chainDB.config.chainId)
+  let networkId = vmState.chainDB.networkId
   # PoA consensus engine have no reward for miner
-  result = chainId in {GoerliNet, RinkebyNet, KovanNet}
+  result = networkId in {GoerliNet, RinkebyNet, KovanNet}
 
 proc getSignature(bytes: openArray[byte], output: var Signature): bool =
   let sig = Signature.fromRaw(bytes)


### PR DESCRIPTION
Now the `BaseChainDB` carry around a `networkId`, probably in the future, it will have more configuration fields.

The reason why `BaseChainDB` need to carry some configuration around is because some times it will have different configuration 
than the global `NimbusConfiguration`.

It also probably indicate that we don't have a proper design of a `Nimbus` context that can be passed around. Right now, the `Nimbus` object is used only in `nimbus.nim` and nowhere else.