### PR TITLE
update mapper.jq in hive_integration/nimbus

### DIFF
--- a/hive_integration/nimbus/mapper.jq
+++ b/hive_integration/nimbus/mapper.jq
@@ -38,7 +38,18 @@ def to_bool:
 ;
 
 # Replace config in input.
-. + {
+{
+  "genesis": {
+    "coinbase"   : .coinbase,
+    "difficulty" : .difficulty,
+    "extraData"  : .extraData,
+    "gasLimit"   : .gasLimit,
+    "mixHash"    : .mixHash,
+    "nonce"      : .nonce,
+    "parentHash" : .parentHash,
+    "timestamp"  : .timestamp,
+    "alloc"      : .alloc
+  }|remove_empty,
   "config": {
     "chainId": env.HIVE_CHAIN_ID|to_int,
     "homesteadBlock": env.HIVE_FORK_HOMESTEAD|to_int,


### PR DESCRIPTION
this changes is required due to recent #654.
custom genesis and chain config parser are fixed
and the genesis fields are grouped into "genesis"
field, similar with chain config fields,
they are grouped in "config" field.