### PR TITLE
No priority for RPC transactions

### DIFF
--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -248,11 +248,9 @@ proc setupEthRpc*(node: EthereumNode, ctx: EthContext, chain: BaseChainDB, txPoo
       eip155   = chain.currentBlock >= chain.config.eip155Block
       signedTx = signTransaction(tx, acc.privateKey, chain.config.chainId, eip155)
       rlpTx    = rlp.encode(signedTx)
-      res      = txPool.addLocal(signedTx, force = true)
 
-    if res.isErr:
-      raise newException(ValueError, $res.error)
-
+    txPool.jobAddTx(signedTx)
+    txPool.jobCommit(true)
     result = keccak_256.digest(rlpTx).ethHashStr
 
   server.rpc("eth_sendRawTransaction") do(data: HexDataStr) -> EthHashStr:
@@ -264,11 +262,9 @@ proc setupEthRpc*(node: EthereumNode, ctx: EthContext, chain: BaseChainDB, txPoo
     let
       txBytes = hexToSeqByte(data.string)
       signedTx = rlp.decode(txBytes, Transaction)
-      res = txPool.addLocal(signedTx, force = true)
 
-    if res.isErr:
-      raise newException(ValueError, $res.error)
-
+    txPool.jobAddTx(signedTx)
+    txPool.jobCommit(true)
     result = keccak_256.digest(txBytes).ethHashStr
 
   server.rpc("eth_call") do(call: EthCall, quantityTag: string) -> HexDataStr:


### PR DESCRIPTION
Currently, there is no meaningful way to have a single local transaction. Only an account can be local.

This will be changed and local transactions will be introduced.