### PR TITLE
Add pruning metrics

### DIFF
--- a/fluffy/grafana/fluffy_grafana_dashboard.json
+++ b/fluffy/grafana/fluffy_grafana_dashboard.json
@@ -2089,6 +2089,99 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 77
+      },
+      "id": 48,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "portal_pruning_counter_total{protocol_id=\"500b\"}",
+          "legendFormat": "Number of pruning event",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "portal_pruning_deleted_elements{protocol_id=\"500b\"}",
+          "hide": false,
+          "legendFormat": "Number of elements deleted in pruning event",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "History network pruning statistics",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/fluffy/tests/test_content_db.nim
+++ b/fluffy/tests/test_content_db.nim
@@ -182,6 +182,7 @@ suite "Content Database":
       pr10.kind == DbPruned
 
     check:
+      pr10.numOfDeletedElements == 2
       uint32(db.size()) < maxDbSize
       # With current settings 2 furthers elements will be delted i.e 30 and 40
       # so the furthest non deleted one will be 20


### PR DESCRIPTION
Adds new pruning metrics.
Addition:
- counter of pruning events which happens during node lifetime
- gauge of quantity of elements deleted in each pruning event
- new grafana panel showing, those statistics in history network. Putting all networks in one graph made it harder to discern what is happening