### PR TITLE
Remove unused import of config to avoid select_backend db import

### DIFF
--- a/.github/workflows/fluffy.yml
+++ b/.github/workflows/fluffy.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: NimBinaries
-          key: 'nim-linux-amd64-${{ steps.versions.outputs.nimbus_build_system }}'
+          key: 'nim-linux-amd64-${{ steps.versions.outputs.nimbus_build_system }}-fluffy'
 
       - name: Build Nim and Nimbus-eth1 dependencies
         run: |
@@ -215,7 +215,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: external/dlls-${{ matrix.target.cpu }}
-          key: 'dlls-${{ matrix.target.cpu }}'
+          key: 'dlls-${{ matrix.target.cpu }}-fluffy'
 
       - name: Install DLLs dependencies (Windows)
         if: >
@@ -247,7 +247,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: NimBinaries
-          key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}'
+          key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}-fluffy'
 
       - name: Build Nim and Nimbus-eth1 dependencies
         run: |

--- a/.github/workflows/fluffy.yml
+++ b/.github/workflows/fluffy.yml
@@ -272,7 +272,7 @@ jobs:
           env CC=gcc make ${DEFAULT_MAKE_FLAGS} fluffy-tools
           build/fluffy --help
           # CC is needed to select correct compiler 32/64 bit
-          env CC=gcc CXX=g++ make ${DEFAULT_MAKE_FLAGS} fluffy-test fluffy-test-reproducibility
+          env CC=gcc CXX=g++ make ${DEFAULT_MAKE_FLAGS} fluffy-test
 
       - name: Run fluffy tests (Macos)
         if: runner.os == 'Macos'
@@ -282,7 +282,7 @@ jobs:
           make ${DEFAULT_MAKE_FLAGS} fluffy-tools
           build/fluffy --help
           # "-static" option will not work for osx unless static system libraries are provided
-          make ${DEFAULT_MAKE_FLAGS} fluffy-test fluffy-test-reproducibility
+          make ${DEFAULT_MAKE_FLAGS} fluffy-test
 
       - name: Run fluffy testnet
         run: |

--- a/fluffy/rpc/bridge_client.nim
+++ b/fluffy/rpc/bridge_client.nim
@@ -8,7 +8,7 @@
 {.push raises: [Defect].}
 
 import
-  std/json, 
+  std/json,
   stew/[byteutils, results],
   eth/common, chronos, json_rpc/rpcclient
 
@@ -52,10 +52,10 @@ proc getNextItem*(bridgeClient: BridgeClient, blockHash: Hash256, acctAddr: EthA
 
 # bridge_getBlockWitness
 # Returns a list of all RLP-encoded merkle trie values (including contract bytecode) accessed during block execution
-proc getBlockWitness*(bridgeClient: BridgeClient, blockNumber: BlockNumber): 
+proc getBlockWitness*(bridgeClient: BridgeClient, blockNumber: BlockNumber):
   Future[Result[seq[seq[byte]], string]] {.async, raises: [Defect, CatchableError].} =
   let result = await bridgeClient.call("bridge_getBlockWitnessblockNumber", %[%blockNumber])
   return parseWitness(result)
 
-proc close*(bridgeClient: BridgeClient): Future[void] {.async, raises: [Defect, CatchableError].} = 
+proc close*(bridgeClient: BridgeClient): Future[void] {.async, raises: [Defect, CatchableError].} =
   await bridgeClient.close()

--- a/nimbus/vm2/state.nim
+++ b/nimbus/vm2/state.nim
@@ -11,7 +11,6 @@
 import
   std/[json, macros, options, sets, strformat, tables],
   ../../stateless/[witness_from_tree, witness_types],
-  ../config,
   ../constants,
   ../db/[db_chain, accounts_cache],
   ../errors,


### PR DESCRIPTION
- Importing nimbus-eth1 config.nim causes import of select_backend
which will default cause an import of kvstore_rocksdb and thus a
require rocksdb. Remove unused one to avoid rocksdb dependency
for Fluffy.
- Remove some whitespace in bridge_client (to make fluffy CI
trigger for sure).

