### PR TITLE
update hive/ethereum/consensus stat

### DIFF
--- a/hive_integration/README.md
+++ b/hive_integration/README.md
@@ -87,7 +87,7 @@ These Hive suites/simulators don't work with `nimbus-eth1` currently:
 
 The number of passes and fails output at the time of writing (2021-04-26) is:
 
-    ethereum/consensus:  16556 pass, 11643 fail, 28199 total
+    ethereum/consensus:  27353 pass,   892 fail, 28245 total
     ethereum/graphql:       36 pass,    10 fail,    46 total
     devp2p/discv4:           0 pass,    14 fail,    14 total
     devp2p/eth:              0 pass,     1 fail,     1 total


### PR DESCRIPTION
from: ethereum/consensus:  16556 pass, 11643 fail, 28199 total
to  : ethereum/consensus:  27353 pass,   892 fail, 28245 total