### PR TITLE
Fixtures: Verify EVM continuation is clear after `c.executeOpcodes`

### DIFF
--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -322,6 +322,8 @@ proc fixtureCallEvm*(vmState: BaseVMState, call: RpcCallData,
   # Next line differs from all the other EVM calls.  With `execComputation`,
   # most "vm json tests" fail with either `balanceDiff` or `nonceDiff` errors.
   c.executeOpcodes()
+  doAssert c.continuation.isNil
+  doAssert c.child.isNil
 
   # Some of these are extra returned state, for testing, that a normal EVMC API
   # computation doesn't return.  We'll have to obtain them outside EVMC.


### PR DESCRIPTION
Fixtures: Verify EVM continuation is clear after `c.executeOpcodes`

`c.executeOpcodes` is called some JSON fixture tests.  These tests bypass some of the setup and return, and because of this call, continuations aren't processed either.  Opcodes that use continuations will behave incorrectly.

The opcodes used in these particular tests don't use continuations currently, so just add some assertions to verify this remains the case.

This is only used by local tests, and the call to `c.executeOpcodes` will be replaced by the common entry point (that handles things like this correctly in all cases) so we don't need to spend more time on this.