### PR TITLE
Update/clarify tx validation

### DIFF
--- a/nimbus/p2p/chain/chain_desc.nim
+++ b/nimbus/p2p/chain/chain_desc.nim
@@ -204,35 +204,35 @@ method getTrieDB*(c: Chain): TrieDatabaseRef {.gcsafe.} =
 # Public `Chain` getters
 # ------------------------------------------------------------------------------
 
-proc clique*(c: Chain): var Clique {.inline.} =
+proc clique*(c: Chain): var Clique =
   ## Getter
   c.poa
 
-proc pow*(c: Chain): PowRef {.inline.} =
+proc pow*(c: Chain): PowRef =
   ## Getter
   c.pow
 
-proc db*(c: Chain): auto {.inline.} =
+proc db*(c: Chain): BaseChainDB =
   ## Getter
   c.db
 
-proc extraValidation*(c: Chain): auto {.inline.} =
+proc extraValidation*(c: Chain): bool =
   ## Getter
   c.extraValidation
 
-proc forkIds*(c: Chain): auto {.inline.} =
+proc forkIds*(c: Chain): array[ChainFork,ForkID] =
   ## Getter
   c.forkIds
 
-proc verifyFrom*(c: Chain): auto {.inline.} =
+proc verifyFrom*(c: Chain): BlockNumber =
   ## Getter
   c.verifyFrom
 
-proc lastBlockHash*(c: Chain): auto {.inline.} =
+proc lastBlockHash*(c: Chain): KeccakHash =
   ## Getter
   c.lastBlockHash
 
-proc parentStateRoot*(c: Chain): auto {.inline.} =
+proc parentStateRoot*(c: Chain): KeccakHash =
   ## Getter
   c.parentStateRoot
 
@@ -247,22 +247,26 @@ proc currentBlock*(c: Chain): BlockHeader
 # Public `Chain` setters
 # ------------------------------------------------------------------------------
 
-proc `extraValidation=`*(c: Chain; extraValidation: bool) {.inline.} =
+proc `extraValidation=`*(c: Chain; extraValidation: bool) =
   ## Setter. If set `true`, the assignment value `extraValidation` enables
   ## extra block chain validation.
   c.extraValidation = extraValidation
 
-proc `verifyFrom=`*(c: Chain; verifyFrom: uint64) {.inline.} =
+proc `verifyFrom=`*(c: Chain; verifyFrom: BlockNumber) =
   ## Setter. The  assignment value `verifyFrom` defines the first block where
   ## validation should start if the `Clique` field `extraValidation` was set
   ## `true`.
+  c.verifyFrom = verifyFrom
+
+proc `verifyFrom=`*(c: Chain; verifyFrom: uint64) =
+  ## Variant of `verifyFrom=`
   c.verifyFrom = verifyFrom.u256
 
-proc `lastBlockHash=`*(c: Chain; blockHash: KeccakHash) {.inline.} =
+proc `lastBlockHash=`*(c: Chain; blockHash: KeccakHash) =
   ## Setter.
   c.lastBlockHash = blockHash
 
-proc `parentStateRoot=`*(c: Chain; stateRoot: KeccakHash) {.inline.} =
+proc `parentStateRoot=`*(c: Chain; stateRoot: KeccakHash) =
   ## Setter.
   c.parentStateRoot = stateRoot
 

--- a/nimbus/p2p/executor/executor_helpers.nim
+++ b/nimbus/p2p/executor/executor_helpers.nim
@@ -61,16 +61,16 @@ func createBloom*(receipts: openArray[Receipt]): Bloom =
   result = bloom.value.toByteArrayBE
 
 proc getForkUnsafe*(vmState: BaseVMState): Fork
-                       {.inline, raises: [Exception].} =
+                       {.gcsafe, raises: [Exception].} =
   ## Shortcut for configured fork, deliberately not naming it toFork(). This
   ## function may throw an `Exception` and must be wrapped.
   vmState.chainDB.config.toFork(vmState.blockNumber)
 
 proc makeReceipt*(vmState: BaseVMState; txType: TxType): Receipt
-                    {.inline, raises: [Defect,CatchableError].} =
+                    {.gcsafe, raises: [Defect,CatchableError].} =
 
   proc getFork(vmState: BaseVMState): Fork
-               {.inline, raises: [Defect,CatchableError].} =
+               {.gcsafe, raises: [Defect,CatchableError].} =
     safeExecutor("getFork"):
       result = vmState.getForkUnsafe
 

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -85,7 +85,7 @@ proc setupEnv(chainDB: BaseChainDB, signer, ks2: EthAddress, ctx: EthContext): T
   vmState.cumulativeGasUsed = 0
   for txIndex, tx in txs:
     let sender = tx.getSender()
-    discard processTransaction(tx, sender, vmState)
+    discard vmState.processTransaction(tx, sender, vmState.blockHeader)
     vmState.receipts[txIndex] = makeReceipt(vmState, tx.txType)
 
   let


### PR DESCRIPTION
details:
  1. The check for cumulativeGasUsed + tx.gasLimit <= header.gasLimit
     makes neither sense nor is it part of the Eip1559 specs. Nevertheless
     a check tx.gasLimit <= header.gasLimit is added to satisfy some
     unit test (see comments in validateTransaction() body.)
  2. As a replacement check for the one removed in 1, a check for
     cumulativeGasUsed + gasBurned <= header.gasLimit has been added
     (see comments in processTransactionImpl() body.)
  3. Prototypes for processTransaction() variants have been cleaned up and
     commented.

why:
  Detail 1. in particular produces an error for tightly packed blocks when
  the last tx in the list has a generous gasLimit.