### PR TITLE
Transaction: Treat `CREATE2` salt as a 256-bit blob not a number

### DIFF
--- a/nimbus/constants.nim
+++ b/nimbus/constants.nim
@@ -16,8 +16,8 @@ const
   # address zero by accident, unrecoverably, due to poor user interface issues.
   ZERO_ADDRESS* =                           default(EthAddress)
 
-  # ZERO_HASH32 is the parent hash of genesis blocks.
-  ZERO_HASH32* =                            Hash256()
+  # ZERO_HASH256 is the parent hash of genesis blocks.
+  ZERO_HASH256* =                           Hash256()
 
   GAS_LIMIT_EMA_DENOMINATOR* =              1_024
   GAS_LIMIT_ADJUSTMENT_FACTOR* =            1_024
@@ -43,10 +43,10 @@ const
   GENESIS_BLOCK_NUMBER* =                   0.toBlockNumber
   GENESIS_DIFFICULTY* =                     131_072.u256
   GENESIS_GAS_LIMIT* =                      3_141_592
-  GENESIS_PARENT_HASH* =                    ZERO_HASH32
+  GENESIS_PARENT_HASH* =                    ZERO_HASH256
   GENESIS_COINBASE* =                       ZERO_ADDRESS
   GENESIS_NONCE* =                          "\x00\x00\x00\x00\x00\x00\x00B"
-  GENESIS_MIX_HASH* =                       ZERO_HASH32
+  GENESIS_MIX_HASH* =                       ZERO_HASH256
   GENESIS_EXTRA_DATA* =                     ""
   GAS_LIMIT_MINIMUM* =                      5000
   GAS_LIMIT_MAXIMUM* =                      high(GasInt)

--- a/nimbus/p2p/clique/clique_verify.nim
+++ b/nimbus/p2p/clique/clique_verify.nim
@@ -295,7 +295,7 @@ proc cliqueVerifyImpl*(c: Clique; header: BlockHeader;
   ## optionally pass in a batch of parents (ascending order) to avoid looking
   ## those up from the database. This is useful for concurrently verifying
   ## a batch of new headers.
-  c.failed = (ZERO_HASH32,cliqueNoError)
+  c.failed = (ZERO_HASH256,cliqueNoError)
 
   block:
     # Check header fields independent of parent blocks

--- a/nimbus/transaction/host_call_nested.nim
+++ b/nimbus/transaction/host_call_nested.nim
@@ -11,7 +11,7 @@
 import
   sets, stint, chronicles, stew/ranges/ptr_arith,
   eth/common/eth_types,
-  ".."/[vm_types, vm_computation],
+  ".."/[vm_types, vm_computation, utils],
   ./host_types
 
 proc evmcResultRelease(res: var EvmcResult) {.cdecl, gcsafe.} =
@@ -28,8 +28,8 @@ proc beforeExecCreateEvmcNested(host: TransactionHost,
     value: m.value.fromEvmc,
     data: @(makeOpenArray(m.inputData, m.inputSize.int))
   )
-  # TODO: Salt should maybe change endianness when called via EVMC glue.
-  return newComputation(host.vmState, childMsg, m.create2_salt.fromEvmc)
+  return newComputation(host.vmState, childMsg,
+                        cast[ContractSalt](m.create2_salt))
 
 proc afterExecCreateEvmcNested(host: TransactionHost, child: Computation,
                                res: var EvmcResult) {.inline.} =

--- a/nimbus/utils.nim
+++ b/nimbus/utils.nim
@@ -22,7 +22,13 @@ func keccakHash*(value: openarray[byte]): Hash256 {.inline.} =
 func generateAddress*(address: EthAddress, nonce: AccountNonce): EthAddress =
   result[0..19] = keccakHash(rlp.encodeList(address, nonce)).data.toOpenArray(12, 31)
 
-func generateSafeAddress*(address: EthAddress, salt: Uint256, data: openArray[byte]): EthAddress =
+type ContractSalt* = object
+  bytes*: array[32, byte]
+
+const ZERO_CONTRACTSALT* = default(ContractSalt)
+
+func generateSafeAddress*(address: EthAddress, salt: ContractSalt,
+                          data: openArray[byte]): EthAddress =
   const prefix = [0xff.byte]
   let dataHash = keccakHash(data)
   var hashResult: Hash256
@@ -31,7 +37,7 @@ func generateSafeAddress*(address: EthAddress, salt: Uint256, data: openArray[by
   ctx.init()
   ctx.update(prefix)
   ctx.update(address)
-  ctx.update(salt.toByteArrayBE())
+  ctx.update(salt.bytes)
   ctx.update(dataHash.data)
   ctx.finish hashResult.data
   ctx.clear()

--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -136,7 +136,7 @@ template getCode*(c: Computation, address: EthAddress): seq[byte] =
   else:
     c.vmState.readOnlyStateDB.getCode(address)
 
-proc generateContractAddress(c: Computation, salt: Uint256): EthAddress =
+proc generateContractAddress(c: Computation, salt: ContractSalt): EthAddress =
   if c.msg.kind == evmcCreate:
     let creationNonce = c.vmState.readOnlyStateDb().getNonce(c.msg.sender)
     result = generateAddress(c.msg.sender, creationNonce)
@@ -145,7 +145,8 @@ proc generateContractAddress(c: Computation, salt: Uint256): EthAddress =
 
 import stew/byteutils
 
-proc newComputation*(vmState: BaseVMState, message: Message, salt= 0.u256): Computation =
+proc newComputation*(vmState: BaseVMState, message: Message,
+                     salt: ContractSalt = ZERO_CONTRACTSALT): Computation =
   new result
   result.vmState = vmState
   result.msg = message

--- a/nimbus/vm/evmc_host.nim
+++ b/nimbus/vm/evmc_host.nim
@@ -134,7 +134,8 @@ proc enterCreateImpl(c: Computation, m: nimbus_message): Computation =
     value: Uint256.fromEvmc(m.value),
     data: @(makeOpenArray(m.inputData, m.inputSize.int))
     )
-  return newComputation(c.vmState, childMsg, Uint256.fromEvmc(m.create2_salt))
+  return newComputation(c.vmState, childMsg,
+                        ContractSalt.fromEvmc(m.create2_salt))
 
 template leaveCreateImpl(c, child: Computation, res: nimbus_result) =
   if not child.shouldBurnGas:

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -10,8 +10,8 @@ import
   chronicles, stint, nimcrypto, stew/ranges/ptr_arith, eth/common,
   ./utils/[macros_procs_opcodes, utils_numeric],
   ./gas_meter, ./gas_costs, ./opcode_values,
-  ../memory, ../stack, ../code_stream, ../computation, ../state, ../types,
-  ../../errors, ../../constants, ../../forks,
+  ".."/[memory, stack, code_stream, computation, state, types],
+  ".."/../[errors, constants, forks, utils],
   ../../db/[db_chain, accounts_cache]
 
 when defined(evmc_enabled):
@@ -612,11 +612,11 @@ template genCreate(callName: untyped, opCode: Op): untyped =
     when opCode == Create:
       const callKind = evmcCreate
       let memLen {.inject.} = c.stack.peekInt().safeInt
-      let salt = 0.u256
+      const salt: ContractSalt = ZERO_CONTRACTSALT
     else:
       const callKind = evmcCreate2
       let memLen {.inject.} = c.stack.popInt().safeInt
-      let salt = c.stack.peekInt()
+      let salt = ContractSalt(bytes: c.stack.peekInt().toBytesBE)
 
     c.stack.top(0)
 
@@ -659,7 +659,7 @@ template genCreate(callName: untyped, opCode: Op): untyped =
         input_data: c.memory.readPtr(memPos),
         input_size: memLen.uint,
         value: toEvmc(endowment),
-        create2_salt: toEvmc(salt)
+        create2_salt: toEvmc(salt),
       )
 
       c.chainTo(msg):

--- a/nimbus/vm2/computation.nim
+++ b/nimbus/vm2/computation.nim
@@ -35,7 +35,7 @@ when defined(chronicles_log_level):
 # Helpers
 # ------------------------------------------------------------------------------
 
-proc generateContractAddress(c: Computation, salt: Uint256): EthAddress =
+proc generateContractAddress(c: Computation, salt: ContractSalt): EthAddress =
   if c.msg.kind == evmcCreate:
     let creationNonce = c.vmState.readOnlyStateDb().getNonce(c.msg.sender)
     result = generateAddress(c.msg.sender, creationNonce)
@@ -105,8 +105,8 @@ template selfDestruct*(c: Computation, address: EthAddress) =
 template getCode*(c: Computation, address: EthAddress): seq[byte] =
   c.vmState.readOnlyStateDB.getCode(address)
 
-proc newComputation*(vmState: BaseVMState,
-                     message: Message, salt= 0.u256): Computation =
+proc newComputation*(vmState: BaseVMState, message: Message,
+                     salt: ContractSalt = ZERO_CONTRACTSALT): Computation =
   new result
   result.vmState = vmState
   result.msg = message

--- a/nimbus/vm2/interpreter/op_handlers/oph_create.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_create.nim
@@ -16,6 +16,7 @@ import
   ../../../constants,
   ../../../errors,
   ../../../forks,
+  ../../../utils,
   ../../computation,
   ../../memory,
   ../../stack,
@@ -37,7 +38,8 @@ import
 # Private helpers
 # ------------------------------------------------------------------------------
 
-proc execSubCreate(k: var Vm2Ctx; childMsg: Message; salt = 0.u256) =
+proc execSubCreate(k: var Vm2Ctx; childMsg: Message;
+                   salt: ContractSalt = ZERO_CONTRACTSALT) =
   ## Create new VM -- helper for `Create`-like operations
 
   # need to provide explicit <c> and <child> for capturing in chainTo proc()
@@ -123,7 +125,7 @@ const
       endowment = k.cpt.stack.popInt()
       memPos    = k.cpt.stack.popInt().safeInt
       memLen    = k.cpt.stack.popInt().safeInt
-      salt      = k.cpt.stack.peekInt()
+      salt      = ContractSalt(bytes: k.cpt.stack.peekInt().toBytesBE)
 
     k.cpt.stack.top(0)
 


### PR DESCRIPTION
This changes fixes a bug in `CREATE2` ops when used with EVMC.
Because it changes the salt type, it affects non-EVMC code as well.

The salt was passed through EVMC with the wrong byte order, although this went unnoticed as the Nimbus host flipped the byte order before using it.

This was found when running Nimbus with third-party EVM, ["evmone"](https://github.com/ethereum/evmone).

There are different ways to remedy this.

If treated as a number, Nimbus EVM would byte-flip the value when calling EVMC, then Nimbus host would flip the received value.  Finally, it would be flipped a third time when generating the address in `generateSafeAddress`.  The first two flips can be eliminated by negotiation (like other numbers), but there would always be one flip.

As a bit pattern, Nimbus EVM would flip the same way it does when dealing with hashes on the stack (e.g. with `getBlockHash`).  Nimbus host wouldn't flip at all - and when using third-party EVMs there would be no flips in Nimbus.

Because this value is not for arithmetic, any bit pattern is valid, and there shouldn't be any flips when using a third-party EVM, the bit-pattern interpretation is favoured.  The only flip is done in Nimbus EVM (and might be eliminated in an optimised version).

We'll use `Hash256` because Nimbus uses this for "opaque 256 bits" and handles byte-endian conversions on this type, even though salt isn't a hash.