### PR TITLE
ci: clear github actions cache in linux/macos runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: rocks-db-cache-${{ matrix.target.cpu }}
-          key: 'rocksdb-${{ matrix.target.os }}-${{ matrix.target.cpu }}'
+          key: 'rocksdb-v1-${{ matrix.target.os }}-${{ matrix.target.cpu }}'
 
       - name: Build and install rocksdb (Linux i386)
         # no librocksdb-dev:i386


### PR DESCRIPTION
it seemed that github actions macOs image have changed
(version changed from 20211002.1 to 20211011.2)
which made cached rocksdb not findable.