### PR TITLE
Move contract address generation outside the EVM

### DIFF
--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -26,7 +26,7 @@ proc processTransaction*(tx: Transaction, sender: EthAddress, vmState: BaseVMSta
     let txFee = result.u256 * tx.gasPrice.u256
     db.addBalance(miner, txFee)
 
-    for deletedAccount in vmState.suicides:
+    for deletedAccount in vmState.selfDestructs:
       db.deleteAccount deletedAccount
 
     if fork >= FkSpurious:

--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -163,6 +163,24 @@ proc newComputation*(vmState: BaseVMState, message: Message, salt= 0.u256): Comp
       cast[evmc_host_context](result)
     )
 
+proc newComputation*(vmState: BaseVMState, message: Message, code: seq[byte]): Computation =
+  new result
+  result.vmState = vmState
+  result.msg = message
+  result.memory = Memory()
+  result.stack = newStack()
+  result.returnStack = @[]
+  result.gasMeter.init(message.gas)
+  result.touchedAccounts = initHashSet[EthAddress]()
+  result.selfDestructs = initHashSet[EthAddress]()
+  result.code = newCodeStream(code)
+
+  when evmc_enabled:
+    result.host.init(
+      nim_host_get_interface(),
+      cast[evmc_host_context](result)
+    )
+
 template gasCosts*(c: Computation): untyped =
   c.vmState.gasCosts
 

--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -148,7 +148,7 @@ proc newComputation*(vmState: BaseVMState, message: Message, salt= 0.u256): Comp
   result.returnStack = @[]
   result.gasMeter.init(message.gas)
   result.touchedAccounts = initHashSet[EthAddress]()
-  result.suicides = initHashSet[EthAddress]()
+  result.selfDestructs = initHashSet[EthAddress]()
 
   if result.msg.isCreate():
     result.msg.contractAddress = result.generateContractAddress(salt)
@@ -182,8 +182,8 @@ template isError*(c: Computation): bool =
 func shouldBurnGas*(c: Computation): bool =
   c.isError and c.error.burnsGas
 
-proc isSuicided*(c: Computation, address: EthAddress): bool =
-  result = address in c.suicides
+proc isSelfDestructed*(c: Computation, address: EthAddress): bool =
+  result = address in c.selfDestructs
 
 proc snapshot*(c: Computation) =
   c.savePoint = c.vmState.accountDb.beginSavePoint()
@@ -212,7 +212,7 @@ proc writeContract*(c: Computation, fork: Fork): bool {.gcsafe.} =
     return false
 
   let storageAddr = c.msg.contractAddress
-  if c.isSuicided(storageAddr): return
+  if c.isSelfDestructed(storageAddr): return
 
   let gasParams = GasParams(kind: Create, cr_memLength: contractCode.len)
   let codeCost = c.gasCosts[Create].c_handler(0.u256, gasParams).gasCost
@@ -351,7 +351,7 @@ else:
 proc merge*(c, child: Computation) =
   c.logEntries.add child.logEntries
   c.gasMeter.refundGas(child.gasMeter.gasRefunded)
-  c.suicides.incl child.suicides
+  c.selfDestructs.incl child.selfDestructs
   c.touchedAccounts.incl child.touchedAccounts
 
 proc execSelfDestruct*(c: Computation, beneficiary: EthAddress) =
@@ -375,7 +375,7 @@ proc execSelfDestruct*(c: Computation, beneficiary: EthAddress) =
 
   c.touchedAccounts.incl beneficiary
   # Register the account to be deleted
-  c.suicides.incl(c.msg.contractAddress)
+  c.selfDestructs.incl(c.msg.contractAddress)
 
 proc addLogEntry*(c: Computation, log: Log) {.inline.} =
   c.logEntries.add(log)
@@ -386,7 +386,7 @@ proc getGasRefund*(c: Computation): GasInt =
 
 proc refundSelfDestruct*(c: Computation) =
   let cost = gasFees[c.fork][RefundSelfDestruct]
-  c.gasMeter.refundGas(cost * c.suicides.len)
+  c.gasMeter.refundGas(cost * c.selfDestructs.len)
 
 proc tracingEnabled*(c: Computation): bool {.inline.} =
   EnableTracing in c.vmState.tracer.flags

--- a/nimbus/vm/interpreter.nim
+++ b/nimbus/vm/interpreter.nim
@@ -61,7 +61,7 @@ export
   vmc.isError,
   vmc.isOriginComputation,
   vmc.isSuccess,
-  vmc.isSuicided,
+  vmc.isSelfDestructed,
   vmc.merge,
   vmc.newComputation,
   vmc.prepareTracer,

--- a/nimbus/vm/state.nim
+++ b/nimbus/vm/state.nim
@@ -114,7 +114,7 @@ proc getMinerAddress(vmState: BaseVMState): EthAddress =
 proc updateBlockHeader*(vmState: BaseVMState, header: BlockHeader) =
   vmState.blockHeader = header
   vmState.touchedAccounts.clear()
-  vmState.suicides.clear()
+  vmState.selfDestructs.clear()
   if EnableTracing in vmState.tracer.flags:
     vmState.tracer.initTracer(vmState.tracer.flags)
   vmState.logEntries = @[]

--- a/nimbus/vm/state_transactions.nim
+++ b/nimbus/vm/state_transactions.nim
@@ -20,7 +20,7 @@ proc execComputation*(c: Computation) =
 
   if c.isSuccess:
     c.refundSelfDestruct()
-    shallowCopy(c.vmState.suicides, c.suicides)
+    shallowCopy(c.vmState.selfDestructs, c.selfDestructs)
     shallowCopy(c.vmState.logEntries, c.logEntries)
     c.vmState.touchedAccounts.incl c.touchedAccounts
 

--- a/nimbus/vm/types.nim
+++ b/nimbus/vm/types.nim
@@ -44,7 +44,7 @@ type
     accountDb*     : AccountsCache
     cumulativeGasUsed*: GasInt
     touchedAccounts*: HashSet[EthAddress]
-    suicides*      : HashSet[EthAddress]
+    selfDestructs* : HashSet[EthAddress]
     txOrigin*      : EthAddress
     txGasPrice*    : GasInt
     gasCosts*      : GasCosts
@@ -85,7 +85,7 @@ type
     returnData*:            seq[byte]
     error*:                 Error
     touchedAccounts*:       HashSet[EthAddress]
-    suicides*:              HashSet[EthAddress]
+    selfDestructs*:         HashSet[EthAddress]
     logEntries*:            seq[Log]
     savePoint*:             SavePoint
     instr*:                 Op

--- a/nimbus/vm2/state.nim
+++ b/nimbus/vm2/state.nim
@@ -102,7 +102,7 @@ proc getMinerAddress(vmState: BaseVMState): EthAddress =
 proc updateBlockHeader*(vmState: BaseVMState, header: BlockHeader) =
   vmState.blockHeader = header
   vmState.touchedAccounts.clear()
-  vmState.suicides.clear()
+  vmState.selfDestructs.clear()
   if EnableTracing in vmState.tracer.flags:
     vmState.tracer.initTracer(vmState.tracer.flags)
   vmState.logEntries = @[]

--- a/nimbus/vm2/state_transactions.nim
+++ b/nimbus/vm2/state_transactions.nim
@@ -89,7 +89,7 @@ proc execComputation*(c: Computation) =
 
   if c.isSuccess:
     c.refundSelfDestruct()
-    shallowCopy(c.vmState.suicides, c.suicides)
+    shallowCopy(c.vmState.selfDestructs, c.selfDestructs)
     shallowCopy(c.vmState.logEntries, c.logEntries)
     c.vmState.touchedAccounts.incl c.touchedAccounts
 

--- a/nimbus/vm2/types.nim
+++ b/nimbus/vm2/types.nim
@@ -35,7 +35,7 @@ type
     accountDb*     : AccountsCache
     cumulativeGasUsed*: GasInt
     touchedAccounts*: HashSet[EthAddress]
-    suicides*      : HashSet[EthAddress]
+    selfDestructs* : HashSet[EthAddress]
     txOrigin*      : EthAddress
     txGasPrice*    : GasInt
     gasCosts*      : GasCosts
@@ -74,7 +74,7 @@ type
     returnData*:            seq[byte]
     error*:                 Error
     touchedAccounts*:       HashSet[EthAddress]
-    suicides*:              HashSet[EthAddress]
+    selfDestructs*:         HashSet[EthAddress]
     logEntries*:            seq[Log]
     savePoint*:             SavePoint
     instr*:                 Op

--- a/nimbus/vm_computation.nim
+++ b/nimbus/vm_computation.nim
@@ -52,7 +52,7 @@ export
   vmc.isError,
   vmc.isOriginComputation,
   vmc.isSuccess,
-  vmc.isSuicided,
+  vmc.isSelfDestructed,
   vmc.merge,
   vmc.newComputation,
   vmc.prepareTracer,

--- a/nimbus/vm_internals.nim
+++ b/nimbus/vm_internals.nim
@@ -112,7 +112,7 @@ else:
     bChp.isError,
     bChp.isOriginComputation,
     bChp.isSuccess,
-    bChp.isSuicided,
+    bChp.isSelfDestructed,
     bChp.merge,
     bChp.newComputation,
     bChp.prepareTracer,

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -124,7 +124,7 @@ proc testFixtureIndexes(tester: Tester, testStatusIMPL: var TestStatus) =
   # as well as conditionally cleaning up the coinbase account when left
   # empty in VMs after the state clearing rules came into effect.
   let miner = tester.header.coinbase
-  if miner in vmState.suicides:
+  if miner in vmState.selfDestructs:
     vmState.mutateStateDB:
       db.addBalance(miner, 0.u256)
       if tester.fork >= FkSpurious:


### PR DESCRIPTION
The current EVM generates its own new contract addresses, and this is why there are separate `msg.contractAddress` and `msg.codeAddress` fields in the computation start message.

In EVMC, account updates are only allowed on the host side, including contract generation, and the start message has one destination field, `msg.destination`. The EVM cannot select addresses, only use them.  It's a sensible design.

The difference makes the current EVM incompatible with EVMC and its message format, so this patch corrects the difference by moving contract address generation to the host side.

While we are here, apply EIP-6 and change all the `suicide` names to `selfDestruct`consistently, matching current Ethereum specifications, later testsuite entries, etc.