### PR TITLE
Fix fluffy discovery rpc tests after nim-json-rpc bump

### DIFF
--- a/fluffy/tests/test_discovery_rpc.nim
+++ b/fluffy/tests/test_discovery_rpc.nim
@@ -34,7 +34,7 @@ proc setupTest(rng: ref BrHmacDrbgContext): Future[TestCase] {.async.} =
   rpcHttpServerWithProxy.installDiscoveryApiHandlers(localDiscoveryNode)
 
   await rpcHttpServerWithProxy.start()
-  await client.connect(localSrvAddress, Port(localSrvPort))
+  await client.connect(localSrvAddress, Port(localSrvPort), false)
   return TestCase(localDiscovery: localDiscoveryNode, server: rpcHttpServerWithProxy, client: client)
 
 proc stop(t: TestCase) {.async.} =


### PR DESCRIPTION
Like https://github.com/status-im/nimbus-eth1/pull/895 but for fluffy.

Reason this is no longer spotted in CI is because it failed on the nim-json-rpc bump (as fluffy CI is ran for updates in vendor), but not on the following commit as that is a commit changing files only in nimbus folder (and Fluffy CI does not run in that case).