### PR TITLE
Bump nim-eth for max discv5 packet size

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -111,9 +111,9 @@ proc run(config: PortalConf) {.raises: [CatchableError, Defect].} =
 
   # One instance of UtpDiscv5Protocol is shared over all the PortalStreams.
   let
-    maxPayloadSize = uint32(discv5MaxSize - talkReqOverhead - utpHeaderOverhead)
     socketConfig = SocketConfig.init(
-      incomingSocketReceiveTimeout = none(Duration), payloadSize = maxPayloadSize)
+      incomingSocketReceiveTimeout = none(Duration),
+      payloadSize = uint32(maxUtpPayloadSize))
     streamTransport = UtpDiscv5Protocol.new(
       d,
       utpProtocolId,

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -97,7 +97,6 @@ const
     9 + # request id (max = 8) + 1 byte from rlp encoding byte string
     3 + # rlp encoding response byte string, max length in 2 bytes
     16 # HMAC
-  discv5MaxSize = 1280
 
   # These are the concurrent offers per Portal wire protocol that is running.
   # Using the `offerQueue` allows for limiting the amount of offers send and
@@ -278,8 +277,8 @@ proc handleFindNodes(p: PortalProtocol, fn: FindNodesMessage): seq[byte] =
       # over the discv5 packet size limits. ENRs are sorted so the closest nodes
       # will still be passed.
       const
-        portalNodesOverhead = 1 + 1 + 4 # msg id + total + container offset
-        maxPayloadSize = discv5MaxSize - talkRespOverhead - portalNodesOverhead
+        nodesOverhead = 1 + 1 + 4 # msg id + total + container offset
+        maxPayloadSize = maxDiscv5PacketSize - talkRespOverhead - nodesOverhead
         enrOverhead = 4 # per added ENR, 4 bytes offset overhead
 
       let enrs = truncateEnrs(nodes, maxPayloadSize, enrOverhead)
@@ -296,8 +295,8 @@ proc handleFindContent(
   let contentIdOpt = p.toContentId(fc.contentKey)
   if contentIdOpt.isSome():
     const
-      portalContentOverhead = 1 + 1 # msg id + SSZ Union selector
-      maxPayloadSize = discv5MaxSize - talkRespOverhead - portalContentOverhead
+      contentOverhead = 1 + 1 # msg id + SSZ Union selector
+      maxPayloadSize = maxDiscv5PacketSize - talkRespOverhead - contentOverhead
       enrOverhead = 4 # per added ENR, 4 bytes offset overhead
 
     let

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -25,18 +25,22 @@ const
   utpProtocolId* = "utp".toBytes()
   defaultConnectionTimeout = 5.seconds
   defaultReadTimeout = 2.seconds
-  # TalkReq message is used as transport message
-  talkReqOverhead* =
+
+  # TalkReq message is used as transport for uTP. It is assumed here that Portal
+  # protocol messages were exchanged before sending uTP over discv5 data. This
+  # means that a session is established and that the discv5 messages send are
+  # discv5 ordinary message packets, for which below calculation applies.
+  talkReqOverhead =
     16 + # IV size
     55 + # header size
     1 + # talkReq msg id
     3 + # rlp encoding outer list, max length will be encoded in 2 bytes
     9 + # request id (max = 8) + 1 byte from rlp encoding byte string
+    len(utpProtocolId) + 1 + # + 1 is necessary due to rlp encoding of byte string
     3 + # rlp encoding response byte string, max length in 2 bytes
-    16 + # HMAC
-    len(utpProtocolId) + 1 # + 1 is necessary due to rlp encoding of those bytes
-  utpHeaderOverhead* = 20
-  discv5MaxSize* = 1280
+    16 # HMAC
+  utpHeaderOverhead = 20
+  maxUtpPayloadSize* = maxDiscv5PacketSize - talkReqOverhead - utpHeaderOverhead
 
 type
   ContentRequest = object


### PR DESCRIPTION
Additionally make use of the maxDiscv5PacketSize constant for
payload limiting in Portal wire protocol & stream