### PR TITLE
Arrow Glacier fork

### DIFF
--- a/nimbus/p2p/chain/chain_desc.nim
+++ b/nimbus/p2p/chain/chain_desc.nim
@@ -23,8 +23,10 @@ import
   stint
 
 type
-  # Chain's forks not always equals to EVM's forks
   ChainFork* = enum
+    ## `ChainFork` has extra forks not in the EVM fork list.  These are the
+    ## unique `DAOFork`, and Glacier forks `MuirGlacier` and `ArrowGlacier`.
+    ## At the Glacier forks, only block difficulty calculation changed.
     Frontier,
     Homestead,
     DAOFork,
@@ -36,7 +38,8 @@ type
     Istanbul,
     MuirGlacier,
     Berlin,
-    London
+    London,
+    ArrowGlacier
 
   Chain* = ref object of AbstractChainDB
     db: BaseChainDB
@@ -85,7 +88,8 @@ func getNextFork(c: ChainConfig, fork: ChainFork): uint64 =
     toNextFork(c.istanbulBlock),
     toNextFork(c.muirGlacierBlock),
     toNextFork(c.berlinBlock),
-    toNextFork(c.londonBlock)
+    toNextFork(c.londonBlock),
+    toNextFork(c.arrowGlacierBlock)
   ]
 
   if fork == high(ChainFork):

--- a/nimbus/p2p/chain/chain_misc.nim
+++ b/nimbus/p2p/chain/chain_misc.nim
@@ -24,7 +24,8 @@ import
 # ------------------------------------------------------------------------------
 
 func toChainFork(c: ChainConfig, number: BlockNumber): ChainFork =
-  if number >= c.londonBlock: London
+  if number >= c.arrowGlacierBlock: ArrowGlacier
+  elif number >= c.londonBlock: London
   elif number >= c.berlinBlock: Berlin
   elif number >= c.muirGlacierBlock: MuirGlacier
   elif number >= c.istanbulBlock: Istanbul

--- a/nimbus/utils/difficulty.nim
+++ b/nimbus/utils/difficulty.nim
@@ -134,22 +134,39 @@ func makeDifficultyCalculator(bombDelay: static[int], timeStamp: EthTime, parent
   result = diff
 
 template calcDifficultyByzantium*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
+  ## "EIP-649: Metropolis Difficulty Bomb Delay and Block Reward Reduction"
+  ## <https://eips.ethereum.org/EIPS/eip-649>
   makeDifficultyCalculator(3_000_000, timeStamp, parent)
 
 template calcDifficultyConstantinople*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
+  ## "EIP-1234: Constantinople Difficulty Bomb Delay and Block Reward Adjustment"
+  ## <https://eips.ethereum.org/EIPS/eip-1234>
+  ## Keep using Byzantium's rules but offset the bomb 5.0M blocks.
   makeDifficultyCalculator(5_000_000, timeStamp, parent)
 
 template calcDifficultyMuirGlacier*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
-  # EIP-2384
+  ## "EIP-2384: Muir Glacier Difficulty Bomb Delay"
+  ## <https://eips.ethereum.org/EIPS/eip-2384>
+  ## Offset the bomb 4.0M more blocks than Constantinople, total 9.0M blocks.
   makeDifficultyCalculator(9_000_000, timeStamp, parent)
 
 template calcDifficultyLondon*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
-  # EIP-3554
+  ## "EIP-3554: Difficulty Bomb Delay to December 2021"
+  ## <https://eips.ethereum.org/EIPS/eip-3554>
+  ## Offset the bomb a total of 9.7M blocks.
   makeDifficultyCalculator(9_700_000, timeStamp, parent)
+
+template calcDifficultyArrowGlacier*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
+  ## "EIP-4345: Difficulty Bomb Delay to June 2022"
+  ## <https://eips.ethereum.org/EIPS/eip-4345>
+  ## Offset the bomb a total of 10.7M blocks.
+  makeDifficultyCalculator(10_700_000, timeStamp, parent)
 
 func calcDifficulty*(c: ChainConfig, timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
   let next = parent.blockNumber + bigOne
-  if next >= c.londonBlock:
+  if next >= c.arrowGlacierBlock:
+    result = calcDifficultyArrowGlacier(timeStamp, parent)
+  elif next >= c.londonBlock:
     result = calcDifficultyLondon(timeStamp, parent)
   elif next >= c.muirGlacierBlock:
     result = calcDifficultyMuirGlacier(timeStamp, parent)

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -145,6 +145,7 @@ func vmConfiguration(network: string, c: var ChainConfig) =
     c.muirGlacierBlock    = number[FkBerlin]
     c.berlinBlock         = number[FkBerlin]
     c.londonBlock         = number[FkLondon]
+    c.arrowGlacierBlock   = number[FkLondon]
 
   case network
   of "EIP150":

--- a/tests/test_forkid.nim
+++ b/tests/test_forkid.nim
@@ -26,8 +26,10 @@ const
     (blockNumber: 12243999'u64, id: (crc: 0xE029E991'u32, nextFork: 12244000'u64)), # Last MuirGlacier block
     (blockNumber: 12244000'u64, id: (crc: 0x0eb440f6'u32, nextFork: 12965000'u64)), # First Berlin block
     (blockNumber: 12964999'u64, id: (crc: 0x0eb440f6'u32, nextFork: 12965000'u64)), # Last Berlin block
-    (blockNumber: 12965000'u64, id: (crc: 0xb715077d'u32, nextFork: 0'u64)),        # First London block
-    (blockNumber: 20000000'u64, id: (crc: 0xb715077d'u32, nextFork: 0'u64)),        # Future London block
+    (blockNumber: 12965000'u64, id: (crc: 0xb715077d'u32, nextFork: 13773000'u64)), # First London block
+    (blockNumber: 13772999'u64, id: (crc: 0xb715077d'u32, nextFork: 13773000'u64)), # Last London block
+    (blockNumber: 13773000'u64, id: (crc: 0x20c327fc'u32, nextFork: 0'u64)),        # First Arrow Glacier block
+    (blockNumber: 20000000'u64, id: (crc: 0x20c327fc'u32, nextFork: 0'u64)),        # Future Arrow Glacier block
   ]
 
   RopstenNetIDs = [

--- a/tests/test_graphql.nim
+++ b/tests/test_graphql.nim
@@ -40,7 +40,8 @@ proc setupChain(): BaseChainDB =
     istanbulBlock       : 0.toBlockNumber,
     muirGlacierBlock    : 0.toBlockNumber,
     berlinBlock         : 10.toBlockNumber,
-    londonBlock         : high(BlockNumber).toBlockNumber
+    londonBlock         : high(BlockNumber),
+    arrowGlacierBlock   : high(BlockNumber)
   )
 
   var jn = json.parseFile(dataFolder / "oneUncle.json")


### PR DESCRIPTION
Add the new [Arrow Glacier fork](https://eips.ethereum.org/EIPS/eip-4345).

Only the difficulty calculation is changed, but as a new fork it still affects a number of places in the code.

To the best of my knowledge the change is only scheduled on Mainnet.

In addition:

- The fork date comments in `chain_config.nim` have been checked against the real networks, set consistently in UTC instead of random timezones, and made neater.  Maybe we'll keep these when transferring config to a file someday.

- It's added to forkid hash tests (EIP-2124/EIP-2364), of course.