### PR TITLE
Add launch_local_testnet as part of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,11 @@ jobs:
             # hide CI failures
             env CC=gcc GOARCH=${GOARCH} CXX=g++ CGO_ENABLED=1 make ${DEFAULT_MAKE_FLAGS} test || true
           else
+            pushd vendor/nimbus-eth2
+            env NIMBUSEL_BINARY=../../build/nimbus NIMBUSEL_GENESIS=scripts/nimbusel_genesis.json \
+            ./scripts/launch_local_testnet.sh --nodes=3 --stop-at-epoch=7 \
+            --disable-htop --reuse-binaries --run-nimbus-el --dl-eth2 --verbose --kill-old-processes
+            popd
             env CC=gcc GOARCH=${GOARCH} CXX=g++ CGO_ENABLED=1 make ${DEFAULT_MAKE_FLAGS} test
           fi
 
@@ -299,5 +304,10 @@ jobs:
           make ${DEFAULT_MAKE_FLAGS}
           build/nimbus --help
           # "-static" option will not work for osx unless static system libraries are provided
+          pushd vendor/nimbus-eth2
+          env NIMBUSEL_BINARY=../../build/nimbus NIMBUSEL_GENESIS=scripts/nimbusel_genesis.json \
+          ./scripts/launch_local_testnet.sh --nodes=3 --stop-at-epoch=7 \
+          --disable-htop --reuse-binaries --run-nimbus-el --dl-eth2 --verbose --kill-old-processes
+          popd
           make ${DEFAULT_MAKE_FLAGS} test
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -173,3 +173,7 @@
 	url = https://github.com/status-im/nim-ssz-serialization.git
 	ignore = untracked
 	branch = master
+[submodule "vendor/nimbus-eth2"]
+	path = vendor/nimbus-eth2
+	url = https://github.com/status-im/nimbus-eth2.git
+	branch = unstable

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,38 @@ BUILD_SYSTEM_DIR := vendor/nimbus-build-system
 
 LINK_PCRE := 0
 
+EXCLUDED_NIM_PACKAGES := 	\
+	vendor/nimbus-eth2/vendor/nim-bearssl 					\
+	vendor/nimbus-eth2/vendor/nim-blscurve 					\
+	vendor/nimbus-eth2/vendor/nim-bearssl 					\
+	vendor/nimbus-eth2/vendor/nim-blscurve					\
+	vendor/nimbus-eth2/vendor/nimbus-build-system		\
+	vendor/nimbus-eth2/vendor/nim-chronicles				\
+	vendor/nimbus-eth2/vendor/nim-chronos						\
+	vendor/nimbus-eth2/vendor/nim-confutils					\
+	vendor/nimbus-eth2/vendor/nimcrypto							\
+	vendor/nimbus-eth2/vendor/nim-eth								\
+	vendor/nimbus-eth2/vendor/nim-faststreams				\
+	vendor/nimbus-eth2/vendor/nim-http-utils				\
+	vendor/nimbus-eth2/vendor/nim-json-rpc					\
+	vendor/nimbus-eth2/vendor/nim-json-serialization\
+	vendor/nimbus-eth2/vendor/nim-libbacktrace			\
+	vendor/nimbus-eth2/vendor/nim-metrics						\
+	vendor/nimbus-eth2/vendor/nim-nat-traversal			\
+	vendor/nimbus-eth2/vendor/nim-secp256k1					\
+	vendor/nimbus-eth2/vendor/nim-serialization			\
+	vendor/nimbus-eth2/vendor/nim-snappy						\
+	vendor/nimbus-eth2/vendor/nim-sqlite3-abi				\
+	vendor/nimbus-eth2/vendor/nim-ssz-serialization	\
+	vendor/nimbus-eth2/vendor/nim-stew							\
+	vendor/nimbus-eth2/vendor/nim-stint							\
+	vendor/nimbus-eth2/vendor/nim-testutils					\
+	vendor/nimbus-eth2/vendor/nim-toml-serialization\
+	vendor/nimbus-eth2/vendor/nim-unittest2					\
+	vendor/nimbus-eth2/vendor/nim-web3							\
+	vendor/nimbus-eth2/vendor/nim-websock						\
+	vendor/nimbus-eth2/vendor/nim-zlib
+
 # we don't want an error here, so we can handle things later, in the ".DEFAULT" target
 -include $(BUILD_SYSTEM_DIR)/makefiles/variables.mk
 


### PR DESCRIPTION
Adds nimbus ETH2 as a sub-module.
Modifies the CI workflow to run the launch_local_testnet.sh script as part of testing.
