### PR TITLE
Fix format of content message

### DIFF
--- a/fluffy/network/state/messages.nim
+++ b/fluffy/network/state/messages.nim
@@ -48,10 +48,7 @@ type
     # also be limited to 300 bytes instead of 2048
 
   FindContentMessage* = object
-    contentKey*: ContentKey
-  # TODO: According to the specification, this is actually a ByteList from the
-  # serialized ContentKey container, which will result in a different
-  # serialization
+    contentKey*: ByteList
 
   FoundContentMessage* = object
     enrs*: List[ByteList, 32]

--- a/fluffy/network/state/portal_protocol.nim
+++ b/fluffy/network/state/portal_protocol.nim
@@ -176,9 +176,12 @@ proc findNode*(p: PortalProtocol, dst: Node, distances: List[uint16, 256]):
   # TODO Add nodes validation
   return await reqResponse[FindNodeMessage, NodesMessage](p, dst, PortalProtocolId, fn)
 
+# TODO It maybe better to accept bytelist, to not tie network layer to particular
+# content
 proc findContent*(p: PortalProtocol, dst: Node, contentKey: ContentKey):
     Future[PortalResult[FoundContentMessage]] {.async.} =
-  let fc = FindContentMessage(contentKey: contentKey)
+  let encKey = encodeKeyAsList(contentKey)
+  let fc = FindContentMessage(contentKey: encKey)
 
   trace "Send message request", dstId = dst.id, kind = MessageKind.findcontent
   return await reqResponse[FindContentMessage, FoundContentMessage](p, dst, PortalProtocolId, fc)

--- a/fluffy/tests/test_portal_encoding.nim
+++ b/fluffy/tests/test_portal_encoding.nim
@@ -113,18 +113,21 @@ suite "Portal Protocol Message Encodings":
         networkId: 0'u16,
         contentType: ContentType.Account,
         nodeHash: nodeHash)
-      fn = FindContentMessage(contentKey: contentKey)
+
+      contentEncoded: ByteList = encodeKeyAsList(contentKey)
+      
+      fn = FindContentMessage(contentKey: contentEncoded)
 
     let encoded = encodeMessage(fn)
-    check encoded.toHex == "050000010000000000000000000000000000000000000000000000000000000000000000"
+    check encoded.toHex == "05040000000000010000000000000000000000000000000000000000000000000000000000000000"
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()
-
+    
     let message = decoded.get()
     check:
       message.kind == findcontent
-      message.findcontent.contentKey == contentKey
+      message.findcontent.contentKey == contentEncoded
 
   test "FoundContent Response - payload":
     let


### PR DESCRIPTION
According to state network specs (and chain history spec) the find content message should have format
```
Container(content_key: byte_list)
```
This encoding has advantage of not tying network messages to particual content key structure.