### PR TITLE
Fix testnet tests

### DIFF
--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -502,10 +502,6 @@ proc processContentLoop(n: HistoryNetwork) {.async.} =
       let (contentKeys, contentItems) =
         await n.portalProtocol.stream.contentQueue.popFirst()
 
-      let lenReceived = len(contentItems)
-
-      debug "Receied inoming offered content", contentKeys, len = lenReceived
-
       # content passed here can have less items then contentKeys, but not more.
       for i, contentItem in contentItems:
         let contentKey = contentKeys[i]

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -280,21 +280,21 @@ proc getBlockHeader*(
 
   let headerFromDb = n.getContentFromDb(BlockHeader, contentId)
   if headerFromDb.isSome():
-    info "Fetched block header from database", hash
+    info "Fetched block header from database", hash, contentKey = keyEncoded
     return headerFromDb
 
   for i in 0..<requestRetries:
     let headerContentLookup =
       await n.portalProtocol.contentLookup(keyEncoded, contentId)
     if headerContentLookup.isNone():
-      warn "Failed fetching block header from the network", hash
+      warn "Failed fetching block header from the network", hash, contentKey = keyEncoded
       return none(BlockHeader)
 
     let headerContent = headerContentLookup.unsafeGet()
 
     let res = validateBlockHeaderBytes(headerContent.content, hash)
     if res.isOk():
-      info "Fetched block header from the network", hash
+      info "Fetched block header from the network", hash, contentKey = keyEncoded
       # Content is valid we can propagate it to interested peers
       n.portalProtocol.triggerPoke(
         headerContent.nodesInterestedInContent,
@@ -306,7 +306,7 @@ proc getBlockHeader*(
 
       return some(res.get())
     else:
-      warn "Validation of block header failed", err = res.error, hash
+      warn "Validation of block header failed", err = res.error, hash, contentKey = keyEncoded
 
   # Headers were requested `requestRetries` times and all failed on validation
   return none(BlockHeader)
@@ -324,7 +324,7 @@ proc getBlockBody*(
     bodyFromDb = n.getContentFromDb(BlockBody, contentId)
 
   if bodyFromDb.isSome():
-    info "Fetched block body from database", hash
+    info "Fetched block body from database", hash, contentKey = keyEncoded
     return bodyFromDb
 
   for i in 0..<requestRetries:
@@ -332,7 +332,7 @@ proc getBlockBody*(
       await n.portalProtocol.contentLookup(keyEncoded, contentId)
 
     if bodyContentLookup.isNone():
-      warn "Failed fetching block body from the network", hash
+      warn "Failed fetching block body from the network", hash, contentKey = keyEncoded
       return none(BlockBody)
 
     let bodyContent = bodyContentLookup.unsafeGet()
@@ -340,7 +340,7 @@ proc getBlockBody*(
     let res = validateBlockBodyBytes(
       bodyContent.content, header.txRoot, header.ommersHash)
     if res.isOk():
-      info "Fetched block body from the network", hash
+      info "Fetched block body from the network", hash, contentKey = keyEncoded
 
       # body is valid, propagate it to interested peers
       n.portalProtocol.triggerPoke(
@@ -353,15 +353,18 @@ proc getBlockBody*(
 
       return some(res.get())
     else:
-      warn "Validation of block body failed", err = res.error, hash
+      warn "Validation of block body failed", err = res.error, hash, contentKey = keyEncoded
 
   return none(BlockBody)
 
 proc getBlock*(
     n: HistoryNetwork, chainId: uint16, hash: BlockHash):
     Future[Option[Block]] {.async.} =
+  debug "Trying to retrieve block with hash", hash
+
   let headerOpt = await n.getBlockHeader(chainId, hash)
   if headerOpt.isNone():
+    warn "Failed to get header when getting block with hash", hash
     # Cannot validate block without header.
     return none(Block)
 
@@ -370,6 +373,7 @@ proc getBlock*(
   let bodyOpt = await n.getBlockBody(chainId, hash, header)
 
   if bodyOpt.isNone():
+    warn "Failed to get body when gettin block with hash", hash
     return none(Block)
 
   let body = bodyOpt.unsafeGet()
@@ -397,14 +401,14 @@ proc getReceipts*(
     let receiptsContentLookup =
       await n.portalProtocol.contentLookup(keyEncoded, contentId)
     if receiptsContentLookup.isNone():
-      warn "Failed fetching receipts from the network", hash
+      warn "Failed fetching receipts from the network", hash, contentKey = keyEncoded
       return none(seq[Receipt])
 
     let receiptsContent = receiptsContentLookup.unsafeGet()
 
     let res = validateReceiptsBytes(receiptsContent.content, header.receiptRoot)
     if res.isOk():
-      info "Fetched receipts from the network", hash
+      info "Fetched receipts from the network", hash, contentKey = keyEncoded
 
       let receipts = res.get()
 
@@ -419,7 +423,7 @@ proc getReceipts*(
 
       return some(res.get())
     else:
-      warn "Validation of receipts failed", err = res.error, hash
+      warn "Validation of receipts failed", err = res.error, hash, contentKey = keyEncoded
 
   return none(seq[Receipt])
 
@@ -497,6 +501,10 @@ proc processContentLoop(n: HistoryNetwork) {.async.} =
     while true:
       let (contentKeys, contentItems) =
         await n.portalProtocol.stream.contentQueue.popFirst()
+
+      let lenReceived = len(contentItems)
+
+      debug "Receied inoming offered content", contentKeys, len = lenReceived
 
       # content passed here can have less items then contentKeys, but not more.
       for i, contentItem in contentItems:

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -1108,7 +1108,6 @@ proc neighborhoodGossip*(
   for i, contentItem in content:
     let contentInfo =
       ContentInfo(contentKey: contentKeys[i], content: contentItem)
-    debug "Scheduling content for gossip", contentKey = contentInfo.contentKey
     discard contentList.add(contentInfo)
 
   # Just taking the first content item as target id.
@@ -1148,18 +1147,12 @@ proc neighborhoodGossip*(
 
   if gossipNodes.len >= 8: # use local nodes for gossip
     portal_gossip_without_lookup.inc(labelValues = [$p.protocolId])
-    let lenGossip = min(gossipNodes.len, maxGossipNodes)
-    debug "Scheduling gossip to len local found nodes", len = lenGossip
-
     for node in gossipNodes[0..<min(gossipNodes.len, maxGossipNodes)]:
       let req = OfferRequest(dst: node, kind: Direct, contentList: contentList)
       await p.offerQueue.addLast(req)
   else: # use looked up nodes for gossip
     portal_gossip_with_lookup.inc(labelValues = [$p.protocolId])
     let closestNodes = await p.lookup(NodeId(contentId))
-    let lenGossip = min(closestNodes.len, maxGossipNodes)
-    debug "Scheduling gossip to len closest found nodes", len = lenGossip
-
     for node in closestNodes[0..<min(closestNodes.len, maxGossipNodes)]:
       # Note: opportunistically not checking if the radius of the node is known
       # and thus if the node is in radius with the content. Reason is, these

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -24,7 +24,7 @@ logScope:
 const
   utpProtocolId* = "utp".toBytes()
   defaultConnectionTimeout = 5.seconds
-  defaultContentReadTimeout = 2.seconds
+  defaultContentReadTimeout = 15.seconds
 
   # TalkReq message is used as transport for uTP. It is assumed here that Portal
   # protocol messages were exchanged before sending uTP over discv5 data. This
@@ -102,6 +102,9 @@ proc addContentOffer*(
 
   # uTP protocol uses BE for all values in the header, incl. connection id.
   let id = uint16.fromBytesBE(connectionId)
+
+  debug "Register new incoming offer", contentKeys
+
   let contentOffer = ContentOffer(
     connectionId: id,
     nodeId: nodeId,
@@ -244,12 +247,12 @@ proc readContentOffer(
       else:
         # Invalid data, stop reading content, but still process data received
         # so far.
-        debug "Reading content item failed, content offer failed"
+        debug "Reading content item failed, content offer failed", contentKeys = offer.contentKeys
         break
     else:
       # Read timed out, stop further reading, but still process data received
       # so far.
-      debug "Reading data from socket timed out, content offer failed"
+      debug "Reading data from socket timed out, content offer failed", contentKeys = offer.contentKeys
       break
 
   if socket.atEof():
@@ -304,6 +307,8 @@ proc registerIncomingSocketCallback*(
             let fut = socket.writeContentRequest(stream, request)
             stream.contentRequests.del(i)
             return fut
+          else:
+            debug "Received unknown content connection"
 
         for i, offer in stream.contentOffers:
           if offer.connectionId == socket.connectionId and
@@ -311,6 +316,8 @@ proc registerIncomingSocketCallback*(
             let fut = socket.readContentOffer(stream, offer)
             stream.contentOffers.del(i)
             return fut
+          else:
+            debug "Received unknown offer connection"
 
       # TODO: Is there a scenario where this can happen,
       # considering `allowRegisteredIdCallback`? If not, doAssert?

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -307,8 +307,6 @@ proc registerIncomingSocketCallback*(
             let fut = socket.writeContentRequest(stream, request)
             stream.contentRequests.del(i)
             return fut
-          else:
-            debug "Received unknown content connection"
 
         for i, offer in stream.contentOffers:
           if offer.connectionId == socket.connectionId and
@@ -316,8 +314,6 @@ proc registerIncomingSocketCallback*(
             let fut = socket.readContentOffer(stream, offer)
             stream.contentOffers.del(i)
             return fut
-          else:
-            debug "Received unknown offer connection"
 
       # TODO: Is there a scenario where this can happen,
       # considering `allowRegisteredIdCallback`? If not, doAssert?


### PR DESCRIPTION
Improves stability of fluffy testnet tests.

Main culprit of failures was to agressive `defaultContentReadTimeout`, which could sometimes lead to failure of all offers with larger content, which in turn lead to given content not being available on testnet

On 2 core vm in which I was testing changes  (and is pretty similar to the ones used in CI) even standard `talkreq` call would fail with timeouts when there are 64 fluffy nodes running, even though response timeout is set to 4 second on discv5 level. So 2 second for reading all content is definitely to small especially as:
- control over incoming connection is given to the app almost just after receiving utp SYN packet, which means it is at least 1 round trip before receiving any data from sender as sender of data first needs to receive SYN-ACK, and only after that he can send first data packet
- Initial utp window size fits only 2 data packets, so if content is larger than 3 packets, then sender need to receive at least one ack before sending 3rd packet.

In general 15s is maybe a bit on larger side, so maybe its worth making this configurable and increase it only for this testnet tests.

Another finds:
- 64 fluffy nodes were sometimes consuming 3.5GB ram on the machine which seems pretty large. On 32 bit systems, I would not be suprised if some kind OOM would happen during this tests. It maybe worth more investigation.
- During whole test run all nodes usually make around 18k offers, from which only 2k results in success. Most of offers ends up with no accepted content, I would say around 15k. Rest ends up with different kinds of timeouts. 
- In our testnet a lot of nodes receive invalid offered content as they are unable at the beginning to retrieve header for giver body or receipit.