### PR TITLE
Adhere to transport limits in seed methods

### DIFF
--- a/fluffy/network/history/history_content.nim
+++ b/fluffy/network/history/history_content.nim
@@ -18,6 +18,12 @@ import
 export ssz_serialization, common_types, hash
 
 ## Types and calls for history network content keys
+const
+  # Maximum content key size comes from:
+  # 34 bytes for ssz serialized BlockKey
+  # 1 byte for contentType
+  # TODO it would be nice to caluclate it somehow from the object definition (macro?)
+  maxContentKeySize* = 35
 
 type
   ContentType* = enum

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -692,6 +692,23 @@ proc getContentKeys(o: OfferRequest): ContentKeysList =
   of Database:
     return o.contentKeys
 
+func getMaxOfferedContentKeys*(protocolIdLen: uint32, maxKeySize: uint32): int =
+  ## Calculates how many ContentKeys will fit in one offer message which
+  ## will be small enouch to fit into discv5 limit.
+  ## This is neccesarry as contentKeysLimit (64) is sometimes to big, and even
+  ## half of this can be too much to fit into discv5 limits.
+
+  let maxTalkReqPayload = maxDiscv5PacketSize - getTalkReqOverhead(int(protocolIdLen))
+  # To calculate how much bytes `n` content keys of size `maxKeySize` will take
+  # we can use following equation:
+  # bytes = (n * (maxKeySize + perContentKeyOverhead)) + offerMessageOverhead
+  # to calculate maximal number of keys which will will given space this can be
+  # transformed to:
+  # n = trunc((bytes - offerMessageOverhead) / (maxKeySize + perContentKeyOverhead))
+  return (
+    (maxTalkReqPayload - 5) div (int(maxKeySize) + 4)
+  )
+
 proc offer(p: PortalProtocol, o: OfferRequest):
   Future[PortalResult[void]] {.async.} =
   ## Offer triggers offer-accept interaction with one peer

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -699,7 +699,7 @@ func getMaxOfferedContentKeys*(protocolIdLen: uint32, maxKeySize: uint32): int =
   ## half of this can be too much to fit into discv5 limits.
 
   let maxTalkReqPayload = maxDiscv5PacketSize - getTalkReqOverhead(int(protocolIdLen))
-  # To calculate how much bytes `n` content keys of size `maxKeySize` will take
+  # To calculate how much bytes, `n` content keys of size `maxKeySize` will take
   # we can use following equation:
   # bytes = (n * (maxKeySize + perContentKeyOverhead)) + offerMessageOverhead
   # to calculate maximal number of keys which will will given space this can be

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -30,15 +30,7 @@ const
   # protocol messages were exchanged before sending uTP over discv5 data. This
   # means that a session is established and that the discv5 messages send are
   # discv5 ordinary message packets, for which below calculation applies.
-  talkReqOverhead =
-    16 + # IV size
-    55 + # header size
-    1 + # talkReq msg id
-    3 + # rlp encoding outer list, max length will be encoded in 2 bytes
-    9 + # request id (max = 8) + 1 byte from rlp encoding byte string
-    len(utpProtocolId) + 1 + # + 1 is necessary due to rlp encoding of byte string
-    3 + # rlp encoding response byte string, max length in 2 bytes
-    16 # HMAC
+  talkReqOverhead = getTalkReqOverhead(utpProtocolId)
   utpHeaderOverhead = 20
   maxUtpPayloadSize* = maxDiscv5PacketSize - talkReqOverhead - utpHeaderOverhead
 

--- a/fluffy/rpc/rpc_calls/rpc_portal_debug_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_debug_calls.nim
@@ -10,7 +10,7 @@ proc portal_history_propagateEpochAccumulator(
 proc portal_history_storeContentInNodeRange(
     dbPath: string, max: uint32, starting: uint32): bool
 proc portal_history_offerContentInNodeRange(
-    dbPath: string, nodeId: NodeId, max: uint32, starting: uint32): bool
+    dbPath: string, nodeId: NodeId, max: uint32, starting: uint32): int
 proc portal_history_depthContentPropagate(
   dbPath: string, max: uint32): bool
 proc portal_history_breadthContentPropagate(

--- a/fluffy/rpc/rpc_portal_debug_api.nim
+++ b/fluffy/rpc/rpc_portal_debug_api.nim
@@ -88,13 +88,13 @@ proc installPortalDebugApiHandlers*(
       dbPath: string,
       nodeId: NodeId,
       max: uint32,
-      starting: uint32) -> bool:
+      starting: uint32) -> int:
     # waiting for offer result, by the end of this call remote node should
     # have received offered content
     let offerResult = await p.offerContentInNodeRange(dbPath, nodeId, max, starting)
 
     if offerResult.isOk():
-      return true
+      return offerResult.get()
     else:
       raise newException(ValueError, $offerResult.error)
 

--- a/fluffy/scripts/test_portal_testnet.nim
+++ b/fluffy/scripts/test_portal_testnet.nim
@@ -346,7 +346,7 @@ procSuite "Portal testnet tests":
       for i in 1..lastNodeIdx:
         let receipientId = nodeInfos[i].nodeId
         let offerResponse = await retryUntil(
-          proc (): Future[bool] {.async.} =
+          proc (): Future[int] {.async.} =
             try:
               let res = await clients[0].portal_history_offerContentInNodeRange(tempDbPath, receipientId, 64, 0)
               await clients[0].close()
@@ -355,11 +355,12 @@ procSuite "Portal testnet tests":
               await clients[0].close()
               raise exc
           ,
-          proc (os: bool): bool = return os,
+          proc (os: int): bool = return true,
           "Offer failed",
           i
         )
-        check offerResponse
+        check:
+          offerResponse > 0
 
       for i, client in clients:
         # Note: Once there is the Canonical Indices Network, we don't need to

--- a/fluffy/tests/test_history_network.nim
+++ b/fluffy/tests/test_history_network.nim
@@ -56,6 +56,32 @@ proc stop(hn: HistoryNode) {.async.} =
   hn.historyNetwork.stop()
   await hn.discoveryProtocol.closeWait()
 
+proc containsId(hn: HistoryNode, contentId: ContentId): bool =
+  return hn.historyNetwork.contentDb.get(contentId).isSome()
+
+proc createEmptyHeaders(fromNum: int, toNum: int): seq[BlockHeader] =
+  var headers: seq[BlockHeader]
+  for i in fromNum..toNum:
+    var bh = BlockHeader()
+    bh.blockNumber = u256(i)
+    bh.difficulty = u256(i)
+    # empty so that we won't care about creating fake block bodies
+    bh.ommersHash = EMPTY_UNCLE_HASH
+    bh.txRoot = BLANK_ROOT_HASH
+    headers.add(bh)
+  return headers
+
+proc headersToContentInfo(headers: seq[BlockHeader]): seq[ContentInfo] =
+  var contentInfos: seq[ContentInfo]
+  for h in headers:
+    let headerHash = h.blockHash()
+    let bk = BlockKey(chainId: 1'u16, blockHash: headerHash)
+    let ck = encode(ContentKey(contentType: blockHeader, blockHeaderKey: bk))
+    let headerEncoded = rlp.encode(h)
+    let ci = ContentInfo(contentKey: ck, content: headerEncoded)
+    contentInfos.add(ci)
+  return contentInfos
+
 procSuite "History Content Network":
   let rng = newRng()
   asyncTest "Get block by block number":
@@ -65,15 +91,7 @@ procSuite "History Content Network":
 
     # enough headers so there will be at least two epochs
     let numHeaders = 9000
-    var headers: seq[BlockHeader]
-    for i in 0..numHeaders:
-      var bh = BlockHeader()
-      bh.blockNumber = u256(i)
-      bh.difficulty = u256(i)
-      # empty so that we won't care about creating fake block bodies
-      bh.ommersHash = EMPTY_UNCLE_HASH
-      bh.txRoot = BLANK_ROOT_HASH
-      headers.add(bh)
+    var headers: seq[BlockHeader] = createEmptyHeaders(0, numHeaders)
 
     let masterAccumulator = buildAccumulator(headers)
     let epochAccumulators = buildAccumulatorData(headers)
@@ -118,6 +136,63 @@ procSuite "History Content Network":
 
       check:
         blockHeader == headers[i]
+
+    await historyNode1.stop()
+    await historyNode2.stop()
+
+  asyncTest "Offer maximum amout of content in one offer message":
+    let
+      historyNode1 = newHistoryNode(rng, 20302)
+      historyNode2 = newHistoryNode(rng, 20303)
+
+    check historyNode1.portalWireProtocol().addNode(historyNode2.localNodeInfo()) == Added
+    check historyNode2.portalWireProtocol().addNode(historyNode1.localNodeInfo()) == Added
+
+    check (await historyNode1.portalWireProtocol().ping(historyNode2.localNodeInfo())).isOk()
+    check (await historyNode2.portalWireProtocol().ping(historyNode1.localNodeInfo())).isOk()
+
+    let maxOfferedHistoryContent = getMaxOfferedContentKeys(
+        uint32(len(historyProtocolId)), maxContentKeySize)
+
+    # one header too many to fit offer message, talkReq with this amout of header will fail
+    let headers = createEmptyHeaders(0, maxOfferedHistoryContent)
+    let masterAccumulator = buildAccumulator(headers)
+
+    await historyNode1.historyNetwork.initMasterAccumulator(some(masterAccumulator))
+    await historyNode2.historyNetwork.initMasterAccumulator(some(masterAccumulator))
+
+    let contentInfos = headersToContentInfo(headers)
+
+    # node 1 will offer content so it need to have it in its database
+    for ci in contentInfos:
+      let id = toContentId(ci.contentKey)
+      historyNode1.portalWireProtocol.storeContent(id, ci.content)
+
+
+    let offerResultTooMany = await historyNode1.portalWireProtocol.offer(
+      historyNode2.localNodeInfo(),
+      contentInfos
+    )
+
+    check:
+      # failing due timeout, as remote side won't respond to large discv5 packets
+      offerResultTooMany.isErr()
+
+    for ci in contentInfos:
+      let id = toContentId(ci.contentKey)
+      check:
+        historyNode2.containsId(id) == false
+
+    # one contentkey less should make offer go through
+    let correctInfos = contentInfos[0..<len(contentInfos)-1]
+
+    let offerResultCorrect = await historyNode1.portalWireProtocol.offer(
+      historyNode2.localNodeInfo(),
+      correctInfos
+    )
+
+    check:
+      offerResultCorrect.isOk()
 
     await historyNode1.stop()
     await historyNode2.stop()

--- a/fluffy/tests/test_history_network.nim
+++ b/fluffy/tests/test_history_network.nim
@@ -17,7 +17,6 @@ import
   ../content_db,
   ./test_helpers
 
-
 type HistoryNode = ref object
   discoveryProtocol*: discv5_protocol.Protocol
   historyNetwork*: HistoryNetwork


### PR DESCRIPTION
Currently offered number of items is restricted to `64` on protocol level, but we cannot use this limit in every network as in some networks even less items is enough to overflow discv5 packet limit of 1280 bytes.

For example, for history network, largest content keys are 35 bytes which means, only 37 of those will have 1295bytes which is above discv5 limit. In reality, maximum offered number will be even less due to OfferMessage envelope, discv5 header, and the fact that content keys are kept in ssz list which adds 4 bytes per key overhead. With this restriction maximum number of history network content keys per offer is 29.

This pr add apis and functions necessary to calculate this overhead and uses them in seeding methods which are main uses of multiple content items offers. We do not need to validate that offers we receive adhere to those limits, as if packets are larger thatn 1280 bytes, they won't be accepted by discv5 layer (which is used defacto as transport layer for portal netowork)