### PR TITLE
Add cli option to start fluffy with a netkey file

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -83,17 +83,23 @@ type
             "This option allows to enable/disable this functionality"
       name: "enr-auto-update" .}: bool
 
-    networkKey* {.
-      desc: "Private key (secp256k1) for the p2p network, hex encoded. Safer keyfile support to be added.",
-      defaultValue: PrivateKey.random(keys.newRng()[])
-      defaultValueDesc: "random"
-      name: "network-key-unsafe" .}: PrivateKey
-
     dataDir* {.
       desc: "The directory where fluffy will store the content data"
       defaultValue: defaultDataDir()
       defaultValueDesc: $defaultDataDirDesc
       name: "data-dir" .}: OutDir
+
+    networkKeyFile* {.
+      desc: "Source of network (secp256k1) private key file"
+      defaultValue: config.dataDir / "netkey",
+      name: "netkey-file" }: string
+
+    networkKey* {.
+      hidden
+      desc: "Private key (secp256k1) for the p2p network, hex encoded.",
+      defaultValue: none(PrivateKey)
+      defaultValueDesc: "none"
+      name: "netkey-unsafe" .}: Option[PrivateKey]
 
     metricsEnabled* {.
       defaultValue: false

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -54,6 +54,11 @@ proc run(config: PortalConf) {.raises: [CatchableError, Defect].} =
       except CatchableError as exc: raise exc
       # TODO: Ideally we don't have the Exception here
       except Exception as exc: raiseAssert exc.msg
+    netkey =
+      if config.networkKey.isSome():
+        config.networkKey.get()
+      else:
+        getPersistentNetKey(rng[], config.networkKeyFile, config.dataDir.string)
 
   var bootstrapRecords: seq[Record]
   loadBootstrapFile(string config.bootstrapNodesFile, bootstrapRecords)
@@ -63,7 +68,7 @@ proc run(config: PortalConf) {.raises: [CatchableError, Defect].} =
     discoveryConfig = DiscoveryConfig.init(
       config.tableIpLimit, config.bucketIpLimit, config.bitsPerHop)
     d = newProtocol(
-      config.networkKey,
+      netkey,
       extIp, none(Port), extUdpPort,
       bootstrapRecords = bootstrapRecords,
       bindIp = bindIp, bindPort = udpPort,


### PR DESCRIPTION
Default the network key will be taken from a network key file
instead of randomly generated on each run. This is done because
the data that gets stored in the content database is dependant on
the network key used, as the node id is derived from this.

Resolving https://github.com/status-im/nimbus-eth1/issues/851