### PR TITLE
Avoid opening an uTP stream when no content was accepted

### DIFF
--- a/fluffy/populate_db.nim
+++ b/fluffy/populate_db.nim
@@ -107,7 +107,7 @@ iterator blocks*(
             transactions: rlp.read(seq[Transaction]),
             uncles: rlp.read(seq[BlockHeader]))
           let rlpdata = encode(blockBody)
-          echo rlpdata.toHex()
+
           res.add((contentKey, rlpdata))
           # res.add((contentKey, @(rlp.rawData())))
           # rlp.skipElem()


### PR DESCRIPTION
When the returned content key bitlist of an accept message is all
zeroes, neither side should try to set up an uTP stream.