### PR TITLE
Add api to get db size to content db

### DIFF
--- a/fluffy/tests/test_content_db.nim
+++ b/fluffy/tests/test_content_db.nim
@@ -12,6 +12,14 @@ import
   ../network/state/state_content,
   ../content_db
 
+proc genByteSeq(length: int): seq[byte] = 
+  var i = 0
+  var resultSeq = newSeq[byte](length)
+  while i < length:
+    resultSeq[i] = byte(i)
+    inc i
+  return resultSeq
+
 suite "Content Database":
   # Note: We are currently not really testing something new here just basic
   # underlying kvstore.
@@ -43,3 +51,21 @@ suite "Content Database":
       check:
         val.isNone()
         db.contains(key) == false
+
+  test "ContentDB size":
+    let
+      db = ContentDB.new("", inMemory = true)
+
+    let numBytes = 10000
+    let size1 = db.size()
+    db.put(@[1'u8], genByteSeq(numBytes))
+    let size2 = db.size()
+    db.put(@[2'u8], genByteSeq(numBytes))
+    let size3 = db.size()
+    db.put(@[2'u8], genByteSeq(numBytes))
+    let size4 = db.size()
+
+    check:
+      size2 > size1
+      size3 > size2
+      size3 == size4

--- a/fluffy/tests/test_content_db.nim
+++ b/fluffy/tests/test_content_db.nim
@@ -69,3 +69,19 @@ suite "Content Database":
       size2 > size1
       size3 > size2
       size3 == size4
+
+    db.del(@[2'u8])
+    db.del(@[1'u8])
+    
+    let size5 = db.size()
+    
+    check:
+      size4 == size5
+
+    db.reclaimSpace()
+
+    let size6 = db.size()
+
+    check:
+      # After space reclamation size of db should be equal to initial size
+      size6 == size1


### PR DESCRIPTION
Solves https://github.com/status-im/nimbus-eth1/issues/871

It uses sqlite pragmas `page_count` and `page_size` to return current size of db as product of `page_count * page_size`

Imo main reason to use sqlite specific functions, is that `fluffy` is supposed to work on resource restricted devices so it is more valuable to know whole db size (with all metadata and mechanics of how sqlite deletes files) and not only size of stored content.

It also add way to reclaim space after deleting stuff, so it may be possible to delete multiple keys and then reclaim used space if necessary.