### PR TITLE
remove unused calcGasLimit code

### DIFF
--- a/nimbus/constants.nim
+++ b/nimbus/constants.nim
@@ -19,17 +19,7 @@ const
   # ZERO_HASH256 is the parent hash of genesis blocks.
   ZERO_HASH256* =                           Hash256()
 
-  GAS_LIMIT_EMA_DENOMINATOR* =              1_024
   GAS_LIMIT_ADJUSTMENT_FACTOR* =            1_024
-  GAS_LIMIT_USAGE_ADJUSTMENT_NUMERATOR* =   3
-  GAS_LIMIT_USAGE_ADJUSTMENT_DENOMINATOR* = 2
-
-  DIFFICULTY_ADJUSTMENT_DENOMINATOR* =      2_048.u256
-  DIFFICULTY_MINIMUM* =                     131_072.u256
-  BYZANTIUM_DIFFICULTY_ADJUSTMENT_CUTOFF* = 9
-
-  BOMB_EXPONENTIAL_PERIOD* =                100_000.u256
-  BOMB_EXPONENTIAL_FREE_PERIODS* =          2.u256
 
   BLOCK_REWARD* =                           5.u256 * 2.u256 # denoms.ether
 

--- a/nimbus/utils/header.nim
+++ b/nimbus/utils/header.nim
@@ -19,44 +19,6 @@ proc hasUncles*(header: BlockHeader): bool = header.ommersHash != EMPTY_UNCLE_HA
 proc `$`*(header: BlockHeader): string =
   result = &"BlockHeader(timestamp: {header.timestamp} difficulty: {header.difficulty} blockNumber: {header.blockNumber} gasLimit: {header.gasLimit})"
 
-proc computeGasLimit*(parent: BlockHeader, gasLimitFloor: GasInt): GasInt =
-  #[
-    For each block:
-    - decrease by 1/1024th of the gas limit from the previous block
-    - increase by 50% of the total gas used by the previous block
-    If the value is less than the given `gas_limit_floor`:
-    - increase the gas limit by 1/1024th of the gas limit from the previous block.
-    If the value is less than the GAS_LIMIT_MINIMUM:
-    - use the GAS_LIMIT_MINIMUM as the new gas limit.
-  ]#
-  if gasLimitFloor < GAS_LIMIT_MINIMUM:
-      raise newException(ValueError,
-          &"""
-          The `gasLimitFloor` value must be greater than the GAS_LIMIT_MINIMUM.
-          Got {gasLimitFloor}. Must be greater than {GAS_LIMIT_MINIMUM}
-          """
-      )
-
-  let decay = parent.gasLimit div GAS_LIMIT_EMA_DENOMINATOR
-  var usageIncrease: GasInt
-
-  if parent.gasUsed > 0:
-      usageIncrease = (
-          parent.gas_used * GAS_LIMIT_USAGE_ADJUSTMENT_NUMERATOR
-      ) div GAS_LIMIT_USAGE_ADJUSTMENT_DENOMINATOR div GAS_LIMIT_EMA_DENOMINATOR
-
-  let gasLimit = max(
-      GAS_LIMIT_MINIMUM,
-      parent.gasLimit - decay + usageIncrease
-  )
-
-  if gasLimit < GAS_LIMIT_MINIMUM:
-    return GAS_LIMIT_MINIMUM
-  elif gasLimit < gasLimitFloor:
-    return parent.gasLimit + decay
-  else:
-    return gasLimit
-
 # CalcGasLimit computes the gas limit of the next block after parent. It aims
 # to keep the baseline gas above the provided floor, and increase it towards the
 # ceil if the blocks are full. If the ceil is exceeded, it will always decrease
@@ -95,7 +57,7 @@ func computeGasLimit*(parentGasUsed, parentGasLimit, gasFloor, gasCeil: GasInt):
 
 proc generateHeaderFromParentHeader*(config: ChainConfig, parent: BlockHeader,
     coinbase: EthAddress, timestamp: Option[EthTime],
-    gasLimit: Option[GasInt], extraData: Blob, baseFee: Option[Uint256]): BlockHeader =
+    gasLimit: GasInt, extraData: Blob, baseFee: Option[Uint256]): BlockHeader =
 
   var lcTimestamp: EthTime
   if timestamp.isNone:
@@ -110,7 +72,7 @@ proc generateHeaderFromParentHeader*(config: ChainConfig, parent: BlockHeader,
     timestamp: lcTimestamp,
     blockNumber: (parent.blockNumber + 1),
     difficulty: config.calcDifficulty(lcTimestamp, parent),
-    gasLimit: if gasLimit.isSome: gasLimit.get() else: computeGasLimit(parent, gasLimitFloor = GENESIS_GAS_LIMIT),
+    gasLimit: gasLimit,
     stateRoot: parent.stateRoot,
     coinbase: coinbase,
     extraData: extraData,
@@ -119,7 +81,7 @@ proc generateHeaderFromParentHeader*(config: ChainConfig, parent: BlockHeader,
 
 # CalcGasLimit1559 calculates the next block gas limit under 1559 rules.
 func calcGasLimit1559*(parentGasLimit, desiredLimit: GasInt): GasInt =
-  let delta = parentGasLimit div GAS_LIMIT_EMA_DENOMINATOR - 1.GasInt
+  let delta = parentGasLimit div GAS_LIMIT_ADJUSTMENT_FACTOR - 1.GasInt
   var limit = parentGasLimit
   var desiredLimit = desiredLimit
 

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -234,7 +234,7 @@ proc importBlock(tester: var Tester, chainDB: BaseChainDB,
       parentHeader,
       preminedBlock.header.coinbase,
       some(preminedBlock.header.timestamp),
-      some(preminedBlock.header.gasLimit),
+      preminedBlock.header.gasLimit,
       @[],
       preminedBlock.header.fee
   )


### PR DESCRIPTION
we have new calcGasLimit tested in sealing engine.
so we can safely remove the old unused calcGasLimit