### PR TITLE
EVMC: Bump `nim-evmc` module for type improvements (API 7.5 branch)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -152,7 +152,7 @@
 	path = vendor/nim-evmc
 	url = https://github.com/status-im/nim-evmc
   ignore = dirty
-  branch = master
+	branch = api-version-7.5
 [submodule "vendor/nim-libbacktrace"]
 	path = vendor/nim-libbacktrace
 	url = https://github.com/status-im/nim-libbacktrace.git


### PR DESCRIPTION
This bump is required by `TransactionHost` coming next.

There have been many changes to `nim-evmc` since earlier developments on `nimbus-eth1`.  The types in the API have changed, and there is no longer a need to cast the function types.

This commit bumps the submodule while keeping with EVMC API 7.5 for now. `.gitmodules` is updated to follow the module branch `api-version-7.5`.

Submodule changes:

  > Nim: Function casts no longer required, type-checking finally works
  > Nim: Make the test host use exactly the type signatures in the API
  > add github action script
  > Nim: Export `evmc_create_vm_name_fn`
  > Nim: Use `var` instead of `ptr` for arguments that are pass-by-ref
  > Nim: Fix missing `ptr` in signature of `execute`
  > Nim: Use `ptr` in `release` for API consistency
  > Nim: Disable "Imported and not used" warning in test program
  > Nim: Remove unnecessary exports from the Nim example host/VM
  > Nim: Simplify Nim C++ codegen bug workaround
  > Nim: Add type and documentation for `evmc_create_example_fn`
  > Nim: Workaround Nim compiler bug with Nim 1.2.10
  > Nim: Workaround Nim compiler bug with `uint32`-sized bitset
  > Nim: Use a more varied bit pattern in `get_capabilities` test
  > Nim: Convert `evmc_capabilities` to Nim bitset
  > Nim: Convert `evmc_flags` to Nim bitset
  > Nim: Compile time verify that target C enums are `int` sized
  > Nim: Recognise that target C enums are not always `cint`
  > Nim: Make `evmc_status_code` a normal enum
  > Nim: Use `csize_t` in test program and Nim example host/VM
  > Nim: Use `csize_t` in the VM support API
  > Nim: Use `csize_t` in appropriate places to match EVMC API
  > Nim: Use binary-compatible C99 `bool` without target assumptions
  > Version (README): Announce we support EVMC 7.5.0 and Istanbul fork
  > Doc: Tweak GitHub badges on README
  > Doc: Make title fit on GitHub page without wrapping
  > Doc: README edits
  > Doc: Update the README for 2021 - the year of Nimbus!
  > License: Add licensing info about third-party files
  > License: Update license text in README
  > License: Fix incorrect name of Apache v2 license file and tweak
  > License: Add missing MIT license file
  > Nim: Add and update copyright headers
  > Nim: Update Nim API to follow EVMC API 7.5.0
  > Nim: Update doc comments and fix formatting
  > Make the tests work with the new C++ mini-EVM in EVMC 7.5.0
  > Change C++ `example_host` to workaround Nim -> C call type mismatch
  > The EVMC package expects C++14 now
  > Upgrade C++ `example_host` in `tests/evmc_c` to EVMC 7.5.0
  > Upgrade C++ `example_vm` in `tests/evmc_c` to EVMC 7.5.0
  > Upgrade C/C++ headers in `tests/evmc_c` to EVMC 7.5.0

Signed-off-by: Jamie Lokier <jamie@shareable.org>