### PR TITLE
Allow access to contentDB from portal wire protocol

### DIFF
--- a/fluffy/common/common_types.nim
+++ b/fluffy/common/common_types.nim
@@ -14,3 +14,5 @@ type
   ByteList* = List[byte, 2048]
   Bytes2* = array[2, byte]
   Bytes32* = array[32, byte]
+
+  ContentId* = Uint256

--- a/fluffy/network/history/history_content.nim
+++ b/fluffy/network/history/history_content.nim
@@ -38,8 +38,6 @@ type
     of receipts:
       receiptsKey*: ContentKeyType
 
-  ContentId* = Uint256
-
 func encode*(contentKey: ContentKey): ByteList =
   ByteList.init(SSZ.encode(contentKey))
 

--- a/fluffy/network/state/state_content.nim
+++ b/fluffy/network/state/state_content.nim
@@ -67,8 +67,6 @@ type
     of contractBytecode:
       contractBytecodeKey*: ContractBytecodeKey
 
-  ContentId* = Uint256
-
 func encode*(contentKey: ContentKey): ByteList =
   ByteList.init(SSZ.encode(contentKey))
 

--- a/fluffy/tests/test_discovery_rpc.nim
+++ b/fluffy/tests/test_discovery_rpc.nim
@@ -12,15 +12,16 @@ import
   json_rpc/[rpcproxy, rpcserver], json_rpc/clients/httpclient,
   stint,eth/p2p/discoveryv5/enr, eth/keys,
   eth/p2p/discoveryv5/protocol as discv5_protocol,
-  ../rpc/rpc_discovery_api, ./test_helpers
+  ../rpc/rpc_discovery_api,
+  ./test_helpers
 
 type TestCase = ref object
-  localDiscovery: discv5_protocol.Protocol 
+  localDiscovery: discv5_protocol.Protocol
   server: RpcProxy
   client: RpcHttpClient
 
 proc setupTest(rng: ref BrHmacDrbgContext): Future[TestCase] {.async.} =
-  let 
+  let
     localSrvAddress = "127.0.0.1"
     localSrvPort = 8545
     ta = initTAddress(localSrvAddress, localSrvPort)

--- a/fluffy/tests/test_helpers.nim
+++ b/fluffy/tests/test_helpers.nim
@@ -34,9 +34,3 @@ proc initDiscoveryNode*(rng: ref BrHmacDrbgContext,
     rng = rng)
 
   result.open()
-
-proc random*(T: type UInt256, rng: var BrHmacDrbgContext): T =
-  var key: UInt256
-  brHmacDrbgGenerate(addr rng, addr key, csize_t(sizeof(key)))
-
-  key


### PR DESCRIPTION
- Allow access to contentDB from portal wire protocol
- Use this to do the db.get in `handleFindContent` directly
- Use this to check the `contentKeys` list in `handleOffer`