### PR TITLE
Transaction: Use same log level for all block rejection causes

### DIFF
--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -166,12 +166,7 @@ proc processBlock*(chainDB: BaseChainDB, header: BlockHeader, body: BlockBody, v
 
   let stateDb = vmState.accountDb
   if header.stateRoot != stateDb.rootHash:
-    when defined(geth):
-      error "Wrong state root in block", blockNumber=header.blockNumber, expected=header.stateRoot, actual=stateDb.rootHash
-    else:
-      error "Wrong state root in block", blockNumber=header.blockNumber, expected=header.stateRoot, actual=stateDb.rootHash, arrivedFrom=chainDB.getCanonicalHead().stateRoot
-    # this one is a show stopper until we are confident in our VM's
-    # compatibility with the main chain
+    debug "wrong state root in block", blockNumber=header.blockNumber, expected=header.stateRoot, actual=stateDb.rootHash, arrivedFrom=chainDB.getCanonicalHead().stateRoot
     return ValidationResult.Error
 
   let bloom = createBloom(vmState.receipts)


### PR DESCRIPTION
Block validation failure isn't an error, it's correct rejection of a bad block from the network.  All conditions that lead to block rejection return a simple boolean.

When a block is rejected, most reasons log at `debug` level.  Only `stateRoot` mismatch shouts a loud, highlighted, multi-line error message with big red `error` alert.

Historically this was to assist EVM development, because it was more likely to be a Nimbus EVM bug than a real bad block.  But now the EVM is in good shape, has a large and thorough testsuite, and `stateRoot` mismatch is more likely to be a real bad block that should be rejected with less fuss.

If there's a genuine EVM bug, we'll still get an alert: Consensus failure will quickly become obvious, and the block where it happens is easily fetched.

So a big, loud error is no longer useful, and it became a problem during tests. Recently a few hundred tests were added that trigger it, and now successful test output is filled with attention-grabbing errors which aren't really errors or particularly useful.

Since it's not really an error, the original motivation is now backwards, and other reasons warn at `debug` level, make this like the others.