### PR TITLE
hive: fix missing comma in hive_integration/mapper.jq

### DIFF
--- a/hive_integration/nimbus/mapper.jq
+++ b/hive_integration/nimbus/mapper.jq
@@ -63,7 +63,7 @@ def to_bool:
     "petersburgBlock": env.HIVE_FORK_PETERSBURG|to_int,
     "istanbulBlock": env.HIVE_FORK_ISTANBUL|to_int,
     "muirGlacierBlock": env.HIVE_FORK_MUIR_GLACIER|to_int,
-    "berlinBlock": env.HIVE_FORK_BERLIN|to_int
+    "berlinBlock": env.HIVE_FORK_BERLIN|to_int,
     "londonBlock": env.HIVE_FORK_LONDON|to_int
   }|remove_empty
 }


### PR DESCRIPTION
from:
  "berlinBlock": env.HIVE_FORK_BERLIN|to_int
  "londonBlock": env.HIVE_FORK_LONDON|to_int

to:
  "berlinBlock": env.HIVE_FORK_BERLIN|to_int,
  "londonBlock": env.HIVE_FORK_LONDON|to_int