### PR TITLE
evm: fixes EIP2929 opcodes

### DIFF
--- a/nimbus/vm/interpreter/gas_costs.nim
+++ b/nimbus/vm/interpreter/gas_costs.nim
@@ -724,6 +724,12 @@ func istanbulGasFees(previousFees: GasFeeSchedule): GasFeeSchedule =
 func berlinGasFees(previousFees: GasFeeSchedule): GasFeeSchedule =
   # https://eips.ethereum.org/EIPS/eip-2929
   result = previousFees
+
+  # these opcodes gas are calculated inside opcode
+  result[GasBalance]     = 0
+  result[GasExtCodeHash] = 0
+  result[GasExtCode]     = 0
+
   # SLOAD gasCost become fully dynamic, see sloadEIP2929
   result[GasSLoad]        = 0
   result[GasCall]         = WarmStorageReadCost

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -1018,20 +1018,20 @@ op extCodeHash, inline = true:
 op balanceEIP2929, inline = true:
   ## 0x31, Get balance of the given account.
   let address = c.stack.popAddress()
-  c.gasMeter.consumeGas(c.accessGas(address) - gasFees[c.fork][GasBalance],
+  c.gasMeter.consumeGas(c.accessGas(address),
                         reason = "balanceEIP2929")
   push: c.getBalance(address)
 
 op extCodeHashEIP2929, inline = true:
   let address = c.stack.popAddress()
-  c.gasMeter.consumeGas(c.accessGas(address) - gasFees[c.fork][GasExtCodeHash],
+  c.gasMeter.consumeGas(c.accessGas(address),
                         reason = "extCodeHashEIP2929")
   push: c.getCodeHash(address)
 
 op extCodeSizeEIP2929, inline = true:
   ## 0x3b, Get size of an account's code
   let address = c.stack.popAddress()
-  c.gasMeter.consumeGas(c.accessGas(address) - gasFees[c.fork][GasExtCode],
+  c.gasMeter.consumeGas(c.accessGas(address),
                         reason = "extCodeSizeEIP2929")
   push: c.getCodeSize(address)
 
@@ -1045,7 +1045,7 @@ op extCodeCopyEIP2929, inline = true:
     c.gasCosts[ExtCodeCopy].m_handler(c.memory.len, memPos, len),
     reason="ExtCodeCopy fee")
 
-  c.gasMeter.consumeGas(c.accessGas(address) - gasFees[c.fork][GasExtCode],
+  c.gasMeter.consumeGas(c.accessGas(address),
                         reason = "extCodeCopyEIP2929")
 
   let codeBytes = c.getCode(address)

--- a/nimbus/vm2/interpreter/gas_costs.nim
+++ b/nimbus/vm2/interpreter/gas_costs.nim
@@ -693,6 +693,12 @@ func istanbulGasFees(previousFees: GasFeeSchedule): GasFeeSchedule =
 func berlinGasFees(previousFees: GasFeeSchedule): GasFeeSchedule =
   # https://eips.ethereum.org/EIPS/eip-2929
   result = previousFees
+
+  # these opcodes gas are calculated inside opcode
+  result[GasBalance]     = 0
+  result[GasExtCodeHash] = 0
+  result[GasExtCode]     = 0
+
   # SLOAD gasCost become fully dynamic, see sloadEIP2929
   result[GasSLoad]        = 0
   result[GasCall]         = WarmStorageReadCost

--- a/nimbus/vm2/interpreter/op_handlers/oph_envinfo.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_envinfo.nim
@@ -75,8 +75,7 @@ const
     ## 0x31, EIP292: Get balance of the given account for Berlin and later
     let address = k.cpt.stack.popAddress()
 
-    k.cpt.gasEip2929AccountCheck(
-      address, gasFees[k.cpt.fork][GasBalance])
+    k.cpt.gasEip2929AccountCheck(address)
     k.cpt.stack.push:
       k.cpt.getBalance(address)
 
@@ -177,8 +176,7 @@ const
     ## 0x3b, Get size of an account's code
     let address = k.cpt.stack.popAddress()
 
-    k.cpt.gasEip2929AccountCheck(
-      address, gasFees[k.cpt.fork][GasExtCode])
+    k.cpt.gasEip2929AccountCheck(address)
     k.cpt.stack.push:
       k.cpt.getCodeSize(address)
 
@@ -211,8 +209,7 @@ const
       k.cpt.gasCosts[ExtCodeCopy].m_handler(k.cpt.memory.len, memPos, len),
       reason = "ExtCodeCopy fee")
 
-    k.cpt.gasEip2929AccountCheck(
-      address, gasFees[k.cpt.fork][GasExtCode])
+    k.cpt.gasEip2929AccountCheck(address)
 
     let codeBytes = k.cpt.getCode(address)
     k.cpt.memory.writePaddedResult(codeBytes, memPos, codePos, len)
@@ -258,8 +255,7 @@ const
     ## 0x3f, EIP2929: Returns the keccak256 hash of a contract’s code
     let address = k.cpt.stack.popAddress()
 
-    k.cpt.gasEip2929AccountCheck(
-      address, gasFees[k.cpt.fork][GasExtCodeHash])
+    k.cpt.gasEip2929AccountCheck(address)
 
     k.cpt.stack.push:
       k.cpt.getCodeHash(address)

--- a/nimbus/vm2/interpreter/op_handlers/oph_helpers.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_helpers.nim
@@ -28,8 +28,7 @@ import
 # Public
 # ------------------------------------------------------------------------------
 
-proc gasEip2929AccountCheck*(c: Computation;
-                             address: EthAddress, prevCost = 0.GasInt) =
+proc gasEip2929AccountCheck*(c: Computation; address: EthAddress) =
   c.vmState.mutateStateDB:
     let gasCost = if not db.inAccessList(address):
                     db.accessList(address)
@@ -38,7 +37,7 @@ proc gasEip2929AccountCheck*(c: Computation;
                     WarmStorageReadCost
 
     c.gasMeter.consumeGas(
-      gasCost - prevCost,
+      gasCost,
       reason = "gasEIP2929AccountCheck")
 
 

--- a/tests/test_op_custom.nim
+++ b/tests/test_op_custom.nim
@@ -187,6 +187,15 @@ proc opCustomMain*() =
         Balance
       stack: "0x000000000000000000000000000000000000000000000000cff56a1b273a8000"
 
+    assembler: # EIP2929 BALANCE OP
+      title: "EIP2929 BALANCE_1"
+      code:
+        Address
+        Balance
+      stack: "0x000000000000000000000000000000000000000000000000cff56a1b273a8000"
+      fork: berlin
+      gasused: 2602
+
     assembler: # ORIGIN OP
       title: "ORIGIN_1"
       code:
@@ -302,3 +311,6 @@ proc opCustomMain*() =
       code: "0x60012F6002"
       stack: "0x0000000000000000000000000000000000000000000000000000000000000001"
       success: false
+
+when isMainModule:
+  opCustomMain()

--- a/tests/test_op_env.nim
+++ b/tests/test_op_env.nim
@@ -307,3 +307,27 @@ proc opEnvMain*() =
         "0x6014525451606001601e5254516080016028525460a052546016604860003960"
         "0x166000f26000603f556103e75660005460005360200235"
       stack: "0x94"
+
+    assembler: # EIP2929 EXTCODESIZE OP
+      title: "EIP2929 EXTCODESIZE_1"
+      code:
+        Push20 "0xfbe0afcd7658ba86be41922059dd879c192d4c73"
+        ExtCodeSize
+        STOP
+      stack: "0x94"
+      fork: berlin
+      gasused: 2603
+
+    assembler: # EIP2929 EXTCODEHASH OP
+      title: "EIP2929 EXTCODEHASH_1"
+      code:
+        Push20 "0xfbe0afcd7658ba86be41922059dd879c192d4c73"
+        ExtCodeHash
+        STOP
+      stack:
+        "0xc862129bffb73168481c6a51fd36afb8342887fbc5314c763ac731c732d7310c"
+      fork: berlin
+      gasused: 2603
+
+when isMainModule:
+  opEnvMain()


### PR DESCRIPTION
op balanceEIP2929, extCodeHashEIP2929, extCodeSizeEIP2929, and
extCodeCopyEIP2929 are fixed due to their wrong gasConsume
position