### PR TITLE
Add a basic content db for portal networks

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -8,6 +8,7 @@
 {.push raises: [Defect].}
 
 import
+  std/os,
   uri, confutils, confutils/std/net, chronicles,
   eth/keys, eth/net/nat, eth/p2p/discoveryv5/[enr, node],
   json_rpc/rpcproxy
@@ -59,6 +60,11 @@ type
       desc: "P2P node private key as hex",
       defaultValue: PrivateKey.random(keys.newRng()[])
       name: "nodekey" .}: PrivateKey
+
+    dataDir* {.
+      desc: "The directory where fluffy will store the content data"
+      defaultValue: config.defaultDataDir()
+      name: "data-dir" }: OutDir
 
     # Note: This will add bootstrap nodes for each enabled Portal network.
     # No distinction is being made on bootstrap nodes for a specific network.
@@ -164,3 +170,13 @@ proc parseCmdArg*(T: type ClientConfig, p: TaintedString): T
 
 proc completeCmdArg*(T: type ClientConfig, val: TaintedString): seq[string] =
   return @[]
+
+proc defaultDataDir*(config: PortalConf): string =
+  let dataDir = when defined(windows):
+    "AppData" / "Roaming" / "Fluffy"
+  elif defined(macosx):
+    "Library" / "Application Support" / "Fluffy"
+  else:
+    ".cache" / "fluffy"
+
+  getHomeDir() / dataDir

--- a/fluffy/content_db.nim
+++ b/fluffy/content_db.nim
@@ -14,6 +14,8 @@ import
   stint,
   ./network/state/state_content
 
+export kvstore_sqlite3
+
 # This version of content db is the most basic, simple solution where data is
 # stored no matter what content type or content network in the same kvstore with
 # the content id as key. The content id is derived from the content key, and the
@@ -45,10 +47,6 @@ proc new*(T: type ContentDB, path: string, inMemory = false): ContentDB =
       SqStoreRef.init(path, "fluffy").expectDb()
 
   ContentDB(kv: kvStore db.openKvStore().expectDb())
-
-proc huh(path: string) =
-  let db = SqStoreRef.init(path, "fluffy").expectDb()
-  discard ContentDB(kv: kvStore db.openKvStore().expectDb())
 
 proc get*(db: ContentDB, key: openArray[byte]): Option[seq[byte]] =
   var res: Option[seq[byte]]

--- a/fluffy/content_db.nim
+++ b/fluffy/content_db.nim
@@ -46,6 +46,10 @@ proc new*(T: type ContentDB, path: string, inMemory = false): ContentDB =
 
   ContentDB(kv: kvStore db.openKvStore().expectDb())
 
+proc huh(path: string) =
+  let db = SqStoreRef.init(path, "fluffy").expectDb()
+  discard ContentDB(kv: kvStore db.openKvStore().expectDb())
+
 proc get*(db: ContentDB, key: openArray[byte]): Option[seq[byte]] =
   var res: Option[seq[byte]]
   proc onData(data: openArray[byte]) = res = some(@data)

--- a/fluffy/content_db.nim
+++ b/fluffy/content_db.nim
@@ -1,0 +1,76 @@
+# Nimbus
+# Copyright (c) 2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+import
+  std/options,
+  eth/db/kvstore,
+  eth/db/kvstore_sqlite3,
+  stint,
+  ./network/state/state_content
+
+type
+  ContentDB* = ref object
+    kv: KvStoreRef
+
+template expectDb(x: auto): untyped =
+  # There's no meaningful error handling implemented for a corrupt database or
+  # full disk - this requires manual intervention, so we'll panic for now
+  x.expect("working database (disk broken/full?)")
+
+proc new*(T: type ContentDB, path: string, inMemory = false): ContentDB =
+  let db =
+    if inMemory:
+      SqStoreRef.init("", "fluffy-test", inMemory = true).expect(
+        "working database (out of memory?)")
+    else:
+      SqStoreRef.init(path, "fluffy").expectDb()
+
+  ContentDB(kv: kvStore db.openKvStore().expectDb())
+
+proc get*(db: ContentDB, key: openArray[byte]): Option[seq[byte]] =
+  var res: Option[seq[byte]]
+  proc onData(data: openArray[byte]) = res = some(@data)
+
+  discard db.kv.get(key, onData).expectDb()
+
+  return res
+
+proc put*(db: ContentDB, key, value: openArray[byte]) =
+  db.kv.put(key, value).expectDb()
+
+proc contains*(db: ContentDB, key: openArray[byte]): bool =
+  db.kv.contains(key).expectDb()
+
+proc del*(db: ContentDB, key: openArray[byte]) =
+  db.kv.del(key).expectDb()
+
+# Note: For now the the ContentId is used as key to store the data.
+# Perhaps in future different kvstores will be used for the different types of
+# network and specific content key info could be used to access the data.
+
+# TODO: Could also decide to use the ContentKey SSZ bytestring, as this is what
+# gets send over the network in requests, but that would be a bigger key. Or the
+# same hashing could be done on it here.
+# However ContentId itself is already derived through different digests
+# depending on the content type, and this ContentId typically needs to be
+# checked with the Radius/distance of the node anyhow. So lets see how we end up
+# using this mostly in the code.
+
+proc get*(db: ContentDB, key: ContentId): Option[seq[byte]] =
+  # TODO: Here it is unfortunate that ContentId is a uint256 instead of Digest256.
+  db.get(key.toByteArrayBE())
+
+proc put*(db: ContentDB, key: ContentId, value: openArray[byte]) =
+  db.put(key.toByteArrayBE(), value)
+
+proc contains*(db: ContentDB, key: ContentId): bool =
+  db.contains(key.toByteArrayBE())
+
+proc del*(db: ContentDB, key: ContentId) =
+  db.del(key.toByteArrayBE())

--- a/fluffy/content_db.nim
+++ b/fluffy/content_db.nim
@@ -14,6 +14,19 @@ import
   stint,
   ./network/state/state_content
 
+# This version of content db is the most basic, simple solution where data is
+# stored no matter what content type or content network in the same kvstore with
+# the content id as key. The content id is derived from the content key, and the
+# deriviation is different depending on the content type. As we use content id,
+# this part is currently out of the scope / API of the ContentDB.
+# In the future it is likely that that either:
+# 1. More kvstores are added per network, and thus depending on the network a
+# different kvstore needs to be selected.
+# 2. Or more kvstores are added per network and per content type, and thus
+# content key fields are required to access the data.
+# 3. Or databases are created per network (and kvstores pre content type) and
+# thus depending on the network the right db needs to be selected.
+
 type
   ContentDB* = ref object
     kv: KvStoreRef
@@ -49,10 +62,6 @@ proc contains*(db: ContentDB, key: openArray[byte]): bool =
 
 proc del*(db: ContentDB, key: openArray[byte]) =
   db.kv.del(key).expectDb()
-
-# Note: For now the the ContentId is used as key to store the data.
-# Perhaps in future different kvstores will be used for the different types of
-# network and specific content key info could be used to access the data.
 
 # TODO: Could also decide to use the ContentKey SSZ bytestring, as this is what
 # gets send over the network in requests, but that would be a bigger key. Or the

--- a/fluffy/tests/all_fluffy_tests.nim
+++ b/fluffy/tests/all_fluffy_tests.nim
@@ -12,5 +12,6 @@ import
   ./test_portal_wire_protocol,
   ./test_custom_distance,
   ./test_state_network,
+  ./test_content_db,
   ./test_discovery_rpc,
   ./test_bridge_parser

--- a/fluffy/tests/test_content_db.nim
+++ b/fluffy/tests/test_content_db.nim
@@ -1,0 +1,45 @@
+# Nimbus
+# Copyright (c) 2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  unittest2, stint,
+  ../network/state/state_content,
+  ../content_db
+
+suite "Content Database":
+  # Note: We are currently not really testing something new here just basic
+  # underlying kvstore.
+  test "ContentDB basic API":
+    let
+      db = ContentDB.new("", inMemory = true)
+      key = ContentId(UInt256.high()) # Some key
+
+    block:
+      let val = db.get(key)
+
+      check:
+        val.isNone()
+        db.contains(key) == false
+
+    block:
+      db.put(key, [byte 0, 1, 2, 3])
+      let val = db.get(key)
+
+      check:
+        val.isSome()
+        val.get() == [byte 0, 1, 2, 3]
+        db.contains(key) == true
+
+    block:
+      db.del(key)
+      let val = db.get(key)
+
+      check:
+        val.isNone()
+        db.contains(key) == false


### PR DESCRIPTION
Simple db for content from portal networks. Resolves https://github.com/status-im/nimbus-eth1/issues/753

Smarter things can be done in the future, see also comments, but that is not a priority for now.