### PR TITLE
Add network retries for fluffy block requests

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -433,7 +433,7 @@ proc fromLogRadius(T: type UInt256, logRadius: uint16): T =
   # Get the max value of the logRadius range
   pow((2).stuint(256), logRadius) - 1
 
-proc getInitialRadius(rc: RadiusConfig): UInt256 = 
+proc getInitialRadius(rc: RadiusConfig): UInt256 =
   case rc.kind
   of Static:
     return UInt256.fromLogRadius(rc.logRadius)
@@ -946,8 +946,11 @@ proc contentLookup*(p: PortalProtocol, target: ByteList, targetId: UInt256):
   ## target. Maximum value for n is `BUCKET_SIZE`.
   # `closestNodes` holds the k closest nodes to target found, sorted by distance
   # Unvalidated nodes are used for requests as a form of validation.
-  var closestNodes = p.routingTable.neighbours(targetId, BUCKET_SIZE,
-    seenOnly = false)
+  var closestNodes = p.routingTable.neighbours(
+    targetId, BUCKET_SIZE, seenOnly = false)
+  # Shuffling the order of the nodes in order to not always hit the same node
+  # first for the same request.
+  p.baseProtocol.rng[].shuffle(closestNodes)
 
   var asked, seen = initHashSet[NodeId]()
   asked.incl(p.baseProtocol.localNode.id) # No need to ask our own node

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -235,40 +235,48 @@ proc installEthApiHandlers*(
   # rpcServerWithProxy.rpc("eth_getTransactionReceipt") do(
   #     data: EthHashStr) -> Option[ReceiptObject]:
 
-  rpcServerWithProxy.rpc("eth_getLogs") do(filterOptions: FilterOptions) -> seq[FilterLog]:
+  rpcServerWithProxy.rpc("eth_getLogs") do(
+      filterOptions: FilterOptions) -> seq[FilterLog]:
     if filterOptions.blockhash.isNone():
-      # currently only queries with provided blockhash are supported. To support
-      # range queries it would require Indicies network.
-      raise newException(ValueError, "Unsupported query. Field `blockhash` needs to be provided")
+      # Currently only queries by blockhash are supported.
+      # To support range queries the Indicies network is required.
+      raise newException(ValueError,
+        "Unsupported query: Only `blockhash` queries are currently supported")
     else:
       let hash = filterOptions.blockHash.unsafeGet()
 
-      let maybeHeader = await historyNetwork.getBlockHeader(1'u16, hash)
+      let headerOpt = await historyNetwork.getBlockHeader(1'u16, hash)
+      if headerOpt.isNone():
+        raise newException(ValueError,
+          "Could not find header with requested hash")
 
-      if maybeHeader.isNone():
-        raise newException(ValueError, "Could not find header with requested hash")
-
-      let header = maybeHeader.unsafeGet()
+      let header = headerOpt.unsafeGet()
 
       if headerBloomFilter(header, filterOptions.address, filterOptions.topics):
         # TODO: These queries could be done concurrently, investigate if there
         # are no assumptions about usage of concurrent queries on portal
         # wire protocol level
-        let maybeBody = await historyNetwork.getBlockBody(1'u16, hash, header)
-        let maybeReceipts = await historyNetwork.getReceipts(1'u16, hash, header)
+        let
+          bodyOpt = await historyNetwork.getBlockBody(1'u16, hash, header)
+          receiptsOpt = await historyNetwork.getReceipts(1'u16, hash, header)
 
-        if maybeBody.isSome() and maybeReceipts.isSome():
-          let body = maybeBody.unsafeGet()
-          let receipts = maybeReceipts.unsafeGet()
-          let logs = deriveLogs(header, body.transactions, receipts)
-          let filteredLogs = filterLogs(logs, filterOptions.address, filterOptions.topics)
+        if bodyOpt.isSome() and receiptsOpt.isSome():
+          let
+            body = bodyOpt.unsafeGet()
+            receipts = receiptsOpt.unsafeGet()
+            logs = deriveLogs(header, body.transactions, receipts)
+            filteredLogs = filterLogs(
+              logs, filterOptions.address, filterOptions.topics)
+
           return filteredLogs
         else:
-          if maybeBody.isNone():
-            raise newException(ValueError, "Could not find body for requested hash")
+          if bodyOpt.isNone():
+            raise newException(ValueError,
+              "Could not find block body for requested hash")
           else:
-            raise newException(ValueError, "Could not find receipts for requested hash")
+            raise newException(ValueError,
+              "Could not find receipts for requested hash")
       else:
-        # bloomfilter returned false, we do known that there is no logs matching
-        # given criteria
+        # bloomfilter returned false, we do known that there are no logs
+        # matching the given criteria
         return @[]


### PR DESCRIPTION
- Add retries when the network request failed on validation of
block header, body or receipts.
- Shuffle the first set of neighbours that the request is send to
in order to not always hit the same peer first for the same content
- Some general clean-up