### PR TITLE
code cleanup removed unused imports

### DIFF
--- a/nimbus/conf_utils.nim
+++ b/nimbus/conf_utils.nim
@@ -8,10 +8,8 @@
 # those terms.
 
 import
-  std/[terminal, os],
-  chronicles, eth/trie/db, eth/[common, rlp], stew/[io2, byteutils],
-  ./config, ./genesis, ./p2p/chain,
-  ./db/[db_chain, select_backend, storage_types]
+  chronicles, eth/[common, rlp], stew/io2,
+  ./p2p/chain, ./db/[db_chain, select_backend]
 
 type
   # trick the rlp decoder

--- a/nimbus/genesis.nim
+++ b/nimbus/genesis.nim
@@ -1,5 +1,5 @@
 import
-  std/[json, strutils, times, tables],
+  std/[json, times, tables],
   eth/[common, rlp, trie, p2p], stew/[byteutils],
   chronicles, eth/trie/db,
   ./db/[db_chain, state_db],

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -18,7 +18,7 @@ import
   eth/p2p/rlpx_protocols/les_protocol,
   ./p2p/blockchain_sync, eth/net/nat, eth/p2p/peer_pool,
   ./sync/protocol_eth65,
-  config, genesis, rpc/[common, p2p, debug, key_storage], p2p/chain,
+  config, genesis, rpc/[common, p2p, debug], p2p/chain,
   eth/trie/db, metrics, metrics/[chronos_httpserver, chronicles_support],
   graphql/ethapi,
   "."/[utils, conf_utils]

--- a/nimbus/rpc/debug.nim
+++ b/nimbus/rpc/debug.nim
@@ -8,7 +8,7 @@
 # those terms.
 
 import
-  strutils, json, options,
+  json, options,
   json_rpc/rpcserver, rpc_utils, eth/common,
   hexstrings, ../tracer, ../vm_types,
   ../db/[db_chain]

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -8,7 +8,7 @@
 # those terms.
 
 import
-  strutils, times, options, tables,
+  times, options, tables,
   json_rpc/rpcserver, hexstrings, stint, stew/byteutils,
   eth/[common, keys, rlp, p2p], nimcrypto,
   ../transaction, ../config, ../vm_state, ../constants,

--- a/nimbus/rpc/rpc_utils.nim
+++ b/nimbus/rpc/rpc_utils.nim
@@ -9,11 +9,9 @@
 
 import hexstrings, eth/[common, rlp, keys, trie/db], stew/byteutils, nimcrypto,
   ../db/db_chain, strutils, algorithm, options, times, json,
-  ../constants, stint, hexstrings, rpc_types, ../chain_config,
+  ../constants, stint, hexstrings, rpc_types,
   ../utils, ../transaction,
   ../transaction/call_evm
-
-import eth/common/transaction as common_transaction
 
 func toAddress*(value: EthAddressStr): EthAddress = hexToPaddedByteArray[20](value.string)
 

--- a/nimbus/sync/protocol_eth65.nim
+++ b/nimbus/sync/protocol_eth65.nim
@@ -13,8 +13,7 @@
 import
   chronos, stint, chronicles, stew/byteutils, macros,
   eth/[common/eth_types, rlp, p2p],
-  eth/p2p/[rlpx, private/p2p_types, blockchain_utils],
-  ../p2p/chain
+  eth/p2p/[rlpx, private/p2p_types, blockchain_utils]
 
 type
   NewBlockHashesAnnounce* = object

--- a/nimbus/transaction/call_common.nim
+++ b/nimbus/transaction/call_common.nim
@@ -10,8 +10,8 @@ import
   eth/common/eth_types, stint, options, stew/ranges/ptr_arith,
   ".."/[vm_types, vm_state, vm_computation, vm_state_transactions],
   ".."/[vm_internals, vm_precompiles, vm_gas_costs],
-  ".."/[db/accounts_cache, utils, forks],
-  ./host_types, ./host_services
+  ".."/[db/accounts_cache, forks],
+  ./host_types
 
 type
   # Standard call parameters.

--- a/nimbus/transaction/host_services.nim
+++ b/nimbus/transaction/host_services.nim
@@ -11,7 +11,7 @@
 import
   sets, times, stint, chronicles,
   eth/common/eth_types, ../db/accounts_cache, ../forks,
-  ".."/[vm_types, vm_state, vm_computation, vm_internals],
+  ".."/[vm_state, vm_computation, vm_internals],
   ./host_types, ./host_trace, ./host_call_nested
 
 proc setupTxContext(host: TransactionHost) =

--- a/nimbus/vm/interpreter_dispatch.nim
+++ b/nimbus/vm/interpreter_dispatch.nim
@@ -9,8 +9,7 @@ import
   tables, macros,
   chronicles,
   ./interpreter/[opcode_values, opcodes_impl, gas_costs, gas_meter, utils/macros_gen_opcodes],
-  ./code_stream, ./types, ../errors, ../forks, ./precompiles, ./stack,
-  terminal # Those are only needed for logging
+  ./code_stream, ./types, ../errors, ../forks, ./precompiles, ./stack
 
 logScope:
   topics = "vm opcode"

--- a/nimbus/vm/state_transactions.nim
+++ b/nimbus/vm/state_transactions.nim
@@ -8,7 +8,7 @@
 import
   options, sets,
   eth/common, chronicles, ../db/accounts_cache,
-  ../transaction, ../forks,
+  ../forks,
   ./computation, ./interpreter, ./state, ./types
 
 proc execComputation*(c: Computation) =

--- a/nimbus/vm2/interpreter/gas_costs.nim
+++ b/nimbus/vm2/interpreter/gas_costs.nim
@@ -431,8 +431,7 @@ template gasCosts(fork: Fork, prefix, ResultGasCostsName: untyped) =
 
   # ###################################################################################################
 
-  # TODO - change this `let` into `const` - pending: https://github.com/nim-lang/Nim/issues/8015
-  let `ResultGasCostsName`*{.inject, compileTime.}: GasCosts = block:
+  const `ResultGasCostsName`*{.inject, compileTime.}: GasCosts = block:
     # We use a block expression to avoid name redefinition conflicts
     # with "fixed" and "dynamic"
 


### PR DESCRIPTION
I removed unused imports to remove the warning when compiling and changed the 'let' to a 'const' as mentioned in the PR [here](https://github.com/status-im/nimbus-eth1/blob/87b54b33219de6555770ba9b3492038d5a411081/nimbus/vm2/interpreter/gas_costs.nim#L435)