### PR TITLE
Transaction: Don't calculate `contractAddress` redundantly

### DIFF
--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -36,11 +36,7 @@ proc rpcSetupComputation(vmState: BaseVMState, call: RpcCallData,
     depth: 0,
     gas: gasLimit,
     sender: call.source,
-    contractAddress:
-      if not call.contractCreation:
-        call.to
-      else:
-        generateAddress(call.source, vmState.readOnlyStateDB.getNonce(call.source)),
+    contractAddress: call.to,
     codeAddress: call.to,
     value: call.value,
     data: call.data
@@ -163,7 +159,7 @@ proc txSetupComputation(tx: Transaction, sender: EthAddress, vmState: BaseVMStat
     depth: 0,
     gas: gas,
     sender: sender,
-    contractAddress: tx.getRecipient(sender),
+    contractAddress: tx.to,
     codeAddress: tx.to,
     value: tx.value,
     data: tx.payload
@@ -297,7 +293,7 @@ proc fixtureSetupComputation(vmState: BaseVMState, call: RpcCallData,
     depth: 0,
     gas: call.gas,            # Differs from `rpcSetupComputation`
     sender: call.source,
-    contractAddress: call.to, # Differs from `rpcSetupComputation`
+    contractAddress: call.to,
     codeAddress: call.to,
     value: call.value,
     data: call.data


### PR DESCRIPTION
Each place in `call_evm` that sets up an EVM call calculates the new contract address for contract creations.  But it's redundant, because `newComputation` ignores the provided value and does the calculation again.

Remove the unused address calculation.

This is also a step to merging different entry points and EVMC.  This change ends up with the same value in both `msg.contractAddress` and `msg.codeAddress` for every entry point, and this is good because it matches the EVMC message structure, where they are replaced by only one value called `msg.destination`