### PR TITLE
Tested eth/65 support

### DIFF
--- a/hive_integration/nodocker/graphql/graphql_sim.nim
+++ b/hive_integration/nodocker/graphql/graphql_sim.nim
@@ -10,7 +10,7 @@
 import
   std/[os, parseopt, json],
   eth/[p2p, trie/db], ../../../nimbus/db/db_chain,
-  eth/p2p/rlpx_protocols/eth_protocol,
+  ../../../nimbus/sync/protocol_eth65,
   ../../../nimbus/[genesis, config, conf_utils],
   ../../../nimbus/graphql/ethapi, ../../../tests/test_helpers,
   graphql, ../sim_utils

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -15,11 +15,13 @@ import
   eth/keys, db/[storage_types, db_chain, select_backend],
   eth/common as eth_common, eth/p2p as eth_p2p,
   chronos, json_rpc/rpcserver, chronicles,
-  eth/p2p/rlpx_protocols/[eth_protocol, les_protocol],
+  eth/p2p/rlpx_protocols/les_protocol,
   eth/p2p/blockchain_sync, eth/net/nat, eth/p2p/peer_pool,
+  ./sync/protocol_eth65,
   config, genesis, rpc/[common, p2p, debug, key_storage], p2p/chain,
   eth/trie/db, metrics, metrics/[chronos_httpserver, chronicles_support],
-  graphql/ethapi, utils, ./conf_utils
+  graphql/ethapi,
+  "."/[utils, conf_utils]
 
 ## TODO:
 ## * No IPv6 support

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -16,7 +16,7 @@ import
   eth/common as eth_common, eth/p2p as eth_p2p,
   chronos, json_rpc/rpcserver, chronicles,
   eth/p2p/rlpx_protocols/les_protocol,
-  eth/p2p/blockchain_sync, eth/net/nat, eth/p2p/peer_pool,
+  ./p2p/blockchain_sync, eth/net/nat, eth/p2p/peer_pool,
   ./sync/protocol_eth65,
   config, genesis, rpc/[common, p2p, debug, key_storage], p2p/chain,
   eth/trie/db, metrics, metrics/[chronos_httpserver, chronicles_support],

--- a/nimbus/p2p/blockchain_sync.nim
+++ b/nimbus/p2p/blockchain_sync.nim
@@ -1,0 +1,413 @@
+# nim-eth
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  std/[sets, options, random, hashes],
+  chronos, chronicles,
+  eth/common/eth_types,
+  eth/[p2p, p2p/private/p2p_types, p2p/rlpx, p2p/peer_pool],
+  ../sync/protocol_eth65
+
+const
+  minPeersToStartSync* = 2 # Wait for consensus of at least this
+                           # number of peers before syncing
+
+type
+  SyncStatus* = enum
+    syncSuccess
+    syncNotEnoughPeers
+    syncTimeOut
+
+  WantedBlocksState = enum
+    Initial,
+    Requested,
+    Received,
+    Persisted
+
+  WantedBlocks = object
+    startIndex: BlockNumber
+    numBlocks: uint
+    state: WantedBlocksState
+    headers: seq[BlockHeader]
+    bodies: seq[BlockBody]
+
+  SyncContext = ref object
+    workQueue: seq[WantedBlocks]
+    endBlockNumber: BlockNumber
+    finalizedBlock: BlockNumber # Block which was downloaded and verified
+    chain: AbstractChainDB
+    peerPool: PeerPool
+    trustedPeers: HashSet[Peer]
+    hasOutOfOrderBlocks: bool
+
+proc hash*(p: Peer): Hash = hash(cast[pointer](p))
+
+proc endIndex(b: WantedBlocks): BlockNumber =
+  result = b.startIndex
+  result += (b.numBlocks - 1).toBlockNumber
+
+proc availableWorkItem(ctx: SyncContext): int =
+  var maxPendingBlock = ctx.finalizedBlock # the last downloaded & processed
+  trace "queue len", length = ctx.workQueue.len
+  result = -1
+  for i in 0 .. ctx.workQueue.high:
+    case ctx.workQueue[i].state
+    of Initial:
+      # When there is a work item at Initial state, immediatly use this one.
+      # This usually means a previous work item that failed somewhere in the
+      # process, and thus can be reused to work on.
+      return i
+    of Persisted:
+      # In case of Persisted, we can reset this work item to a new one.
+      result = i
+      # No break here to give work items in Initial state priority and to
+      # calculate endBlock.
+    else:
+      discard
+
+    # Check all endBlocks of all workqueue items to decide on next range of
+    # blocks to collect & process.
+    let endBlock = ctx.workQueue[i].endIndex
+    if endBlock > maxPendingBlock:
+      maxPendingBlock = endBlock
+
+  let nextRequestedBlock = maxPendingBlock + 1
+  # If this next block doesn't exist yet according to any of our peers, don't
+  # return a work item (and sync will be stopped).
+  if nextRequestedBlock >= ctx.endBlockNumber:
+    return -1
+
+  # Increase queue when there are no free (Initial / Persisted) work items in
+  # the queue. At start, queue will be empty.
+  if result == -1:
+    result = ctx.workQueue.len
+    ctx.workQueue.setLen(result + 1)
+
+  # Create new work item when queue was increased, reset when selected work item
+  # is at Persisted state.
+  var numBlocks = (ctx.endBlockNumber - nextRequestedBlock).toInt
+  if numBlocks > maxHeadersFetch:
+    numBlocks = maxHeadersFetch
+  ctx.workQueue[result] = WantedBlocks(startIndex: nextRequestedBlock, numBlocks: numBlocks.uint, state: Initial)
+
+proc persistWorkItem(ctx: SyncContext, wi: var WantedBlocks): ValidationResult =
+  result = ctx.chain.persistBlocks(wi.headers, wi.bodies)
+  case result
+  of ValidationResult.OK:
+    ctx.finalizedBlock = wi.endIndex
+    wi.state = Persisted
+  of ValidationResult.Error:
+    wi.state = Initial
+  # successful or not, we're done with these blocks
+  wi.headers = @[]
+  wi.bodies = @[]
+
+proc persistPendingWorkItems(ctx: SyncContext): (int, ValidationResult) =
+  var nextStartIndex = ctx.finalizedBlock + 1
+  var keepRunning = true
+  var hasOutOfOrderBlocks = false
+  trace "Looking for out of order blocks"
+  while keepRunning:
+    keepRunning = false
+    hasOutOfOrderBlocks = false
+    # Go over the full work queue and check for every work item if it is in
+    # Received state and has the next blocks in line to be processed.
+    for i in 0 ..< ctx.workQueue.len:
+      let start = ctx.workQueue[i].startIndex
+      # There should be at least 1 like this, namely the just received work item
+      # that initiated this call.
+      if ctx.workQueue[i].state == Received:
+        if start == nextStartIndex:
+          trace "Processing pending work item", number = start
+          result = (i, ctx.persistWorkItem(ctx.workQueue[i]))
+          # TODO: We can stop here on failure, but have to set
+          # hasOutofORderBlocks. Is this always valid?
+          nextStartIndex = ctx.finalizedBlock + 1
+          keepRunning = true
+          break
+        else:
+          hasOutOfOrderBlocks = true
+
+  ctx.hasOutOfOrderBlocks = hasOutOfOrderBlocks
+
+proc returnWorkItem(ctx: SyncContext, workItem: int): ValidationResult =
+  let wi = addr ctx.workQueue[workItem]
+  let askedBlocks = wi.numBlocks.int
+  let receivedBlocks = wi.headers.len
+  let start = wi.startIndex
+
+  if askedBlocks == receivedBlocks:
+    trace "Work item complete",
+      start,
+      askedBlocks,
+      receivedBlocks
+
+    if wi.startIndex != ctx.finalizedBlock + 1:
+      trace "Blocks out of order", start, final = ctx.finalizedBlock
+      ctx.hasOutOfOrderBlocks = true
+
+    if ctx.hasOutOfOrderBlocks:
+      let (index, validation) = ctx.persistPendingWorkItems()
+      # Only report an error if it was this peer's work item that failed
+      if validation == ValidationResult.Error and index == workitem:
+        result = ValidationResult.Error
+      # TODO: What about failures on other peers' work items?
+      # In that case the peer will probably get disconnected on future erroneous
+      # work items, but before this occurs, several more blocks (that will fail)
+      # might get downloaded from this peer. This will delay the sync and this
+      # should be improved.
+    else:
+      trace "Processing work item", number = wi.startIndex
+      # Validation result needs to be returned so that higher up can be decided
+      # to disconnect from this peer in case of error.
+      result = ctx.persistWorkItem(wi[])
+  else:
+    trace "Work item complete but we got fewer blocks than requested, so we're ditching the whole thing.",
+      start,
+      askedBlocks,
+      receivedBlocks
+    return ValidationResult.Error
+
+proc newSyncContext(chain: AbstractChainDB, peerPool: PeerPool): SyncContext =
+  new result
+  result.chain = chain
+  result.peerPool = peerPool
+  result.trustedPeers = initHashSet[Peer]()
+  result.finalizedBlock = chain.getBestBlockHeader().blockNumber
+
+proc handleLostPeer(ctx: SyncContext) =
+  # TODO: ask the PeerPool for new connections and then call
+  # `obtainBlocksFromPeer`
+  discard
+
+proc getBestBlockNumber(p: Peer): Future[BlockNumber] {.async.} =
+  let request = BlocksRequest(
+    startBlock: HashOrNum(isHash: true,
+                          hash: p.state(eth).bestBlockHash),
+    maxResults: 1,
+    skip: 0,
+    reverse: true)
+
+  let latestBlock = await p.getBlockHeaders(request)
+
+  if latestBlock.isSome and latestBlock.get.headers.len > 0:
+    result = latestBlock.get.headers[0].blockNumber
+
+proc obtainBlocksFromPeer(syncCtx: SyncContext, peer: Peer) {.async.} =
+  # Update our best block number
+  try:
+    let bestBlockNumber = await peer.getBestBlockNumber()
+    if bestBlockNumber > syncCtx.endBlockNumber:
+      trace "New sync end block number", number = bestBlockNumber
+      syncCtx.endBlockNumber = bestBlockNumber
+  except TransportError:
+    debug "Transport got closed during obtainBlocksFromPeer"
+  except CatchableError as e:
+    debug "Exception in getBestBlockNumber()", exc = e.name, err = e.msg
+    # no need to exit here, because the context might still have blocks to fetch
+    # from this peer
+
+  while (let workItemIdx = syncCtx.availableWorkItem(); workItemIdx != -1 and
+         peer.connectionState notin {Disconnecting, Disconnected}):
+    template workItem: auto = syncCtx.workQueue[workItemIdx]
+    workItem.state = Requested
+    trace "Requesting block headers", start = workItem.startIndex,
+      count = workItem.numBlocks, peer = peer.remote.node
+    let request = BlocksRequest(
+      startBlock: HashOrNum(isHash: false, number: workItem.startIndex),
+      maxResults: workItem.numBlocks,
+      skip: 0,
+      reverse: false)
+
+    var dataReceived = false
+    try:
+      let results = await peer.getBlockHeaders(request)
+      if results.isSome:
+        shallowCopy(workItem.headers, results.get.headers)
+
+        var bodies = newSeq[BlockBody]()
+        var hashes = newSeq[KeccakHash]()
+        var nextIndex = workItem.startIndex
+        for i in workItem.headers:
+          if i.blockNumber != nextIndex:
+            raise newException(CatchableError, "The block numbers are not in sequence. Not processing this workItem.")
+          else:
+            nextIndex = nextIndex + 1
+          hashes.add(blockHash(i))
+          if hashes.len == maxBodiesFetch:
+            let b = await peer.getBlockBodies(hashes)
+            if b.isNone:
+              raise newException(CatchableError, "Was not able to get the block bodies.")
+            hashes.setLen(0)
+            bodies.add(b.get.blocks)
+
+        if hashes.len != 0:
+          let b = await peer.getBlockBodies(hashes)
+          if b.isNone:
+            raise newException(CatchableError, "Was not able to get the block bodies.")
+          bodies.add(b.get.blocks)
+
+        if bodies.len == workItem.headers.len:
+          shallowCopy(workItem.bodies, bodies)
+          dataReceived = true
+        else:
+          warn "Bodies len != headers.len", bodies = bodies.len, headers = workItem.headers.len
+    except TransportError:
+      debug "Transport got closed during obtainBlocksFromPeer"
+    except CatchableError as e:
+      # the success case sets `dataReceived`, so we can just fall back to the
+      # failure path below. If we signal time-outs with exceptions such
+      # failures will be easier to handle.
+      debug "Exception in obtainBlocksFromPeer()", exc = e.name, err = e.msg
+
+    var giveUpOnPeer = false
+
+    if dataReceived:
+      workItem.state = Received
+      if syncCtx.returnWorkItem(workItemIdx) != ValidationResult.OK:
+        giveUpOnPeer = true
+    else:
+      giveUpOnPeer = true
+
+    if giveUpOnPeer:
+      workItem.state = Initial
+      try:
+        await peer.disconnect(SubprotocolReason)
+      except CatchableError:
+        discard
+      syncCtx.handleLostPeer()
+      break
+
+  trace "Finished obtaining blocks", peer
+
+proc peersAgreeOnChain(a, b: Peer): Future[bool] {.async.} =
+  # Returns true if one of the peers acknowledges existence of the best block
+  # of another peer.
+  var
+    a = a
+    b = b
+
+  if a.state(eth).bestDifficulty < b.state(eth).bestDifficulty:
+    swap(a, b)
+
+  let request = BlocksRequest(
+    startBlock: HashOrNum(isHash: true,
+                          hash: b.state(eth).bestBlockHash),
+    maxResults: 1,
+    skip: 0,
+    reverse: true)
+
+  let latestBlock = await a.getBlockHeaders(request)
+  result = latestBlock.isSome and latestBlock.get.headers.len > 0
+
+proc randomTrustedPeer(ctx: SyncContext): Peer =
+  var k = rand(ctx.trustedPeers.len - 1)
+  var i = 0
+  for p in ctx.trustedPeers:
+    result = p
+    if i == k: return
+    inc i
+
+proc startSyncWithPeer(ctx: SyncContext, peer: Peer) {.async.} =
+  trace "start sync", peer, trustedPeers = ctx.trustedPeers.len
+  if ctx.trustedPeers.len >= minPeersToStartSync:
+    # We have enough trusted peers. Validate new peer against trusted
+    if await peersAgreeOnChain(peer, ctx.randomTrustedPeer()):
+      ctx.trustedPeers.incl(peer)
+      asyncCheck ctx.obtainBlocksFromPeer(peer)
+  elif ctx.trustedPeers.len == 0:
+    # Assume the peer is trusted, but don't start sync until we reevaluate
+    # it with more peers
+    trace "Assume trusted peer", peer
+    ctx.trustedPeers.incl(peer)
+  else:
+    # At this point we have some "trusted" candidates, but they are not
+    # "trusted" enough. We evaluate `peer` against all other candidates.
+    # If one of the candidates disagrees, we swap it for `peer`. If all
+    # candidates agree, we add `peer` to trusted set. The peers in the set
+    # will become "fully trusted" (and sync will start) when the set is big
+    # enough
+    var
+      agreeScore = 0
+      disagreedPeer: Peer
+
+    for tp in ctx.trustedPeers:
+      if await peersAgreeOnChain(peer, tp):
+        inc agreeScore
+      else:
+        disagreedPeer = tp
+
+    let disagreeScore = ctx.trustedPeers.len - agreeScore
+
+    if agreeScore == ctx.trustedPeers.len:
+      ctx.trustedPeers.incl(peer) # The best possible outcome
+    elif disagreeScore == 1:
+      trace "Peer is no longer trusted for sync", peer
+      ctx.trustedPeers.excl(disagreedPeer)
+      ctx.trustedPeers.incl(peer)
+    else:
+      trace "Peer not trusted for sync", peer
+
+    if ctx.trustedPeers.len == minPeersToStartSync:
+      for p in ctx.trustedPeers:
+        asyncCheck ctx.obtainBlocksFromPeer(p)
+
+
+proc onPeerConnected(ctx: SyncContext, peer: Peer) =
+  trace "New candidate for sync", peer
+  try:
+    let f = ctx.startSyncWithPeer(peer)
+    f.callback = proc(data: pointer) {.gcsafe.} =
+      if f.failed:
+        if f.error of TransportError:
+          debug "Transport got closed during startSyncWithPeer"
+        else:
+          error "startSyncWithPeer failed", msg = f.readError.msg, peer
+  except TransportError:
+    debug "Transport got closed during startSyncWithPeer"
+  except CatchableError as e:
+    debug "Exception in startSyncWithPeer()", exc = e.name, err = e.msg
+
+
+proc onPeerDisconnected(ctx: SyncContext, p: Peer) =
+  trace "peer disconnected ", peer = p
+  ctx.trustedPeers.excl(p)
+
+proc startSync(ctx: SyncContext) =
+  var po: PeerObserver
+  po.onPeerConnected = proc(p: Peer) {.gcsafe.} =
+    ctx.onPeerConnected(p)
+
+  po.onPeerDisconnected = proc(p: Peer) {.gcsafe.} =
+    ctx.onPeerDisconnected(p)
+
+  po.setProtocol eth
+  ctx.peerPool.addObserver(ctx, po)
+
+proc findBestPeer(node: EthereumNode): (Peer, DifficultyInt) =
+  var
+    bestBlockDifficulty: DifficultyInt = 0.stuint(256)
+    bestPeer: Peer = nil
+
+  for peer in node.peers(eth):
+    let peerEthState = peer.state(eth)
+    if peerEthState.initialized:
+      if peerEthState.bestDifficulty > bestBlockDifficulty:
+        bestBlockDifficulty = peerEthState.bestDifficulty
+        bestPeer = peer
+
+  result = (bestPeer, bestBlockDifficulty)
+
+proc fastBlockchainSync*(node: EthereumNode): Future[SyncStatus] {.async.} =
+  ## Code for the fast blockchain sync procedure:
+  ## https://github.com/ethereum/wiki/wiki/Parallel-Block-Downloads
+  ## https://github.com/ethereum/go-ethereum/pull/1889
+  # TODO: This needs a better interface. Consider removing this function and
+  # exposing SyncCtx
+  var syncCtx = newSyncContext(node.chain, node.peerPool)
+  syncCtx.startSync()
+

--- a/nimbus/p2p/executor/process_block.nim
+++ b/nimbus/p2p/executor/process_block.nim
@@ -50,9 +50,9 @@ proc procBlkPreamble(vmState: BaseVMState; dbTx: DbTransaction;
         blockNumber = header.blockNumber
       return false
     else:
-      trace "Has transactions",
-        blockNumber = header.blockNumber,
-        blockHash = header.blockHash
+      #trace "Has transactions",
+      #  blockNumber = header.blockNumber,
+      #  blockHash = header.blockHash
       vmState.receipts = newSeq[Receipt](body.transactions.len)
       vmState.cumulativeGasUsed = 0
       for txIndex, tx in body.transactions:

--- a/nimbus/p2p/executor/process_transaction.nim
+++ b/nimbus/p2p/executor/process_transaction.nim
@@ -37,8 +37,8 @@ proc processTransactionImpl(tx: Transaction, sender: EthAddress,
                             vmState: BaseVMState, fork: Fork): GasInt
                               # wildcard exception, wrapped below
                               {.gcsafe, raises: [Exception].} =
-  trace "Sender", sender
-  trace "txHash", rlpHash = tx.rlpHash
+  #trace "Sender", sender
+  #trace "txHash", rlpHash = tx.rlpHash
 
   var tx = eip1559TxNormalization(tx)
   var priorityFee: GasInt

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -38,6 +38,12 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB , server: RpcServer) =
     result = getAccountDb(chain.headerFromTag(tag))
 
   server.rpc("eth_protocolVersion") do() -> string:
+    # Old Ethereum wiki documents this as returning a decimal string.
+    # Infura documents this as returning 0x-prefixed hex string.
+    # Geth 1.10.0 has removed this call "as it makes no sense".
+    # - https://eth.wiki/json-rpc/API#eth_protocolversion
+    # - https://infura.io/docs/ethereum/json-rpc/eth-protocolVersion
+    # - https://blog.ethereum.org/2021/03/03/geth-v1-10-0/#compatibility
     result = $protocol_eth65.protocolVersion
 
   server.rpc("eth_syncing") do() -> JsonNode:

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -11,7 +11,7 @@ import
   strutils, times, options, tables,
   json_rpc/rpcserver, hexstrings, stint, stew/byteutils,
   eth/[common, keys, rlp, p2p], nimcrypto,
-  eth/p2p/rlpx_protocols/eth_protocol,
+  ../sync/protocol_eth65,
   ../transaction, ../config, ../vm_state, ../constants,
   ../utils, ../db/[db_chain, state_db],
   rpc_types, rpc_utils,
@@ -38,7 +38,7 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB , server: RpcServer) =
     result = getAccountDb(chain.headerFromTag(tag))
 
   server.rpc("eth_protocolVersion") do() -> string:
-    result = $eth_protocol.protocolVersion
+    result = $protocol_eth65.protocolVersion
 
   server.rpc("eth_syncing") do() -> JsonNode:
     ## Returns SyncObject or false when not syncing.

--- a/nimbus/sync/protocol_eth65.nim
+++ b/nimbus/sync/protocol_eth65.nim
@@ -37,11 +37,11 @@ const
   maxBodiesFetch* = 128
   maxReceiptsFetch* = 256
   maxHeadersFetch* = 192
-  protocolVersion* = 65
+  ethVersion = 65
 
 func toHex(x: KeccakHash): string = x.data.toHex
 
-p2pProtocol eth(version = protocolVersion,
+p2pProtocol eth(version = ethVersion,
                 peerState = PeerState,
                 useRequestIds = false):
 
@@ -56,7 +56,7 @@ p2pProtocol eth(version = protocolVersion,
         forkNext: chainForkId.nextFork.u256,
       )
 
-    let m = await peer.status(protocolVersion,
+    let m = await peer.status(ethVersion,
                               network.networkId,
                               bestBlock.difficulty,
                               bestBlock.blockHash,
@@ -82,7 +82,7 @@ p2pProtocol eth(version = protocolVersion,
   handshake:
     # User message 0x00: Status.
     proc status(peer: Peer,
-                protocolVersion: uint,
+                ethVersionArg: uint,
                 networkId: NetworkId,
                 totalDifficulty: DifficultyInt,
                 bestHash: KeccakHash,

--- a/nimbus/sync/protocol_eth65.nim
+++ b/nimbus/sync/protocol_eth65.nim
@@ -34,6 +34,7 @@ type
 
 const
   tracePackets* = true       # Set `true` or `false` to control packet traces.
+  traceHandshakes* = true
 
 const
   maxStateFetch* = 384
@@ -77,6 +78,15 @@ p2pProtocol eth(version = ethVersion,
                               chain.genesisHash,
                               forkId,
                               timeout = chronos.seconds(10))
+
+    if traceHandshakes:
+      trace "Handshake: Local and remote networkId",
+        local=network.networkId, remote=m.networkId
+      trace "Handshake: Local and remote genesisHash",
+        local=chain.genesisHash.toHex, remote=m.genesisHash.toHex
+      trace "Handshake: Local and remote forkId",
+        local=(forkId.forkHash.toHex & "/" & $forkId.forkNext),
+        remote=(m.forkId.forkHash.toHex & "/" & $m.forkId.forkNext)
 
     if m.networkId != network.networkId:
       trace "Peer for a different network (networkId)", peer,

--- a/nimbus/sync/protocol_eth65.nim
+++ b/nimbus/sync/protocol_eth65.nim
@@ -21,9 +21,7 @@ type
     hash: KeccakHash
     number: uint64           # Note: Was `uint`, wrong on 32-bit targets.
 
-  NewBlockAnnounce* = object
-    header*: BlockHeader
-    body* {.rlpInline.}: BlockBody
+  NewBlockAnnounce* = EthBlock
 
   ForkId* = object
     forkHash: array[4, byte] # The RLP encoding must be exactly 4 bytes.
@@ -124,7 +122,9 @@ p2pProtocol eth(version = protocolVersion,
     proc blockBodies(peer: Peer, blocks: openArray[BlockBody])
 
   # User message 0x07: NewBlock.
-  proc newBlock(peer: Peer, bh: NewBlockAnnounce, totalDifficulty: DifficultyInt) =
+  proc newBlock(peer: Peer, bh: EthBlock, totalDifficulty: DifficultyInt) =
+    # (Note, needs to use `EthBlock` instead of its alias `NewBlockAnnounce`
+    # because either `p2pProtocol` or RLPx doesn't work with an alias.)
     discard
 
   # User message 0x08: NewPooledTransactionHashes.

--- a/nimbus/sync/protocol_eth65.nim
+++ b/nimbus/sync/protocol_eth65.nim
@@ -1,0 +1,160 @@
+# Nimbus - Ethereum Wire Protocol, version eth/65
+#
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## This module implements Ethereum Wire Protocol version 65, `eth/65`.
+## Specification:
+##   https://github.com/ethereum/devp2p/blob/master/caps/eth.md
+
+import
+  chronos, stint, chronicles, stew/byteutils, macros,
+  eth/[common/eth_types, rlp, p2p],
+  eth/p2p/[rlpx, private/p2p_types, blockchain_utils],
+  ../p2p/chain
+
+type
+  NewBlockHashesAnnounce* = object
+    hash: KeccakHash
+    number: uint64           # Note: Was `uint`, wrong on 32-bit targets.
+
+  NewBlockAnnounce* = object
+    header*: BlockHeader
+    body* {.rlpInline.}: BlockBody
+
+  ForkId* = object
+    forkHash: array[4, byte] # The RLP encoding must be exactly 4 bytes.
+    forkNext: BlockNumber    # The RLP encoding must be variable-length
+
+  PeerState = ref object
+    initialized*: bool
+    bestBlockHash*: KeccakHash
+    bestDifficulty*: DifficultyInt
+
+const
+  maxStateFetch* = 384
+  maxBodiesFetch* = 128
+  maxReceiptsFetch* = 256
+  maxHeadersFetch* = 192
+  protocolVersion* = 65
+
+func toHex(x: KeccakHash): string = x.data.toHex
+
+p2pProtocol eth(version = protocolVersion,
+                peerState = PeerState,
+                useRequestIds = false):
+
+  onPeerConnected do (peer: Peer):
+    let
+      network = peer.network
+      chain = network.chain
+      bestBlock = chain.getBestBlockHeader
+      chainForkId = chain.getForkId(bestBlock.blockNumber)
+      forkId = ForkId(
+        forkHash: chainForkId.crc.toBytesBe,
+        forkNext: chainForkId.nextFork.u256,
+      )
+
+    let m = await peer.status(protocolVersion,
+                              network.networkId,
+                              bestBlock.difficulty,
+                              bestBlock.blockHash,
+                              chain.genesisHash,
+                              forkId,
+                              timeout = chronos.seconds(10))
+
+    if m.networkId != network.networkId:
+      trace "Peer for a different network (networkId)", peer,
+        expectNetworkId=network.networkId, gotNetworkId=m.networkId
+      raise newException(UselessPeerError, "Eth handshake for different network")
+
+    if m.genesisHash != chain.genesisHash:
+      trace "Peer for a different network (genesisHash)", peer,
+        expectGenesis=chain.genesisHash.toHex, gotGenesis=m.genesisHash.toHex
+      raise newException(UselessPeerError, "Eth handshake for different network")
+
+    trace "Peer matches our network", peer
+    peer.state.initialized = true
+    peer.state.bestDifficulty = m.totalDifficulty
+    peer.state.bestBlockHash = m.bestHash
+
+  handshake:
+    # User message 0x00: Status.
+    proc status(peer: Peer,
+                protocolVersion: uint,
+                networkId: NetworkId,
+                totalDifficulty: DifficultyInt,
+                bestHash: KeccakHash,
+                genesisHash: KeccakHash,
+                forkId: ForkId)
+
+  # User message 0x01: NewBlockHashes.
+  proc newBlockHashes(peer: Peer, hashes: openArray[NewBlockHashesAnnounce]) =
+    discard
+
+  # User message 0x02: Transactions.
+  proc transactions(peer: Peer, transactions: openArray[Transaction]) =
+    discard
+
+  requestResponse:
+    # User message 0x03: GetBlockHeaders.
+    proc getBlockHeaders(peer: Peer, request: BlocksRequest) =
+      if request.maxResults > uint64(maxHeadersFetch):
+        await peer.disconnect(BreachOfProtocol)
+        return
+
+      await response.send(peer.network.chain.getBlockHeaders(request))
+
+    # User message 0x04: BlockHeaders.
+    proc blockHeaders(p: Peer, headers: openArray[BlockHeader])
+
+  requestResponse:
+    # User message 0x05: GetBlockBodies.
+    proc getBlockBodies(peer: Peer, hashes: openArray[KeccakHash]) =
+      if hashes.len > maxBodiesFetch:
+        await peer.disconnect(BreachOfProtocol)
+        return
+
+      await response.send(peer.network.chain.getBlockBodies(hashes))
+
+    # User message 0x06: BlockBodies.
+    proc blockBodies(peer: Peer, blocks: openArray[BlockBody])
+
+  # User message 0x07: NewBlock.
+  proc newBlock(peer: Peer, bh: NewBlockAnnounce, totalDifficulty: DifficultyInt) =
+    discard
+
+  # User message 0x08: NewPooledTransactionHashes.
+  proc newPooledTransactionHashes(peer: Peer, hashes: openArray[KeccakHash]) =
+    discard
+
+  requestResponse:
+    # User message 0x09: GetPooledTransactions.
+    proc getPooledTransactions(peer: Peer, hashes: openArray[KeccakHash]) =
+      await response.send([])
+
+    # User message 0x0a: PooledTransactions.
+    proc pooledTransactions(peer: Peer, transactions: openArray[Transaction])
+
+  nextId 0x0d
+
+  requestResponse:
+    # User message 0x0d: GetNodeData.
+    proc getNodeData(peer: Peer, hashes: openArray[KeccakHash]) =
+      await response.send(peer.network.chain.getStorageNodes(hashes))
+
+    # User message 0x0e: NodeData.
+    proc nodeData(peer: Peer, data: openArray[Blob])
+
+  requestResponse:
+    # User message 0x0f: GetReceipts.
+    proc getReceipts(peer: Peer, hashes: openArray[KeccakHash]) =
+      await response.send([])
+      # TODO: implement `getReceipts` and reactivate this code
+      # await response.send(peer.network.chain.getReceipts(hashes))
+
+    # User message 0x10: Receipts.
+    proc receipts(peer: Peer, receipts: openArray[Receipt])

--- a/nimbus/vm/interpreter/gas_meter.nim
+++ b/nimbus/vm/interpreter/gas_meter.nim
@@ -21,12 +21,12 @@ proc consumeGas*(gasMeter: var GasMeter; amount: GasInt; reason: string) =
     raise newException(OutOfGas,
       &"Out of gas: Needed {amount} - Remaining {gasMeter.gasRemaining} - Reason: {reason}")
   gasMeter.gasRemaining -= amount
-  trace "GAS CONSUMPTION", total = gasMeter.gasRemaining + amount, amount, remaining = gasMeter.gasRemaining, reason
+#  trace "GAS CONSUMPTION", total = gasMeter.gasRemaining + amount, amount, remaining = gasMeter.gasRemaining, reason
 
 proc returnGas*(gasMeter: var GasMeter; amount: GasInt) =
   gasMeter.gasRemaining += amount
-  trace "GAS RETURNED", consumed = gasMeter.gasRemaining - amount, amount, remaining = gasMeter.gasRemaining
+#  trace "GAS RETURNED", consumed = gasMeter.gasRemaining - amount, amount, remaining = gasMeter.gasRemaining
 
 proc refundGas*(gasMeter: var GasMeter; amount: GasInt) =
   gasMeter.gasRefunded += amount
-  trace "GAS REFUND", consumed = gasMeter.gasRemaining - amount, amount, refunded = gasMeter.gasRefunded
+#  trace "GAS REFUND", consumed = gasMeter.gasRemaining - amount, amount, refunded = gasMeter.gasRefunded

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -827,7 +827,7 @@ template genCall(callName: untyped, opCode: Op): untyped =
     when opCode in {CallCode, Call}:
       let senderBalance = c.getBalance(sender)
       if senderBalance < value:
-        debug "Insufficient funds", available = senderBalance, needed = c.msg.value
+        #debug "Insufficient funds", available = senderBalance, needed = c.msg.value
         # return unused gas
         c.gasMeter.returnGas(childGasLimit)
         return

--- a/nimbus/vm/interpreter_dispatch.nim
+++ b/nimbus/vm/interpreter_dispatch.nim
@@ -267,7 +267,7 @@ proc opTableToCaseStmt(opTable: array[Op, NimNode], c: NimNode): NimNode =
     let branchStmt = block:
       if op == Stop:
         quote do:
-          trace "op: Stop"
+          #trace "op: Stop"
           if not `c`.code.atEnd() and `c`.tracingEnabled:
             # we only trace `REAL STOP` and ignore `FAKE STOP`
             `c`.opIndex = `c`.traceOpCodeStarted(`asOp`)
@@ -416,4 +416,4 @@ proc executeOpcodes(c: Computation) =
 
   if c.isError() and c.continuation.isNil:
     if c.tracingEnabled: c.traceError()
-    debug "executeOpcodes error", msg=c.error.info
+    #trace "executeOpcodes error", msg=c.error.info

--- a/nimbus/vm/precompiles.nim
+++ b/nimbus/vm/precompiles.nim
@@ -120,7 +120,7 @@ proc ecRecover*(computation: Computation) =
 
   computation.output.setLen(32)
   computation.output[12..31] = pubkey[].toCanonicalAddress()
-  trace "ECRecover precompile", derivedKey = pubkey[].toCanonicalAddress()
+  #trace "ECRecover precompile", derivedKey = pubkey[].toCanonicalAddress()
 
 proc sha256*(computation: Computation) =
   let
@@ -129,7 +129,7 @@ proc sha256*(computation: Computation) =
 
   computation.gasMeter.consumeGas(gasFee, reason="SHA256 Precompile")
   computation.output = @(nimcrypto.sha_256.digest(computation.msg.data).data)
-  trace "SHA256 precompile", output = computation.output.toHex
+  #trace "SHA256 precompile", output = computation.output.toHex
 
 proc ripemd160*(computation: Computation) =
   let
@@ -139,7 +139,7 @@ proc ripemd160*(computation: Computation) =
   computation.gasMeter.consumeGas(gasFee, reason="RIPEMD160 Precompile")
   computation.output.setLen(32)
   computation.output[12..31] = @(nimcrypto.ripemd160.digest(computation.msg.data).data)
-  trace "RIPEMD160 precompile", output = computation.output.toHex
+  #trace "RIPEMD160 precompile", output = computation.output.toHex
 
 proc identity*(computation: Computation) =
   let
@@ -148,7 +148,7 @@ proc identity*(computation: Computation) =
 
   computation.gasMeter.consumeGas(gasFee, reason="Identity Precompile")
   computation.output = computation.msg.data
-  trace "Identity precompile", output = computation.output.toHex
+  #trace "Identity precompile", output = computation.output.toHex
 
 proc modExpInternal(computation: Computation, baseLen, expLen, modLen: int, T: type StUint) =
   template data: untyped {.dirty.} =
@@ -683,7 +683,7 @@ proc execPrecompiles*(computation: Computation, fork: Fork): bool {.inline.} =
   if lb in PrecompileAddresses.low.byte .. maxPrecompileAddr.byte:
     result = true
     let precompile = PrecompileAddresses(lb)
-    trace "Call precompile", precompile = precompile, codeAddr = computation.msg.codeAddress
+    #trace "Call precompile", precompile = precompile, codeAddr = computation.msg.codeAddress
     try:
       case precompile
       of paEcRecover: ecRecover(computation)

--- a/nimbus/vm2/interpreter/gas_meter.nim
+++ b/nimbus/vm2/interpreter/gas_meter.nim
@@ -21,12 +21,12 @@ proc consumeGas*(gasMeter: var GasMeter; amount: GasInt; reason: string) =
     raise newException(OutOfGas,
       &"Out of gas: Needed {amount} - Remaining {gasMeter.gasRemaining} - Reason: {reason}")
   gasMeter.gasRemaining -= amount
-  trace "GAS CONSUMPTION", total = gasMeter.gasRemaining + amount, amount, remaining = gasMeter.gasRemaining, reason
+  #trace "GAS CONSUMPTION", total = gasMeter.gasRemaining + amount, amount, remaining = gasMeter.gasRemaining, reason
 
 proc returnGas*(gasMeter: var GasMeter; amount: GasInt) =
   gasMeter.gasRemaining += amount
-  trace "GAS RETURNED", consumed = gasMeter.gasRemaining - amount, amount, remaining = gasMeter.gasRemaining
+  #trace "GAS RETURNED", consumed = gasMeter.gasRemaining - amount, amount, remaining = gasMeter.gasRemaining
 
 proc refundGas*(gasMeter: var GasMeter; amount: GasInt) =
   gasMeter.gasRefunded += amount
-  trace "GAS REFUND", consumed = gasMeter.gasRemaining - amount, amount, refunded = gasMeter.gasRefunded
+  #trace "GAS REFUND", consumed = gasMeter.gasRemaining - amount, amount, refunded = gasMeter.gasRefunded

--- a/nimbus/vm2/interpreter/op_dispatcher.nim
+++ b/nimbus/vm2/interpreter/op_dispatcher.nim
@@ -36,7 +36,7 @@ export
 # ------------------------------------------------------------------------------
 
 template handleStopDirective(k: var Vm2Ctx) =
-  trace "op: Stop"
+  #trace "op: Stop"
   if not k.cpt.code.atEnd() and k.cpt.tracingEnabled:
     # we only trace `REAL STOP` and ignore `FAKE STOP`
     k.cpt.opIndex = k.cpt.traceOpCodeStarted(Stop)

--- a/nimbus/vm2/interpreter/op_handlers/oph_call.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_call.nim
@@ -212,9 +212,9 @@ const
 
     let senderBalance = k.cpt.getBalance(p.sender)
     if senderBalance < p.value:
-      debug "Insufficient funds",
-        available = senderBalance,
-        needed = k.cpt.msg.value
+      #debug "Insufficient funds",
+      #  available = senderBalance,
+      #  needed = k.cpt.msg.value
       k.cpt.gasMeter.returnGas(childGasLimit)
       return
 
@@ -278,9 +278,9 @@ const
 
     let senderBalance = k.cpt.getBalance(p.sender)
     if senderBalance < p.value:
-      debug "Insufficient funds",
-        available = senderBalance,
-        needed = k.cpt.msg.value
+      #debug "Insufficient funds",
+      #  available = senderBalance,
+      #  needed = k.cpt.msg.value
       k.cpt.gasMeter.returnGas(childGasLimit)
       return
 

--- a/nimbus/vm2/interpreter_dispatch.nim
+++ b/nimbus/vm2/interpreter_dispatch.nim
@@ -204,7 +204,7 @@ proc executeOpcodes*(c: Computation) =
 
   if c.isError() and c.continuation.isNil:
     if c.tracingEnabled: c.traceError()
-    debug "executeOpcodes error", msg=c.error.info
+    #trace "executeOpcodes error", msg=c.error.info
 
 
 proc execCallOrCreate*(cParam: Computation) =

--- a/nimbus/vm2/precompiles.nim
+++ b/nimbus/vm2/precompiles.nim
@@ -130,7 +130,7 @@ proc ecRecover*(computation: Computation) =
 
   computation.output.setLen(32)
   computation.output[12..31] = pubkey[].toCanonicalAddress()
-  trace "ECRecover precompile", derivedKey = pubkey[].toCanonicalAddress()
+  #trace "ECRecover precompile", derivedKey = pubkey[].toCanonicalAddress()
 
 proc sha256*(computation: Computation) =
   let
@@ -139,7 +139,7 @@ proc sha256*(computation: Computation) =
 
   computation.gasMeter.consumeGas(gasFee, reason="SHA256 Precompile")
   computation.output = @(nimcrypto.sha_256.digest(computation.msg.data).data)
-  trace "SHA256 precompile", output = computation.output.toHex
+  #trace "SHA256 precompile", output = computation.output.toHex
 
 proc ripemd160*(computation: Computation) =
   let
@@ -149,7 +149,7 @@ proc ripemd160*(computation: Computation) =
   computation.gasMeter.consumeGas(gasFee, reason="RIPEMD160 Precompile")
   computation.output.setLen(32)
   computation.output[12..31] = @(nimcrypto.ripemd160.digest(computation.msg.data).data)
-  trace "RIPEMD160 precompile", output = computation.output.toHex
+  #trace "RIPEMD160 precompile", output = computation.output.toHex
 
 proc identity*(computation: Computation) =
   let
@@ -158,7 +158,7 @@ proc identity*(computation: Computation) =
 
   computation.gasMeter.consumeGas(gasFee, reason="Identity Precompile")
   computation.output = computation.msg.data
-  trace "Identity precompile", output = computation.output.toHex
+  #trace "Identity precompile", output = computation.output.toHex
 
 proc modExpInternal(computation: Computation, baseLen, expLen, modLen: int, T: type StUint) =
   template data: untyped {.dirty.} =
@@ -693,7 +693,7 @@ proc execPrecompiles*(computation: Computation, fork: Fork): bool {.inline.} =
   if lb in PrecompileAddresses.low.byte .. maxPrecompileAddr.byte:
     result = true
     let precompile = PrecompileAddresses(lb)
-    trace "Call precompile", precompile = precompile, codeAddr = computation.msg.codeAddress
+    #trace "Call precompile", precompile = precompile, codeAddr = computation.msg.codeAddress
     try:
       case precompile
       of paEcRecover: ecRecover(computation)

--- a/tests/graphql/queries.toml
+++ b/tests/graphql/queries.toml
@@ -473,7 +473,7 @@ mutation {
 """
   result = """
 {
-  "protocolVersion":63
+  "protocolVersion":65
 }
 """
 

--- a/tests/test_graphql.nim
+++ b/tests/test_graphql.nim
@@ -11,8 +11,8 @@ import
   std/[os, json],
   stew/byteutils, unittest2,
   eth/[p2p, common, trie/db, rlp, trie],
-  eth/p2p/rlpx_protocols/eth_protocol,
   graphql, ../nimbus/graphql/ethapi, graphql/test_common,
+  ../nimbus/sync/protocol_eth65,
   ../nimbus/[genesis, config, chain_config], ../nimbus/db/[db_chain, state_db],
   ../nimbus/p2p/chain, ../premix/parser, ./test_helpers
 

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -193,7 +193,12 @@ proc rpcMain*() =
 
     test "eth_protocolVersion":
       let res = await client.eth_protocolVersion()
-      check res == $protocol_eth65.protocolVersion
+      # Use a hard-coded number instead of the same expression as the client,
+      # so that bugs introduced via that expression are detected.  Using the
+      # same expression as the client can hide issues when the value is wrong
+      # in both places.  When the expected value genuinely changes, it'll be
+      # obvious.  Just change this number.
+      check res == "65"
 
     test "eth_syncing":
       let res = await client.eth_syncing()

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -9,12 +9,12 @@ import
   asynctest, json, strformat, strutils, options, tables, os,
   nimcrypto, stew/byteutils, times,
   json_rpc/[rpcserver, rpcclient], eth/common as eth_common,
-  eth/[rlp, keys], eth/trie/db, eth/p2p/rlpx_protocols/eth_protocol,
-  eth/p2p/private/p2p_types,
+  eth/[rlp, keys, trie/db, p2p/private/p2p_types],
   ../nimbus/rpc/[common, p2p, hexstrings, rpc_types, rpc_utils],
   ../nimbus/[constants, vm_state, config, genesis, utils, transaction],
   ../nimbus/db/[accounts_cache, db_chain, storage_types, state_db],
   ../nimbus/p2p/[chain, executor, executor/executor_helpers],
+  ../nimbus/sync/protocol_eth65,
   ../nimbus/utils/difficulty,
   ./rpcclient/test_hexstrings, ./test_helpers, ./macro_assembler
 
@@ -193,7 +193,7 @@ proc rpcMain*() =
 
     test "eth_protocolVersion":
       let res = await client.eth_protocolVersion()
-      check res == $eth_protocol.protocolVersion
+      check res == $protocol_eth65.protocolVersion
 
     test "eth_syncing":
       let res = await client.eth_syncing()


### PR DESCRIPTION
This is an intentionally simple PR, designed to not break, change or depend on other functionality much, so that the "old sync" methods can be run usefully again and observed.  This patch isn't "new sync" (a different set of
sync algorithms), but it is one of the foundations.

For a while now Nimbus Eth1 only supported protocol `eth/63`.  But that's obsolete, and very few nodes still support it.  This meant Nimbus Eth1 would make slow progress trying to sync, as most up to date clients rejected it.

The current specification is `eth/66`, and the functionality we really need is in `eth/64`.

So why `eth/65`?

- `eth/64` is essential because of the `forkId` feature.  But `eth/64` is on its way out as well.  Many clients, especially the most up to date Geth running the current hard-forks (Berlin/London) don't talk `eth/64` any more.

- `eth/66` is the current specification, but some clients don't talk `eth/66` yet.  We'd like to have the best peer connectivity during tests, and currently everything that talks `eth/66` also talks `eth/65`.

- Nimbus Eth1 RLPx only talks one version at a time.  (Without changes to the RLPx module.  When those go in we'll add `eth/64..eth/66` for greater peer reach and testing the `eth/66` behaviour.  For simplicity and decoupling, this patch contains just one version, the most useful.)

What are `eth/64` and `eth/65`?

- `eth/64` (EIP-2364) added `forkId` which allows nodes to distinguish between Ethereum (ETH) and Ethereum Classic (ETC) blockchains, which share the same genesis block.  `forkId` also protects the system when a new hard fork is going to be rolled out, by blocking interaction with out of date nodes.  The feature is required nowadays.

  We send the right details to allow connection (this has been tested a lot), but don't apply the full validation rules of EIP-2124/EIP-2364 in this patch. It's to keep this patch simple (in its effects) and because those rules have consequences best tested separately.  In practice the other node will reject us when we would reject it, so this is ok for testing, as long as it doesn't get seriously deployed.

- `eth/65` added more efficient transaction pool methods.

- Then a later version of `eth/65` (without a new number) added typed  transactions, described in [EIP-2976](https://eips.ethereum.org/EIPS/eip-2976).

Why it's moved to `nimbus-eth1`:

- Mainly because `eth/64` onwards depend on the current state of block synchronisation, as well as the blockchain's sequence of hard-fork block numbers, both of which are part of `nimbus-eth1` run-time state.  These aren't available to pure `nim-eth` code.  Although it would be possible to add an API to let `nimbus-eth1` set these numbers, there isn't any point because the protocol would still only be useful to `nimbus-eth1`.