### PR TITLE
Tests: Add loopMul.json and loopExp.json to skipped, slow tests

### DIFF
--- a/tests/test_allowed_to_fail.nim
+++ b/tests/test_allowed_to_fail.nim
@@ -87,6 +87,8 @@ func slowGSTTests(folder: string, name: string): bool =
 
               # Istanbul slow tests
               "CALLBlake2f_MaxRounds.json",
+              "loopMul.json",
+              "loopExp.json",
 
               ]
 


### PR DESCRIPTION
Add these to the list of specially disabled tests during `make test`, as they are exceptionally slow.