### PR TITLE
Generalize network layer for portal

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -13,7 +13,8 @@ import
   json_rpc/rpcproxy,
   eth/keys, eth/net/nat,
   eth/p2p/discoveryv5/protocol as discv5_protocol,
-  ./conf, ./network/state/portal_protocol, ./rpc/eth_api, ./rpc/bridge_client
+  ./conf, ./rpc/eth_api, ./rpc/bridge_client,
+  ./network/state/[portal_network, content]
 
 proc initializeBridgeClient(maybeUri: Option[string]): Option[BridgeClient] =
   try:
@@ -52,7 +53,7 @@ proc run(config: PortalConf) {.raises: [CatchableError, Defect].} =
 
   d.open()
 
-  let portal = PortalProtocol.new(d)
+  let portal = PortalNetwork.new(d, newEmptyInMemoryStorage())
 
   if config.metricsEnabled:
     let

--- a/fluffy/network/state/content.nim
+++ b/fluffy/network/state/content.nim
@@ -101,3 +101,7 @@ proc getContent*(storage: ContentStorage, key: ContentKey): Option[seq[byte]] =
 
 proc getContent*(storage: ContentStorage, contentKey: ByteList): Option[seq[byte]] =
   decodeKey(contentKey).flatMap((key: ContentKey) => getContent(storage, key))
+
+proc newEmptyInMemoryStorage*(): ContentStorage =
+  let trie = initHexaryTrie(newMemoryDb())
+  ContentStorage(trie: trie)

--- a/fluffy/network/state/messages.nim
+++ b/fluffy/network/state/messages.nim
@@ -13,12 +13,13 @@
 import
   options,
   stint, stew/[results, objects],
-  eth/ssz/ssz_serialization,
-  ./content
+  eth/ssz/ssz_serialization
 
-export ssz_serialization, stint, content
+export ssz_serialization, stint
 
 type
+  ByteList* = List[byte, 2048]
+
   MessageKind* = enum
     unused = 0x00
 
@@ -103,6 +104,9 @@ template messageKind*(T: typedesc[SomeMessage]): MessageKind =
 
 template toSszType*(x: UInt256): array[32, byte] =
   toBytesLE(x)
+
+template toSszType*(x: auto): auto =
+  x
 
 func fromSszBytes*(T: type UInt256, data: openArray[byte]):
     T {.raises: [MalformedSszError, Defect].} =

--- a/fluffy/network/state/portal_network.nim
+++ b/fluffy/network/state/portal_network.nim
@@ -11,13 +11,12 @@ type PortalNetwork* = ref object
   portalProtocol*: PortalProtocol
 
 proc getHandler(storage: ContentStorage): ContentHandler =
-  result =
-    proc (contentKey: content.ByteList): ContentResult =
+    return (proc (contentKey: content.ByteList): ContentResult =
       let maybeContent = storage.getContent(contentKey)
       if (maybeContent.isSome()):
         ContentResult(kind: ContentFound, content: maybeContent.unsafeGet())
       else:
-        ContentResult(kind: ContentMissing, contentId: toContentId(contentKey))
+        ContentResult(kind: ContentMissing, contentId: toContentId(contentKey)))
 
 # Further improvements which may be necessary:
 # 1. Return proper domain types instead of bytes

--- a/fluffy/network/state/portal_network.nim
+++ b/fluffy/network/state/portal_network.nim
@@ -1,0 +1,46 @@
+import
+  std/options,
+  stew/results,
+  eth/p2p/discoveryv5/[protocol, node],
+  ./messages, ./content, ./portal_protocol
+
+# TODO expose function in domain specific way i.e operating od state network objects i.e
+# nodes, tries, hashes
+type PortalNetwork* = ref object
+  storage: ContentStorage
+  proto*: PortalProtocol
+
+proc getHandler(storage: ContentStorage): ContentHandler =
+  result =
+    proc (contentKey: ByteList): ContentResult =
+      let maybeContent = storage.getContent(contentKey)
+      if (maybeContent.isSome()):
+        ContentResult(kind: ContentFound, content: maybeContent.unsafeGet())
+      else:
+        ContentResult(kind: ContentMissing, contentId: toContentId(contentKey))
+
+# TODO temporary find content exposing Node, ulimatly this function would use
+# contentLookup, so uper layer would not need to know anything about
+# routing table nodes
+proc findContent*(p:PortalNetwork, key: ContentKey, dst: Node): Future[Option[seq[byte]]] {.async.} = 
+  var maybeContent: Option[seq[byte]] = none[seq[byte]]()
+  let keyAsBytes = encodeKeyAsList(key)
+  let fcResponse = await p.proto.findcontent(dst, keyAsBytes)
+
+  if (fcResponse.isOk()):
+    let message = fcResponse.get()
+    if (len(message.payload) > 0):
+      maybeContent = some(message.payload.asSeq())
+
+  return maybeContent
+
+proc new*(T: type PortalNetwork, baseProtocol: protocol.Protocol, storage: ContentStorage , dataRadius = UInt256.high()): T =
+  let portalProto = PortalProtocol.new(baseProtocol, getHandler(storage), dataRadius)
+  return PortalNetwork(storage: storage, proto: portalProto)
+
+proc start*(p: PortalNetwork) =
+  p.proto.start()
+
+proc stop*(p: PortalNetwork) =
+  p.proto.stop()
+

--- a/fluffy/network/state/portal_network.nim
+++ b/fluffy/network/state/portal_network.nim
@@ -2,7 +2,7 @@ import
   std/options,
   stew/results,
   eth/p2p/discoveryv5/[protocol, node],
-  ./messages, ./content, ./portal_protocol
+  ./content, ./portal_protocol
 
 # TODO expose function in domain specific way i.e operating od state network objects i.e
 # nodes, tries, hashes
@@ -12,7 +12,7 @@ type PortalNetwork* = ref object
 
 proc getHandler(storage: ContentStorage): ContentHandler =
   result =
-    proc (contentKey: ByteList): ContentResult =
+    proc (contentKey: content.ByteList): ContentResult =
       let maybeContent = storage.getContent(contentKey)
       if (maybeContent.isSome()):
         ContentResult(kind: ContentFound, content: maybeContent.unsafeGet())

--- a/fluffy/network/state/portal_protocol.nim
+++ b/fluffy/network/state/portal_protocol.nim
@@ -11,7 +11,7 @@ import
   std/[sequtils, sets, algorithm],
   stew/[results, byteutils], chronicles, chronos,
   eth/rlp, eth/p2p/discoveryv5/[protocol, node, enr, routing_table, random2],
-  ./content, ./messages
+  ./messages
 
 export messages
 
@@ -30,17 +30,32 @@ const
   InitialLookups = 1 ## Amount of lookups done when populating the routing table
 
 type
+  ContentResultKind* = enum
+    ContentFound, ContentMissing, ContentKeyValidationFailure
+
+  ContentResult* = object
+    case kind*: ContentResultKind
+    of ContentFound:
+      content*: seq[byte]
+    of ContentMissing:
+      contentId*: ContentId
+    of ContentKeyValidationFailure:
+      error*: string
+
+  # Treating Result as typed union type. If content is present handler should return
+  # it, if not it should return content id so that closest neighbours can be localized.
+  ContentHandler* = proc (contentKey: ByteList): ContentResult {.raises: [Defect], gcsafe.}
+
   PortalProtocol* = ref object of TalkProtocol
     routingTable: RoutingTable
     baseProtocol*: protocol.Protocol
     dataRadius*: UInt256
-    contentStorage*: ContentStorage
+    handleContentRequest: ContentHandler
     lastLookup: chronos.Moment
     refreshLoop: Future[void]
     revalidateLoop: Future[void]
 
   PortalResult*[T] = Result[T, cstring]
-
 
 proc addNode*(p: PortalProtocol, node: Node): NodeStatus =
   p.routingTable.addNode(node)
@@ -87,17 +102,18 @@ proc handleFindNode(p: PortalProtocol, fn: FindNodeMessage): seq[byte] =
       encodeMessage(NodesMessage(total: 1, enrs: enrs))
 
 proc handleFindContent(p: PortalProtocol, fc: FindContentMessage): seq[byte] =
+  let contentHandlingResult = p.handleContentRequest(fc.contentKey)
   # TODO: Need to check networkId, type, trie path
-  let
-    # TODO: Should we first do a simple check on ContentId versus Radius?
-    contentId = toContentId(fc.contentKey)
-    content = p.contentStorage.getContent(fc.contentKey)
-  if content.isSome():
+  case contentHandlingResult.kind
+  of ContentFound:
+    let content = contentHandlingResult.content
     let enrs = List[ByteList, 32](@[]) # Empty enrs when payload is send
     encodeMessage(FoundContentMessage(
-      enrs: enrs, payload: ByteList(content.get())))
-  else:
+      enrs: enrs, payload: ByteList(content)))
+  of ContentMissing:
     let
+      contentId = contentHandlingResult.contentId
+      # TODO: Should we first do a simple check on ContentId versus Radius?
       closestNodes = p.routingTable.neighbours(
         NodeId(readUintBE[256](contentId.data)), seenOnly = true)
       payload = ByteList(@[]) # Empty payload when enrs are send
@@ -106,6 +122,13 @@ proc handleFindContent(p: PortalProtocol, fc: FindContentMessage): seq[byte] =
 
     encodeMessage(FoundContentMessage(
       enrs: List[ByteList, 32](List(enrs)), payload: payload))
+
+  of ContentKeyValidationFailure:
+    # Retrun empty response when content key validation fail
+    let content = ByteList(@[])
+    let enrs = List[ByteList, 32](@[]) # Empty enrs when payload is send
+    encodeMessage(FoundContentMessage(
+      enrs: enrs, payload: content))
 
 proc handleAdvertise(p: PortalProtocol, a: AdvertiseMessage): seq[byte] =
   # TODO: Not implemented
@@ -139,11 +162,13 @@ proc messageHandler*(protocol: TalkProtocol, request: seq[byte]): seq[byte] =
     @[]
 
 proc new*(T: type PortalProtocol, baseProtocol: protocol.Protocol,
+    contentHandler: ContentHandler,
     dataRadius = UInt256.high()): T =
   let proto = PortalProtocol(
     protocolHandler: messageHandler,
     baseProtocol: baseProtocol,
-    dataRadius: dataRadius)
+    dataRadius: dataRadius,
+    handleContentRequest: contentHandler)
 
   proto.routingTable.init(baseProtocol.localNode, DefaultBitsPerHop,
     DefaultTableIpLimits, baseProtocol.rng)
@@ -191,12 +216,9 @@ proc findNode*(p: PortalProtocol, dst: Node, distances: List[uint16, 256]):
   # TODO Add nodes validation
   return await reqResponse[FindNodeMessage, NodesMessage](p, dst, PortalProtocolId, fn)
 
-# TODO It maybe better to accept bytelist, to not tie network layer to particular
-# content
-proc findContent*(p: PortalProtocol, dst: Node, contentKey: ContentKey):
+proc findContent*(p: PortalProtocol, dst: Node, contentKey: ByteList):
     Future[PortalResult[FoundContentMessage]] {.async.} =
-  let encKey = encodeKeyAsList(contentKey)
-  let fc = FindContentMessage(contentKey: encKey)
+  let fc = FindContentMessage(contentKey: contentKey)
 
   trace "Send message request", dstId = dst.id, kind = MessageKind.findcontent
   return await reqResponse[FindContentMessage, FoundContentMessage](p, dst, PortalProtocolId, fc)

--- a/fluffy/network/state/portal_protocol.nim
+++ b/fluffy/network/state/portal_protocol.nim
@@ -9,7 +9,7 @@
 
 import
   std/[sequtils, sets, algorithm],
-  stew/[results, byteutils], chronicles, chronos,
+  stew/[results, byteutils], chronicles, chronos, nimcrypto/hash,
   eth/rlp, eth/p2p/discoveryv5/[protocol, node, enr, routing_table, random2],
   ./messages
 
@@ -38,7 +38,7 @@ type
     of ContentFound:
       content*: seq[byte]
     of ContentMissing:
-      contentId*: ContentId
+      contentId*: MDigest[32 * 8]
     of ContentKeyValidationFailure:
       error*: string
 

--- a/fluffy/network/state/portal_protocol.nim
+++ b/fluffy/network/state/portal_protocol.nim
@@ -352,7 +352,7 @@ proc handleFoundContentMessage(p: PortalProtocol, m: FoundContentMessage, dst: N
   else:
     return LookupResult(kind: Nodes, nodes: nodes)
 
-proc contentLookupWorker(p: PortalProtocol, destNode: Node, target: ContentKey):
+proc contentLookupWorker(p: PortalProtocol, destNode: Node, target: ByteList):
     Future[LookupResult] {.async.} =
   var nodes: seq[Node]
 
@@ -366,8 +366,7 @@ proc contentLookupWorker(p: PortalProtocol, destNode: Node, target: ContentKey):
 # TODO ContentLookup and Lookup look almost exactly the same, also lookups in other
 # networks will probably be very similar. Extract lookup function to separate module
 # and make it more generaic
-proc contentLookup*(p: PortalProtocol, target: ContentKey): Future[Option[ByteList]] {.async.} =
-  let targetId = contentIdAsUint256(toContentId(target))
+proc contentLookup*(p: PortalProtocol, target: ByteList, targetId: UInt256): Future[Option[ByteList]] {.async.} =
   ## Perform a lookup for the given target, return the closest n nodes to the
   ## target. Maximum value for n is `BUCKET_SIZE`.
   # `closestNodes` holds the k closest nodes to target found, sorted by distance

--- a/fluffy/tests/test_portal.nim
+++ b/fluffy/tests/test_portal.nim
@@ -9,7 +9,7 @@
 
 import
   chronos, testutils/unittests, stew/shims/net,
-  eth/keys, eth/p2p/discoveryv5/routing_table,
+  eth/keys, eth/p2p/discoveryv5/routing_table, nimcrypto/[hash, sha2],
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   ../network/state/portal_protocol,
   ./test_helpers
@@ -26,6 +26,10 @@ type Default2NodeTest = ref object
   proto1: PortalProtocol
   proto2: PortalProtocol
 
+proc testHandler(contentKey: ByteList): ContentResult =
+  let id =  sha256.digest("test")
+  ContentResult(kind: ContentMissing, contentId: id)
+
 proc defaultTestCase(rng: ref BrHmacDrbgContext): Default2NodeTest =
   let
     node1 = initDiscoveryNode(
@@ -33,8 +37,8 @@ proc defaultTestCase(rng: ref BrHmacDrbgContext): Default2NodeTest =
     node2 = initDiscoveryNode(
       rng, PrivateKey.random(rng[]), localAddress(20303))
 
-    proto1 = PortalProtocol.new(node1)
-    proto2 = PortalProtocol.new(node2)
+    proto1 = PortalProtocol.new(node1, testHandler)
+    proto2 = PortalProtocol.new(node2, testHandler)
 
   Default2NodeTest(node1: node1, node2: node2, proto1: proto1, proto2: proto2)
 
@@ -143,11 +147,7 @@ procSuite "Portal Tests":
     # table.
     test.proto2.start()
 
-    var nodeHash: NodeHash
-
-    let contentKey = ContentKey(networkId: 0'u16,
-      contentType: ContentType.Account,
-      nodeHash: nodeHash)
+    let contentKey = List.init(@[1'u8], 2048)
 
     # content does not exist so this should provide us with the closest nodes
     # to the content, which is the only node in the routing table.

--- a/fluffy/tests/test_portal_encoding.nim
+++ b/fluffy/tests/test_portal_encoding.nim
@@ -107,19 +107,13 @@ suite "Portal Protocol Message Encodings":
       message.nodes.enrs[1] == ByteList(e2.raw)
 
   test "FindContent Request":
-    var nodeHash: NodeHash # zeroes hash
     let
-      contentKey = ContentKey(
-        networkId: 0'u16,
-        contentType: ContentType.Account,
-        nodeHash: nodeHash)
-
-      contentEncoded: ByteList = encodeKeyAsList(contentKey)
+      contentEncoded: ByteList = List.init(@[1'u8], 2048)
       
       fn = FindContentMessage(contentKey: contentEncoded)
 
     let encoded = encodeMessage(fn)
-    check encoded.toHex == "05040000000000010000000000000000000000000000000000000000000000000000000000000000"
+    check encoded.toHex == "050400000001"
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()


### PR DESCRIPTION
Makes network layer unaware of content storage, and upper layers of network messages. 

This way we could re-use network layer primitives for other network  as long as they support the same set of messages. (it is probable) 

