### PR TITLE
Fix utp connection leak on cancel

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -614,12 +614,20 @@ proc findContent*(p: PortalProtocol, dst: Node, contentKey: ByteList):
         error "Trying to connect to node with unknown address",
           id = dst.id
         return err("Trying to connect to node with unknown address")
-
-      let connectionResult =
-        await p.stream.connectTo(
+        
+      let connFuture = p.stream.connectTo(
           nodeAddress.unsafeGet(),
           uint16.fromBytesBE(m.connectionId)
         )
+
+      yield connFuture
+
+      var connectionResult: Result[UtpSocket[NodeAddress], string]
+
+      if connFuture.completed():
+        connectionResult = connFuture.read()
+      else:
+        raise connFuture.error
 
       if connectionResult.isErr():
         debug "Utp connection error while trying to find content",
@@ -627,24 +635,32 @@ proc findContent*(p: PortalProtocol, dst: Node, contentKey: ByteList):
         return err("Error connecting uTP socket")
 
       let socket = connectionResult.get()
-      # Read all bytes from the socket
-      # This will either end with a FIN, or because the read action times out.
-      # A FIN does not necessarily mean that the data read is complete. Further
-      # validation is required, using a length prefix here might be beneficial for
-      # this.
-      let readData = socket.read()
-      readData.cancelCallback = proc(udate: pointer) {.gcsafe.} =
-        # In case this `findContent` gets cancelled while reading the data,
-        # send a FIN and clean up the socket.
-        socket.close()
 
-      if await readData.withTimeout(p.stream.readTimeout):
-        let content = readData.read
-        await socket.destroyWait()
-        return ok(FoundContent(src: dst, kind: Content, content: content))
-      else:
-        socket.close()
-        return err("Reading data from socket timed out, content request failed")
+      try:
+        # Read all bytes from the socket
+        # This will either end with a FIN, or because the read action times out.
+        # A FIN does not necessarily mean that the data read is complete. Further
+        # validation is required, using a length prefix here might be beneficial for
+        # this.
+        let readFut = socket.read()
+        if await readFut.withTimeout(p.stream.readTimeout):
+          let content = readFut.read
+          return ok(FoundContent(src: dst, kind: Content, content: content))
+        else :
+          return err("Reading data from socket timed out, content request failed")
+      finally:
+        if socket.atEof():
+          # socket received remote FIN and drained whole buffer, it can be
+          # safely destroyed without notifing remote
+          debug "Socket read fully",
+            socketKey = socket.socketKey
+          socket.destroy()
+        else:
+          # socket read interrupted, either cancelled or timeout on reading
+          # data, inform remote by sending FIN and cleaning up resources
+          debug "Socket read interrupted",
+            socketKey = socket.socketKey
+          socket.close()
     of contentType:
       return ok(FoundContent(src: dst, kind: Content, content: m.content.asSeq()))
     of enrsType:


### PR DESCRIPTION
Fixes https://github.com/status-im/nimbus-eth1/issues/1075 by bumping nim-eth and adding fixes to portal_protocol.

Summary: The main culprit of this leak is that cancellation and `await` do not play with each other very well when allocating some resource inside the `async` procs.

Consider simplified code:
```
import
  chronos

type SomeResourceWhichNeedToBeReleased = object

proc freeResource(res: SomeResourceWhichNeedToBeReleased): void = discard

proc use(res: SomeResourceWhichNeedToBeReleased): void= discard

proc allocateResource: Future[SomeResourceWhichNeedToBeReleased] = discard

proc someProcWhichUsesResource: Future[void] {.async.} =
  let resource = await allocateResource()
  try:
    resource.use()
  finally:
    resource.freeResource()

proc someProcWhichStartAndCancel() {.async.} =
  let fut = someProcWhichUsesResource()

  fut.cancel()

```

What was happening in current case was:
1. When calling `fut.cancel()`, the path with the [child](https://github.com/status-im/nim-chronos/blob/master/chronos/asyncfutures2.nim#L287) is taken where child future is `allocateResource` future (and the parent future is `someProcWhichUsesResource`)
2. But child future have already finished but not yet given control to the corresponding yield statement, so child cancel returns [false](https://github.com/status-im/nim-chronos/blob/master/chronos/asyncfutures2.nim#L284). So before cancel return, only the flag `mustCancel` on cancelled future is set to [true](https://github.com/status-im/nim-chronos/blob/master/chronos/asyncfutures2.nim#L295)
3. In the next eventLoop step control is given to the yield statement in `await allocateResource()` [yield](https://github.com/status-im/nim-chronos/blob/master/chronos/asyncmacro2.nim#L274), as the child future already finished (`allocateResource` future is child of `someProcWhichUsesResource` future ). As this child future already finished and not cancelled, resource was already allocated so to clean it up, call to `freeResource` is needed.
4. But as `mustCancel`  was set to true in point `2` for parent future, `await` actually throws and cancellation [exception](https://github.com/status-im/nim-chronos/blob/master/chronos/asyncmacro2.nim#L287) 
5. So it leads to the situation that there is no way to release resources allocated by `SomeResourceWhichNeedToBeReleased` 

