### PR TITLE
Add initial implementation of overlay protocol

### DIFF
--- a/fluffy/network/overlay/messages.nim
+++ b/fluffy/network/overlay/messages.nim
@@ -1,0 +1,138 @@
+# Nimbus - Portal Network- Message types
+# Copyright (c) 2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# As per spec:
+# https://github.com/ethereum/stateless-ethereum-specs/blob/master/state-network.md#wire-protocol
+
+{.push raises: [Defect].}
+
+import
+  options,
+  stint, stew/[results, objects],
+  eth/ssz/ssz_serialization
+
+export ssz_serialization, stint
+
+type
+  ByteList* = List[byte, 2048]
+
+  MessageKind* = enum
+    unused = 0x00
+
+    ping = 0x01
+    pong = 0x02
+    findnode = 0x03
+    nodes = 0x04
+
+  PingMessage* = object
+    enrSeq*: uint64
+    subProtocolId*: ByteList
+    subProtocolPayload*: ByteList
+
+  PongMessage* = object
+    enrSeq*: uint64
+    subProtocolId*: ByteList
+    subProtocolPayload*: ByteList
+
+  FindNodeMessage* = object
+    subProtocolId*: ByteList
+    distances*: List[uint16, 256]
+
+  NodesMessage* = object
+    subProtocolId*: ByteList
+    total*: uint8
+    enrs*: List[ByteList, 32] # ByteList here is the rlp encoded ENR. This could
+    # also be limited to 300 bytes instead of 2048
+
+  Message* = object
+    case kind*: MessageKind
+    of ping:
+      ping*: PingMessage
+    of pong:
+      pong*: PongMessage
+    of findnode:
+      findNode*: FindNodeMessage
+    of nodes:
+      nodes*: NodesMessage
+    else:
+      discard
+
+  OverlayMessage* =
+    PingMessage or PongMessage or
+    FindNodeMessage or NodesMessage
+
+template messageKind*(T: typedesc[OverlayMessage]): MessageKind =
+  when T is PingMessage: ping
+  elif T is PongMessage: pong
+  elif T is FindNodeMessage: findNode
+  elif T is NodesMessage: nodes
+
+template toSszType*(x: UInt256): array[32, byte] =
+  toBytesLE(x)
+
+template toSszType*(x: auto): auto =
+  x
+
+func fromSszBytes*(T: type UInt256, data: openArray[byte]):
+    T {.raises: [MalformedSszError, Defect].} =
+  if data.len != sizeof(result):
+    raiseIncorrectSize T
+
+  T.fromBytesLE(data)
+
+proc encodeMessage*[T: OverlayMessage](m: T): seq[byte] =
+  ord(messageKind(T)).byte & SSZ.encode(m)
+
+proc decodeMessage*(body: openarray[byte]): Result[Message, cstring] =
+  # Decodes to the specific `Message` type.
+  if body.len < 1:
+    return err("No message data")
+
+  var kind: MessageKind
+  if not checkedEnumAssign(kind, body[0]):
+    return err("Invalid message type")
+
+  var message = Message(kind: kind)
+
+  try:
+    case kind
+    of unused: return err("Invalid message type")
+    of ping:
+      message.ping = SSZ.decode(body.toOpenArray(1, body.high), PingMessage)
+    of pong:
+      message.pong = SSZ.decode(body.toOpenArray(1, body.high), PongMessage)
+    of findNode:
+      message.findNode = SSZ.decode(body.toOpenArray(1, body.high), FindNodeMessage)
+    of nodes:
+      message.nodes = SSZ.decode(body.toOpenArray(1, body.high), NodesMessage)
+  except SszError:
+    return err("Invalid message encoding")
+
+  ok(message)
+
+template innerMessage[T: OverlayMessage](message: Message, expected: MessageKind): Option[T] =
+  if (message.kind == expected):
+    some[T](message.expected)
+  else:
+    none[T]()
+
+# All our Message variants coresponds to enum MessageKind, therefore we are able to
+# zoom in on inner structure of message by defining expected type T.
+# If expected variant is not active, retrun None
+proc getInnnerMessage*[T: OverlayMessage](m: Message): Option[T] =
+  innerMessage[T](m, messageKind(T))
+
+# Simple conversion from Option to Result, looks like somethif which coul live in
+# Result library.
+proc optToResult*[T, E](opt: Option[T], e: E): Result[T, E] =
+  if (opt.isSome()):
+    ok(opt.unsafeGet())
+  else:
+    err(e)
+
+proc getInnerMessageResult*[T: OverlayMessage](m: Message, errMessage: cstring): Result[T, cstring] =
+  optToResult(getInnnerMessage[T](m), errMessage)

--- a/fluffy/network/overlay/overlay_protocol.nim
+++ b/fluffy/network/overlay/overlay_protocol.nim
@@ -1,0 +1,446 @@
+# Nimbus - Portal Network
+# Copyright (c) 2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+import
+  std/[sequtils, sets, algorithm, tables],
+  stew/[results, byteutils], chronicles, chronos,
+  eth/rlp, eth/p2p/discoveryv5/[protocol, node, enr, routing_table, random2],
+  ./messages
+
+export messages
+
+logScope:
+  topics = "overlay"
+
+const
+  OverlayProtocolId* = "overlay".toBytes()
+  Alpha = 3 ## Kademlia concurrency factor
+  LookupRequestLimit = 3 ## Amount of distances requested in a single Findnode
+  ## message for a lookup or query
+  RefreshInterval = 5.minutes ## Interval of launching a random query to
+  ## refresh the routing table.
+  RevalidateMax = 10000 ## Revalidation of a peer is done between 0 and this
+  ## value in milliseconds
+  InitialLookups = 1 ## Amount of lookups done when populating the routing table
+
+type
+  ByteList* = List[byte, 2048]
+
+  SubProtocolPayload* = ByteList
+
+  SubProtocolId* = seq[byte]
+
+  SubProtocolDefinition* = object
+    subProtocolId*: SubProtocolId
+    subProtocolPayLoad*: SubProtocolPayload
+
+  SubProtocol* = ref object
+    subProtocolId: SubProtocolId
+    subProtocolPayLoad: SubProtocolPayload
+    routingTable: RoutingTable
+    baseProtocol*: protocol.Protocol
+    lastLookup: chronos.Moment
+    refreshLoop: Future[void]
+    revalidateLoop: Future[void]
+
+  OverlayProtocol* = ref object of TalkProtocol
+    baseProtocol*: protocol.Protocol
+    subProtocols: Table[SubProtocolId, SubProtocol]
+
+  SubProtocolResult*[T] = Result[T, cstring]
+
+# TODO:
+# - setJustSeen and replaceNode on (all) message replies
+# - On incoming portal ping of unknown node: add node to routing table by
+# grabbing ENR from discv5 routing table (might not have it)?
+# - ENRs with portal protocol capabilities as field?
+
+proc subProtocolIdAsList(p: SubProtocol): ByteList = List.init(p.subProtocolId, 2048)
+
+proc handlePing(p: SubProtocol, ping: PingMessage):
+    seq[byte] =
+  let p = PongMessage(
+    enrSeq: p.baseProtocol.localNode.record.seqNum, 
+    subProtocolId: p.subProtocolIdAsList(), 
+    subProtocolPayLoad: p.subProtocolPayLoad)
+
+  encodeMessage(p)
+
+proc handleFindNode(p: SubProtocol, fn: FindNodeMessage): seq[byte] =
+  if fn.distances.len == 0:
+    let enrs = List[ByteList, 32](@[])
+    encodeMessage(NodesMessage(subProtocolId: p.subProtocolIdAsList(), total: 1, enrs: enrs))
+  elif fn.distances.contains(0):
+    # A request for our own record.
+    let enr = ByteList(rlp.encode(p.baseProtocol.localNode.record))
+    encodeMessage(NodesMessage(subProtocolId: p.subProtocolIdAsList(), total: 1, enrs: List[ByteList, 32](@[enr])))
+  else:
+    let distances = fn.distances.asSeq()
+    if distances.all(proc (x: uint16): bool = return x <= 256):
+      let
+        nodes = p.routingTable.neighboursAtDistances(distances, seenOnly = true)
+        enrs = nodes.map(proc(x: Node): ByteList = ByteList(x.record.raw))
+
+      # TODO: Fixed here to total message of 1 for now, as else we would need to
+      # either move the send of the talkresp messages here, or allow for
+      # returning multiple messages.
+      # On the long run, it might just be better to use a stream in these cases?
+      encodeMessage(
+        NodesMessage(subProtocolId: p.subProtocolIdAsList(), total: 1, enrs: List[ByteList, 32](List(enrs))))
+    else:
+      # invalid request, send empty back
+      let enrs = List[ByteList, 32](@[])
+      encodeMessage(NodesMessage(subProtocolId: p.subProtocolIdAsList(), total: 1, enrs: enrs))
+
+proc new*(T: type SubProtocol, baseProtocol: protocol.Protocol, subProtocolId: SubProtocolId, subProtocolPayLoad: SubProtocolPayload): T =
+  let proto = SubProtocol(
+      subProtocolId: subProtocolId,
+      subProtocolPayLoad: subProtocolPayLoad,
+      baseProtocol: baseProtocol
+    )
+
+  proto.routingTable.init(baseProtocol.localNode, DefaultBitsPerHop,
+    DefaultTableIpLimits, baseProtocol.rng)
+
+  return proto
+
+proc reqResponse[Request: OverlayMessage, Response: OverlayMessage](
+      p: SubProtocol,
+      toNode: Node,
+      protocol: seq[byte],
+      request: Request
+    ): Future[SubProtocolResult[Response]] {.async.} = 
+    let respResult = await talkreq(p.baseProtocol, toNode, protocol, encodeMessage(request))
+    return respResult
+      .flatMap(proc (x: seq[byte]): Result[Message, cstring] = decodeMessage(x))
+      .flatMap(proc (m: Message): Result[Response, cstring] = 
+        getInnerMessageResult[Response](m, cstring"Invalid message response received")
+      )
+
+proc ping*(p: SubProtocol, dst: Node):
+    Future[SubProtocolResult[PongMessage]] {.async.} =
+  let ping = PingMessage(
+    enrSeq: p.baseProtocol.localNode.record.seqNum,
+    subProtocolid: p.subProtocolIdAsList(),
+    subProtocolPayload: p.subProtocolPayLoad)
+
+  trace "Send message request", dstId = dst.id, kind = MessageKind.ping
+  return await reqResponse[PingMessage, PongMessage](p, dst, OverlayProtocolId, ping)
+
+proc findNode*(p: SubProtocol, dst: Node, distances: List[uint16, 256]):
+    Future[SubProtocolResult[NodesMessage]] {.async.} =
+  let fn = FindNodeMessage(subProtocolid: p.subProtocolIdAsList(), distances: distances)
+
+  trace "Send message request", dstId = dst.id, kind = MessageKind.findnode
+  # TODO Add nodes validation
+  return await reqResponse[FindNodeMessage, NodesMessage](p, dst, OverlayProtocolId, fn)
+
+proc recordsFromBytes(rawRecords: List[ByteList, 32]): seq[Record] =
+  var records: seq[Record]
+  for r in rawRecords.asSeq():
+    var record: Record
+    if record.fromBytes(r.asSeq()):
+      records.add(record)
+
+  records
+
+proc lookupDistances(target, dest: NodeId): seq[uint16] =
+  var distances: seq[uint16]
+  let td = logDist(target, dest)
+  distances.add(td)
+  var i = 1'u16
+  while distances.len < LookupRequestLimit:
+    if td + i < 256:
+      distances.add(td + i)
+    if td - i > 0'u16:
+      distances.add(td - i)
+    inc i
+
+proc lookupWorker(p: SubProtocol, destNode: Node, target: NodeId):
+    Future[seq[Node]] {.async.} =
+  var nodes: seq[Node]
+  let distances = lookupDistances(target, destNode.id)
+
+  let nodesMessage = await p.findNode(destNode,  List[uint16, 256](distances))
+  if nodesMessage.isOk():
+    let records = recordsFromBytes(nodesMessage.get().enrs)
+    let verifiedNodes = verifyNodesRecords(records, destNode, @[0'u16])
+    nodes.add(verifiedNodes)
+
+    # Attempt to add all nodes discovered
+    for n in nodes:
+      discard p.routingTable.addNode(n)
+
+  return nodes
+
+proc lookup*(p: SubProtocol, target: NodeId): Future[seq[Node]] {.async.} =
+  ## Perform a lookup for the given target, return the closest n nodes to the
+  ## target. Maximum value for n is `BUCKET_SIZE`.
+  # `closestNodes` holds the k closest nodes to target found, sorted by distance
+  # Unvalidated nodes are used for requests as a form of validation.
+  var closestNodes = p.routingTable.neighbours(target, BUCKET_SIZE,
+    seenOnly = false)
+
+  var asked, seen = initHashSet[NodeId]()
+  asked.incl(p.baseProtocol.localNode.id) # No need to ask our own node
+  seen.incl(p.baseProtocol.localNode.id) # No need to discover our own node
+  for node in closestNodes:
+    seen.incl(node.id)
+
+  var pendingQueries = newSeqOfCap[Future[seq[Node]]](Alpha)
+
+  while true:
+    var i = 0
+    # Doing `alpha` amount of requests at once as long as closer non queried
+    # nodes are discovered.
+    while i < closestNodes.len and pendingQueries.len < Alpha:
+      let n = closestNodes[i]
+      if not asked.containsOrIncl(n.id):
+        pendingQueries.add(p.lookupWorker(n, target))
+      inc i
+
+    trace "Pending lookup queries", total = pendingQueries.len
+
+    if pendingQueries.len == 0:
+      break
+
+    let query = await one(pendingQueries)
+    trace "Got lookup query response"
+
+    let index = pendingQueries.find(query)
+    if index != -1:
+      pendingQueries.del(index)
+    else:
+      error "Resulting query should have been in the pending queries"
+
+    let nodes = query.read
+    # TODO: Remove node on timed-out query?
+    for n in nodes:
+      if not seen.containsOrIncl(n.id):
+        # If it wasn't seen before, insert node while remaining sorted
+        closestNodes.insert(n, closestNodes.lowerBound(n,
+          proc(x: Node, n: Node): int =
+            cmp(distanceTo(x, target), distanceTo(n, target))
+        ))
+
+        if closestNodes.len > BUCKET_SIZE:
+          closestNodes.del(closestNodes.high())
+
+  p.lastLookup = now(chronos.Moment)
+  return closestNodes
+
+proc query*(p: SubProtocol, target: NodeId, k = BUCKET_SIZE): Future[seq[Node]]
+    {.async.} =
+  ## Query k nodes for the given target, returns all nodes found, including the
+  ## nodes queried.
+  ##
+  ## This will take k nodes from the routing table closest to target and
+  ## query them for nodes closest to target. If there are less than k nodes in
+  ## the routing table, nodes returned by the first queries will be used.
+  var queryBuffer = p.routingTable.neighbours(target, k, seenOnly = false)
+
+  var asked, seen = initHashSet[NodeId]()
+  asked.incl(p.baseProtocol.localNode.id) # No need to ask our own node
+  seen.incl(p.baseProtocol.localNode.id) # No need to discover our own node
+  for node in queryBuffer:
+    seen.incl(node.id)
+
+  var pendingQueries = newSeqOfCap[Future[seq[Node]]](Alpha)
+
+  while true:
+    var i = 0
+    while i < min(queryBuffer.len, k) and pendingQueries.len < Alpha:
+      let n = queryBuffer[i]
+      if not asked.containsOrIncl(n.id):
+        pendingQueries.add(p.lookupWorker(n, target))
+      inc i
+
+    trace "Pending lookup queries", total = pendingQueries.len
+
+    if pendingQueries.len == 0:
+      break
+
+    let query = await one(pendingQueries)
+    trace "Got lookup query response"
+
+    let index = pendingQueries.find(query)
+    if index != -1:
+      pendingQueries.del(index)
+    else:
+      error "Resulting query should have been in the pending queries"
+
+    let nodes = query.read
+    # TODO: Remove node on timed-out query?
+    for n in nodes:
+      if not seen.containsOrIncl(n.id):
+        queryBuffer.add(n)
+
+  p.lastLookup = now(chronos.Moment)
+  return queryBuffer
+
+proc queryRandom*(p: SubProtocol): Future[seq[Node]] =
+  ## Perform a query for a random target, return all nodes discovered.
+  p.query(NodeId.random(p.baseProtocol.rng[]))
+
+proc seedTable(p: SubProtocol) =
+  # TODO: Just picking something here for now. Maybe nodes should have info in
+  # enrs which sub protocols they support
+  let closestNodes = p.baseProtocol.neighbours(
+    NodeId.random(p.baseProtocol.rng[]), seenOnly = true)
+
+  for node in closestNodes:
+    if p.routingTable.addNode(node) == Added:
+      debug "Added node from discv5 routing table", uri = toURI(node.record)
+    else:
+      debug "Node from discv5 routing table could not be added", uri = toURI(node.record)
+
+proc populateTable(p: SubProtocol) {.async.} =
+  ## Do a set of initial lookups to quickly populate the table.
+  # start with a self target query (neighbour nodes)
+  let selfQuery = await p.query(p.baseProtocol.localNode.id)
+  trace "Discovered nodes in self target query", nodes = selfQuery.len
+
+  for i in 0..<InitialLookups:
+    let randomQuery = await p.queryRandom()
+    trace "Discovered nodes in random target query", nodes = randomQuery.len
+
+  debug "Total nodes in routing table after populate",
+    total = p.routingTable.len()
+
+proc revalidateNode*(p: SubProtocol, n: Node) {.async.} =
+  let pong = await p.ping(n)
+
+  if pong.isOK():
+    let res = pong.get()
+    if res.enrSeq > n.record.seqNum:
+      # Request new ENR
+      let nodes = await p.findNode(n, List[uint16, 256](@[0'u16]))
+      if nodes.isOk():
+        let records = recordsFromBytes(nodes.get().enrs)
+        let verifiedNodes = verifyNodesRecords(records, n, @[0'u16])
+        if verifiedNodes.len > 0:
+          discard p.routingTable.addNode(verifiedNodes[0])
+
+proc revalidateLoop(p: SubProtocol) {.async.} =
+  ## Loop which revalidates the nodes in the routing table by sending the ping
+  ## message.
+  try:
+    while true:
+      await sleepAsync(milliseconds(p.baseProtocol.rng[].rand(RevalidateMax)))
+      let n = p.routingTable.nodeToRevalidate()
+      if not n.isNil:
+        asyncSpawn p.revalidateNode(n)
+  except CancelledError:
+    trace "revalidateLoop canceled"
+
+proc refreshLoop(p: SubProtocol) {.async.} =
+  ## Loop that refreshes the routing table by starting a random query in case
+  ## no queries were done since `refreshInterval` or more.
+  ## It also refreshes the majority address voted for via pong responses.
+  try:
+    await p.populateTable()
+
+    while true:
+      let currentTime = now(chronos.Moment)
+      if currentTime > (p.lastLookup + RefreshInterval):
+        let randomQuery = await p.queryRandom()
+        trace "Discovered nodes in random target query", nodes = randomQuery.len
+        debug "Total nodes in routing table", total = p.routingTable.len()
+
+      await sleepAsync(RefreshInterval)
+  except CancelledError:
+    trace "refreshLoop canceled"
+
+proc start*(p: SubProtocol) =
+  p.seedTable()
+
+  p.refreshLoop = refreshLoop(p)
+  p.revalidateLoop = revalidateLoop(p)
+
+proc stop*(p: SubProtocol) =
+  if not p.revalidateLoop.isNil:
+    p.revalidateLoop.cancel()
+  if not p.refreshLoop.isNil:
+    p.refreshLoop.cancel()
+
+# Definition of OverlayProtocol
+
+proc handleMessage(subProtocol: SubProtocol, m: OverlayMessage): seq[byte] =
+  when m is PingMessage:
+    subProtocol.handlePing(m)
+  elif m is FindNodeMessage:
+    subProtocol.handleFindNode(m)
+  else:
+    @[]
+
+proc handleIfKnown(
+  p: OverlayProtocol,
+  message: OverlayMessage,
+  subProtocolId: SubProtocolId
+  ): seq[byte] =
+  let subProtocol = p.subProtocols.getOrDefault(subProtocolId)
+  if subProtocol.isNil():
+    @[]
+  else:
+    handleMessage(subProtocol, message)
+    
+proc messageHandler*(protocol: TalkProtocol, request: seq[byte]): seq[byte] =
+  doAssert(protocol of OverlayProtocol)
+
+  let p = OverlayProtocol(protocol)
+
+  let decoded = decodeMessage(request)
+  if decoded.isOk():
+    let message = decoded.get()
+    trace "Received message response", kind = message.kind
+    case message.kind
+    of MessageKind.ping:
+      let subProtocolId = message.ping.subProtocolId.asSeq()
+      handleIfKnown(p, message.ping, subProtocolId)
+    of MessageKind.findnode:
+      let subProtocolId = message.findnode.subProtocolId.asSeq()
+      handleIfKnown(p, message.findnode, subProtocolId)
+    else:
+      @[]
+  else:
+    @[]
+
+proc new*(T: type OverlayProtocol, baseProtocol: protocol.Protocol, supportedProtocols: seq[SubProtocolDefinition]): T =
+  let proto = OverlayProtocol(
+      protocolHandler: messageHandler,
+      baseProtocol: baseProtocol
+    )
+
+  for subProtocol in supportedProtocols:
+    let newSub = SubProtocol.new(baseProtocol, subProtocol.subProtocolId, subProtocol.subProtocolPayLoad)
+    proto.subProtocols[subProtocol.subProtocolId] = newSub
+
+  proto.baseProtocol.registerTalkProtocol(OverlayProtocolId, proto).expect(
+    "Only one protocol should have this id")
+
+  return proto
+
+proc start*(p: OverlayProtocol) =
+  for subProtocol in p.subProtocols.values:
+    subProtocol.start()
+
+proc stop*(p: OverlayProtocol) =
+  for subProtocol in p.subProtocols.values:
+    subProtocol.stop()
+
+proc getSubProtocol*(p: OverlayProtocol, id: SubProtocolId): Option[SubProtocol] =
+  let subProt = p.subProtocols.getOrDefault(id)
+  if subProt.isNil():
+    none[SubProtocol]()
+  else:
+    some(subProt)
+
+## **Note:** Use it only when you are **absolutely sure** the subprotocol is present
+proc unsafeGetSubProtocol*(p: OverlayProtocol, id: SubProtocolId): SubProtocol =
+  getSubProtocol(p, id).unsafeGet()

--- a/fluffy/tests/all_fluffy_tests.nim
+++ b/fluffy/tests/all_fluffy_tests.nim
@@ -12,7 +12,8 @@ import ../../test_macro
 import
   ./test_portal_encoding,
   ./test_portal,
-  ./test_content_network
+  ./test_content_network,
+  ./test_overlay
 
 cliBuilder:
   import

--- a/fluffy/tests/test_content_network.nim
+++ b/fluffy/tests/test_content_network.nim
@@ -9,6 +9,7 @@ import
   std/os,
   testutils/unittests,
   eth/[keys, trie/db, trie/hexary, ssz/ssz_serialization],
+  eth/p2p/discoveryv5/protocol as discv5_protocol,
   ../../nimbus/[genesis, chain_config, db/db_chain],
   ../network/portal_protocol, ../content,
   ./test_helpers
@@ -73,3 +74,6 @@ procSuite "Content Network":
 
       let hash = hexary.keccak(foundContent.get().payload.asSeq())
       check hash.data == key
+    
+    await node1.closeWait()
+    await node2.closeWait()

--- a/fluffy/tests/test_overlay.nim
+++ b/fluffy/tests/test_overlay.nim
@@ -1,0 +1,113 @@
+# Nimbus - Portal Network
+# Copyright (c) 2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  chronos, testutils/unittests, stew/shims/net,
+  eth/keys, eth/p2p/discoveryv5/routing_table,
+  eth/p2p/discoveryv5/protocol as discv5_protocol,
+  ../network/overlay/overlay_protocol,
+  ./test_helpers
+
+proc random(T: type UInt256, rng: var BrHmacDrbgContext): T =
+  var key: UInt256
+  brHmacDrbgGenerate(addr rng, addr key, csize_t(sizeof(key)))
+
+  key
+
+procSuite "Overlay Tests":
+  let rng = newRng()
+
+  asyncTest "Overlay Ping/Pong compatible protocols":
+    let
+      node1 = initDiscoveryNode(
+        rng, PrivateKey.random(rng[]), localAddress(20302))
+      node2 = initDiscoveryNode(
+        rng, PrivateKey.random(rng[]), localAddress(20303))
+
+      node1Payload = List.init(@[1'u8], 2048)
+      node2Payload = List.init(@[2'u8], 2048)
+
+      # Both nodes support same protocol with different payloads
+      node1Sub = SubProtocolDefinition(subProtocolId: @[1'u8], subProtocolPayLoad: node1Payload)
+      node2Sub = SubProtocolDefinition(subProtocolId: @[1'u8], subProtocolPayLoad: node2Payload)
+
+      proto1 = OverlayProtocol.new(node1 , @[node1Sub])
+      proto2 = OverlayProtocol.new(node2 , @[node2Sub])
+
+    let pong = await proto1.getSubProtocol(@[1'u8]).unsafeGet().ping(proto2.baseProtocol.localNode)
+
+    check:
+      pong.isOk()
+      pong.get().enrSeq == 1'u64
+      pong.get().subProtocolPayload == node2Payload
+
+    await node1.closeWait()
+    await node2.closeWait()
+
+  asyncTest "Overlay FindNode/Nodes":
+    let
+      node1 = initDiscoveryNode(
+        rng, PrivateKey.random(rng[]), localAddress(20302))
+      node2 = initDiscoveryNode(
+        rng, PrivateKey.random(rng[]), localAddress(20303))
+
+      node1Payload = List.init(@[1'u8], 2048)
+      node2Payload = List.init(@[2'u8], 2048)
+
+      supportedProto = @[1'u8]
+
+      # Both nodes support same protocol with different payloads
+      node1Sub = SubProtocolDefinition(subProtocolId: supportedProto, subProtocolPayLoad: node1Payload)
+      node2Sub = SubProtocolDefinition(subProtocolId: supportedProto, subProtocolPayLoad: node2Payload)
+
+      proto1 = OverlayProtocol.new(node1 , @[node1Sub])
+      proto2 = OverlayProtocol.new(node2 , @[node2Sub])
+
+    block: # Find itself
+      let nodes = await proto1.unsafeGetSubProtocol(supportedProto).findNode(proto2.baseProtocol.localNode,
+        List[uint16, 256](@[0'u16]))
+
+      check:
+        nodes.isOk()
+        nodes.get().total == 1'u8
+        nodes.get().enrs.len() == 1
+
+    block: # Find nothing: this should result in nothing as we haven't started
+      # the seeding of the portal protocol routing table yet.
+      let nodes = await proto1.unsafeGetSubProtocol(supportedProto).findNode(proto2.baseProtocol.localNode,
+        List[uint16, 256](@[]))
+
+      check:
+        nodes.isOk()
+        nodes.get().total == 1'u8
+        nodes.get().enrs.len() == 0
+
+    block: # Find for distance
+      # ping in one direction to add, ping in the other to update as seen,
+      # adding the node in the discovery v5 routing table. Could also launch
+      # with bootstrap node instead.
+      check (await node1.ping(node2.localNode)).isOk()
+      check (await node2.ping(node1.localNode)).isOk()
+
+      # Start the portal protocol to seed nodes from the discoveryv5 routing
+      # table.
+      proto2.start()
+
+      let distance = logDist(node1.localNode.id, node2.localNode.id)
+      let nodes = await proto1.unsafeGetSubProtocol(supportedProto).findNode(proto2.baseProtocol.localNode,
+        List[uint16, 256](@[distance]))
+
+      check:
+        nodes.isOk()
+        nodes.get().total == 1'u8
+        nodes.get().enrs.len() == 1
+
+    proto2.stop()
+    await node1.closeWait()
+    await node2.closeWait()


### PR DESCRIPTION
There is proposal to introduce one protocol called `overlay` which will unify handling of routing table in some of the fluffy networks - https://notes.ethereum.org/tPzmxQD_S3S3uvtpUSA0-g.

This pr adds initial implementation which we will be able to discuss further.