### PR TITLE
Add Portal protocol config and add config options to fluffy cli

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -54,7 +54,7 @@ type
       defaultValue: defaultListenAddress
       defaultValueDesc: $defaultListenAddressDesc
       desc: "Listening address for the Discovery v5 traffic"
-      name: "listen-address" }: ValidIpAddress
+      name: "listen-address" .}: ValidIpAddress
 
     # Note: This will add bootstrap nodes for both Discovery v5 network and each
     # enabled Portal network. No distinction is made on bootstrap nodes per
@@ -66,7 +66,7 @@ type
     bootstrapNodesFile* {.
       desc: "Specifies a line-delimited file of ENR URIs to bootstrap Discovery v5 and Portal networks from"
       defaultValue: ""
-      name: "bootstrap-file" }: InputFile
+      name: "bootstrap-file" .}: InputFile
 
     nat* {.
       desc: "Specify method to use for determining public address. " &
@@ -92,7 +92,7 @@ type
       desc: "The directory where fluffy will store the content data"
       defaultValue: defaultDataDir()
       defaultValueDesc: $defaultDataDirDesc
-      name: "data-dir" }: OutDir
+      name: "data-dir" .}: OutDir
 
     metricsEnabled* {.
       defaultValue: false
@@ -113,18 +113,18 @@ type
     rpcEnabled* {.
       desc: "Enable the JSON-RPC server"
       defaultValue: false
-      name: "rpc" }: bool
+      name: "rpc" .}: bool
 
     rpcPort* {.
       desc: "HTTP port for the JSON-RPC server"
       defaultValue: 8545
-      name: "rpc-port" }: Port
+      name: "rpc-port" .}: Port
 
     rpcAddress* {.
       desc: "Listening address of the RPC server"
       defaultValue: defaultAdminListenAddress
       defaultValueDesc: $defaultAdminListenAddressDesc
-      name: "rpc-address" }: ValidIpAddress
+      name: "rpc-address" .}: ValidIpAddress
 
     bridgeUri* {.
       defaultValue: none(string)
@@ -139,6 +139,24 @@ type
       defaultValueDesc: $defaultClientConfigDesc
       desc: "URI of eth client where to proxy unimplemented rpc methods to"
       name: "proxy-uri" .}: ClientConfig
+
+    tableIpLimit* {.
+      hidden
+      desc: "Maximum amount of nodes with the same IP in the routing tables"
+      defaultValue: DefaultTableIpLimit
+      name: "table-ip-limit" .}: uint
+
+    bucketIpLimit* {.
+      hidden
+      desc: "Maximum amount of nodes with the same IP in the routing tables buckets"
+      defaultValue: DefaultBucketIpLimit
+      name: "bucket-ip-limit" .}: uint
+
+    bitsPerHop* {.
+      hidden
+      desc: "Kademlia's b variable, increase for less hops per lookup"
+      defaultValue: DefaultBitsPerHop
+      name: "bits-per-hop" .}: int
 
     case cmd* {.
       command
@@ -182,7 +200,7 @@ proc parseCmdArg*(T: type PrivateKey, p: TaintedString): T
 proc completeCmdArg*(T: type PrivateKey, val: TaintedString): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type ClientConfig, p: TaintedString): T 
+proc parseCmdArg*(T: type ClientConfig, p: TaintedString): T
       {.raises: [Defect, ConfigurationError].} =
   let uri = parseUri(p)
   if (uri.scheme == "http" or uri.scheme == "https"):

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -19,7 +19,7 @@ import
     rpc_portal_debug_api],
   ./network/state/[state_network, state_content],
   ./network/history/[history_network, history_content],
-  ./network/wire/portal_stream,
+  ./network/wire/[portal_stream, portal_protocol_config],
   ./content_db
 
 proc initializeBridgeClient(maybeUri: Option[string]): Option[BridgeClient] =
@@ -73,11 +73,13 @@ proc run(config: PortalConf) {.raises: [CatchableError, Defect].} =
 
     # One instance of PortalStream and thus UtpDiscv5Protocol is shared over all
     # the Portal networks.
+    portalConfig = PortalProtocolConfig.init(
+      config.tableIpLimit, config.bucketIpLimit, config.bitsPerHop)
     portalStream = PortalStream.new(d)
     stateNetwork = StateNetwork.new(d, db, portalStream,
-      bootstrapRecords = bootstrapRecords)
+      bootstrapRecords = bootstrapRecords, portalConfig = portalConfig)
     historyNetwork = HistoryNetwork.new(d, db, portalStream,
-      bootstrapRecords = bootstrapRecords)
+      bootstrapRecords = bootstrapRecords, portalConfig = portalConfig)
 
   # TODO: If no new network key is generated then we should first check if an
   # enr file exists, and in the case it does read out the seqNum from it and

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -10,7 +10,7 @@ import
   stew/results, chronos,
   eth/p2p/discoveryv5/[protocol, enr],
   ../../content_db,
-  ../wire/[portal_protocol, portal_stream],
+  ../wire/[portal_protocol, portal_stream, portal_protocol_config],
   ./history_content
 
 const
@@ -53,10 +53,12 @@ proc new*(
     contentDB: ContentDB,
     portalStream: PortalStream,
     dataRadius = UInt256.high(),
-    bootstrapRecords: openArray[Record] = []): T =
+    bootstrapRecords: openArray[Record] = [],
+    portalConfig: PortalProtocolConfig = defaultPortalProtocolConfig): T =
   let portalProtocol = PortalProtocol.new(
     baseProtocol, historyProtocolId, contentDB, toContentIdHandler,
-    portalStream, dataRadius, bootstrapRecords)
+    portalStream, dataRadius, bootstrapRecords,
+    config = portalConfig)
 
   return HistoryNetwork(portalProtocol: portalProtocol, contentDB: contentDB)
 

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -10,7 +10,7 @@ import
   stew/results, chronos,
   eth/p2p/discoveryv5/[protocol, enr],
   ../../content_db,
-  ../wire/[portal_protocol, portal_stream],
+  ../wire/[portal_protocol, portal_stream, portal_protocol_config],
   ./state_content,
   ./state_distance
 
@@ -53,10 +53,12 @@ proc new*(
     contentDB: ContentDB,
     portalStream: PortalStream,
     dataRadius = UInt256.high(),
-    bootstrapRecords: openArray[Record] = []): T =
+    bootstrapRecords: openArray[Record] = [],
+    portalConfig: PortalProtocolConfig = defaultPortalProtocolConfig): T =
   let portalProtocol = PortalProtocol.new(
     baseProtocol, stateProtocolId, contentDB, toContentIdHandler,
-    portalStream, dataRadius, bootstrapRecords, stateDistanceCalculator)
+    portalStream, dataRadius, bootstrapRecords, stateDistanceCalculator,
+    config = portalConfig)
 
   return StateNetwork(portalProtocol: portalProtocol, contentDB: contentDB)
 

--- a/fluffy/network/wire/portal_protocol_config.nim
+++ b/fluffy/network/wire/portal_protocol_config.nim
@@ -1,0 +1,26 @@
+import
+  eth/p2p/discoveryv5/routing_table
+
+type
+  PortalProtocolConfig* = object
+    tableIpLimits*: TableIpLimits
+    bitsPerHop*: int
+
+const
+  defaultPortalProtocolConfig* = PortalProtocolConfig(
+    tableIpLimits: DefaultTableIpLimits,
+    bitsPerHop: DefaultBitsPerHop)
+
+proc init*(
+    T: type PortalProtocolConfig,
+    tableIpLimit: uint,
+    bucketIpLimit: uint,
+    bitsPerHop: int): T =
+
+  PortalProtocolConfig(
+    tableIpLimits: TableIpLimits(
+      tableIpLimit: tableIpLimit,
+      bucketIpLimit: bucketIpLimit),
+    bitsPerHop: bitsPerHop
+  )
+

--- a/fluffy/scripts/launch_local_testnet.sh
+++ b/fluffy/scripts/launch_local_testnet.sh
@@ -284,6 +284,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --metrics \
     --metrics-address="127.0.0.1" \
     --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE ))" \
+    --bits-per-hop=5 \
     ${EXTRA_ARGS} \
     > "${DATA_DIR}/log${NUM_NODE}.txt" 2>&1 &
 

--- a/fluffy/scripts/test_portal_testnet.nim
+++ b/fluffy/scripts/test_portal_testnet.nim
@@ -53,7 +53,12 @@ procSuite "Portal testnet tests":
       let routingTableInfo = await client.discv5_routingTableInfo()
       var start: seq[NodeId]
       let nodes = foldl(routingTableInfo.buckets, a & b, start)
-      if i == 0: # bootstrap node has all nodes (however not all verified)
+      if i == 0:
+        # bootstrap node has all nodes (however not all verified), however this
+        # is highly dependent on the bits per hop and the amount of nodes
+        # launched and can thus easily fail.
+        # TODO: Set up the network with multiple bootstrap nodes to have a more
+        # robust set-up.
         check nodes.len == config.nodeCount - 1
       else: # Other nodes will have bootstrap node at this point, and maybe more
         check nodes.len > 0


### PR DESCRIPTION
Some options that will be useful in testnets to adjust (e.g. more nodes on the same host).

The IP limit one is somewhat risky, so I've considered a compile time option, but would just become a pain to use probably.

Will require something similar on discv5 level too to make it work properly.
