### PR TITLE
Add validation handler to Portal wire protocol

### DIFF
--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -56,6 +56,9 @@ proc getContent*(n: StateNetwork, key: ContentKey):
   # domain types.
   return some(contentResult.content)
 
+proc validateContent(content: openArray[byte], contentKey: ByteList): bool =
+  true
+
 proc new*(
     T: type StateNetwork,
     baseProtocol: protocol.Protocol,
@@ -64,7 +67,8 @@ proc new*(
     bootstrapRecords: openArray[Record] = [],
     portalConfig: PortalProtocolConfig = defaultPortalProtocolConfig): T =
   let portalProtocol = PortalProtocol.new(
-    baseProtocol, stateProtocolId, contentDB, toContentIdHandler,
+    baseProtocol, stateProtocolId, contentDB,
+    toContentIdHandler, validateContent,
     dataRadius, bootstrapRecords, stateDistanceCalculator,
     config = portalConfig)
 

--- a/fluffy/tools/portalcli.nim
+++ b/fluffy/tools/portalcli.nim
@@ -187,6 +187,9 @@ proc testHandler(contentKey: ByteList): Option[ContentId] =
   let idHash = sha256.digest("test")
   some(readUintBE[256](idHash.data))
 
+proc validateContent(content: openArray[byte], contentKey: ByteList): bool =
+  true
+
 proc run(config: PortalCliConf) =
   let
     rng = newRng()
@@ -212,7 +215,8 @@ proc run(config: PortalCliConf) =
 
   let
     db = ContentDB.new("", inMemory = true)
-    portal = PortalProtocol.new(d, config.protocolId, db, testHandler,
+    portal = PortalProtocol.new(d, config.protocolId, db,
+      testHandler, validateContent,
       bootstrapRecords = bootstrapRecords)
     socketConfig = SocketConfig.init(
       incomingSocketReceiveTimeout = none(Duration))


### PR DESCRIPTION
- Validation handler allows for network specific validation of
the content
- Added also pruning of the allowed connections on PortalStream

Requires more work (for follow-up PR) but these 2 items would already allow for the fleet to not get bogus headers. 