### PR TITLE
Add put method which preserves max size

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -33,6 +33,9 @@ const
   defaultAdminListenAddressDesc = $defaultAdminListenAddress
   defaultDataDirDesc = defaultDataDir()
   defaultClientConfigDesc = $(defaultClientConfig.httpUri)
+  # 100mb seems a bit smallish we may consider increasing defaults after some
+  # network measurements
+  defaultStorageSize* = uint32(1000 * 1000 * 100)
 
 type
   PortalCmd* = enum
@@ -183,6 +186,14 @@ type
       desc: "Kademlia's b variable, increase for less hops per lookup"
       defaultValue: DefaultBitsPerHop
       name: "bits-per-hop" .}: int
+
+    # TODO maybe it is worth defining minimal storage size and throw error if
+    # value provided is smaller than minimum
+    storageSize* {.
+      desc: "Maximum amount (in bytes) of content which will be stored " &
+            "in local database."
+      defaultValue: defaultStorageSize
+      name: "storage-size" .}: uint32
 
     case cmd* {.
       command

--- a/fluffy/content_db.nim
+++ b/fluffy/content_db.nim
@@ -173,7 +173,7 @@ proc get*(db: ContentDB, key: openArray[byte]): Option[seq[byte]] =
 
   return res
 
-proc put*(db: ContentDB, key, value: openArray[byte]) =
+proc put(db: ContentDB, key, value: openArray[byte]) =
   db.kv.put(key, value).expectDb()
 
 proc contains*(db: ContentDB, key: openArray[byte]): bool =
@@ -194,7 +194,7 @@ proc get*(db: ContentDB, key: ContentId): Option[seq[byte]] =
   # TODO: Here it is unfortunate that ContentId is a uint256 instead of Digest256.
   db.get(key.toByteArrayBE())
 
-proc put*(db: ContentDB, key: ContentId, value: openArray[byte]) =
+proc put(db: ContentDB, key: ContentId, value: openArray[byte]) =
   db.put(key.toByteArrayBE(), value)
 
 proc contains*(db: ContentDB, key: ContentId): bool =
@@ -225,7 +225,7 @@ proc deleteNelemsNoMoreThan(
       db.reclaimSpace()
       return (elem.distFrom, deltedFraction)
 
-proc putAndPrune*(
+proc put*(
   db: ContentDB, 
   key: ContentId, 
   value: openArray[byte],
@@ -236,8 +236,7 @@ proc putAndPrune*(
   if dbSize < int64(db.maxSize):
     return PutResult(kind: ContentStored)
   else:
-    # TODO maybe caller should decide how many elements should be deleted and what
-    # fraction of content should be left ?
+    # TODO Add some configuration for this magic numbers
     let (furthestNonDeletedElement, deletedFraction) = db.deleteNelemsNoMoreThan(target, 100000, 0.25)
     return PutResult(
       kind: DbPruned,

--- a/fluffy/content_db.nim
+++ b/fluffy/content_db.nim
@@ -194,6 +194,8 @@ proc get*(db: ContentDB, key: ContentId): Option[seq[byte]] =
   # TODO: Here it is unfortunate that ContentId is a uint256 instead of Digest256.
   db.get(key.toByteArrayBE())
 
+# TODO: Public due to usage in populating portal db, should be made private after
+# improving db populating to use local node id
 proc put*(db: ContentDB, key: ContentId, value: openArray[byte]) =
   db.put(key.toByteArrayBE(), value)
 

--- a/fluffy/content_db.nim
+++ b/fluffy/content_db.nim
@@ -194,7 +194,7 @@ proc get*(db: ContentDB, key: ContentId): Option[seq[byte]] =
   # TODO: Here it is unfortunate that ContentId is a uint256 instead of Digest256.
   db.get(key.toByteArrayBE())
 
-proc put(db: ContentDB, key: ContentId, value: openArray[byte]) =
+proc put*(db: ContentDB, key: ContentId, value: openArray[byte]) =
   db.put(key.toByteArrayBE(), value)
 
 proc contains*(db: ContentDB, key: ContentId): bool =

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -100,7 +100,7 @@ proc run(config: PortalConf) {.raises: [CatchableError, Defect].} =
   let
     radius = UInt256.fromLogRadius(config.logRadius)
     db = ContentDB.new(config.dataDir / "db" / "contentdb_" &
-      d.localNode.id.toByteArrayBE().toOpenArray(0, 8).toHex())
+      d.localNode.id.toByteArrayBE().toOpenArray(0, 8).toHex(), maxSize = config.storageSize)
 
     portalConfig = PortalProtocolConfig.init(
       config.tableIpLimit, config.bucketIpLimit, config.bitsPerHop)
@@ -180,7 +180,7 @@ when isMainModule:
     run(config)
   of PortalCmd.populateHistoryDb:
     let
-      db = ContentDB.new(config.dbDir.string)
+      db = ContentDB.new(config.dbDir.string, config.storageSize)
       res = populateHistoryDb(db, config.dataFile.string)
     if res.isErr():
       fatal "Failed populating the history content db", error = $res.error

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -148,7 +148,12 @@ proc getBlockHeader*(
 
     if h.portalProtocol.inRange(contentId):
       # content is valid and in our range, save it into our db
-      h.contentDB.put(contentId, headerContent.content)
+      # TODO handle radius adjustments
+      discard h.contentDB.putAndPrune(
+                contentId, 
+                headerContent.content,
+                h.portalProtocol.localNode.id
+              )
 
   return maybeHeader
 
@@ -198,7 +203,11 @@ proc getBlock*(
 
   # content is in range and valid, put into db
   if h.portalProtocol.inRange(contentId):
-    h.contentDB.put(contentId, bodyContent.content)
+    # TODO handle radius adjustments
+    discard h.contentDB.putAndPrune(
+              contentId, bodyContent.content,
+              h.portalProtocol.localNode.id
+            )
 
   return some[Block]((header, blockBody))
 

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -149,7 +149,7 @@ proc getBlockHeader*(
     if h.portalProtocol.inRange(contentId):
       # content is valid and in our range, save it into our db
       # TODO handle radius adjustments
-      discard h.contentDB.putAndPrune(
+      discard h.contentDB.put(
                 contentId, 
                 headerContent.content,
                 h.portalProtocol.localNode.id
@@ -204,7 +204,7 @@ proc getBlock*(
   # content is in range and valid, put into db
   if h.portalProtocol.inRange(contentId):
     # TODO handle radius adjustments
-    discard h.contentDB.putAndPrune(
+    discard h.contentDB.put(
               contentId, bodyContent.content,
               h.portalProtocol.localNode.id
             )

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -53,7 +53,7 @@ proc getContent*(n: StateNetwork, key: ContentKey):
   # When content is found on the network and is in the radius range, store it.
   if content.isSome() and contentInRange:
     # TODO Add poke when working on state network
-    n.contentDB.put(contentId, contentResult.content)
+    discard n.contentDB.put(contentId, contentResult.content, n.portalProtocol.localNode.id)
 
   # TODO: for now returning bytes, ultimately it would be nice to return proper
   # domain types.

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -1047,7 +1047,12 @@ proc processContent(
 
       let contentId = contentIdOpt.get()
       # Store content, should we recheck radius?
-      p.contentDB.put(contentId, content)
+      # TODO handle radius adjustments
+      discard p.contentDB.putAndPrune(
+                contentId, 
+                content, 
+                p.baseProtocol.localNode.id
+              )
 
       info "Received valid offered content", contentKey
 

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -1048,7 +1048,7 @@ proc processContent(
       let contentId = contentIdOpt.get()
       # Store content, should we recheck radius?
       # TODO handle radius adjustments
-      discard p.contentDB.putAndPrune(
+      discard p.contentDB.put(
                 contentId, 
                 content, 
                 p.baseProtocol.localNode.id

--- a/fluffy/populate_db.nim
+++ b/fluffy/populate_db.nim
@@ -137,6 +137,8 @@ iterator blocks*(
     else:
       error "Failed reading block from block data", error = res.error
 
+# TODO pass nodeid as uint256 so it will be possible to use put method which
+# preserves size
 proc populateHistoryDb*(
     db: ContentDB, dataFile: string, verify = false): Result[void, string] =
   let blockData = ? readBlockDataTable(dataFile)
@@ -144,6 +146,7 @@ proc populateHistoryDb*(
   for b in blocks(blockData, verify):
     for value in b:
       # Note: This is the slowest part due to the hashing that takes place.
+      # TODO use put method which preserves size 
       db.put(history_content.toContentId(value[0]), value[1])
 
   ok()

--- a/fluffy/rpc/rpc_portal_debug_api.nim
+++ b/fluffy/rpc/rpc_portal_debug_api.nim
@@ -23,7 +23,8 @@ proc installPortalDebugApiHandlers*(
       contentId: string, content: string) -> bool:
     # Using content id as parameter to make it more easy to store. Might evolve
     # in using content key.
-    p.contentDB.put(hexToSeqByte(contentId), hexToSeqByte(content))
+    let cId = UInt256.fromBytesBE(hexToSeqByte(contentId))
+    discard p.contentDB.put(cId, hexToSeqByte(content), p.localNode.id)
 
     return true
 

--- a/fluffy/tests/test_content_db.nim
+++ b/fluffy/tests/test_content_db.nim
@@ -35,7 +35,7 @@ proc generateNRandomU256(rng: var BrHmacDrbgContext, n: int): seq[UInt256] =
 
 suite "Content Database":
   let rng = newRng()
-
+  let testId = u256(0)
   # Note: We are currently not really testing something new here just basic
   # underlying kvstore.
   test "ContentDB basic API":
@@ -51,7 +51,7 @@ suite "Content Database":
         db.contains(key) == false
 
     block:
-      db.put(key, [byte 0, 1, 2, 3])
+      discard db.put(key, [byte 0, 1, 2, 3], testId)
       let val = db.get(key)
 
       check:
@@ -73,11 +73,11 @@ suite "Content Database":
 
     let numBytes = 10000
     let size1 = db.size()
-    db.put(@[1'u8], genByteSeq(numBytes))
+    discard db.put(u256(1), genByteSeq(numBytes), testId)
     let size2 = db.size()
-    db.put(@[2'u8], genByteSeq(numBytes))
+    discard db.put(u256(2), genByteSeq(numBytes), testId)
     let size3 = db.size()
-    db.put(@[2'u8], genByteSeq(numBytes))
+    discard db.put(u256(2), genByteSeq(numBytes), testId)
     let size4 = db.size()
 
     check:
@@ -85,8 +85,8 @@ suite "Content Database":
       size3 > size2
       size3 == size4
 
-    db.del(@[2'u8])
-    db.del(@[1'u8])
+    db.del(u256(2))
+    db.del(u256(1))
     
     let size5 = db.size()
     
@@ -137,7 +137,7 @@ suite "Content Database":
         db = ContentDB.new("", uint32.high, inMemory = true)
 
       for elem in testCase.keys:
-        db.put(elem, genByteSeq(32))
+        discard db.put(elem, genByteSeq(32), testId)
 
       let (furthest, _) = db.getNFurthestElements(zero, testCase.n)
 
@@ -165,16 +165,16 @@ suite "Content Database":
 
 
     let numBytes = 10000
-    let pr1 = db.putAndPrune(u256(1), genByteSeq(numBytes), u256(0))
-    let pr2 = db.putAndPrune(thirdFurthest, genByteSeq(numBytes), u256(0))
-    let pr3 = db.putAndPrune(u256(3), genByteSeq(numBytes), u256(0))
-    let pr4 = db.putAndPrune(u256(10), genByteSeq(numBytes), u256(0))
-    let pr5 = db.putAndPrune(u256(5), genByteSeq(numBytes), u256(0))
-    let pr6 = db.putAndPrune(u256(10), genByteSeq(numBytes), u256(0))
-    let pr7 = db.putAndPrune(furthestElement, genByteSeq(numBytes), u256(0))
-    let pr8 = db.putAndPrune(secondFurthest, genByteSeq(numBytes), u256(0))
-    let pr9 = db.putAndPrune(u256(2), genByteSeq(numBytes), u256(0))
-    let pr10 = db.putAndPrune(u256(4), genByteSeq(numBytes), u256(0))
+    let pr1 = db.put(u256(1), genByteSeq(numBytes), u256(0))
+    let pr2 = db.put(thirdFurthest, genByteSeq(numBytes), u256(0))
+    let pr3 = db.put(u256(3), genByteSeq(numBytes), u256(0))
+    let pr4 = db.put(u256(10), genByteSeq(numBytes), u256(0))
+    let pr5 = db.put(u256(5), genByteSeq(numBytes), u256(0))
+    let pr6 = db.put(u256(10), genByteSeq(numBytes), u256(0))
+    let pr7 = db.put(furthestElement, genByteSeq(numBytes), u256(0))
+    let pr8 = db.put(secondFurthest, genByteSeq(numBytes), u256(0))
+    let pr9 = db.put(u256(2), genByteSeq(numBytes), u256(0))
+    let pr10 = db.put(u256(4), genByteSeq(numBytes), u256(0))
 
     check:
       pr1.kind == ContentStored

--- a/fluffy/tests/test_portal_wire_protocol.nim
+++ b/fluffy/tests/test_portal_wire_protocol.nim
@@ -259,7 +259,7 @@ procSuite "Portal Wire Protocol Tests":
       contentId = readUintBE[256](sha256.digest(content).data)
 
     # Only node3 have content
-    db3.put(contentId, content)
+    discard db3.put(contentId, content, proto3.localNode.id)
 
     # Node1 knows about Node2, and Node2 knows about Node3 which hold all content
     # Node1 needs to known Node2 radius to determine if node2 is interested in content

--- a/fluffy/tests/test_portal_wire_protocol.nim
+++ b/fluffy/tests/test_portal_wire_protocol.nim
@@ -49,8 +49,8 @@ proc defaultTestCase(rng: ref BrHmacDrbgContext): Default2NodeTest =
     node2 = initDiscoveryNode(
       rng, PrivateKey.random(rng[]), localAddress(20303))
 
-    db1 = ContentDB.new("", inMemory = true)
-    db2 = ContentDB.new("", inMemory = true)
+    db1 = ContentDB.new("", uint32.high, inMemory = true)
+    db2 = ContentDB.new("", uint32.high, inMemory = true)
 
     proto1 =
       PortalProtocol.new(node1, protocolId, db1, testHandler, validateContent)
@@ -207,9 +207,9 @@ procSuite "Portal Wire Protocol Tests":
         node3 = initDiscoveryNode(
           rng, PrivateKey.random(rng[]), localAddress(20304))
 
-        db1 = ContentDB.new("", inMemory = true)
-        db2 = ContentDB.new("", inMemory = true)
-        db3 = ContentDB.new("", inMemory = true)
+        db1 = ContentDB.new("", uint32.high, inMemory = true)
+        db2 = ContentDB.new("", uint32.high, inMemory = true)
+        db3 = ContentDB.new("", uint32.high, inMemory = true)
 
         proto1 = PortalProtocol.new(
           node1, protocolId, db1, testHandler, validateContent)
@@ -243,9 +243,9 @@ procSuite "Portal Wire Protocol Tests":
       node3 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20304))
 
-      db1 = ContentDB.new("", inMemory = true)
-      db2 = ContentDB.new("", inMemory = true)
-      db3 = ContentDB.new("", inMemory = true)
+      db1 = ContentDB.new("", uint32.high, inMemory = true)
+      db2 = ContentDB.new("", uint32.high, inMemory = true)
+      db3 = ContentDB.new("", uint32.high, inMemory = true)
 
       proto1 = PortalProtocol.new(
         node1, protocolId, db1, testHandlerSha256, validateContent)
@@ -291,8 +291,8 @@ procSuite "Portal Wire Protocol Tests":
       node2 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20303))
 
-      db1 = ContentDB.new("", inMemory = true)
-      db2 = ContentDB.new("", inMemory = true)
+      db1 = ContentDB.new("", uint32.high, inMemory = true)
+      db2 = ContentDB.new("", uint32.high, inMemory = true)
 
       proto1 = PortalProtocol.new(
         node1, protocolId, db1, testHandler, validateContent)
@@ -317,7 +317,7 @@ procSuite "Portal Wire Protocol Tests":
       node2 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20303))
 
-      db = ContentDB.new("", inMemory = true)
+      db = ContentDB.new("", uint32.high, inMemory = true)
       # No portal protocol for node1, hence an invalid bootstrap node
       proto2 = PortalProtocol.new(node2, protocolId, db, testHandler,
         validateContent, bootstrapRecords = [node1.localNode.record])

--- a/fluffy/tests/test_state_network.nim
+++ b/fluffy/tests/test_state_network.nim
@@ -64,7 +64,7 @@ procSuite "State Content Network":
           contentType: accountTrieNode, accountTrieNodeKey: accountTrieNodeKey)
         contentId = toContentId(contentKey)
 
-      proto1.contentDB.put(contentId, v)
+      discard proto1.contentDB.put(contentId, v, proto1.portalProtocol.localNode.id)
 
     for key in keys:
       var nodeHash: NodeHash
@@ -124,10 +124,10 @@ procSuite "State Content Network":
           contentType: accountTrieNode, accountTrieNodeKey: accountTrieNodeKey)
         contentId = toContentId(contentKey)
 
-      proto2.contentDB.put(contentId, v)
+      discard proto2.contentDB.put(contentId, v, proto2.portalProtocol.localNode.id)
       # Not needed right now as 1 node is enough considering node 1 is connected
       # to both.
-      proto3.contentDB.put(contentId, v)
+      discard proto3.contentDB.put(contentId, v, proto3.portalProtocol.localNode.id)
 
     # Get first key
     var nodeHash: NodeHash

--- a/fluffy/tests/test_state_network.nim
+++ b/fluffy/tests/test_state_network.nim
@@ -45,8 +45,8 @@ procSuite "State Content Network":
       node2 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20303))
 
-      proto1 = StateNetwork.new(node1, ContentDB.new("", inMemory = true))
-      proto2 = StateNetwork.new(node2, ContentDB.new("", inMemory = true))
+      proto1 = StateNetwork.new(node1, ContentDB.new("", uint32.high, inMemory = true))
+      proto2 = StateNetwork.new(node2, ContentDB.new("", uint32.high, inMemory = true))
 
     check proto2.portalProtocol.addNode(node1.localNode) == Added
 
@@ -101,9 +101,9 @@ procSuite "State Content Network":
       node3 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20304))
 
-      proto1 = StateNetwork.new(node1, ContentDB.new("", inMemory = true))
-      proto2 = StateNetwork.new(node2, ContentDB.new("", inMemory = true))
-      proto3 = StateNetwork.new(node3, ContentDB.new("", inMemory = true))
+      proto1 = StateNetwork.new(node1, ContentDB.new("", uint32.high, inMemory = true))
+      proto2 = StateNetwork.new(node2, ContentDB.new("", uint32.high, inMemory = true))
+      proto3 = StateNetwork.new(node3, ContentDB.new("", uint32.high, inMemory = true))
 
     # Node1 knows about Node2, and Node2 knows about Node3 which hold all content
     check proto1.portalProtocol.addNode(node2.localNode) == Added
@@ -160,8 +160,8 @@ procSuite "State Content Network":
         rng, PrivateKey.random(rng[]), localAddress(20303))
 
 
-      proto1 = StateNetwork.new(node1, ContentDB.new("", inMemory = true))
-      proto2 = StateNetwork.new(node2, ContentDB.new("", inMemory = true))
+      proto1 = StateNetwork.new(node1, ContentDB.new("", uint32.high, inMemory = true))
+      proto2 = StateNetwork.new(node2, ContentDB.new("", uint32.high, inMemory = true))
 
     check (await node1.ping(node2.localNode)).isOk()
     check (await node2.ping(node1.localNode)).isOk()

--- a/fluffy/tools/portalcli.nim
+++ b/fluffy/tools/portalcli.nim
@@ -24,7 +24,10 @@ const
 
   defaultListenAddressDesc = $defaultListenAddress
   defaultAdminListenAddressDesc = $defaultAdminListenAddress
-
+  # 100mb seems a bit smallish we may consider increasing defaults after some
+  # network measurements
+  defaultStorageSize* = uint32(1000 * 1000 * 100)
+  
 type
   PortalCmd* = enum
     noCommand

--- a/fluffy/tools/portalcli.nim
+++ b/fluffy/tools/portalcli.nim
@@ -103,6 +103,14 @@ type
       desc: "Portal wire protocol id for the network to connect to"
       name: "protocol-id" .}: PortalProtocolId
 
+    # TODO maybe it is worth defining minimal storage size and throw error if
+    # value provided is smaller than minimum
+    storageSize* {.
+      desc: "Maximum amount (in bytes) of content which will be stored " &
+            "in local database."
+      defaultValue: defaultStorageSize
+      name: "storage-size" .}: uint32
+
     case cmd* {.
       command
       defaultValue: noCommand }: PortalCmd
@@ -214,7 +222,7 @@ proc run(config: PortalCliConf) =
   d.open()
 
   let
-    db = ContentDB.new("", inMemory = true)
+    db = ContentDB.new("", config.storageSize, inMemory = true)
     portal = PortalProtocol.new(d, config.protocolId, db,
       testHandler, validateContent,
       bootstrapRecords = bootstrapRecords)


### PR DESCRIPTION
Add put method to content db which preserves total size and return information about if database was pruned. 
If db was pruned there are two important information which may be necessary for radius adjustments:
- what is current furthest element in db (so caller will never drop radius below this value)
- what fraction of content was deleted
In general we do not want to perform pruning to often thats why we like to delete even 25% of db at one go.

Radius adjustments will be done in next pr.

Also it is a bit not natural that we have content db in history network and in portal protocol, maybe some refactor is needed there.

Current open questions are:
- what is reasonable size for portal node database or if we want to allow nodes without storage ?
- is there possibility for some attacker to craft content and content keys which will be correct and close to our id so it would never be delted and pollute our db ?
