### PR TITLE
EVMC: Improve `--evm`, remove it in non-EVMC builds, change imports

### DIFF
--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -108,6 +108,18 @@ const
   defaultAdminListenAddressDesc = $defaultAdminListenAddress & ", meaning local host only"
   logLevelDesc = getLogLevels()
 
+# `when` around an option doesn't work with confutils; it fails to compile.
+# Workaround that by setting the `ignore` pragma on EVMC-specific options.
+when defined(evmc_enabled):
+  {.pragma: includeIfEvmc.}
+else:
+  {.pragma: includeIfEvmc, ignore.}
+
+const sharedLibText = if defined(linux): " (*.so, *.so.N)"
+                      elif defined(windows): " (*.dll)"
+                      elif defined(macosx): " (*.dylib)"
+                      else: ""
+
 type
   PruneMode* {.pure.} = enum
     Full
@@ -177,10 +189,10 @@ type
       name: "verify-from" }: Option[uint64]
 
     evm* {.
-      desc: "Load alternative EVM from EVMC-compatible shared library (.so/.dll/.dylib)"
+      desc: "Load alternative EVM from EVMC-compatible shared library" & sharedLibText
       defaultValue: ""
-      defaultValueDesc: "Nimbus built-in EVM"
-      name: "evm" }: string
+      name: "evm"
+      includeIfEvmc }: string
 
     network {.
       separator: "\pETHEREUM NETWORK OPTIONS:"

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -20,10 +20,12 @@ import
   ./p2p/blockchain_sync, eth/net/nat, eth/p2p/peer_pool,
   ./sync/protocol_eth65,
   config, genesis, rpc/[common, p2p, debug], p2p/chain,
-  transaction/evmc_dynamic_loader,
   eth/trie/db, metrics, metrics/[chronos_httpserver, chronicles_support],
   graphql/ethapi, context,
   "."/[conf_utils, sealer, constants]
+
+when defined(evmc_enabled):
+  import transaction/evmc_dynamic_loader
 
 ## TODO:
 ## * No IPv6 support
@@ -199,7 +201,8 @@ proc start(nimbus: NimbusNode, conf: NimbusConf) =
     defaultChroniclesStream.output.outFile = nil # to avoid closing stdout
     discard defaultChroniclesStream.output.open(logFile, fmAppend)
 
-  evmcSetLibraryPath(conf.evm)
+  when defined(evmc_enabled):
+    evmcSetLibraryPath(conf.evm)
 
   createDir(string conf.dataDir)
   let trieDB = trieDB newChainDb(string conf.dataDir)

--- a/nimbus/transaction/evmc_dynamic_loader.nim
+++ b/nimbus/transaction/evmc_dynamic_loader.nim
@@ -16,12 +16,11 @@ import
 # The built-in Nimbus EVM, via imported C function.
 proc evmc_create_nimbus_evm(): ptr evmc_vm {.cdecl, importc.}
 
-# Import this module to pull in the definition of `evmc_create_nimbus_evm`.
+# Import this module to link in the definition of `evmc_create_nimbus_evm`.
 # Nim thinks the module is unused because the function is only called via
 # `.exportc` -> `.importc`.
 {.warning[UnusedImport]: off.}:
-  when defined(evmc_enabled):
-    import ./evmc_vm_glue
+  import ./evmc_vm_glue
 
 var evmcLibraryPath {.threadvar.}: string
   ## Library path set by `--evm` command line option.


### PR DESCRIPTION
- Remove the `--evm` option on non-EVMC builds.

  `when` around an option doesn't work with confutils; it fails to compile. Workaround that by setting the `ignore` pragma on EVMC-specific options. (Thanks @jangko for that new pragma).  I prefer this to a solution which moves the whole option's pragma elsewhere, especially if we add more options.

- Improve the help text, so that it shows the standard library extension on each target platform (or none if on another platform).

- Undo b3f21bf4 "add missing evmc_enabled conditional compilation in evmc_dynamic_loader".  Move the conditional to `nimbus.nim`, and take more care there to only use the loader function in EVMC builds.

  It's ok to just not include this EVMC-only module (like some other EVMC modules), rather than making the module itself a bit broken: Without this change, it references a function that's not imported or linked to, and it only links because there is no call sequence reaching that function.