### PR TITLE
EVMC: Use same host interface for nested calls as top-level, drop the second copy

### DIFF
--- a/nimbus/transaction/evmc_host_glue.nim
+++ b/nimbus/transaction/evmc_host_glue.nim
@@ -108,6 +108,7 @@ proc evmcExecComputation*(host: TransactionHost): EvmcResult {.inline.} =
     return
 
   let hostContext = cast[evmc_host_context](host)
+  host.hostInterface = hostInterface.unsafeAddr
 
   # Without `{.gcsafe.}:` here, the call via `vm.execute` results in a Nim
   # compile-time error in a far away function.  Starting here, a cascade of

--- a/nimbus/transaction/host_types.nim
+++ b/nimbus/transaction/host_types.nim
@@ -63,6 +63,8 @@ type
     touchedAccounts*: HashSet[EthAddress]
     selfDestructs*:   HashSet[EthAddress]
     depth*:           int
+    saveComputation*: seq[Computation]
+    hostInterface*:   ptr evmc_host_interface
 
 # These versions of `toEvmc` and `fromEvmc` don't flip big/little-endian like
 # the older functions in `evmc_helpers`.  New code only flips with _explicit_


### PR DESCRIPTION
Prior to this patch, top-level EVM executions and nested EVM executions did their `getStorage` and other requests using a completely different set of host functions.  It was just unfinished, to get top-level "new" EVMC working.

This finishes the job - it stops using the old methods.  Effect:

- Functionality added at the EVMC host level will be used by all EVM calls.
  (The target here is Beam Sync).

- The old set of functions are no longer used, so they can be removed.

- When EVMC host call tracing is enabled (`showTxCalls = true`), it traces the calls from nested EVM executions as well as top-level.