### PR TITLE
sealing engine: remove redundant clique epoch and period check

### DIFF
--- a/nimbus/sealer.nim
+++ b/nimbus/sealer.nim
@@ -47,12 +47,6 @@ proc validateSealer*(chain: Chain): Result[void, string] =
   if not chainConf.poaEngine:
     return err("currently only PoA engine is supported")
 
-  if chainConf.cliquePeriod <= 0:
-    return err("clique period should be greater than 0")
-
-  if chainConf.cliqueEpoch <= 0:
-    return err("clique epoch should be greater than 0")
-
   ok()
 
 proc isLondon(c: ChainConfig, number: BlockNumber): bool {.inline.} =


### PR DESCRIPTION
both clique epoch and clique period already checked in
newClique and will use default configuration they are not set.

this redundant check in sealing engine also failed with
some configuration where only one of them is set and the
other one not set.