### PR TITLE
Handle EIP-3675 (TheMerge) switch block

### DIFF
--- a/nimbus/p2p/chain/chain_desc.nim
+++ b/nimbus/p2p/chain/chain_desc.nim
@@ -39,7 +39,8 @@ type
     MuirGlacier,
     Berlin,
     London,
-    ArrowGlacier
+    ArrowGlacier,
+    MergeFork
 
   Chain* = ref object of AbstractChainDB
     db: BaseChainDB
@@ -75,6 +76,12 @@ func toNextFork(n: BlockNumber): uint64 =
   else:
     result = n.truncate(uint64)
 
+func toNextFork(n: Option[BlockNumber]): uint64 =
+  if n.isSome:
+    n.get.truncate(uint64)
+  else:
+    0'u64
+
 func isBlockAfterTtd*(c: Chain, blockHeader: BlockHeader): bool =
   c.db.totalDifficulty + blockHeader.difficulty >= c.db.ttd
 
@@ -92,7 +99,8 @@ func getNextFork(c: ChainConfig, fork: ChainFork): uint64 =
     toNextFork(c.muirGlacierBlock),
     toNextFork(c.berlinBlock),
     toNextFork(c.londonBlock),
-    toNextFork(c.arrowGlacierBlock)
+    toNextFork(c.arrowGlacierBlock),
+    toNextFork(c.mergeForkBlock)
   ]
 
   if fork == high(ChainFork):

--- a/nimbus/p2p/chain/chain_misc.nim
+++ b/nimbus/p2p/chain/chain_misc.nim
@@ -24,6 +24,8 @@ import
 # ------------------------------------------------------------------------------
 
 func toChainFork(c: ChainConfig, number: BlockNumber): ChainFork =
+  if c.mergeForkBlock.isSome and number >= c.mergeForkBlock.get:
+    return MergeFork
   if number >= c.arrowGlacierBlock: ArrowGlacier
   elif number >= c.londonBlock: London
   elif number >= c.berlinBlock: Berlin


### PR DESCRIPTION
why:
  If configured/activated, this block is advertised as FORK_NEXT in the
  status(0x01) message of the RPLx wire protocol.