### PR TITLE
Inital poke implementation

### DIFF
--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -130,11 +130,21 @@ proc getBlockHeader*(
 
   let headerContent = maybeHeaderContent.unsafeGet()
 
-  let maybeHeader = validateHeaderBytes(headerContent, hash)
+  let maybeHeader = validateHeaderBytes(headerContent.content, hash)
 
   # content is in range and valid, put into db
   if maybeHeader.isSome() and h.portalProtocol.inRange(contentId):
-     h.contentDB.put(contentId, headerContent)
+    # TODO this bit is quite troubling, currently we may trigger offer/accept
+    # only when content is in our db and we save content only when is in our range
+    # which means we cannot propagate content which is not in our range, but maybe
+    # in range of other nodes. 
+    h.contentDB.put(contentId, headerContent.content)
+    # content is valid and in db we may propagate it through the network
+    h.portalProtocol.triggerPoke(
+      headerContent.nodesInterestedInContent,
+      keyEncoded, 
+      contentId
+    )
 
   return maybeHeader
 
@@ -164,7 +174,7 @@ proc getBlock*(
 
   let bodyContent = maybeBodyContent.unsafeGet()
 
-  let maybeBody = validateBodyBytes(bodyContent, header.txRoot, header.ommersHash)
+  let maybeBody = validateBodyBytes(bodyContent.content, header.txRoot, header.ommersHash)
 
   if maybeBody.isNone():
     return none(Block)
@@ -173,7 +183,17 @@ proc getBlock*(
 
   # content is in range and valid, put into db
   if h.portalProtocol.inRange(contentId):
-     h.contentDB.put(contentId, bodyContent)
+    # TODO this bit is quite troubling, currently we may trigger offer/accept
+    # only when content is in our db and we save content only when is in our range
+    # which means we cannot propagate content which is not in our range, but maybe
+    # in range of other nodes. 
+    h.contentDB.put(contentId, bodyContent.content)
+    # content is valid and in db we may propagate it through the network
+    h.portalProtocol.triggerPoke(
+      bodyContent.nodesInterestedInContent,
+      keyEncoded, 
+      contentId
+    )
 
   return some[Block]((header, blockBody))
 

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -139,7 +139,7 @@ proc getBlockHeader*(
     # which means we cannot propagate content which is not in our range, but maybe
     # in range of other nodes. 
     h.contentDB.put(contentId, headerContent.content)
-    # content is valid and in db we may propagate it through the network
+    # content is valid and in the db, it may be propagated it through the network
     h.portalProtocol.triggerPoke(
       headerContent.nodesInterestedInContent,
       keyEncoded, 

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -42,13 +42,19 @@ proc getContent*(n: StateNetwork, key: ContentKey):
 
   let content = await n.portalProtocol.contentLookup(keyEncoded, contentId)
 
+  if content.isNone():
+    return none[seq[byte]]()
+
+  let contentResult = content.get()
+
   # When content is found on the network and is in the radius range, store it.
   if content.isSome() and contentInRange:
-    n.contentDB.put(contentId, content.get())
+    # TODO Add poke when working on state network
+    n.contentDB.put(contentId, contentResult.content)
 
   # TODO: for now returning bytes, ultimately it would be nice to return proper
   # domain types.
-  return content
+  return some(contentResult.content)
 
 proc new*(
     T: type StateNetwork,

--- a/fluffy/network/wire/messages.nim
+++ b/fluffy/network/wire/messages.nim
@@ -19,7 +19,7 @@ import
 export ssz_serialization, stint, common_types
 
 const
-  contentKeysLimit = 64
+  contentKeysLimit* = 64
 
 type
   ContentKeysList* = List[ByteList, contentKeysLimit]

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -144,11 +144,27 @@ type
     Content
 
   FoundContent* = object
+    dst*: Node
     case kind*: FoundContentKind
     of Content:
       content*: seq[byte]
     of Nodes:
       nodes*: seq[Node]
+
+  ContentLookupResult* = object
+    content*: seq[byte]
+    # List of nodes which do not have requested content, and for which
+    # content is in their range
+    nodesInterestedInContent*: seq[Node]
+
+proc init*(
+  T: type ContentLookupResult, 
+  content: seq[byte], 
+  nodesInterestedInContent: seq[Node]): T =
+  ContentLookupResult(
+    content: content, 
+    nodesInterestedInContent: nodesInterestedInContent
+  )
 
 func `$`(id: PortalProtocolId): string =
   id.toHex()
@@ -168,9 +184,16 @@ func localNode*(p: PortalProtocol): Node = p.baseProtocol.localNode
 func neighbours*(p: PortalProtocol, id: NodeId, seenOnly = false): seq[Node] =
   p.routingTable.neighbours(id = id, seenOnly = seenOnly)
 
+proc inRangeImpl(
+  p: PortalProtocol,
+  nodeId: NodeId, 
+  nodeRadius: Uint256, 
+  contentId: ContentId): bool =
+  let distance = p.routingTable.distance(nodeId, contentId)
+  distance <= nodeRadius
+
 func inRange*(p: PortalProtocol, contentId: ContentId): bool =
-  let distance = p.routingTable.distance(p.localNode.id, contentId)
-  distance <= p.dataRadius
+  p.inRangeImpl(p.localNode.id, p.dataRadius, contentId)
 
 func truncateEnrs(
     nodes: seq[Node], maxSize: int, enrOverhead: int): List[ByteList, 32] =
@@ -549,19 +572,19 @@ proc findContent*(p: PortalProtocol, dst: Node, contentKey: ByteList):
       if await readData.withTimeout(p.stream.readTimeout):
         let content = readData.read
         await socket.destroyWait()
-        return ok(FoundContent(kind: Content, content: content))
+        return ok(FoundContent(dst: dst, kind: Content, content: content))
       else:
         socket.close()
         return err("Reading data from socket timed out, content request failed")
     of contentType:
-      return ok(FoundContent(kind: Content, content: m.content.asSeq()))
+      return ok(FoundContent(dst: dst, kind: Content, content: m.content.asSeq()))
     of enrsType:
       let records = recordsFromBytes(m.enrs)
       if records.isOk():
         let verifiedNodes =
           verifyNodesRecords(records.get(), dst, enrsResultLimit)
 
-        return ok(FoundContent(kind: Nodes, nodes: verifiedNodes))
+        return ok(FoundContent(dst: dst, kind: Nodes, nodes: verifiedNodes))
       else:
         return err("Content message returned invalid ENRs")
 
@@ -758,11 +781,36 @@ proc lookup*(p: PortalProtocol, target: NodeId): Future[seq[Node]] {.async.} =
   p.lastLookup = now(chronos.Moment)
   return closestNodes
 
+proc triggerPoke*(
+    p: PortalProtocol,
+    nodes: seq[Node], 
+    contentKey: ByteList,
+    contentId: ContentId) =
+  ## Trigers asynchronous offer-accept interaction to provided nodes.
+  ## Provided content should be in range of provided nodes
+  ## Provided content should be in database
+  ## TODO Related to todo in `proc offer` it maybe better to pass content to
+  ## offer directly to avoid potential problems when content is not really in database
+  ## this will be especially important when we introduce deleting content
+  ## from database
+  let keys = List[ByteList, contentKeysLimit].init(@[contentKey])
+  for node in nodes:
+    if not p.offerQueue.full():
+      try:
+        p.offerQueue.putNoWait((node, keys))
+      except AsyncQueueFullError as e:
+        # should not happen as we always check is full before putting element to the queue
+        raiseAssert(e.msg)
+    else:
+      # offer queue full, do not start more offer offer-accept interactions
+      return 
+
+
 # TODO ContentLookup and Lookup look almost exactly the same, also lookups in other
 # networks will probably be very similar. Extract lookup function to separate module
 # and make it more generaic
 proc contentLookup*(p: PortalProtocol, target: ByteList, targetId: UInt256):
-    Future[Option[seq[byte]]] {.async.} =
+    Future[Option[ContentLookupResult]] {.async.} =
   ## Perform a lookup for the given target, return the closest n nodes to the
   ## target. Maximum value for n is `BUCKET_SIZE`.
   # `closestNodes` holds the k closest nodes to target found, sorted by distance
@@ -778,6 +826,8 @@ proc contentLookup*(p: PortalProtocol, target: ByteList, targetId: UInt256):
 
   var pendingQueries = newSeqOfCap[Future[PortalResult[FoundContent]]](alpha)
   var requestAmount = 0'i64
+
+  var nodesWithoutContent: seq[Node] = newSeq[Node]()
 
   while true:
     var i = 0
@@ -811,6 +861,13 @@ proc contentLookup*(p: PortalProtocol, target: ByteList, targetId: UInt256):
 
       case content.kind
       of Nodes:
+        let maybeRadius = p.radiusCache.get(content.dst.id)
+        if maybeRadius.isSome() and p.inRangeImpl(content.dst.id, maybeRadius.unsafeGet(), targetId):
+          # we only return nodes which may be interested in content
+          # also we do not need to chec for duplicates in nodesWithoutContent
+          # as we never make requests two times to the same node
+          nodesWithoutContent.add(content.dst)
+
         for n in content.nodes:
           if not seen.containsOrIncl(n.id):
             discard p.routingTable.addNode(n)
@@ -823,20 +880,20 @@ proc contentLookup*(p: PortalProtocol, target: ByteList, targetId: UInt256):
 
             if closestNodes.len > BUCKET_SIZE:
               closestNodes.del(closestNodes.high())
+                        
       of Content:
         # cancel any pending queries as we have find the content
         for f in pendingQueries:
           f.cancel()
-
         portal_lookup_content_requests.observe(requestAmount)
-        return some(content.content)
+        return some(ContentLookupResult.init(content.content, nodesWithoutContent))
     else:
       # TODO: Should we do something with the node that failed responding our
       # query?
       discard
-
+  
   portal_lookup_content_failures.inc()
-  return none[seq[byte]]()
+  return none[ContentLookupResult]()
 
 proc query*(p: PortalProtocol, target: NodeId, k = BUCKET_SIZE): Future[seq[Node]]
     {.async.} =

--- a/fluffy/tests/test_portal_wire_protocol.nim
+++ b/fluffy/tests/test_portal_wire_protocol.nim
@@ -265,7 +265,6 @@ procSuite "Portal Wire Protocol Tests":
 
     let res = lookupResult.unsafeGet()
 
-    echo res
     check:
       res.content == content
       res.nodesInterestedInContent.contains(node2.localNode)


### PR DESCRIPTION
Initial implementation of POKE mechanism i.e offering content to nodes which we discovered do not have it during content lookup.

One caveat for now:
- Currently, due to how code is structured, we may only offer content which is in our db i.e it is in our range. It means we cannot offer content to nodes in case when content is in their range and not in our range. There is one one `todo` in offer procedure which would fix it i.e passing content directly of `offer` procedure, instead of using db as communication channel. It would also cause problem when we add deleting stuff from db, as offer-accept is asynchronous  so the content could be deleted before be send it via uTP. 
