### PR TITLE
add more query fields and resolvers to graphql api

### DIFF
--- a/nimbus/graphql/ethapi.ql
+++ b/nimbus/graphql/ethapi.ql
@@ -62,6 +62,15 @@ type Log {
   transaction: Transaction!
 }
 
+# EIP-2718 Access List
+type AccessTuple {
+  # access list address
+  address: Address!
+  
+  # access list storage keys, null if not present
+  storageKeys: [Bytes32!]
+}
+
 # Transaction is an Ethereum transaction.
 type Transaction {
   # Hash is the hash of this transaction.
@@ -123,6 +132,21 @@ type Transaction {
   # Logs is a list of log entries emitted by this transaction. If the
   # transaction has not yet been mined, this field will be null.
   logs: [Log!]
+
+  # signature field R
+  r: BigInt!
+
+  # signature fields S
+  s: BigInt!
+
+  # signature fields V
+  v: BigInt!
+
+  # EIP 2718: envelope transaction support
+  type: Int
+
+  # EIP 2930: optional access list, null if not present
+  accessList: [AccessTuple!]
 }
 
 # BlockFilterCriteria encapsulates log filter criteria for a filter applied

--- a/tests/graphql/queries.toml
+++ b/tests/graphql/queries.toml
@@ -29,6 +29,7 @@
       {"name":"Bytes"},
       {"name":"String"},
       {"name":"Bytes32"},
+      {"name":"AccessTuple"},
       {"name":"BlockFilterCriteria"},
       {"name":"ID"},
       {"name":"Pending"},
@@ -194,6 +195,14 @@
       logs {
         __typename
       }
+      r
+      s
+      v
+      type
+      accessList {
+        address
+        storageKeys
+      }
     }
     transactionAt(index: 0) {
       __typename
@@ -230,7 +239,12 @@
         "gasUsed":21000,
         "cumulativeGasUsed":21000,
         "createdContract":null,
-        "logs":[]
+        "logs":[],
+        "r":"0x77c7cd36820c71821c1aed59de46e70e701c4a8dd89c9ba508ab722210f60da8",
+        "s":"0x3f29825d40c7c3f7bff3ca69267e0f3fb74b2d18b8c2c4e3c135b5d3b06e288d",
+        "v":"0x1b",
+        "type":0,
+        "accessList":null
       }
     ],
     "transactionAt":{


### PR DESCRIPTION
after EIP2718/EIP2930, we have additional fields:

type AccessTuple {
  address: Address!
  storageKeys : [Bytes32!]
}

type Transaction {
  r: BigInt!
  s: BigInt!
  v: BigInt!
  # Envelope transaction support
  type: Int
  accessList: [AccessTuple!]
}

close #606