### PR TITLE
Concurrent offers

### DIFF
--- a/fluffy/network/state/state_distance.nim
+++ b/fluffy/network/state/state_distance.nim
@@ -19,7 +19,7 @@ const MAX* = high(Uint256)
 #  - modulo operations
 #  - abs operation
 # and the results are eqivalent to function described in spec.
-# 
+#
 # The way it works is as follows. Let say we have integers modulo 8:
 # [0, 1, 2, 3, 4, 5, 6, 7]
 # and we want to calculate minimal distance between 0 and 5.
@@ -27,7 +27,7 @@ const MAX* = high(Uint256)
 # From this we know that the shorter distance is the one wraping around 0, which
 # is equal to 3
 func stateDistance*(node_id: UInt256, content_id: UInt256): UInt256 =
-  let rawDiff = 
+  let rawDiff =
     if node_id > content_id:
       node_id - content_id
     else:
@@ -50,7 +50,7 @@ func log2DistanceImpl(value: UInt256): uint16 =
 
   if value == UInt256.one:
     return 0'u16
-  
+
   var comp = value
   var ret = 0'u16
   while (comp > 1):

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -100,8 +100,8 @@ proc addContentRequest*(
   return connectionId
 
 proc connectTo*(
-  stream: PortalStream, 
-  nodeAddress: NodeAddress, 
+  stream: PortalStream,
+  nodeAddress: NodeAddress,
   connectionId: uint16): Future[Result[UtpSocket[NodeAddress], string]] {.async.} =
   let socketRes = await stream.transport.connectTo(nodeAddress, connectionId)
 
@@ -112,7 +112,7 @@ proc connectTo*(
       # connection id, in our use case it most probably means that other side sent us
       # connection id which is already used.
       # For now we just fail connection and return an error. Another strategy to consider
-      # would be to check what is the connection status, and then re-use it, or 
+      # would be to check what is the connection status, and then re-use it, or
       # close it and retry connection.
       let msg = "Socket to " & $nodeAddress & "with connection id: " & $connectionId & " already exists"
       return err(msg)

--- a/fluffy/populate_db.nim
+++ b/fluffy/populate_db.nim
@@ -154,6 +154,11 @@ proc propagateHistoryDb*(
         # TODO: This call will get the content we just stored in the db, so it
         # might be an improvement to directly pass it.
         await p.neighborhoodGossip(ContentKeysList(@[encode(value[0])]))
+
+    # Need to be sure that all offers where started. TODO: this is not great.
+    while not p.offerQueueEmpty():
+      error "WAITING FOR OFFER QUEUE EMPTY"
+      await sleepAsync(500.milliseconds)
     return ok()
   else:
     return err(blockData.error)


### PR DESCRIPTION
Initial attempt to queue/limit the outgoing offers (currently just in neighborhood gossip).
It needs to be improved (see big comment) to apply to offer + findContent + both directions. Current only outgoing offer is addressed as it allows us to run several offers async which allows for much quicker seeding of content in the network.


The `concurrentOffers = 50`  value was selected based on some tests seeding data in the testnet. See metrics below: value of 50, 100 and 400 concurrent offers can be seen, and their effects. As can be seen, the failure rate vs success rate gets less interesting at 100.

![image](https://user-images.githubusercontent.com/7857583/161271953-da40112e-e09c-4ed0-a2e6-e034bf2811ee.png)


This will have to be fine tuned again later on, in bigger network with more data, but also already when more than 1 content item is being sent per offer/accept cycle.