### PR TITLE
fix rpc and websocket server config if they share the same port with …

### DIFF
--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -678,6 +678,10 @@ proc makeConfig*(cmdLine = commandLineParams()): NimbusConf =
       # if udpPort not set in cli, then
       result.udpPort = result.tcpPort
 
+    # enable rpc server or ws server if they share common port with engine api
+    result.rpcEnabled = result.engineApiEnabled and (result.engineApiPort == result.rpcPort)
+    result.wsEnabled = result.engineApiWsEnabled and (result.engineApiWsPort == result.wsPort)
+
 when isMainModule:
   # for testing purpose
   discard makeConfig()

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -335,11 +335,13 @@ proc stop*(nimbus: NimbusNode, conf: NimbusConf) {.async, gcsafe.} =
   trace "Graceful shutdown"
   if conf.rpcEnabled:
     await nimbus.rpcServer.stop()
-  if conf.engineApiEnabled:
+  # nimbus.engineApiServer can be nil if conf.engineApiPort == conf.rpcPort
+  if conf.engineApiEnabled and nimbus.engineApiServer.isNil.not:
     await nimbus.engineApiServer.stop()
   if conf.wsEnabled:
     nimbus.wsRpcServer.stop()
-  if conf.engineApiWsEnabled:
+  # nimbus.engineApiWsServer can be nil if conf.engineApiWsPort == conf.wsPort
+  if conf.engineApiWsEnabled and nimbus.engineApiWsServer.isNil.not:
     nimbus.engineApiWsServer.stop()
   if conf.graphqlEnabled:
     await nimbus.graphqlServer.stop()

--- a/nimbus/sync/snap/worker/worker_desc.nim
+++ b/nimbus/sync/snap/worker/worker_desc.nim
@@ -216,7 +216,7 @@ proc seen*(sn: Worker; bh: BlockHash; bn: BlockNumber) =
 # -----------
 
 import
-  ../../../tests/replay/pp_light
+  ../../../../tests/replay/pp_light
 
 proc pp*(bh: BlockHash): string =
   bh.Hash256.pp


### PR DESCRIPTION
…engine api

also fixes json-rpc-engine-api server and websocket-engine-api server shutdown code,
checking if they actually created or not at startup.

fix #1119