### PR TITLE
Refactor connection process

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -505,16 +505,14 @@ proc findContent*(p: PortalProtocol, dst: Node, contentKey: ByteList):
           id = dst.id
         return err("Trying to connect to node with unknown address")
 
-      let socketRes = await p.stream.transport.connectTo(
-          nodeAddress.unsafeGet(), uint16.fromBytesBE(m.connectionId))
-      if socketRes.isErr():
-        # TODO: get proper error mapped
-        return err("Error connecting to uTP socket")
-      let socket = socketRes.get()
-      if not socket.isConnected():
-        socket.close()
-        return err("Portal uTP socket is not in connected state")
+      let connectionResult = await p.stream.connectTo(nodeAddress.unsafeGet(), uint16.fromBytesBE(m.connectionId))
 
+      if connectionResult.isErr():
+        error "Utp connection error while trying to find content",
+          msg = connectionResult.error
+        return err("Error connecting uTP socket")
+      
+      let socket = connectionResult.get()
       # Read all bytes from the socket
       # This will either end with a FIN, or because the read action times out.
       # A FIN does not necessarily mean that the data read is complete. Further
@@ -570,17 +568,16 @@ proc offer*(p: PortalProtocol, dst: Node, contentKeys: ContentKeysList):
       error "Trying to connect to node with unknown address",
         id = dst.id
       return err("Trying to connect to node with unknown address")
+      
+    let connectionResult = await p.stream.connectTo(nodeAddress.unsafeGet(), uint16.fromBytesBE(m.connectionId))
 
-    let clientSocketRes = await p.stream.transport.connectTo(
-      nodeAddress.unsafeGet(), uint16.fromBytesBE(m.connectionId))
-    if clientSocketRes.isErr():
-      # TODO: get proper error mapped
-      return err("Error connecting to uTP socket")
-    let clientSocket = clientSocketRes.get()
-    if not clientSocket.isConnected():
-      clientSocket.close()
-      return err("Portal uTP socket is not in connected state")
+    if connectionResult.isErr():
+      error "Utp connection error while trying to offer content",
+        msg = connectionResult.error
+      return err("Error connecting uTP socket")
 
+    let clientSocket = connectionResult.get()
+ 
     for contentKey in requestedContentKeys:
       let contentIdOpt = p.toContentId(contentKey)
       if contentIdOpt.isSome():

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -505,7 +505,11 @@ proc findContent*(p: PortalProtocol, dst: Node, contentKey: ByteList):
           id = dst.id
         return err("Trying to connect to node with unknown address")
 
-      let connectionResult = await p.stream.connectTo(nodeAddress.unsafeGet(), uint16.fromBytesBE(m.connectionId))
+      let connectionResult = 
+        await p.stream.connectTo(
+          nodeAddress.unsafeGet(),
+          uint16.fromBytesBE(m.connectionId)
+        )
 
       if connectionResult.isErr():
         error "Utp connection error while trying to find content",
@@ -569,7 +573,11 @@ proc offer*(p: PortalProtocol, dst: Node, contentKeys: ContentKeysList):
         id = dst.id
       return err("Trying to connect to node with unknown address")
       
-    let connectionResult = await p.stream.connectTo(nodeAddress.unsafeGet(), uint16.fromBytesBE(m.connectionId))
+    let connectionResult = 
+      await p.stream.connectTo(
+        nodeAddress.unsafeGet(), 
+        uint16.fromBytesBE(m.connectionId)
+      )
 
     if connectionResult.isErr():
       error "Utp connection error while trying to offer content",

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -111,16 +111,16 @@ proc connectTo*(
       # This error means that there is already socket to this nodeAddress with given
       # connection id, in our use case it most probably means that other side sent us
       # connection id which is already used.
-      # For now we just fail connection and return error other strategy to consider
-      # would be check this what this this connection status,and then re-use it, or 
-      # close it and re-try connection
+      # For now we just fail connection and return an error. Another strategy to consider
+      # would be to check what is the connection status, and then re-use it, or 
+      # close it and retry connection.
       let msg = "Socket to " & $nodeAddress & "with connection id: " & $connectionId & " already exists"
       return err(msg)
     of ConnectionTimedOut:
-      # Other strategy of handling this error would be to retry conncection few times
-      # before giving up, but we known (as we control uTP impl) that this error will only
-      # be retruned if SYN packet was re-sent 3 times and failed to be acked. This should
-      # be enough for us to known that remote host is not reachable.
+      # Another strategy for handling this error would be to retry connecting a few times
+      # before giving up. But we know (as we control the uTP impl) that this error will only
+      # be returned when a SYN packet was re-sent 3 times and failed to be acked. This
+      # should be enough for us to known that the remote host is not reachable.
       let msg = "uTP timeout while trying to connect to " & $nodeAddress
       return err(msg)
 


### PR DESCRIPTION
Refactor a bit connection process in `PortalStream`. Changes made:

- Make `transport` private to `PortalStream`. Now it will be only component responsible for dealing with underlying uTP implementation
- remove `isConnected` check. Default `connectTo` will only return socket only in connected state.
- Map different connection errors to proper error messages.
- Add some comments about possible future extensions to connection error handling.