### PR TITLE
Add api to get n furthest elements from db

### DIFF
--- a/fluffy/tests/test_content_db.nim
+++ b/fluffy/tests/test_content_db.nim
@@ -22,7 +22,7 @@ proc genByteSeq(length: int): seq[byte] =
     inc i
   return resultSeq
 
-proc generateNRanomU256(rng: var BrHmacDrbgContext, n: int): seq[UInt256] =
+proc generateNRandomU256(rng: var BrHmacDrbgContext, n: int): seq[UInt256] =
   var i = 0
   var res = newSeq[Uint256]()
   while i < n:
@@ -128,8 +128,8 @@ suite "Content Database":
       TestCase.init(@[u256(5), u256(1), u256(2), u256(4)], 4),
       TestCase.init(@[u256(57), u256(32), u256(108), u256(4)], 2),
       TestCase.init(@[u256(57), u256(32), u256(108), u256(4)], 4),
-      TestCase.init(generateNRanomU256(rng[], 10), 5),
-      TestCase.init(generateNRanomU256(rng[], 10), 10)
+      TestCase.init(generateNRandomU256(rng[], 10), 5),
+      TestCase.init(generateNRandomU256(rng[], 10), 10)
     ]
 
     for testCase in testCases:
@@ -139,7 +139,7 @@ suite "Content Database":
       for elem in testCase.keys:
         db.put(elem, genByteSeq(32))
 
-      let furthest = db.getNFurtherstElements(zero, testCase.n)
+      let furthest = db.getNFurthestElements(zero, testCase.n)
 
       var sortedKeys = testCase.keys
 


### PR DESCRIPTION
Partially solves: https://github.com/status-im/nimbus-eth1/issues/870

caveats:

Currently works by querying for all elements in database and doing all necessary 
work on program level. This is mainly due to two facts:
- sqlite does not have build xor function, also it does not handle bitwise
operations on blobs as expected
- our nim wrapper for sqlite does not support create_function api of sqlite
so we cannot create custom function comparing blobs at sql level. If that 
would be possible we may be able to all this work by one sql query

Also for now using hardcoded xor function (as this is the one used for history network). Before customizing distance function it would be good to decide how do we want to deal with different content dbs for each network i.e answet question on top of the file:
```
# 1. More kvstores are added per network, and thus depending on the network a
# different kvstore needs to be selected.
# 2. Or more kvstores are added per network and per content type, and thus
# content key fields are required to access the data.
# 3. Or databases are created per network (and kvstores pre content type) and
# thus depending on the network the right db needs to be selected
```
At this point I am slightly leaning in direction of having different db (i.e different sqlite file) for each network, then each network can manage its own db in the way that is most efficient. The problem would be of course handling json rpc queries which must combine data from different networks, but I am not sure that this will be big problem. 