### PR TITLE
Hive: Add Arrow Glacier fork to Hive integration + related fixes

### DIFF
--- a/hive_integration/nimbus/mapper.jq
+++ b/hive_integration/nimbus/mapper.jq
@@ -68,6 +68,7 @@ def to_bool:
     "istanbulBlock": env.HIVE_FORK_ISTANBUL|to_int,
     "muirGlacierBlock": env.HIVE_FORK_MUIR_GLACIER|to_int,
     "berlinBlock": env.HIVE_FORK_BERLIN|to_int,
-    "londonBlock": env.HIVE_FORK_LONDON|to_int
+    "londonBlock": env.HIVE_FORK_LONDON|to_int,
+    "arrowGlacierBlock": env.HIVE_FORK_ARROW_GLACIER|to_int
   }|remove_empty
 }

--- a/hive_integration/nimbus/nimbus.sh
+++ b/hive_integration/nimbus/nimbus.sh
@@ -28,9 +28,10 @@
 #  - [x] HIVE_FORK_CONSTANTINOPLE     block number for Constantinople transition
 #  - [x] HIVE_FORK_PETERSBURG         block number for ConstantinopleFix/PetersBurg transition
 #  - [x] HIVE_FORK_ISTANBUL           block number for Istanbul transition
-#  - [x] HIVE_FORK_MUIRGLACIER        block number for Muir Glacier transition
+#  - [x] HIVE_FORK_MUIR_GLACIER       block number for Muir Glacier transition
 #  - [x] HIVE_FORK_BERLIN             block number for Berlin transition
 #  - [x] HIVE_FORK_LONDON             block number for London transition
+#  - [x] HIVE_FORK_ARROW_GLACIER      block number for Arrow Glacier transition
 #
 # Clique PoA:
 #

--- a/hive_integration/nodocker/consensus/extract_consensus_data.nim
+++ b/hive_integration/nodocker/consensus/extract_consensus_data.nim
@@ -41,10 +41,14 @@ proc processNetWork(network: string): JsonNode =
     constantinopleBlock = 2000
     petersburgBlock     = 2000
     istanbulBlock       = 2000
+    muirGlacierBlock    = 2000
     berlinBlock         = 2000
     londonBlock         = 2000
+    arrowGlacierBlock   = 2000
 
   case network
+
+  # All the network forks, which includes all the EVM, DAO and Glacier forks.
   of "Frontier":
     discard
   of "Homestead":
@@ -90,6 +94,7 @@ proc processNetWork(network: string): JsonNode =
     constantinopleBlock = 0
     petersburgBlock = 0
     istanbulBlock = 0
+    muirGlacierBlock = 0
     berlinBlock   = 0
   of "London":
     homesteadBlock = 0
@@ -99,28 +104,37 @@ proc processNetWork(network: string): JsonNode =
     constantinopleBlock = 0
     petersburgBlock = 0
     istanbulBlock = 0
+    muirGlacierBlock = 0
     berlinBlock   = 0
     londonBlock = 0
+  of "ArrowGlacier":
+    homesteadBlock = 0
+    eip150Block    = 0
+    eip158Block    = 0
+    byzantiumBlock = 0
+    constantinopleBlock = 0
+    petersburgBlock = 0
+    istanbulBlock = 0
+    muirGlacierBlock = 0
+    berlinBlock   = 0
+    londonBlock = 0
+    arrowGlacierBlock = 0
+
+  # Just the subset of "At5" networks mentioned in the test suite.
   of "FrontierToHomesteadAt5":
     homesteadBlock = 5
-  of "HomesteadToEIP150At5":
-    homesteadBlock = 0
-    eip150Block = 5
   of "HomesteadToDaoAt5":
     homesteadBlock = 0
     daoForkSupport = true
     daoForkBlock   = 5
+  of "HomesteadToEIP150At5":
+    homesteadBlock = 0
+    eip150Block = 5
   of "EIP158ToByzantiumAt5":
     homesteadBlock = 0
     eip150Block = 0
     eip158Block = 0
     byzantiumBlock = 5
-  of "ByzantiumToConstantinopleAt5":
-    homesteadBlock = 0
-    eip150Block = 0
-    eip158Block = 0
-    byzantiumBlock = 0
-    constantinopleBlock = 5
   of "ByzantiumToConstantinopleFixAt5":
     homesteadBlock = 0
     eip150Block = 0
@@ -128,23 +142,6 @@ proc processNetWork(network: string): JsonNode =
     byzantiumBlock = 0
     constantinopleBlock = 5
     petersburgBlock = 5
-  of "ConstantinopleFixToIstanbulAt5":
-    homesteadBlock = 0
-    eip150Block = 0
-    eip158Block = 0
-    byzantiumBlock = 0
-    constantinopleBlock = 0
-    petersburgBlock = 0
-    istanbulBlock = 5
-  of "IstanbulToBerlinAt5":
-    homesteadBlock = 0
-    eip150Block = 0
-    eip158Block = 0
-    byzantiumBlock = 0
-    constantinopleBlock = 0
-    petersburgBlock = 0
-    istanbulBlock = 0
-    berlinBlock = 5
   of "BerlinToLondonAt5":
     homesteadBlock = 0
     eip150Block = 0
@@ -153,8 +150,10 @@ proc processNetWork(network: string): JsonNode =
     constantinopleBlock = 0
     petersburgBlock = 0
     istanbulBlock = 0
+    muirGlacierBlock = 0
     berlinBlock = 0
     londonBlock = 5
+
   else:
     doAssert(false, "unsupported network: " & network)
 
@@ -169,8 +168,10 @@ proc processNetWork(network: string): JsonNode =
   n["constantinopleBlock"] = newJInt(constantinopleBlock)
   n["petersburgBlock"]     = newJInt(petersburgBlock)
   n["istanbulBlock"]       = newJInt(istanbulBlock)
+  n["muirGlacierBlock"]    = newJInt(muirGlacierBlock)
   n["berlinBlock"]         = newJInt(berlinBlock)
   n["londonBlock"]         = newJInt(londonBlock)
+  n["arrowGlacierBlock"]   = newJInt(arrowGlacierBlock)
   n["chainId"]             = newJInt(1)
   result = n
 


### PR DESCRIPTION
Adds changes to Nimbus Hive support for the new [Arrow Glacier fork](https://eips.ethereum.org/EIPS/eip-4345).

While here:

- Fix typo in `nimbus.sh`: `HIVE_FORK_MUIRGLACIER` => `HIVE_FORK_MUIR_GLACIER` (just a comment).

- Add `muirGlacierBlock` to the JSON generated in `extract_consensus_data.nim`. This makes it symmetric with the JSON parsed in `mapper.jq`.

- Removed "At5" network names which are not used by any of the test suite. These are `ByzantiumToConstantinopleAt5`, `ConstantinopleFixToIstanbulAt5` and `IstanbulToBerlinAt5`.

  The motivation for removing these instead of systematically including all possibilities was that I realised `LondonToArrowGlacierAt5` does not appear anywhere in the current test suite, even though `ArrowGlacier` does.  As each section in the code is rather large already, I thought it cleaner to not add this one, and keep only the ones the test suite actually uses.

  This also now better matches the code in `test_blockchain_json.nim`.

- Sorted `HomesteadToDaoAt5` before `HomesteadToEIP150At5` because the DAO fork happened earlier than EIP-150 in real life.