### PR TITLE
Disable the custom distance functions for Portal Protocol

### DIFF
--- a/fluffy/network/state/portal_protocol.nim
+++ b/fluffy/network/state/portal_protocol.nim
@@ -11,7 +11,7 @@ import
   std/[sequtils, sets, algorithm],
   stew/[results, byteutils], chronicles, chronos, nimcrypto/hash,
   eth/rlp, eth/p2p/discoveryv5/[protocol, node, enr, routing_table, random2, nodes_verification],
-  ./messages, ./custom_distance
+  ./messages
 
 export messages
 
@@ -180,7 +180,7 @@ proc new*(T: type PortalProtocol, baseProtocol: protocol.Protocol,
     dataRadius = UInt256.high()): T =
   let proto = PortalProtocol(
     routingTable: RoutingTable.init(baseProtocol.localNode, DefaultBitsPerHop,
-      DefaultTableIpLimits, baseProtocol.rng, customDistanceCalculator),
+      DefaultTableIpLimits, baseProtocol.rng),
     protocolHandler: messageHandler,
     baseProtocol: baseProtocol,
     dataRadius: dataRadius,


### PR DESCRIPTION
The Portal Network tests fail with the custom functions, on one part due to the fact that the portal tests still uses the xor functions (https://github.com/status-im/nimbus-eth1/blob/master/fluffy/tests/test_portal.nim#L122), but also because the `neighboursAtDistances` call appears to filter them out (https://github.com/status-im/nim-eth/blob/master/eth/p2p/discoveryv5/routing_table.nim#L469).

The reverse calculation might be off. To be looked into, disable for now.

The fluffy CI did not fail on these failed tests. I think it has to do with how we run some tests with and some without that cliBuilder macro. Might want to disable that completely as I suggested before.

Failure was introduced here fyi: https://github.com/status-im/nimbus-eth1/pull/831