### PR TITLE
Tests: Don't show visually strong errors in successful block tests

### DIFF
--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -246,9 +246,11 @@ proc importBlock(tester: var Tester, chainDB: BaseChainDB,
     transactions: result.txs,
     uncles: result.uncles
   )
-  let res = processBlock(chainDB, result.header, body, tester.vmState)
+  let expectingError = tb.hasException or (not tb.goodBlock)
+  let res = processBlock(chainDB, result.header, body, tester.vmState,
+                         stateHashLoudError = not expectingError)
   if res == ValidationResult.Error:
-    if not (tb.hasException or (not tb.goodBlock)):
+    if not expectingError:
       raise newException(ValidationError, "process block validation")
   else:
     if tester.vmState.generateWitness():


### PR DESCRIPTION
When developing, and especially when tidying up commits for upstream, it's common (at least for me) to run `make test` often, and see if there's a scrolling terminal full of good, green OK lines all the way to the end,
or any bad, red FAILED lines.

It only takes one red line in a sea of green.  Then the run is stopped and we start looking into what might the cause be.  Usually it doesn't matter which test failed; it matters that something changed to cause a failure at all.

It's not feasible to actually read all the output; there's about 13,000 lines. And it's not reasonable to wait for the end during edit-compile-debug cycles because of the time taken.

Point is, a big red coloured error message in the ocean of scrolling test output is a key visual, and it matters.

As well, real failures often have errors about hashes mismatches specifically, "expected" hashes, "Wrong state root", that sort of thing.  Unsurprisingly, a clear red ERR reporting hash mismatch, more diagnostic data, and a green OK 8, 16 or more lines below it, looks a lot like failures surrounded by successes.

For example, it's not really obvious the text below is 100% success unless you're used to it.  (Failure output is _almost_ the same).  Of course the OK looks clear here, but imagine 13,000 lines scrolling past, when the normal output is thousands of clean "[OK] name" lines and this is the anomaly:

      [OK] tests/fixtures/eth_tests/BlockchainTests/InvalidBlocks/bcInvalidHeaderTest/DifficultyIsZero.json
    ERR 2021-05-25 23:01:37.184+01:00 Wrong state root in block
      tid: 275064
      file: executor.nim:173
      blockNumber: 1
      expected: DA68013FA88783CD4DAE287C5D8BAFD03CA3CA3977A28B6379146467E6B405B7
      actual: 717E99EBF6BE0A556559C88DB2224039BD215C36E1C37F65144E6B24A22B6808
      arrivedFrom: F9A2682EA3B44BA015697535403A3A357710EA1983B6CC5B1AD46A504A45E63F

    ERR 2021-05-25 23:01:37.184+01:00 Wrong state root in block
      tid: 275064
      file: executor.nim:173
      blockNumber: 1
      expected: DA68013FA88783CD4DAE287C5D8BAFD03CA3CA3977A28B6379146467E6B405B7
      actual: 717E99EBF6BE0A556559C88DB2224039BD215C36E1C37F65144E6B24A22B6808
      arrivedFrom: F9A2682EA3B44BA015697535403A3A357710EA1983B6CC5B1AD46A504A45E63F

      [OK] tests/fixtures/eth_tests/BlockchainTests/InvalidBlocks/bcInvalidHeaderTest/GasLimitIsZero.json

Even when you're expecting these, it prevents seeing at a glance whether everything succeeds in the scrolling test output.

The test expects this condition, so don't use a prominent error when testing.

(I think we're close to the point where this particular `error` should be downgraded even in non-test operation; it's just another validation error from network data.  We quite confident in our EVM now.  But let's wait until we have 100% pass on Hive consensus tests before removing the `error` entirely.)