### PR TITLE
EVMC: Byte-endian conversions for 256-bit numeric values

### DIFF
--- a/nimbus/vm/evmc_helpers.nim
+++ b/nimbus/vm/evmc_helpers.nim
@@ -1,7 +1,7 @@
 import eth/common, stint, evmc/evmc, ../utils
 
 const
-  evmc_native* {.booldefine.} = true
+  evmc_native* {.booldefine.} = false
 
 func toEvmc*(a: EthAddress): evmc_address {.inline.} =
   cast[evmc_address](a)


### PR DESCRIPTION
Perform byte-endian conversion for 256-bit numeric values, but not 256-bit hashes.  These conversions are necessary for EVMC binary compatibility.

In new EVMC, all host-side conversions are explicit, calling `flip256`.

These conversions are performed in the EVMC "glue" code, which deals with the binary interface, so the host services aren't aware of conversions.

We intend to skip these conversions when Nimbus host calls Nimbus EVM, even when it's a shared library, using a negotiated EVMC extension.  But for now we're focused on correctness and cross-validation with third party EVMs.

The overhead of endian conversion is not too high because most EVMC host calls access the database anyway.  `getTxContext` does not, so the conversions from that are cached here.  Also, well-optimised EVMs don't call it often.

It is arguable whether endian conversion should occur for storage slots (`key`).

In favour of no conversion: Slot keys are 32-byte blobs, and this is clear in the EVMC definition where slot keys are `evmc_bytes32` (not `evmc_uint256be`), meaning treating as a number is _not_ expected by EVMC.  Although they are
often small numbers, sometimes they are a hash from the contract code plus a number.  Slot keys are hashed on the host side with Keccak256 before any database calls, so the host side does not look at them numerically.

In favour of conversion: They are often small numbers and it is helpful to log them as such, rather than a long string of zero digits with 1-2 non-zero.  The representation in JSON has leading zeros removed, like a number rather than a 32-byte blob.  There is also an interesting space optimisation when the keys are used unhashed in storage.

Nimbus currently treats slot keys on the host side as numbers, and the tests pass when endian conversion is done.  So to remain consistent with other parts of Nimbus we convert slot keys.
