### PR TITLE
Add nlpn

### DIFF
--- a/.github/workflows/nlpn.yml
+++ b/.github/workflows/nlpn.yml
@@ -1,12 +1,9 @@
-name: CI
+name: nlpn CI
 on:
   push:
-    paths-ignore: ['doc/**', 'docs/**', '**/*.md', 'hive_integration/**',
-      'nlpn/**', '.github/workflows/nlpn.yml']
-  # Disable `pull_request`.  Experimenting with using only `push` for PRs.
-  #pull_request:
-  #  paths-ignore: ['doc/**', 'docs/**', '**/*.md', 'hive_integration/**']
-  workflow_dispatch:
+    paths: ['nlpn/**', '.github/workflows/nlpn.yml']
+  pull_request:
+    paths: ['nlpn/**', '.github/workflows/nlpn.yml']
 
 jobs:
   build:
@@ -17,50 +14,14 @@ jobs:
         target:
           - os: linux
             cpu: amd64
-            evmc: nimevm
           - os: linux
             cpu: i386
-            evmc: nimevm
           - os: macos
             cpu: amd64
-            evmc: nimevm
           - os: windows
             cpu: amd64
-            evmc: nimevm
           - os: windows
             cpu: i386
-            evmc: nimevm
-          - os: linux
-            cpu: amd64
-            evmc: evmc
-          - os: linux
-            cpu: i386
-            evmc: evmc
-          - os: macos
-            cpu: amd64
-            evmc: evmc
-          - os: windows
-            cpu: amd64
-            evmc: evmc
-          - os: windows
-            cpu: i386
-            evmc: evmc
-          # vm2
-          - os: linux
-            cpu: amd64
-            evmc: nimvm2
-          - os: linux
-            cpu: i386
-            evmc: nimvm2
-          - os: windows
-            cpu: amd64
-            evmc: nimvm2
-          - os: windows
-            cpu: i386
-            evmc: nimvm2
-          - os: macos
-            cpu: amd64
-            evmc: nimvm2
         include:
           - target:
               os: linux
@@ -79,7 +40,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ matrix.target.evmc }}'
+    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout nimbus-eth1
@@ -91,15 +52,12 @@ jobs:
           if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
             PLATFORM=x64
             GOARCH=amd64
-            USE_MIRACL=0
           else
             PLATFORM=x86
             GOARCH=386
-            USE_MIRACL=1
           fi
           echo "PLATFORM=${PLATFORM}" >> $GITHUB_ENV
           echo "GOARCH=${GOARCH}" >> $GITHUB_ENV
-          echo "USE_MIRACL=${USE_MIRACL}" >> $GITHUB_ENV
 
           # libminiupnp / natpmp
           if [[ '${{ runner.os }}' == 'Linux' && '${{ matrix.target.cpu }}' == 'i386' ]]; then
@@ -122,66 +80,24 @@ jobs:
           [[ -z "$ncpu" || $ncpu -le 0 ]] && ncpu=1
           echo "ncpu=${ncpu}" >> $GITHUB_ENV
 
-          if [[ '${{ matrix.target.evmc }}' == 'evmc' ]]; then
-            echo "ENABLE_EVMC=1" >> $GITHUB_ENV
-            echo "ENABLE_VM2=0" >> $GITHUB_ENV
-          elif [[ '${{ matrix.target.evmc }}' == 'nimvm2' ]]; then
-            echo "ENABLE_EVMC=0" >> $GITHUB_ENV
-            echo "ENABLE_VM2=1" >> $GITHUB_ENV
-          else
-            echo "ENABLE_EVMC=0" >> $GITHUB_ENV
-            echo "ENABLE_VM2=0" >> $GITHUB_ENV
-          fi
-
       - name: Install build dependencies (Linux i386)
         if: runner.os == 'Linux' && matrix.target.cpu == 'i386'
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-fast update -qq
           sudo DEBIAN_FRONTEND='noninteractive' apt-fast install \
-            --no-install-recommends -yq gcc-multilib g++-multilib \
-            libz-dev:i386 libbz2-dev:i386 libssl-dev:i386 libpcre3-dev:i386
+            --no-install-recommends -yq gcc-multilib g++-multilib
           mkdir -p external/bin
           cat << EOF > external/bin/gcc
           #!/bin/bash
-          exec $(which gcc) -m32 "\$@"
+          exec $(which gcc) -m32 -mno-adx "\$@"
           EOF
           cat << EOF > external/bin/g++
           #!/bin/bash
-          exec $(which g++) -m32 "\$@"
+          exec $(which g++) -m32 -mno-adx "\$@"
           EOF
           chmod 755 external/bin/gcc external/bin/g++
-          echo '${{ github.workspace }}/external/bin' >> $GITHUB_PATH
-
-      - name: Restore rocksdb from cache (Macos/Linux)
-        if: runner.os != 'Windows'
-        id: rocksdb-cache
-        uses: actions/cache@v1
-        with:
-          path: rocks-db-cache-${{ matrix.target.cpu }}
-          key: 'rocksdb-${{ matrix.target.os }}-${{ matrix.target.cpu }}'
-
-      - name: Build and install rocksdb (Linux i386)
-        # no librocksdb-dev:i386
-        if: runner.os == 'Linux' && matrix.target.cpu == 'i386'
-        run: |
-          curl -O -L -s -S https://raw.githubusercontent.com/status-im/nimbus-build-system/master/scripts/build_rocksdb.sh
-          bash build_rocksdb.sh rocks-db-cache-${{ matrix.target.cpu }}
-
-      - name: Install rocksdb (Linux amd64)
-        # mysterious illegal instruction error if we build our own librocksdb
-        if: runner.os == 'Linux' && matrix.target.cpu == 'amd64'
-        run: |
-         sudo apt-get -q update
-         sudo apt-get install -y librocksdb-dev libpcre3-dev
-
-      - name: Build and install rocksdb (Macos)
-        if: runner.os == 'Macos'
-        run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install ccache
-          echo "/usr/local/opt/ccache/libexec" >> ${GITHUB_PATH}
-          curl -O -L -s -S https://raw.githubusercontent.com/status-im/nimbus-build-system/master/scripts/build_rocksdb.sh
-          bash build_rocksdb.sh rocks-db-cache-${{ matrix.target.cpu }}
+          echo "${{ github.workspace }}/external/bin" >> $GITHUB_PATH
 
       - name: MSYS2 (Windows i386)
         if: runner.os == 'Windows' && matrix.target.cpu == 'i386'
@@ -217,19 +133,10 @@ jobs:
           steps.windows-dlls-cache.outputs.cache-hit != 'true' &&
           runner.os == 'Windows'
         run: |
-          if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
-            ROCKSDBSUB=x64
-          else
-            ROCKSDBSUB=x86
-          fi
           DLLPATH=external/dlls-${{ matrix.target.cpu }}
           mkdir -p external
           curl -L "https://nim-lang.org/download/windeps.zip" -o external/windeps.zip
           7z x -y external/windeps.zip -o"$DLLPATH"
-          # ROCKSDB
-          curl -L "https://github.com/status-im/nimbus-deps/releases/download/nimbus-deps/nimbus-deps.zip" -o external/nimbus-deps.zip
-          7z x -y external/nimbus-deps.zip
-          cp "./$ROCKSDBSUB/librocksdb.dll" "$DLLPATH/librocksdb.dll"
 
       - name: Path to cached dependencies (Windows)
         if: >
@@ -246,7 +153,7 @@ jobs:
           nbsHash=$(getHash status-im/nimbus-build-system)
           echo "::set-output name=nimbus_build_system::$nbsHash"
 
-      - name: Restore prebuilt Nim from cache
+      - name: Restore prebuilt Nim binaries from cache
         id: nim-cache
         uses: actions/cache@v2
         with:
@@ -257,34 +164,31 @@ jobs:
         run: |
           make -j${ncpu} ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinaries update
 
-      - name: Run nimbus-eth1 tests (Windows)
+      - name: Run nlpn tests (Windows)
         if: runner.os == 'Windows'
         run: |
           gcc --version
-          DEFAULT_MAKE_FLAGS="-j${ncpu} ENABLE_EVMC=${ENABLE_EVMC}"
-          mingw32-make ${DEFAULT_MAKE_FLAGS}
-          build/nimbus.exe --help
-          mingw32-make ${DEFAULT_MAKE_FLAGS} test
-          if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
-            mingw32-make ${DEFAULT_MAKE_FLAGS} test-reproducibility
-          fi
+          DEFAULT_MAKE_FLAGS="-j${ncpu}"
+          mingw32-make ${DEFAULT_MAKE_FLAGS} nlpn
+          build/nlpn.exe --help
+          # mingw32-make ${DEFAULT_MAKE_FLAGS} test
 
-      - name: Run nimbus-eth1 tests (Linux)
+
+      - name: Run nlpn tests (Linux)
         if: runner.os == 'Linux'
         run: |
           export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib"
-          DEFAULT_MAKE_FLAGS="-j${ncpu} USE_MIRACL=${USE_MIRACL} ENABLE_EVMC=${ENABLE_EVMC}"
-          env CC=gcc make ${DEFAULT_MAKE_FLAGS}
-          build/nimbus --help
+          DEFAULT_MAKE_FLAGS="-j${ncpu}"
+          env CC=gcc make ${DEFAULT_MAKE_FLAGS} nlpn
+          build/nlpn --help
           # CC, GOARCH, and CGO_ENABLED are needed to select correct compiler 32/64 bit
-          env CC=gcc GOARCH=${GOARCH} CXX=g++ CGO_ENABLED=1 make ${DEFAULT_MAKE_FLAGS} test test-reproducibility
+          # env CC=gcc GOARCH=${GOARCH} CXX=g++ CGO_ENABLED=1 make ${DEFAULT_MAKE_FLAGS} test test-reproducibility
 
-      - name: Run nimbus-eth1 tests (Macos)
+      - name: Run nlpn tests (Macos)
         if: runner.os == 'Macos'
         run: |
-          DEFAULT_MAKE_FLAGS="-j${ncpu} ENABLE_EVMC=${ENABLE_EVMC}"
-          make ${DEFAULT_MAKE_FLAGS}
-          build/nimbus --help
+          DEFAULT_MAKE_FLAGS="-j${ncpu}"
+          make ${DEFAULT_MAKE_FLAGS} nlpn
+          build/nlpn --help
           # "-static" option will not work for osx unless static system libraries are provided
-          make ${DEFAULT_MAKE_FLAGS} test test-reproducibility
-
+          # make ${DEFAULT_MAKE_FLAGS} test test-reproducibility

--- a/.github/workflows/nlpn.yml
+++ b/.github/workflows/nlpn.yml
@@ -1,9 +1,11 @@
 name: nlpn CI
 on:
   push:
-    paths: ['nlpn/**', '.github/workflows/nlpn.yml']
+    paths: ['nlpn/**', '.github/workflows/nlpn.yml', 'vendor/**', 'Makefile',
+      'nimbus.nimble']
   pull_request:
-    paths: ['nlpn/**', '.github/workflows/nlpn.yml']
+    paths: ['nlpn/**', '.github/workflows/nlpn.yml', 'vendor/**', 'Makefile',
+      'nimbus.nimble']
 
 jobs:
   build:
@@ -51,13 +53,10 @@ jobs:
         run: |
           if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
             PLATFORM=x64
-            GOARCH=amd64
           else
             PLATFORM=x86
-            GOARCH=386
           fi
           echo "PLATFORM=${PLATFORM}" >> $GITHUB_ENV
-          echo "GOARCH=${GOARCH}" >> $GITHUB_ENV
 
           # libminiupnp / natpmp
           if [[ '${{ runner.os }}' == 'Linux' && '${{ matrix.target.cpu }}' == 'i386' ]]; then
@@ -173,7 +172,6 @@ jobs:
           build/nlpn.exe --help
           # mingw32-make ${DEFAULT_MAKE_FLAGS} test
 
-
       - name: Run nlpn tests (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -181,8 +179,8 @@ jobs:
           DEFAULT_MAKE_FLAGS="-j${ncpu}"
           env CC=gcc make ${DEFAULT_MAKE_FLAGS} nlpn
           build/nlpn --help
-          # CC, GOARCH, and CGO_ENABLED are needed to select correct compiler 32/64 bit
-          # env CC=gcc GOARCH=${GOARCH} CXX=g++ CGO_ENABLED=1 make ${DEFAULT_MAKE_FLAGS} test test-reproducibility
+          # CC is needed to select correct compiler 32/64 bit
+          # env CC=gcc CXX=g++ make ${DEFAULT_MAKE_FLAGS} test test-reproducibility
 
       - name: Run nlpn tests (Macos)
         if: runner.os == 'Macos'

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ TOOLS_CSV := $(subst $(SPACE),$(COMMA),$(TOOLS))
 	deps \
 	update \
 	nimbus \
+	nlpn \
 	test \
 	test-reproducibility \
 	clean \
@@ -109,6 +110,10 @@ nimbus: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim nimbus $(NIM_PARAMS) nimbus.nims
 
+nlpn: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim nlpn $(NIM_PARAMS) nimbus.nims
+
 # symlink
 nimbus.nims:
 	ln -s nimbus.nimble $@
@@ -133,7 +138,7 @@ test-reproducibility:
 
 # usual cleaning
 clean: | clean-common
-	rm -rf build/{nimbus,$(TOOLS_CSV),all_tests,test_rpc}
+	rm -rf build/{nimbus,nlpn,$(TOOLS_CSV),all_tests,test_rpc}
 ifneq ($(USE_LIBBACKTRACE), 0)
 	+ $(MAKE) -C vendor/nim-libbacktrace clean $(HANDLE_OUTPUT)
 endif

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -51,3 +51,6 @@ task test, "Run tests":
 
 task nimbus, "Build Nimbus":
   buildBinary "nimbus", "nimbus/", "-d:chronicles_log_level=TRACE"
+
+task nlpn, "Build nlpn":
+  buildBinary "nlpn", "nlpn/", "-d:chronicles_log_level=TRACE"

--- a/nlpn/conf.nim
+++ b/nlpn/conf.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [Defect].}
+
 import
   confutils, confutils/std/net, chronicles,
   eth/keys, eth/net/nat, eth/p2p/discoveryv5/[enr, node]
@@ -85,14 +87,22 @@ type
       defaultValue: DefaultAdminListenAddress
       name: "rpc-address" }: ValidIpAddress
 
-proc parseCmdArg*(T: type enr.Record, p: TaintedString): T =
+    case cmd* {.
+      command
+      defaultValue: noCommand .}: PortalCmd
+    of noCommand:
+      discard
+
+proc parseCmdArg*(T: type enr.Record, p: TaintedString): T
+    {.raises: [Defect, ConfigurationError].} =
   if not fromURI(result, p):
     raise newException(ConfigurationError, "Invalid ENR")
 
 proc completeCmdArg*(T: type enr.Record, val: TaintedString): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type Node, p: TaintedString): T =
+proc parseCmdArg*(T: type Node, p: TaintedString): T
+    {.raises: [Defect, ConfigurationError].} =
   var record: enr.Record
   if not fromURI(record, p):
     raise newException(ConfigurationError, "Invalid ENR")
@@ -109,7 +119,8 @@ proc parseCmdArg*(T: type Node, p: TaintedString): T =
 proc completeCmdArg*(T: type Node, val: TaintedString): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type PrivateKey, p: TaintedString): T =
+proc parseCmdArg*(T: type PrivateKey, p: TaintedString): T
+    {.raises: [Defect, ConfigurationError].} =
   try:
     result = PrivateKey.fromHex(string(p)).tryGet()
   except CatchableError:

--- a/nlpn/conf.nim
+++ b/nlpn/conf.nim
@@ -1,0 +1,119 @@
+# Nimbus
+# Copyright (c) 2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  confutils, confutils/std/net, chronicles,
+  eth/keys, eth/net/nat, eth/p2p/discoveryv5/[enr, node]
+
+const
+  DefaultListenAddress* = (static ValidIpAddress.init("0.0.0.0"))
+  DefaultAdminListenAddress* = (static ValidIpAddress.init("127.0.0.1"))
+
+type
+  PortalCmd* = enum
+    noCommand
+
+  PortalConf* = object
+    logLevel* {.
+      defaultValue: LogLevel.DEBUG
+      desc: "Sets the log level"
+      name: "log-level" .}: LogLevel
+
+    udpPort* {.
+      defaultValue: 9009
+      desc: "UDP listening port"
+      name: "udp-port" .}: uint16
+
+    listenAddress* {.
+      defaultValue: DefaultListenAddress
+      desc: "Listening address for the Discovery v5 traffic"
+      name: "listen-address" }: ValidIpAddress
+
+    bootnodes* {.
+      desc: "ENR URI of node to bootstrap discovery with. Argument may be repeated"
+      name: "bootnode" .}: seq[Record]
+
+    nat* {.
+      desc: "Specify method to use for determining public address. " &
+            "Must be one of: any, none, upnp, pmp, extip:<IP>"
+      defaultValue: NatConfig(hasExtIp: false, nat: NatAny)
+      name: "nat" .}: NatConfig
+
+    enrAutoUpdate* {.
+      defaultValue: false
+      desc: "Discovery can automatically update its ENR with the IP address " &
+            "and UDP port as seen by other nodes it communicates with. " &
+            "This option allows to enable/disable this functionality"
+      name: "enr-auto-update" .}: bool
+
+    nodeKey* {.
+      desc: "P2P node private key as hex",
+      defaultValue: PrivateKey.random(keys.newRng()[])
+      name: "nodekey" .}: PrivateKey
+
+    metricsEnabled* {.
+      defaultValue: false
+      desc: "Enable the metrics server"
+      name: "metrics" .}: bool
+
+    metricsAddress* {.
+      defaultValue: DefaultAdminListenAddress
+      desc: "Listening address of the metrics server"
+      name: "metrics-address" .}: ValidIpAddress
+
+    metricsPort* {.
+      defaultValue: 8008
+      desc: "Listening HTTP port of the metrics server"
+      name: "metrics-port" .}: Port
+
+    rpcEnabled* {.
+      desc: "Enable the JSON-RPC server"
+      defaultValue: false
+      name: "rpc" }: bool
+
+    rpcPort* {.
+      desc: "HTTP port for the JSON-RPC service"
+      defaultValue: 8545
+      name: "rpc-port" }: Port
+
+    rpcAddress* {.
+      desc: "Listening address of the RPC server"
+      defaultValue: DefaultAdminListenAddress
+      name: "rpc-address" }: ValidIpAddress
+
+proc parseCmdArg*(T: type enr.Record, p: TaintedString): T =
+  if not fromURI(result, p):
+    raise newException(ConfigurationError, "Invalid ENR")
+
+proc completeCmdArg*(T: type enr.Record, val: TaintedString): seq[string] =
+  return @[]
+
+proc parseCmdArg*(T: type Node, p: TaintedString): T =
+  var record: enr.Record
+  if not fromURI(record, p):
+    raise newException(ConfigurationError, "Invalid ENR")
+
+  let n = newNode(record)
+  if n.isErr:
+    raise newException(ConfigurationError, $n.error)
+
+  if n[].address.isNone():
+    raise newException(ConfigurationError, "ENR without address")
+
+  n[]
+
+proc completeCmdArg*(T: type Node, val: TaintedString): seq[string] =
+  return @[]
+
+proc parseCmdArg*(T: type PrivateKey, p: TaintedString): T =
+  try:
+    result = PrivateKey.fromHex(string(p)).tryGet()
+  except CatchableError:
+    raise newException(ConfigurationError, "Invalid private key")
+
+proc completeCmdArg*(T: type PrivateKey, val: TaintedString): seq[string] =
+  return @[]

--- a/nlpn/nlpn.nim
+++ b/nlpn/nlpn.nim
@@ -1,0 +1,56 @@
+# Nimbus
+# Copyright (c) 2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  confutils, confutils/std/net, chronicles, chronicles/topics_registry,
+  chronos, metrics, metrics/chronos_httpserver,
+  eth/keys, eth/net/nat,
+  eth/p2p/discoveryv5/protocol as discv5_protocol,
+  eth/p2p/portal/protocol as portal_protocol,
+  ./conf
+
+proc run(config: PortalConf) =
+  let
+    rng = newRng()
+    bindIp = config.listenAddress
+    udpPort = Port(config.udpPort)
+    # TODO: allow for no TCP port mapping!
+    (extIp, _, extUdpPort) = setupAddress(config.nat,
+      config.listenAddress, udpPort, udpPort, "dcli")
+
+  let d = newProtocol(config.nodeKey,
+          extIp, none(Port), extUdpPort,
+          bootstrapRecords = config.bootnodes,
+          bindIp = bindIp, bindPort = udpPort,
+          enrAutoUpdate = config.enrAutoUpdate,
+          rng = rng)
+
+  d.open()
+
+  let portal = PortalProtocol.new(d)
+
+  if config.metricsEnabled:
+    let
+      address = config.metricsAddress
+      port = config.metricsPort
+    notice "Starting metrics HTTP server",
+      url = "http://" & $address & ":" & $port & "/metrics"
+    try:
+      chronos_httpserver.startMetricsHttpServer($address, port)
+    except CatchableError as exc: raise exc
+    except Exception as exc: raiseAssert exc.msg
+
+  d.start()
+
+  runForever()
+
+when isMainModule:
+  let config = PortalConf.load()
+
+  setLogLevel(config.logLevel)
+
+  run(config)


### PR DESCRIPTION
Add the beginnings of the portal client to nimbus-eth1, so far only holding parts of the Portal Wire protocol.

A separate Github Actions workflow is used so that code changed for nlpn does not trigger the full nimbus-eth1 test suite.

