### PR TITLE
Disable mixed usage of cliBuilder to fix incorrect test failure reporting

### DIFF
--- a/fluffy/tests/all_fluffy_tests.nim
+++ b/fluffy/tests/all_fluffy_tests.nim
@@ -5,8 +5,6 @@
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../../test_macro
-
 {. warning[UnusedImport]:off .}
 
 import
@@ -14,8 +12,5 @@ import
   ./test_portal,
   ./test_content_network,
   ./test_discovery_rpc,
-  ./test_custom_distance
-
-cliBuilder:
-  import
-    ./test_bridge_parser
+  ./test_custom_distance,
+  ./test_bridge_parser

--- a/fluffy/tests/test_custom_distance.nim
+++ b/fluffy/tests/test_custom_distance.nim
@@ -8,10 +8,9 @@
 {.used.}
 
 import
-  std/[unittest, sequtils],
-  stint,
+  std/sequtils,
+  stint, unittest2,
   ../network/state/custom_distance
-
 
 suite "State network custom distance function":
   test "Calculate distance according to spec":
@@ -56,4 +55,3 @@ suite "State network custom distance function":
 
     check:
       logDistances == logCalculated
-

--- a/fluffy/tests/test_portal_encoding.nim
+++ b/fluffy/tests/test_portal_encoding.nim
@@ -8,8 +8,7 @@
 {.used.}
 
 import
-  std/unittest,
-  stint, stew/[byteutils, results], eth/p2p/discoveryv5/enr,
+  unittest2, stint, stew/[byteutils, results], eth/p2p/discoveryv5/enr,
   ../network/state/messages
 
 suite "Portal Protocol Message Encodings":


### PR DESCRIPTION
Some of the tests are build under `cliBuilder:` and some are not. This results in incorrect exit status. 

We have to either run all under cliBuilder or none, opted for none for now as I am not sure this functionality is being used (I don't use it) and it increases compile time (I have not assessed how much).

Resolves https://github.com/status-im/nimbus-eth1/issues/835