### PR TITLE
Fixtures: Change fixture tests to use shared `setupComputation`

### DIFF
--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -320,24 +320,18 @@ proc asmCallEvm*(blockNumber: Uint256, chainDB: BaseChainDB, code, data: seq[byt
 
 proc fixtureSetupComputation(vmState: BaseVMState, call: RpcCallData,
                              origin: EthAddress, forkOverride = none(Fork)): Computation =
-  vmState.setupTxContext(
-    origin = origin,          # Differs from `rpcSetupComputation`
-    gasPrice = call.gasPrice,
-    forkOverride = forkOverride,
-  )
-
-  var msg = Message(
-    kind: if call.contractCreation: evmcCreate else: evmcCall,
-    depth: 0,
-    gas: call.gas,            # Differs from `rpcSetupComputation`
-    sender: call.source,
-    contractAddress: call.to,
-    codeAddress: call.to,
-    value: call.value,
-    data: call.data
-  )
-
-  return newComputation(vmState, msg)
+  return setupComputation(CallParams(
+    vmState:      vmState,
+    forkOverride: forkOverride,
+    origin:       some(origin),
+    gasPrice:     call.gasPrice,
+    gasLimit:     call.gas,   # Differs from `rpcSetupComputation`
+    sender:       call.source,
+    to:           call.to,
+    isCreate:     call.contractCreation,
+    value:        call.value,
+    input:        call.data
+  ))
 
 type
   FixtureResult* = object


### PR DESCRIPTION
Change fixtures tests to use shared `setupComputation` instead of their own slightly different variant.
