### PR TITLE
Add state and history content key tests

### DIFF
--- a/fluffy/tests/test_history_content.nim
+++ b/fluffy/tests/test_history_content.nim
@@ -11,17 +11,20 @@ import
   unittest2, stew/byteutils,
   ../network/history/history_content
 
+# According to test vectors:
+# TODO: Add link once test vectors are merged
 suite "History ContentKey Encodings":
-  test "ContentKey":
+  test "BlockHeader":
     var blockHash: BlockHash
     blockHash.data = hexToByteArray[sizeof(BlockHash)](
-      "0x0100000000000000000000000000000000000000000000000000000000000000")
+      "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
     let contentKey =
-      ContentKey(chainId: 1'u16, contentType: BlockBody, blockHash: blockHash)
+      ContentKey(chainId: 15'u16, contentType: BlockHeader, blockHash: blockHash)
 
     let encoded = encode(contentKey)
     check encoded.asSeq.toHex ==
-      "0100020100000000000000000000000000000000000000000000000000000000000000"
+      "0f0001d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+      # "010f00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
     let decoded = decode(encoded)
     check decoded.isSome()
 
@@ -32,4 +35,50 @@ suite "History ContentKey Encodings":
       contentKeyDecoded.blockHash == contentKey.blockHash
 
       toContentId(contentKey).toHex() ==
-        "36a55e9aa5125c5fecc16bcb0234d9d3d6065eabc890c0d3b24d413d6ae9f9da"
+        "9a310df5e6135cbd834041011be1b350e589ba013f11584ed527583bc39d3c27"
+
+  test "BlockBody":
+    var blockHash: BlockHash
+    blockHash.data = hexToByteArray[sizeof(BlockHash)](
+      "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
+    let contentKey =
+      ContentKey(chainId: 20'u16, contentType: BlockBody, blockHash: blockHash)
+
+    let encoded = encode(contentKey)
+    check encoded.asSeq.toHex ==
+      "140002d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+      # "021400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+    let decoded = decode(encoded)
+    check decoded.isSome()
+
+    let contentKeyDecoded = decoded.get()
+    check:
+      contentKeyDecoded.chainId == contentKey.chainId
+      contentKeyDecoded.contentType == contentKey.contentType
+      contentKeyDecoded.blockHash == contentKey.blockHash
+
+      toContentId(contentKey).toHex() ==
+        "42a9bb9fd974f4d3020fe81aa584277010a9e344bed52bf1610e9d360203380a"
+
+  test "Receipts":
+    var blockHash: BlockHash
+    blockHash.data = hexToByteArray[sizeof(BlockHash)](
+      "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
+    let contentKey =
+      ContentKey(chainId: 4'u16, contentType: Receipts, blockHash: blockHash)
+
+    let encoded = encode(contentKey)
+    check encoded.asSeq.toHex ==
+      "040003d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+      # "030400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+    let decoded = decode(encoded)
+    check decoded.isSome()
+
+    let contentKeyDecoded = decoded.get()
+    check:
+      contentKeyDecoded.chainId == contentKey.chainId
+      contentKeyDecoded.contentType == contentKey.contentType
+      contentKeyDecoded.blockHash == contentKey.blockHash
+
+      toContentId(contentKey).toHex() ==
+        "4b92510bafa02f62811ce6d0e27d2424ba34d41fbe38abc3ea4e274d6c76fa3e"

--- a/fluffy/tests/test_portal_wire_encoding.nim
+++ b/fluffy/tests/test_portal_wire_encoding.nim
@@ -11,6 +11,9 @@ import
   unittest2, stint, stew/[byteutils, results], eth/p2p/discoveryv5/enr,
   ../network/wire/messages
 
+# According to test vectors:
+# https://github.com/ethereum/portal-network-specs/blob/master/portal-wire-test-vectors.md
+
 suite "Portal Wire Protocol Message Encodings":
   test "Ping Request":
     let
@@ -120,7 +123,7 @@ suite "Portal Wire Protocol Message Encodings":
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()
-    
+
     let message = decoded.get()
     check:
       message.kind == findcontent

--- a/fluffy/tests/test_state_content.nim
+++ b/fluffy/tests/test_state_content.nim
@@ -11,23 +11,31 @@ import
   unittest2, stew/byteutils,
   ../network/state/state_content
 
+# According to test vectors:
+# TODO: Add link once test vectors are merged
+
 suite "State ContentKey Encodings":
-  test "ContentKey - accountTrieNode":
-    let path = ByteList.init(hexToSeqByte("0x0304"))
+  const
+    stateRoot = hexToByteArray[sizeof(Bytes32)](
+      "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
+    address = hexToByteArray[sizeof(Address)](
+        "0x829bd824b016326a401d083b33d092293333a830")
+
+  test "AccountTrieNode":
     var nodeHash: NodeHash
     nodeHash.data = hexToByteArray[sizeof(NodeHash)](
-      "0x0100000000000000000000000000000000000000000000000000000000000000")
-    let stateRoot = hexToByteArray[sizeof(Bytes32)](
-      "0x0200000000000000000000000000000000000000000000000000000000000000")
+      "0xb8be7903aee73b8f6a59cd44a1f52c62148e1f376c0dfa1f5f773a98666efc2b")
+    let path = ByteList.init(@[byte 1, 2, 0, 1])
 
-    let accountTrieNodeKey = AccountTrieNodeKey(
-      path: path, nodeHash: nodeHash, stateRoot: stateRoot)
-    let contentKey = ContentKey(
-      contentType: accountTrieNode, accountTrieNodeKey: accountTrieNodeKey)
+    let
+      accountTrieNodeKey = AccountTrieNodeKey(
+        path: path, nodeHash: nodeHash, stateRoot: stateRoot)
+      contentKey = ContentKey(
+        contentType: accountTrieNode, accountTrieNodeKey: accountTrieNodeKey)
 
     let encoded = encode(contentKey)
     check encoded.asSeq.toHex ==
-      "0044000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000304"
+      "0044000000b8be7903aee73b8f6a59cd44a1f52c62148e1f376c0dfa1f5f773a98666efc2bd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d01020001"
     let decoded = decode(encoded)
     check decoded.isSome()
 
@@ -37,7 +45,105 @@ suite "State ContentKey Encodings":
       contentKeyDecoded.accountTrieNodeKey == contentKey.accountTrieNodeKey
 
       toContentId(contentKey).toHex() ==
-        "17cc73bd15072a4f62fbec6e4dd0fa99bdc103e73b90143f01bb4079955ba74c"
+        "5b2b5ea9a7384491010c1aa459a0f967dcf8b69988adbfe7e0bed513e9bb8305"
 
-# TODO: Add test for each ContentType, perhaps when path is specced out and
-# test vectors exist.
+  test "ContractStorageTrieNode":
+    var nodeHash: NodeHash
+    nodeHash.data = hexToByteArray[sizeof(NodeHash)](
+      "0x3e190b68719aecbcb28ed2271014dd25f2aa633184988eb414189ce0899cade5")
+    let path = ByteList.init(@[byte 1, 0, 15, 14, 12, 0])
+
+    let
+      contractStorageTrieNodeKey = ContractStorageTrieNodeKey(
+        address: address, path: path, nodeHash: nodeHash, stateRoot: stateRoot)
+      contentKey = ContentKey(
+        contentType: contractStorageTrieNode,
+        contractStorageTrieNodeKey: contractStorageTrieNodeKey)
+
+    let encoded = encode(contentKey)
+    check encoded.asSeq.toHex ==
+      "01829bd824b016326a401d083b33d092293333a830580000003e190b68719aecbcb28ed2271014dd25f2aa633184988eb414189ce0899cade5d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d01000f0e0c00"
+    let decoded = decode(encoded)
+    check decoded.isSome()
+
+    let contentKeyDecoded = decoded.get()
+    check:
+      contentKeyDecoded.contentType == contentKey.contentType
+      contentKeyDecoded.contractStorageTrieNodeKey ==
+        contentKey.contractStorageTrieNodeKey
+
+      toContentId(contentKey).toHex() ==
+        "603cbe7902925ce359822378a4cb1b4b53e1bf19d003de2c26e55812d76956c1"
+
+  test "AccountTrieProof":
+    let
+      accountTrieProofKey = AccountTrieProofKey(
+        address: address, stateRoot: stateRoot)
+      contentKey = ContentKey(
+        contentType: accountTrieProof,
+        accountTrieProofKey: accountTrieProofKey)
+
+    let encoded = encode(contentKey)
+    check encoded.asSeq.toHex ==
+      "02829bd824b016326a401d083b33d092293333a830d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+    let decoded = decode(encoded)
+    check decoded.isSome()
+
+    let contentKeyDecoded = decoded.get()
+    check:
+      contentKeyDecoded.contentType == contentKey.contentType
+      contentKeyDecoded.accountTrieProofKey == contentKey.accountTrieProofKey
+
+      toContentId(contentKey).toHex() ==
+        "6427c4c8d42db15c2aca8dfc7dff7ce2c8c835441b566424fa3377dd031cc60d"
+
+  test "ContractStorageTrieProof":
+    let slot = 239304.stuint(256)
+
+    let
+      contractStorageTrieProofKey = ContractStorageTrieProofKey(
+        address: address, slot: slot, stateRoot: stateRoot)
+      contentKey = ContentKey(
+        contentType: contractStorageTrieProof,
+        contractStorageTrieProofKey: contractStorageTrieProofKey)
+
+    let encoded = encode(contentKey)
+    check encoded.asSeq.toHex ==
+      "03829bd824b016326a401d083b33d092293333a830c8a6030000000000000000000000000000000000000000000000000000000000d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+    let decoded = decode(encoded)
+    check decoded.isSome()
+
+    let contentKeyDecoded = decoded.get()
+    check:
+      contentKeyDecoded.contentType == contentKey.contentType
+      contentKeyDecoded.contractStorageTrieProofKey ==
+        contentKey.contractStorageTrieProofKey
+
+      toContentId(contentKey).toHex() ==
+        "ce5a3a6bc958561da0015d92f2f6b4f5a2cf6a4ae3f6a75c97f05e9e2a6f4387"
+
+  test "ContractBytecode":
+    var codeHash: CodeHash
+    codeHash.data = hexToByteArray[sizeof(CodeHash)](
+      "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
+
+    let
+      contractBytecodeKey = ContractBytecodeKey(
+        address: address, codeHash: codeHash)
+      contentKey = ContentKey(
+        contentType: contractBytecode,
+        contractBytecodeKey: contractBytecodeKey)
+
+    let encoded = encode(contentKey)
+    check encoded.asSeq.toHex ==
+      "04829bd824b016326a401d083b33d092293333a830d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+    let decoded = decode(encoded)
+    check decoded.isSome()
+
+    let contentKeyDecoded = decoded.get()
+    check:
+      contentKeyDecoded.contentType == contentKey.contentType
+      contentKeyDecoded.contractBytecodeKey == contentKey.contractBytecodeKey
+
+      toContentId(contentKey).toHex() ==
+        "146fb937afe42bcf11d25ad57d67734b9a7138677d59eeec3f402908f54dafb0"


### PR DESCRIPTION
Added tests using test vectors as currently provided in PR https://github.com/ethereum/portal-network-specs/pull/123

Currently not (yet) using the test vector results for history content keys as they are not according to specifications. (Union of containers vs raw containers with content type in it).