### PR TITLE
Re-adjust canonical head to parent of block to be inserted

### DIFF
--- a/hive_integration/nodocker/consensus/consensus_sim.nim
+++ b/hive_integration/nodocker/consensus/consensus_sim.nim
@@ -31,7 +31,7 @@ proc processNode(genesisFile, chainFile,
     )
 
   initializeEmptyDb(chainDB)
-  discard importRlpBlock(chainFile, chainDB, forceCanonicalParent = true)
+  discard importRlpBlock(chainFile, chainDB)
   let head = chainDB.getCanonicalHead()
   let blockHash = "0x" & head.blockHash.data.toHex
   check blockHash == lastBlockHash

--- a/hive_integration/nodocker/consensus/consensus_sim.nim
+++ b/hive_integration/nodocker/consensus/consensus_sim.nim
@@ -8,8 +8,8 @@
 # those terms.
 
 import
-  std/[os, parseopt, json],
-  eth/[common, p2p, trie/db], stew/byteutils,
+  std/[os, parseopt, strformat, json],
+  eth/[common, trie/db], stew/byteutils,
   ../../../nimbus/db/db_chain,
   ../../../nimbus/[genesis, config, conf_utils],
   ../sim_utils
@@ -31,7 +31,7 @@ proc processNode(genesisFile, chainFile,
     )
 
   initializeEmptyDb(chainDB)
-  discard importRlpBlock(chainFile, chainDB)
+  discard importRlpBlock(chainFile, chainDB, forceCanonicalParent = true)
   let head = chainDB.getCanonicalHead()
   let blockHash = "0x" & head.blockHash.data.toHex
   check blockHash == lastBlockHash
@@ -42,7 +42,13 @@ proc main() =
                    else:
                      paramStr(1)
 
+  if not caseFolder.dirExists:
+    # Handy early error message and stop directive
+    let progname = getAppFilename().extractFilename
+    quit(&"*** {progname}: Not a case folder: {caseFolder}")
+
   runTest("Consensus", caseFolder):
+    # Variable `fileName` is injected by `runTest()`
     let node = parseFile(fileName)
     processNode(fileName, node["chainfile"].getStr,
       node["lastblockhash"].getStr, testStatusIMPL)

--- a/nimbus/conf_utils.nim
+++ b/nimbus/conf_utils.nim
@@ -19,8 +19,7 @@ type
   EthHeader = object
     header: BlockHeader
 
-proc importRlpBlock*(importFile: string;
-                     chainDB: BasechainDB; forceCanonicalParent = false): bool =
+proc importRlpBlock*(importFile: string; chainDB: BasechainDB): bool =
   let res = io2.readAllBytes(importFile)
   if res.isErr:
     error "failed to import", fileName = importFile
@@ -36,7 +35,7 @@ proc importRlpBlock*(importFile: string;
       let header = rlp.read(EthHeader).header
       let body = rlp.readRecordType(BlockBody, false)
       if header.blockNumber > head.blockNumber:
-        let valid = chain.persistBlocks([header], [body], forceCanonicalParent)
+        let valid = chain.persistBlocks([header], [body])
         if valid == ValidationResult.Error:
           error "failed to import rlp encoded blocks", fileName = importFile
           return false

--- a/nimbus/conf_utils.nim
+++ b/nimbus/conf_utils.nim
@@ -19,7 +19,8 @@ type
   EthHeader = object
     header: BlockHeader
 
-proc importRlpBlock*(importFile: string, chainDB: BasechainDB): bool =
+proc importRlpBlock*(importFile: string;
+                     chainDB: BasechainDB; forceCanonicalParent = false): bool =
   let res = io2.readAllBytes(importFile)
   if res.isErr:
     error "failed to import", fileName = importFile
@@ -35,7 +36,7 @@ proc importRlpBlock*(importFile: string, chainDB: BasechainDB): bool =
       let header = rlp.read(EthHeader).header
       let body = rlp.readRecordType(BlockBody, false)
       if header.blockNumber > head.blockNumber:
-        let valid = chain.persistBlocks([header], [body])
+        let valid = chain.persistBlocks([header], [body], forceCanonicalParent)
         if valid == ValidationResult.Error:
           error "failed to import rlp encoded blocks", fileName = importFile
           return false

--- a/nimbus/p2p/chain.nim
+++ b/nimbus/p2p/chain.nim
@@ -38,44 +38,6 @@ type
     cacheByEpoch: EpochHashCache
     extraValidation: bool
 
-  CanonicalState = object    ## temporary state cache
-    canoHead: BlockHeader    ## current canonical head
-    restoreHead: BlockHeader ## restore value
-    sibling: BlockHeader     ## block number reference of which to be replaced
-    needRestoreOk: bool      ## need to restore canonical head
-
-
-proc updateCanonicalHead(c: Chain; header: BlockHeader;
-                         forceUpdateOk: bool): CanonicalState {.inline.} =
-  ## If enabled via `forceUpdateOk` the canonical head is moved to the
-  ## parent of the argument header and the previous state is captured so
-  ## it can be restored.
-  result.canoHead = c.db.getCanonicalHead()
-  if forceUpdateOk:
-    let
-      canoNumber = result.canoHead.blockNumber
-      canoHash = result.canoHead.hash
-      thisNumber = header.blockNumber
-      parentHash = header.parentHash
-
-    # Check whether there is something to do, at all
-    if forceUpdateOk and parentHash != canoHash and thisNumber <= canoNumber:
-      # Set new caconical head and provide restore information.
-      result.restoreHead = result.canoHead
-      result.canoHead = c.db.getBlockHeader(parentHash)
-      c.db.setHead(result.canoHead)
-
-      # Restore original header only if
-      #  * the restored chain would be the lingest (i.e. the bock number
-      #    of the restored head will be unique maximum number)
-      #  * or the sibling header on the to be restored chain, shadowed by the
-      #     argument header has higher difficulty.
-      result.sibling = c.db.getBlockHeader(thisNumber)
-      if thisNumber < canoNumber or
-         header.difficulty < result.sibling.difficulty:
-        result.needRestoreOk = true
-
-
 func toChainFork(c: ChainConfig, number: BlockNumber): ChainFork =
   if number >= c.berlinBlock: Berlin
   elif number >= c.muirGlacierBlock: MuirGlacier
@@ -179,9 +141,7 @@ method getBlockBody*(c: Chain, blockHash: KeccakHash): BlockBodyRef =
   result = nil
 
 method persistBlocks*(c: Chain; headers: openarray[BlockHeader];
-                      bodies: openarray[BlockBody];
-                      forceCanonicalParent = true):
-                        ValidationResult {.gcsafe,base.} =
+                  bodies: openarray[BlockBody]): ValidationResult {.gcsafe.} =
   # Run the VM here
   if headers.len != bodies.len:
     debug "Number of headers not matching number of bodies"
@@ -197,8 +157,8 @@ method persistBlocks*(c: Chain; headers: openarray[BlockHeader];
 
   for i in 0 ..< headers.len:
     let
-      canoState = c.updateCanonicalHead(headers[i], forceCanonicalParent)
-      vmState = newBaseVMState(canoState.canoHead.stateRoot, headers[i], c.db)
+      head = c.db.getBlockHeader(headers[i].parentHash)
+      vmState = newBaseVMState(head.stateRoot, headers[i], c.db)
       validationResult = processBlock(c.db, headers[i], bodies[i], vmState)
 
     when not defined(release):
@@ -222,9 +182,12 @@ method persistBlocks*(c: Chain; headers: openarray[BlockHeader];
         return ValidationResult.Error
 
     discard c.db.persistHeaderToDb(headers[i])
-    if c.db.getCanonicalHead().blockHash != headers[i].blockHash:
-      debug "Stored block header hash doesn't match declared hash"
-      return ValidationResult.Error
+    # The following check makes no sense anymore if the `head` is the parent
+    # was allowed to be inserted somewhere before the canonocal head.
+    #
+    # if c.db.getCanonicalHead().blockHash != headers[i].blockHash:
+    #   debug "Stored block header hash doesn't match declared hash"
+    #   return ValidationResult.Error
 
     discard c.db.persistTransactions(headers[i].blockNumber, bodies[i].transactions)
     discard c.db.persistReceipts(vmState.receipts)
@@ -233,15 +196,6 @@ method persistBlocks*(c: Chain; headers: openarray[BlockHeader];
     # so the rpc return consistent result
     # between eth_blockNumber and eth_syncing
     c.db.currentBlock = headers[i].blockNumber
-
-    # Reset canonical head (if requested)
-    if canoState.needRestoreOk:
-      # The follong command would restore the block number reference to the
-      # original header which is now shadowed by the argument header. At least
-      # for the tests, this maked no difference so it is omitted.
-      #
-      # c.db.addBlockNumberToHashLookup(canoState.sibling)
-      c.db.setHead(canoState.restoreHead)
 
   transaction.commit()
 

--- a/nimbus/p2p/chain.nim
+++ b/nimbus/p2p/chain.nim
@@ -182,13 +182,6 @@ method persistBlocks*(c: Chain; headers: openarray[BlockHeader];
         return ValidationResult.Error
 
     discard c.db.persistHeaderToDb(headers[i])
-    # The following check makes no sense anymore if the `head` is the parent
-    # was allowed to be inserted somewhere before the canonocal head.
-    #
-    # if c.db.getCanonicalHead().blockHash != headers[i].blockHash:
-    #   debug "Stored block header hash doesn't match declared hash"
-    #   return ValidationResult.Error
-
     discard c.db.persistTransactions(headers[i].blockNumber, bodies[i].transactions)
     discard c.db.persistReceipts(vmState.receipts)
 


### PR DESCRIPTION
why:
  of the failing tests that remain to be solved, 30 of those will succeed
  if the canonical database chain head is cleverly adjusted -- yes, it
  looks like a hack, indeed.

details:
  at the moment, this hack works for the non-hive tests only and is
  triggered by a boolean argument passed on to the chain.persistBlocks()
  method.