### PR TITLE
move stateDB from VMState to chainDB

### DIFF
--- a/nimbus/db/accounts_cache.nim
+++ b/nimbus/db/accounts_cache.nim
@@ -263,6 +263,8 @@ proc persistStorage(acc: RefAccount, db: TrieDatabaseRef, clearCache: bool) =
     else:
       accountTrie.del(slotAsKey)
 
+    # TODO: this can be disabled if we do not perform
+    #       accounts tracing
     # map slothash back to slot value
     # see iterator storage below
     # slotHash can be obtained from accountTrie.put?
@@ -440,7 +442,6 @@ proc persist*(ac: var AccountsCache, clearCache: bool = true) =
     of Remove:
       ac.trie.del address
       if not clearCache:
-        #
         cleanAccounts.incl address
     of DoNothing:
       discard

--- a/nimbus/graphql/ethapi.nim
+++ b/nimbus/graphql/ethapi.nim
@@ -118,9 +118,9 @@ proc aclNode(ctx: GraphqlContextRef, accessPair: AccessPair): Node =
     acl: accessPair
   )
 
-proc getAccountDb(chainDB: BaseChainDB, header: BlockHeader): ReadOnlyStateDB =
+proc getStateDB(chainDB: BaseChainDB, header: BlockHeader): ReadOnlyStateDB =
   ## Retrieves the account db from canonical head
-  ## we don't use accounst_cache here because it's only read operations
+  ## we don't use accounst_cache here because it's read only operations
   let ac = newAccountStateDB(chainDB.db, header.stateRoot, chainDB.pruneTrie)
   ReadOnlyStateDB(ac)
 
@@ -309,7 +309,7 @@ proc getTxByHash(ctx: GraphqlContextRef, hash: Hash256): RespResult =
     err("can't get transaction by hash '$1': $2" % [hash.data.toHex, em.msg])
 
 proc accountNode(ctx: GraphqlContextRef, header: BlockHeader, address: EthAddress): RespResult =
-  let db = getAccountDb(ctx.chainDB, header)
+  let db = getStateDB(ctx.chainDB, header)
   when false:
     # EIP 1767 unclear about non existent account
     # but hive test case demand something
@@ -685,7 +685,7 @@ proc txCreatedContract(ud: RootRef, params: Args, parent: Node): RespResult {.ap
   if hres.isErr:
     return hres
   let h = HeaderNode(hres.get())
-  let db = getAccountDb(ctx.chainDB, h.header)
+  let db = getStateDB(ctx.chainDB, h.header)
   let contractAddress = generateAddress(sender, tx.tx.nonce)
   ctx.accountNode(h.header, contractAddress)
 

--- a/nimbus/p2p/chain/chain_desc.nim
+++ b/nimbus/p2p/chain/chain_desc.nim
@@ -42,6 +42,7 @@ type
     db: BaseChainDB
     forkIds: array[ChainFork, ForkID]
     blockZeroHash: KeccakHash
+    lastBlockHash: KeccakHash
 
     extraValidation: bool ##\
       ## Trigger extra validation, currently within `persistBlocks()`
@@ -222,6 +223,10 @@ proc verifyFrom*(c: Chain): auto {.inline.} =
   ## Getter
   c.verifyFrom
 
+proc lastBlockHash*(c: Chain): auto {.inline.} =
+  ## Getter
+  c.lastBlockHash
+
 proc currentBlock*(c: Chain): BlockHeader
   {.gcsafe, raises: [Defect,CatchableError].} =
   ## currentBlock retrieves the current head block of the canonical chain.
@@ -243,6 +248,10 @@ proc `verifyFrom=`*(c: Chain; verifyFrom: uint64) {.inline.} =
   ## validation should start if the `Clique` field `extraValidation` was set
   ## `true`.
   c.verifyFrom = verifyFrom.u256
+
+proc `lastBlockHash=`*(c: Chain; blockHash: KeccakHash) {.inline.} =
+  ## Setter.
+  c.lastBlockHash = blockHash
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/p2p/executor/executor_helpers.nim
+++ b/nimbus/p2p/executor/executor_helpers.nim
@@ -77,7 +77,7 @@ proc makeReceipt*(vmState: BaseVMState; txType: TxType): Receipt
   var rec: Receipt
   if vmState.getFork < FkByzantium:
     rec.isHash = true
-    rec.hash   = vmState.accountDb.rootHash
+    rec.hash   = vmState.stateDB.rootHash
   else:
     rec.isHash = false
     rec.status = vmState.status

--- a/nimbus/p2p/executor/process_block.nim
+++ b/nimbus/p2p/executor/process_block.nim
@@ -88,7 +88,7 @@ proc procBlkEpilogue(vmState: BaseVMState; dbTx: DbTransaction;
       db.collectWitnessData()
     db.persist(ClearCache in vmState.flags)
 
-  let stateDb = vmState.accountDb
+  let stateDb = vmState.stateDB
   if header.stateRoot != stateDb.rootHash:
     debug "wrong state root in block",
       blockNumber = header.blockNumber,

--- a/nimbus/p2p/executor/process_transaction.nim
+++ b/nimbus/p2p/executor/process_transaction.nim
@@ -59,10 +59,10 @@ proc processTransactionImpl(tx: Transaction, sender: EthAddress,
       # miner only receives the priority fee;
       # note that the base fee is not given to anyone (it is burned)
       let txFee = result.u256 * priorityFee.u256
-      vmState.accountDb.addBalance(miner, txFee)
+      vmState.stateDB.addBalance(miner, txFee)
     else:
       let txFee = result.u256 * tx.gasPrice.u256
-      vmState.accountDb.addBalance(miner, txFee)
+      vmState.stateDB.addBalance(miner, txFee)
 
   vmState.cumulativeGasUsed += result
 
@@ -79,8 +79,8 @@ proc processTransactionImpl(tx: Transaction, sender: EthAddress,
           db.deleteAccount(account)
 
   if vmState.generateWitness:
-    vmState.accountDb.collectWitnessData()
-  vmState.accountDb.persist(clearCache = false)
+    vmState.stateDB.collectWitnessData()
+  vmState.stateDB.persist(clearCache = false)
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -51,14 +51,13 @@ proc rpcDoCall*(call: RpcCallData, header: BlockHeader, chain: BaseChainDB): Hex
   # we use current header stateRoot, unlike block validation
   # which use previous block stateRoot
   # TODO: ^ Check it's correct to use current header stateRoot, not parent
-  let vmState    = newBaseVMState(header.stateRoot, header, chain)
+  let vmState    = newBaseVMState(chain.stateDB, header, chain)
   let callResult = rpcRunComputation(vmState, call, call.gas)
   return hexDataStr(callResult.output)
 
 proc rpcMakeCall*(call: RpcCallData, header: BlockHeader, chain: BaseChainDB): (string, GasInt, bool) =
-  # TODO: handle revert
-  let parent     = chain.getBlockHeader(header.parentHash)
-  let vmState    = newBaseVMState(parent.stateRoot, header, chain)
+  # TODO: handle revert  
+  let vmState    = newBaseVMState(chain.stateDB, header, chain)
   let callResult = rpcRunComputation(vmState, call, call.gas)
   return (callResult.output.toHex, callResult.gasUsed, callResult.isError)
 
@@ -87,7 +86,7 @@ proc rpcEstimateGas*(call: RpcCallData, header: BlockHeader, chain: BaseChainDB,
   var
     # we use current header stateRoot, unlike block validation
     # which use previous block stateRoot
-    vmState = newBaseVMState(header.stateRoot, header, chain)
+    vmState = newBaseVMState(chain.stateDB, header, chain)
     fork    = toFork(chain.config, header.blockNumber)
     gasLimit = if haveGasLimit: call.gas else: header.gasLimit - vmState.cumulativeGasUsed
 

--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -211,17 +211,17 @@ proc isSelfDestructed*(c: Computation, address: EthAddress): bool =
   result = address in c.selfDestructs
 
 proc snapshot*(c: Computation) =
-  c.savePoint = c.vmState.accountDb.beginSavePoint()
+  c.savePoint = c.vmState.stateDB.beginSavePoint()
 
 proc commit*(c: Computation) =
-  c.vmState.accountDb.commit(c.savePoint)
+  c.vmState.stateDB.commit(c.savePoint)
 
 proc dispose*(c: Computation) {.inline.} =
-  c.vmState.accountDb.safeDispose(c.savePoint)
+  c.vmState.stateDB.safeDispose(c.savePoint)
   c.savePoint = nil
 
 proc rollback*(c: Computation) =
-  c.vmState.accountDb.rollback(c.savePoint)
+  c.vmState.stateDB.rollback(c.savePoint)
 
 proc setError*(c: Computation, msg: string, burnsGas = false) {.inline.} =
   c.error = Error(info: msg, burnsGas: burnsGas)

--- a/nimbus/vm/evmc_host.nim
+++ b/nimbus/vm/evmc_host.nim
@@ -31,7 +31,7 @@ proc hostAccountExistsImpl(ctx: Computation, address: EthAddress): bool {.cdecl.
     db.accountExists(address)
 
 proc hostGetStorageImpl(ctx: Computation, address: EthAddress, key: var evmc_bytes32): evmc_bytes32 {.cdecl.} =
-  ctx.vmState.accountDB.getStorage(address, Uint256.fromEvmc(key)).toEvmc()
+  ctx.vmState.stateDB.getStorage(address, Uint256.fromEvmc(key)).toEvmc()
 
 proc sstoreNetGasMetering(ctx: Computation): bool {.inline.} =
   ctx.fork in {FkConstantinople, FkIstanbul, FkBerlin, FkLondon}

--- a/nimbus/vm/state.nim
+++ b/nimbus/vm/state.nim
@@ -43,7 +43,7 @@ proc `$`*(vmState: BaseVMState): string =
   else:
     result = &"VMState {vmState.name}:\n  header: {vmState.blockHeader}\n  chaindb:  {vmState.chaindb}"
 
-proc init*(self: BaseVMState, prevStateRoot: Hash256, header: BlockHeader,
+proc init*(self: BaseVMState, ac: AccountsCache, header: BlockHeader,
            chainDB: BaseChainDB, tracerFlags: set[TracerFlags] = {}) =
   self.prevHeaders = @[]
   self.name = "BaseVM"
@@ -51,21 +51,15 @@ proc init*(self: BaseVMState, prevStateRoot: Hash256, header: BlockHeader,
   self.chaindb = chainDB
   self.tracer.initTracer(tracerFlags)
   self.logEntries = @[]
-  self.accountDb = AccountsCache.init(chainDB.db, prevStateRoot, chainDB.pruneTrie)
+  self.stateDB = ac
   self.touchedAccounts = initHashSet[EthAddress]()
   {.gcsafe.}:
     self.minerAddress = self.getMinerAddress()
 
-proc newBaseVMState*(prevStateRoot: Hash256, header: BlockHeader,
+proc newBaseVMState*(ac: AccountsCache, header: BlockHeader,
                      chainDB: BaseChainDB, tracerFlags: set[TracerFlags] = {}): BaseVMState =
   new result
-  result.init(prevStateRoot, header, chainDB, tracerFlags)
-
-proc newBaseVMState*(prevStateRoot: Hash256,
-                     chainDB: BaseChainDB, tracerFlags: set[TracerFlags] = {}): BaseVMState =
-  new result
-  var header: BlockHeader
-  result.init(prevStateRoot, header, chainDB, tracerFlags)
+  result.init(ac, header, chainDB, tracerFlags)
 
 proc setupTxContext*(vmState: BaseVMState, origin: EthAddress, gasPrice: GasInt, forkOverride=none(Fork)) =
   ## this proc will be called each time a new transaction
@@ -94,6 +88,7 @@ proc updateBlockHeader*(vmState: BaseVMState, header: BlockHeader) =
   vmState.logEntries = @[]
   vmState.receipts = @[]
   vmState.minerAddress = vmState.getMinerAddress()
+  vmState.cumulativeGasUsed = 0.GasInt
 
 method blockhash*(vmState: BaseVMState): Hash256 {.base, gcsafe.} =
   vmState.blockHeader.hash
@@ -144,11 +139,11 @@ method getAncestorHash*(vmState: BaseVMState, blockNumber: BlockNumber): Hash256
     result = header.hash
 
 proc readOnlyStateDB*(vmState: BaseVMState): ReadOnlyStateDB {.inline.} =
-  ReadOnlyStateDB(vmState.accountDb)
+  ReadOnlyStateDB(vmState.stateDB)
 
 template mutateStateDB*(vmState: BaseVMState, body: untyped) =
   block:
-    var db {.inject.} = vmState.accountDb
+    var db {.inject.} = vmState.stateDB
     body
 
 proc getTracingResult*(vmState: BaseVMState): JsonNode {.inline.} =
@@ -194,8 +189,8 @@ proc `generateWitness=`*(vmState: BaseVMState, status: bool) =
  else: vmState.flags.excl GenerateWitness
 
 proc buildWitness*(vmState: BaseVMState): seq[byte] =
-  let rootHash = vmState.accountDb.rootHash
-  let mkeys = vmState.accountDb.makeMultiKeys()
+  let rootHash = vmState.stateDB.rootHash
+  let mkeys = vmState.stateDB.makeMultiKeys()
   let flags = if vmState.fork >= FKSpurious: {wfEIP170} else: {}
 
   # build witness from tree

--- a/nimbus/vm/transaction_tracer.nim
+++ b/nimbus/vm/transaction_tracer.nim
@@ -98,7 +98,7 @@ proc traceOpCodeEnded*(tracer: var TransactionTracer, c: Computation, op: Op, la
   if TracerFlags.DisableStorage notin tracer.flags:
     var storage = newJObject()
     if c.msg.depth < tracer.storageKeys.len:
-      var stateDB = c.vmState.accountDb
+      var stateDB = c.vmState.stateDB
       for key in tracer.storage(c.msg.depth):
         let value = stateDB.getStorage(c.msg.contractAddress, key)
         storage[key.dumpHex] = %(value.dumpHex)

--- a/nimbus/vm/types.nim
+++ b/nimbus/vm/types.nim
@@ -40,7 +40,7 @@ type
     tracer*        : TransactionTracer
     logEntries*    : seq[Log]
     receipts*      : seq[Receipt]
-    accountDb*     : AccountsCache
+    stateDB*       : AccountsCache
     cumulativeGasUsed*: GasInt
     touchedAccounts*: HashSet[EthAddress]
     selfDestructs* : HashSet[EthAddress]

--- a/nimbus/vm2/computation.nim
+++ b/nimbus/vm2/computation.nim
@@ -148,17 +148,17 @@ proc isSelfDestructed*(c: Computation, address: EthAddress): bool =
   result = address in c.selfDestructs
 
 proc snapshot*(c: Computation) =
-  c.savePoint = c.vmState.accountDb.beginSavePoint()
+  c.savePoint = c.vmState.stateDB.beginSavePoint()
 
 proc commit*(c: Computation) =
-  c.vmState.accountDb.commit(c.savePoint)
+  c.vmState.stateDB.commit(c.savePoint)
 
 proc dispose*(c: Computation) {.inline.} =
-  c.vmState.accountDb.safeDispose(c.savePoint)
+  c.vmState.stateDB.safeDispose(c.savePoint)
   c.savePoint = nil
 
 proc rollback*(c: Computation) =
-  c.vmState.accountDb.rollback(c.savePoint)
+  c.vmState.stateDB.rollback(c.savePoint)
 
 proc setError*(c: Computation, msg: string, burnsGas = false) {.inline.} =
   c.error = Error(info: msg, burnsGas: burnsGas)

--- a/nimbus/vm2/transaction_tracer.nim
+++ b/nimbus/vm2/transaction_tracer.nim
@@ -98,7 +98,7 @@ proc traceOpCodeEnded*(tracer: var TransactionTracer, c: Computation, op: Op, la
   if TracerFlags.DisableStorage notin tracer.flags:
     var storage = newJObject()
     if c.msg.depth < tracer.storageKeys.len:
-      var stateDB = c.vmState.accountDb
+      var stateDB = c.vmState.stateDB
       for key in tracer.storage(c.msg.depth):
         let value = stateDB.getStorage(c.msg.contractAddress, key)
         storage[key.dumpHex] = %(value.dumpHex)

--- a/nimbus/vm2/types.nim
+++ b/nimbus/vm2/types.nim
@@ -31,7 +31,7 @@ type
     tracer*        : TransactionTracer
     logEntries*    : seq[Log]
     receipts*      : seq[Receipt]
-    accountDb*     : AccountsCache
+    stateDB*       : AccountsCache
     cumulativeGasUsed*: GasInt
     touchedAccounts*: HashSet[EthAddress]
     selfDestructs* : HashSet[EthAddress]

--- a/premix/debug.nim
+++ b/premix/debug.nim
@@ -21,8 +21,10 @@ proc executeBlock(blockEnv: JsonNode, memoryDB: TrieDatabaseRef, blockNumber: Ui
 
   let transaction = memoryDB.beginTransaction()
   defer: transaction.dispose()
+
+  chainDB.initStateDB(parent.stateRoot)
   let
-    vmState = newBaseVMState(parent.stateRoot, header, chainDB)
+    vmState = newBaseVMState(chainDB.stateDB, header, chainDB)
     validationResult = vmState.processBlockNotPoA(header, body)
 
   if validationResult != ValidationResult.OK:

--- a/premix/dumper.nim
+++ b/premix/dumper.nim
@@ -18,13 +18,18 @@ proc dumpDebug(chainDB: BaseChainDB, blockNumber: Uint256) =
 
   let transaction = memoryDB.beginTransaction()
   defer: transaction.dispose()
+
+  
   let
     parentNumber = blockNumber - 1
     parent = captureChainDB.getBlockHeader(parentNumber)
     header = captureChainDB.getBlockHeader(blockNumber)
     headerHash = header.blockHash
     body = captureChainDB.getBlockBody(headerHash)
-    vmState = newBaseVMState(parent.stateRoot, header, captureChainDB)
+        
+  captureChainDB.initStateDB(parent.stateRoot)
+  let
+    vmState = newBaseVMState(captureChainDB.stateDB, header, captureChainDB)
 
   captureChainDB.setHead(parent, true)
   discard vmState.processBlockNotPoA(header, body)

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -213,7 +213,9 @@ proc initDatabase*(networkId = MainNet): (BaseVMState, BaseChainDB) =
       difficulty: db.config.calcDifficulty(timestamp, parent),
       gasLimit: 100_000
     )
-    vmState = newBaseVMState(parent.stateRoot, header, db)
+
+  db.initStateDB(parent.stateRoot)
+  let vmState = newBaseVMState(db.stateDB, header, db)
 
   (vmState, db)
 
@@ -276,7 +278,7 @@ proc runVM*(vmState: BaseVMState, chainDB: BaseChainDB, boa: Assembler): bool =
       error "different memory value", idx=i, expected=mem, actual=actual
       return false
 
-  var stateDB = vmState.accountDb
+  var stateDB = vmState.stateDB
   stateDB.persist()
 
   var

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -29,7 +29,7 @@ template doTest(fixture: JsonNode, fork: Fork, address: PrecompileAddresses): un
     let
       expectedErr = test.hasKey("ExpectedError")
       expected = if test.hasKey("Expected"): hexToSeqByte(test["Expected"].getStr) else: @[]
-      dataStr = test["Input"].getStr      
+      dataStr = test["Input"].getStr
       gasExpected = if test.hasKey("Gas"): test["Gas"].getInt else: -1
 
     let unsignedTx = Transaction(
@@ -64,8 +64,11 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
     data  = fixtures["data"]
     privateKey = PrivateKey.fromHex("7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d")[]
     header = BlockHeader(blockNumber: 1.u256)
-    vmState = newBaseVMState(header.stateRoot, header, newBaseChainDB(newMemoryDb()))
-    
+    chainDB = newBaseChainDB(newMemoryDb())
+
+  chainDB.initStateDB(header.stateRoot)
+  let vmState = newBaseVMState(chainDB.stateDB, header, chainDB)
+
   case toLowerAscii(label)
   of "ecrecover": data.doTest(fork, paEcRecover)
   of "sha256"   : data.doTest(fork, paSha256)


### PR DESCRIPTION
previously, every time the VMState was created, it will also create
new stateDB, and this action will nullify the advantages of cached accounts.

the new changes will conserve the accounts cache if the executed blocks
are contiguous. if not the stateDB need to be reinited.

this changes also allow rpcCallEvm and rpcEstimateGas executed properly
using current stateDB instead of creating new one each time they are called.