### PR TITLE
Use one bootstrap nodes argument for discv5 and Portal

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -56,12 +56,15 @@ type
       desc: "Listening address for the Discovery v5 traffic"
       name: "listen-address" }: ValidIpAddress
 
+    # Note: This will add bootstrap nodes for both Discovery v5 network and each
+    # enabled Portal network. No distinction is made on bootstrap nodes per
+    # specific network.
     bootstrapNodes* {.
-      desc: "ENR URI of node to bootstrap Discovery v5 from. Argument may be repeated"
+      desc: "ENR URI of node to bootstrap Discovery v5 and the Portal networks from. Argument may be repeated"
       name: "bootstrap-node" .}: seq[Record]
 
     bootstrapNodesFile* {.
-      desc: "Specifies a line-delimited file of ENR URIs to bootstrap Discovery v5 from"
+      desc: "Specifies a line-delimited file of ENR URIs to bootstrap Discovery v5 and Portal networks from"
       defaultValue: ""
       name: "bootstrap-file" }: InputFile
 
@@ -90,17 +93,6 @@ type
       defaultValue: defaultDataDir()
       defaultValueDesc: $defaultDataDirDesc
       name: "data-dir" }: OutDir
-
-    # Note: This will add bootstrap nodes for each enabled Portal network.
-    # No distinction is being made on bootstrap nodes for a specific network.
-    portalBootstrapNodes* {.
-      desc: "ENR URI of node to bootstrap the Portal networks from. Argument may be repeated"
-      name: "portal-bootstrap-node" .}: seq[Record]
-
-    portalBootstrapNodesFile* {.
-      desc: "Specifies a line-delimited file of ENR URIs to bootstrap the Portal networks from"
-      defaultValue: ""
-      name: "portal-bootstrap-file" }: InputFile
 
     metricsEnabled* {.
       defaultValue: false

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -52,12 +52,13 @@ proc run(config: PortalConf) {.raises: [CatchableError, Defect].} =
   loadBootstrapFile(string config.bootstrapNodesFile, bootstrapRecords)
   bootstrapRecords.add(config.bootstrapNodes)
 
-  let d = newProtocol(config.nodeKey,
-          extIp, none(Port), extUdpPort,
-          bootstrapRecords = bootstrapRecords,
-          bindIp = bindIp, bindPort = udpPort,
-          enrAutoUpdate = config.enrAutoUpdate,
-          rng = rng)
+  let d = newProtocol(
+    config.nodeKey,
+    extIp, none(Port), extUdpPort,
+    bootstrapRecords = bootstrapRecords,
+    bindIp = bindIp, bindPort = udpPort,
+    enrAutoUpdate = config.enrAutoUpdate,
+    rng = rng)
 
   d.open()
 
@@ -68,15 +69,9 @@ proc run(config: PortalConf) {.raises: [CatchableError, Defect].} =
     ContentDB.new(config.dataDir / "db" / "contentdb_" &
       d.localNode.id.toByteArrayBE().toOpenArray(0, 8).toHex())
 
-  var portalBootstrapRecords: seq[Record]
-  loadBootstrapFile(string config.portalBootstrapNodesFile, portalBootstrapRecords)
-  portalBootstrapRecords.add(config.portalBootstrapNodes)
-
   let
-    stateNetwork = StateNetwork.new(d, db,
-      bootstrapRecords = portalBootstrapRecords)
-    historyNetwork = HistoryNetwork.new(d, db,
-      bootstrapRecords = portalBootstrapRecords)
+    stateNetwork = StateNetwork.new(d, db, bootstrapRecords = bootstrapRecords)
+    historyNetwork = HistoryNetwork.new(d, db, bootstrapRecords = bootstrapRecords)
 
   # TODO: If no new network key is generated then we should first check if an
   # enr file exists, and in the case it does read out the seqNum from it and

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -58,7 +58,7 @@ proc getContent*(n: HistoryNetwork, key: ContentKey):
 
 proc new*(T: type HistoryNetwork, baseProtocol: protocol.Protocol,
     contentDB: ContentDB , dataRadius = UInt256.high(),
-    bootstrapRecords: openarray[Record] = []): T =
+    bootstrapRecords: openArray[Record] = []): T =
   let portalProtocol = PortalProtocol.new(
     baseProtocol, historyProtocolId, getHandler(contentDB), dataRadius,
     bootstrapRecords)

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -61,7 +61,7 @@ proc getContent*(n: StateNetwork, key: ContentKey):
 
 proc new*(T: type StateNetwork, baseProtocol: protocol.Protocol,
     contentDB: ContentDB , dataRadius = UInt256.high(),
-    bootstrapRecords: openarray[Record] = []): T =
+    bootstrapRecords: openArray[Record] = []): T =
   let portalProtocol = PortalProtocol.new(
     baseProtocol, stateProtocolId, getHandler(contentDB), dataRadius,
     bootstrapRecords, stateDistanceCalculator)

--- a/fluffy/network/wire/messages.nim
+++ b/fluffy/network/wire/messages.nim
@@ -136,7 +136,7 @@ func encodeMessage*[T: SomeMessage](m: T): seq[byte] =
   elif T is OfferMessage: SSZ.encode(Message(kind: offer, offer: m))
   elif T is AcceptMessage: SSZ.encode(Message(kind: accept, accept: m))
 
-func decodeMessage*(body: openarray[byte]): Result[Message, cstring] =
+func decodeMessage*(body: openArray[byte]): Result[Message, cstring] =
   try:
     if body.len < 1: # TODO: This check should probably move a layer down
       return err("No message data, peer might not support this talk protocol")

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -222,7 +222,7 @@ proc new*(T: type PortalProtocol,
     protocolId: PortalProtocolId,
     contentHandler: ContentHandler,
     dataRadius = UInt256.high(),
-    bootstrapRecords: openarray[Record] = [],
+    bootstrapRecords: openArray[Record] = [],
     distanceCalculator: DistanceCalculator = XorDistanceCalculator
     ): T =
   let proto = PortalProtocol(

--- a/fluffy/scripts/launch_local_testnet.sh
+++ b/fluffy/scripts/launch_local_testnet.sh
@@ -245,7 +245,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
   NODE_DATA_DIR="${DATA_DIR}/node${NUM_NODE}"
 
   if [[ ${NUM_NODE} != ${BOOTSTRAP_NODE} ]]; then
-    BOOTSTRAP_ARG="--bootstrap-file=${BOOTSTRAP_ENR_FILE} --portal-bootstrap-file=${BOOTSTRAP_ENR_FILE}"
+    BOOTSTRAP_ARG="--bootstrap-file=${BOOTSTRAP_ENR_FILE}"
 
     # Wait for the bootstrap node to write out its enr file
     START_TIMESTAMP=$(date +%s)

--- a/fluffy/tests/test_helpers.nim
+++ b/fluffy/tests/test_helpers.nim
@@ -17,8 +17,8 @@ proc localAddress*(port: int): Address =
 proc initDiscoveryNode*(rng: ref BrHmacDrbgContext,
     privKey: PrivateKey,
     address: Address,
-    bootstrapRecords: openarray[Record] = [],
-    localEnrFields: openarray[(string, seq[byte])] = [],
+    bootstrapRecords: openArray[Record] = [],
+    localEnrFields: openArray[(string, seq[byte])] = [],
     previousRecord = none[enr.Record]()): discv5_protocol.Protocol =
   # set bucketIpLimit to allow bucket split
   let tableIpLimits = TableIpLimits(tableIpLimit: 1000,  bucketIpLimit: 24)


### PR DESCRIPTION
Currently bootstrap nodes for discv5 and for the Portal nodes
were provided through separate cli arguments. This is however
confusing and cumbersome as typically when (currently) testing
a node will have both discv5 and the Portal networks enabled.
We merge them into one argument.

If a node happens not to support a Portal network, it will be
removed after message request failure.

Commit also contains additional clean-up and nim-eth bump.