### PR TITLE
Clear up meaning of `ZERO_ADDRESS`, delete `CREATE_CONTRACT_ADDRESS`

### DIFF
--- a/nimbus/constants.nim
+++ b/nimbus/constants.nim
@@ -10,11 +10,13 @@ const
   UINT_256_MAX*: UInt256 =                  high(UInt256)
   INT_256_MAX_AS_UINT256* =                 high(Uint256) shr 1
   UINT160CEILING*: UInt256 =                2.u256.pow(160)
+
+  # Transactions to ZERO_ADDRESS are legitimate transfers to that account, not
+  # contract creations.  They are used to "burn" Eth.  People also send Eth to
+  # address zero by accident, unrecoverably, due to poor user interface issues.
   ZERO_ADDRESS* =                           default(EthAddress)
-  # TODO: use Option[EthAddress]?
-  # create contract address cannot be ZERO_ADDRESS
-  # because actual zero address exists
-  CREATE_CONTRACT_ADDRESS* =                ZERO_ADDRESS
+
+  # ZERO_HASH32 is the parent hash of genesis blocks.
   ZERO_HASH32* =                            Hash256()
 
   GAS_LIMIT_EMA_DENOMINATOR* =              1_024

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -7,7 +7,7 @@
 
 import
   unittest2, ../nimbus/vm_precompiles, json, stew/byteutils, test_helpers, os, tables,
-  strformat, strutils, eth/trie/db, eth/common, ../nimbus/db/db_chain,
+  strformat, strutils, eth/trie/db, eth/common, ../nimbus/db/db_chain, ../nimbus/constants,
   ../nimbus/[vm_computation, vm_types, vm_state, vm_types2], macros,
   test_allowed_to_fail,
   ../nimbus/transaction/call_evm, options
@@ -26,7 +26,7 @@ template doTest(fixture: JsonNode, fork: Fork, address: PrecompileAddresses): un
       gasExpected = if test.hasKey("Gas"): test["Gas"].getInt else: -1
 
     var call: RpcCallData
-    call.source = initAddress(0x00)
+    call.source = ZERO_ADDRESS
     call.to = initAddress(address.byte)
     call.gas = 1_000_000_000.GasInt
     call.gasPrice = 1.GasInt


### PR DESCRIPTION
Updated constants + comments:

- There is no valid `CREATE_CONTRACT_ADDRESS`.  Some places on the internet say account zero means contract creation, but that's not correct.

  Transactions to `ZERO_ADDRESS` are legitimate transfers to that account, not contract creations.  They are used to "burn" Eth.  People also send Eth to address zero by accident, unrecoverably, due to poor user interface issues.

Updated test harness to clear a TODO:

- The conditions mentioned in the old TODO comment have been checked.  All fixtures have either 40 hex digits or empty string for "to".  There is a test with all-zeros, and it means send to that account, not contract creation. Empty string means contract creation.

  This patch does not change the relaxed parsing where fewer than 40 digits is accepted.  We should probably be stricter about this.