### PR TITLE
Use SSZ List of content items to send over the uTP stream

### DIFF
--- a/fluffy/common/common_types.nim
+++ b/fluffy/common/common_types.nim
@@ -12,6 +12,7 @@ import
 
 type
   ByteList* = List[byte, 2048]
+  BigByteList* = List[byte, 100 * 1024] # TODO: What size should we take here?
   Bytes2* = array[2, byte]
   Bytes32* = array[32, byte]
 

--- a/fluffy/network/wire/messages.nim
+++ b/fluffy/network/wire/messages.nim
@@ -104,6 +104,9 @@ type
     FindContentMessage or ContentMessage or
     OfferMessage or AcceptMessage
 
+  ContentPayload* = object
+    contentList*: List[BigByteList, contentKeysLimit]
+
 template messageKind*(T: typedesc[SomeMessage]): MessageKind =
   when T is PingMessage: ping
   elif T is PongMessage: pong


### PR DESCRIPTION
Implementation of option two of https://github.com/ethereum/portal-network-specs/issues/134

Using `ContentPayload = Container[contentList: List[BigByteList, max_length=64]]`. Small adjustment there being `BigByteList = List[byte, 100 * 1024]` instead of `ByteList`.

Currently don't see much use of having the `Container` around the `List`. Comes of course with the streaming issue metioned in above issue.
