### PR TITLE
Remove the use of ByteList in PortalStream and for FoundContent

### DIFF
--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -41,11 +41,11 @@ proc getContent*(n: HistoryNetwork, key: ContentKey):
 
   # When content is found and is in the radius range, store it.
   if content.isSome() and contentInRange:
-    n.contentDB.put(contentId, content.get().asSeq())
+    n.contentDB.put(contentId, content.get())
 
   # TODO: for now returning bytes, ultimately it would be nice to return proper
   # domain types.
-  return content.map(x => x.asSeq())
+  return content
 
 proc new*(
     T: type HistoryNetwork,

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -41,11 +41,11 @@ proc getContent*(n: StateNetwork, key: ContentKey):
 
   # When content is found on the network and is in the radius range, store it.
   if content.isSome() and contentInRange:
-    n.contentDB.put(contentId, content.get().asSeq())
+    n.contentDB.put(contentId, content.get())
 
   # TODO: for now returning bytes, ultimately it would be nice to return proper
   # domain types.
-  return content.map(x => x.asSeq())
+  return content
 
 proc new*(
     T: type StateNetwork,

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -27,7 +27,7 @@ type
   ContentRequest = object
     connectionId: uint16
     nodeId: NodeId
-    content: ByteList
+    content: seq[byte]
     timeout: Moment
 
   ContentOffer = object
@@ -74,7 +74,7 @@ proc addContentOffer*(
   return connectionId
 
 proc addContentRequest*(
-    stream: PortalStream, nodeId: NodeId, content: ByteList): Bytes2 =
+    stream: PortalStream, nodeId: NodeId, content: seq[byte]): Bytes2 =
   var connectionId: Bytes2
   brHmacDrbgGenerate(stream.rng[], connectionId)
 
@@ -141,7 +141,7 @@ proc registerIncomingSocketCallback(
       for i, request in stream.contentRequests:
         if request.connectionId == client.connectionId and
             request.nodeId == client.remoteAddress.id:
-          let fut = client.writeAndClose(request.content.asSeq())
+          let fut = client.writeAndClose(request.content)
           stream.contentRequests.del(i)
           return fut
 

--- a/fluffy/rpc/rpc_portal_api.nim
+++ b/fluffy/rpc/rpc_portal_api.nim
@@ -122,7 +122,7 @@ proc installPortalApiHandlers*(
       case foundContent.kind:
       of Content:
         return (
-          some("0x" & foundContent.content.asSeq().toHex()),
+          some("0x" & foundContent.content.toHex()),
           none(seq[Record]))
       of Nodes:
         return (


### PR DESCRIPTION
This ByteList doesn't actually get encoded/decoded anywhere (yet).
It is just a seq[byte] taken from the db, and send/received over
uTP. Additionaly the init call doesn't limit anything either.
So the init + asSeq conversions are rather pointless.