### PR TITLE
config: remove last instance of getConfiguration usage from nimbus code

### DIFF
--- a/hive_integration/nodocker/consensus/consensus_sim.nim
+++ b/hive_integration/nodocker/consensus/consensus_sim.nim
@@ -27,10 +27,11 @@ proc processNode(genesisFile, chainFile,
     conf = getConfiguration()
     chainDB = newBaseChainDB(newMemoryDb(),
       pruneTrie = false,
-      conf.net.networkId
+      conf.net.networkId,
+      conf.customNetwork
     )
 
-  initializeEmptyDb(chainDB, conf.customNetwork)
+  initializeEmptyDb(chainDB)
   discard importRlpBlock(chainFile, chainDB)
   let head = chainDB.getCanonicalHead()
   let blockHash = "0x" & head.blockHash.data.toHex

--- a/hive_integration/nodocker/graphql/graphql_sim.nim
+++ b/hive_integration/nodocker/graphql/graphql_sim.nim
@@ -79,10 +79,11 @@ proc main() =
     ethNode = setupEthNode(conf, ethCtx, eth)
     chainDB = newBaseChainDB(newMemoryDb(),
       pruneTrie = false,
-      conf.net.networkId
+      conf.net.networkId,
+      conf.customNetwork
     )
 
-  initializeEmptyDb(chainDB, conf.customNetwork)
+  initializeEmptyDb(chainDB)
   discard importRlpBlock(blocksFile, chainDB)
   let ctx = setupGraphqlContext(chainDB, ethNode)
 

--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -166,7 +166,7 @@ proc toFork*(c: ChainConfig, number: BlockNumber): Fork =
   elif number >= c.homesteadBlock: FkHomestead
   else: FkFrontier
 
-proc chainConfig*(id: NetworkId): ChainConfig =
+proc chainConfig*(id: NetworkId, cn: CustomNetwork): ChainConfig =
   # For some public networks, NetworkId and ChainId value are identical
   # but that is not always the case
 
@@ -245,10 +245,9 @@ proc chainConfig*(id: NetworkId): ChainConfig =
       londonBlock:    5_062_605.toBlockNumber # June 30, 2021
     )
   else:
-    # everything else will use CustomNet config
-    let conf = getConfiguration()
-    trace "Custom genesis block configuration loaded", conf=conf.customNetwork.config
-    conf.customNetwork.config
+    # everything else will use CustomNet config    
+    trace "Custom genesis block configuration loaded", conf=cn.config
+    cn.config
 
 proc processList(v: string, o: var seq[string]) =
   ## Process comma-separated list of strings.

--- a/nimbus/db/db_chain.nim
+++ b/nimbus/db/db_chain.nim
@@ -18,6 +18,7 @@ type
     pruneTrie*: bool
     config*   : ChainConfig
     networkId*: NetworkId
+    customNetwork*: CustomNetwork
 
     # startingBlock, currentBlock, and highestBlock
     # are progress indicator
@@ -29,12 +30,18 @@ type
     blockNumber: BlockNumber
     index: int
 
-proc newBaseChainDB*(db: TrieDatabaseRef, pruneTrie: bool = true, id: NetworkId = MainNet): BaseChainDB =
+proc newBaseChainDB*(
+       db: TrieDatabaseRef,
+       pruneTrie: bool = true,
+       id: NetworkId = MainNet,
+       cn = CustomNetwork() ): BaseChainDB =
+
   new(result)
   result.db = db
   result.pruneTrie = pruneTrie
-  result.config = chainConfig(id)
+  result.config = chainConfig(id, cn)
   result.networkId = id
+  result.customNetwork = cn
 
 proc `$`*(db: BaseChainDB): string =
   result = "BaseChainDB"

--- a/nimbus/genesis.nim
+++ b/nimbus/genesis.nim
@@ -89,7 +89,7 @@ proc commit*(g: Genesis, db: BaseChainDB) =
   doAssert(b.blockNumber == 0, "can't commit genesis block with number > 0")
   discard db.persistHeaderToDb(b)
 
-proc initializeEmptyDb*(db: BaseChainDB, cn: CustomNetwork) =
+proc initializeEmptyDb*(db: BaseChainDB) =
   trace "Writing genesis to DB"
-  let genesis = genesisBlockForNetwork(db.networkId, cn)
+  let genesis = genesisBlockForNetwork(db.networkId, db.customNetwork)
   genesis.commit(db)

--- a/premix/persist.nim
+++ b/premix/persist.nim
@@ -47,7 +47,7 @@ proc main() {.used.} =
 
   if canonicalHeadHashKey().toOpenArray notin trieDB:
     persistToDb(db):
-      initializeEmptyDb(chainDB, CustomNetwork())
+      initializeEmptyDb(chainDB)
     doAssert(canonicalHeadHashKey().toOpenArray in trieDB)
 
   var head = chainDB.getCanonicalHead()

--- a/tests/test_clique/pool.nim
+++ b/tests/test_clique/pool.nim
@@ -244,7 +244,7 @@ proc newVoterPool*(networkId = GoerliNet): TesterPool =
   TesterPool(
     boot: CustomNetwork(
       genesis: genesisBlockForNetwork(networkId, CustomNetwork()),
-      config:  chainConfig(networkId))).initTesterPool
+      config:  chainConfig(networkId, CustomNetwork()))).initTesterPool
 
 # ------------------------------------------------------------------------------
 # Public: getter

--- a/tests/test_difficulty.nim
+++ b/tests/test_difficulty.nim
@@ -1,7 +1,8 @@
 import unittest2, strutils, tables, os, json,
   ../nimbus/utils/difficulty, stint, times,
   eth/common, test_helpers, stew/byteutils,
-  ../nimbus/constants, ../nimbus/config
+  ../nimbus/constants, ../nimbus/config,
+  ../nimbus/chain_config
 
 type
   Tester = object
@@ -60,11 +61,11 @@ template runTests(name: string, hex: bool, calculator: typed) =
       check diff == t.currentDifficulty
 
 proc difficultyMain*() =
-  let mainnetConfig = chainConfig(MainNet)
+  let mainnetConfig = chainConfig(MainNet, CustomNetwork())
   func calcDifficultyMainNetWork(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
     mainnetConfig.calcDifficulty(timeStamp, parent)
 
-  let ropstenConfig = chainConfig(RopstenNet)
+  let ropstenConfig = chainConfig(RopstenNet, CustomNetwork())
   func calcDifficultyRopsten(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
     ropstenConfig.calcDifficulty(timeStamp, parent)
 

--- a/tests/test_forkid.nim
+++ b/tests/test_forkid.nim
@@ -89,7 +89,6 @@ template runTest(network: untyped) =
       chainDB = newBaseChainDB(memDB, true, network)
       chain = newChain(chainDB)
 
-    chain.setForkId()
     for x in `network IDs`:
       let id = chain.getForkId(x.blockNumber.toBlockNumber)
       check id.crc == x.id.crc


### PR DESCRIPTION
this is a preparation for migration to confutils based config
although there is still some getConfiguration usage in tests code
it will be removed after new config arrived