### PR TITLE
Docs: Add separate section for seeding history data

### DIFF
--- a/fluffy/README.md
+++ b/fluffy/README.md
@@ -91,19 +91,6 @@ make fluffy-tools
 ./build/blockwalk --block-hash:0xf6bfad56d1a45d1661506343dd1e511b5d7e17565b3ec293125ff0890b9709e5
 ```
 
-One can also use the `eth-data-exporter` tool to download history data from
-local geth instance into the format which is suitable for propagating data into
-fluffy client e.g:
-
-```bash
-make fluffy-tools
-
-./build/eth_data_exporter --initial-block:1 --end-block: 10 --data-dir:"/userDirectory/"
-```
-
-Will download blocks from 1 to 10 into user provided director in one json file.
-
-
 ### Run fluffy test suite
 ```bash
 # From the nimbus-eth1 repository
@@ -117,6 +104,36 @@ make fluffy-test
 
 Find more details on the usage and workings of the local testnet script
 [here](./docs/local_testnet.md).
+
+### Seeding history (=block) data into the Portal network
+
+1. Set-up access to an Ethereum JSON-RPC endpoint (e.g. local geth instance)
+that can serve the data.
+2. Use the `eth-data-exporter` tool to download history data through the
+JSON-RPC endpoint into the format which is suitable for reading data into
+Fluffy client and propagating into the network:
+
+```bash
+make fluffy-tools
+
+./build/eth_data_exporter --initial-block:1 --end-block:10 --data-dir:"/user_data_dir/"
+```
+
+This will store blocks 1 to 10 into a json file located at
+`./user_data_dir/eth-history-data.json`.
+
+> Note: Currently only hardcoded address `ws://127.0.0.1:8546` works for the
+Ethereum JSON-RPC endpoint.
+
+3. Run Fluffy and trigger the propagation of data with the
+`portal_history_propagate` JSON-RPC API call:
+
+```bash
+./build/fluffy --network:testnet0 --table-ip-limit:1024 --bucket-ip-limit:24 --log-level:info --rpc
+
+# From another shell
+curl -s -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":"1","method":"portal_history_propagate","params":["./user_data_dir/eth-history-data.json"]}' http://localhost:8545 | jq
+```
 
 ### Windows support
 


### PR DESCRIPTION
- Move section of eth_data_exporter out of default way to run
Fluffy
- Update section to explain full flow of seeding history data
into the network