### PR TITLE
add assertion guard in test_blockchain_json's parseBlock function

### DIFF
--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -103,6 +103,7 @@ proc parseBlocks(blocks: JsonNode): seq[TestBlock] =
          "blocknumber", "chainname", "chainnetwork":
         discard
       else:
+        doAssert("expectException" in key)
         t.hasException = true
 
     result.add t


### PR DESCRIPTION
we don't want any surprise because of unrecognized key in test fixture
classified as `hasException`.