### PR TITLE
[FIX] Add missing gas used validation

### DIFF
--- a/nimbus/p2p/validate.nim
+++ b/nimbus/p2p/validate.nim
@@ -180,6 +180,9 @@ proc validateHeader(db: BaseChainDB; header, parentHeader: BlockHeader;
   if header.gasUsed == 0 and 0 < numTransactions:
     return err("zero gasUsed but tranactions present");
 
+  if header.gasUsed < 0 or header.gasUsed > header.gasLimit:
+    return err("gasUsed should be non negative and smaller or equal gasLimit")
+  
   if header.blockNumber != parentHeader.blockNumber + 1:
     return err("Blocks must be numbered consecutively")
 


### PR DESCRIPTION
While browsing codebase I have noticed that one validation is missing when validating header. 

In https://ethereum.github.io/yellowpaper/paper.pdf in equation `51`, part of equation states that `Hg ≤ Hl`, which means that header.gasUsed should always be lower than header.gasLimit.

I was considering creating and issue, but as fix is easy I decided to go with pr. If the check is implemented elswhere or there is some process for creating consensus level fixes please let me know.