### PR TITLE
Change radius-config option to radius and allow also logRadius

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -183,20 +183,20 @@ type
       name: "bits-per-hop" .}: int
 
     radiusConfig* {.
-      hidden
-      desc: "Radius configuration for a fluffy node. Radius can be either `dynamic`" &
-            "where node adjust radius based on storage size limit," &
-            "or `static:logRadius` where node have hardcoded logRadius value. " &
-            "Warning: Setting it `static:logRadius` disable storage size limits and" &
-            "makes fluffy node to store fraction of the network."
+      desc: "Radius configuration for a fluffy node. Radius can be either `dynamic` " &
+            "where the node adjusts the radius based on `storage-size` option, " &
+            "or `static:<logRadius>` where the node has a hardcoded logarithmic radius value. " &
+            "Warning: `static:<logRadius>` disables `storage-size` limits and " &
+            "makes the node store a fraction of the network based on set radius."
       defaultValue: defaultRadiusConfig
-      name: "radius-config" .}: RadiusConfig
+      defaultValueDesc: $defaultRadiusConfigDesc
+      name: "radius" .}: RadiusConfig
 
     # TODO maybe it is worth defining minimal storage size and throw error if
     # value provided is smaller than minimum
     storageSize* {.
       desc: "Maximum amount (in bytes) of content which will be stored " &
-            "in local database."
+            "in the local database."
       defaultValue: defaultStorageSize
       defaultValueDesc: $defaultStorageSizeDesc
       name: "storage-size" .}: uint32

--- a/fluffy/scripts/launch_local_testnet.sh
+++ b/fluffy/scripts/launch_local_testnet.sh
@@ -248,7 +248,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     BOOTSTRAP_ARG="--bootstrap-file=${BOOTSTRAP_ENR_FILE}"
     # All nodes but bootstrap node run with log. radius of 254 which should
     # result in ~1/4th of the data set stored.
-    RADIUS_ARG="--radius-config=static:254"
+    RADIUS_ARG="--radius=static:254"
 
     # Wait for the bootstrap node to write out its enr file
     START_TIMESTAMP=$(date +%s)


### PR DESCRIPTION
Change `radius-config` back to `radius` option, as I think it makes more sense (everything there is a configuration).
Allow for just the log radius value again too, to get fluffy fleet back up (option was not changed), at least until setting is changed in infra role.