### PR TITLE
Increase wait time for content propagation to avoid CI failures

### DIFF
--- a/fluffy/scripts/test_portal_testnet.nim
+++ b/fluffy/scripts/test_portal_testnet.nim
@@ -192,7 +192,7 @@ procSuite "Portal testnet tests":
     # because the data needs to propagate over the nodes. What one could do is
     # add a json-rpc debug proc that returns whether the offer queue is empty or
     # not. And then poll every node until all nodes have an empty queue.
-    await sleepAsync(10.seconds)
+    await sleepAsync(15.seconds)
 
     let blockData = readBlockDataTable(dataFile)
     check blockData.isOk()


### PR DESCRIPTION
Not the cleanest way to make this test work, oh well. Would fail occasionally on win i386