### PR TITLE
Refactor portal stream

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -444,6 +444,7 @@ proc new*(T: type PortalProtocol,
     contentDB: ContentDB,
     toContentId: ToContentIdHandler,
     dbGet: DbGetHandler,
+    stream: PortalStream,
     bootstrapRecords: openArray[Record] = [],
     distanceCalculator: DistanceCalculator = XorDistanceCalculator,
     config: PortalProtocolConfig = defaultPortalProtocolConfig
@@ -464,15 +465,12 @@ proc new*(T: type PortalProtocol,
     radiusConfig: config.radiusConfig,
     dataRadius: initialRadius,
     bootstrapRecords: @bootstrapRecords,
+    stream: stream,
     radiusCache: RadiusCache.init(256),
     offerQueue: newAsyncQueue[OfferRequest](concurrentOffers))
 
   proto.baseProtocol.registerTalkProtocol(@(proto.protocolId), proto).expect(
     "Only one protocol should have this id")
-
-  let stream = PortalStream.new(udata = proto, rng = proto.baseProtocol.rng)
-
-  proto.stream = stream
 
   proto
 

--- a/fluffy/tests/test_history_network.nim
+++ b/fluffy/tests/test_history_network.nim
@@ -25,21 +25,8 @@ proc newHistoryNode(rng: ref HmacDrbgContext, port: int): HistoryNode =
   let
     node = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(port))
     db = ContentDB.new("", uint32.high, inMemory = true)
-    socketConfig = SocketConfig.init(
-      incomingSocketReceiveTimeout = none(Duration),
-      payloadSize = uint32(maxUtpPayloadSize)
-    )
-    hn = HistoryNetwork.new(node, db)
-    streamTransport = UtpDiscv5Protocol.new(
-      node,
-      utpProtocolId,
-      registerIncomingSocketCallback(@[hn.portalProtocol.stream]),
-      nil,
-      allowRegisteredIdCallback(@[hn.portalProtocol.stream]),
-      socketConfig
-    )
-
-  hn.setStreamTransport(streamTransport)
+    streamManager = StreamManager.new(node)
+    hn = HistoryNetwork.new(node, db, streamManager)
 
   return HistoryNode(discoveryProtocol: node, historyNetwork: hn)
 

--- a/fluffy/tests/test_state_network.nim
+++ b/fluffy/tests/test_state_network.nim
@@ -11,7 +11,7 @@ import
   eth/[keys, trie/db, trie/hexary],
   eth/p2p/discoveryv5/protocol as discv5_protocol, eth/p2p/discoveryv5/routing_table,
   ../../nimbus/[genesis, chain_config, config, db/db_chain, db/state_db],
-  ../network/wire/portal_protocol,
+  ../network/wire/[portal_protocol, portal_stream],
   ../network/state/[state_content, state_network],
   ../content_db,
   ./test_helpers
@@ -42,11 +42,13 @@ procSuite "State Content Network":
 
       node1 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20302))
+      sm1 = StreamManager.new(node1)
       node2 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20303))
+      sm2 = StreamManager.new(node2)
 
-      proto1 = StateNetwork.new(node1, ContentDB.new("", uint32.high, inMemory = true))
-      proto2 = StateNetwork.new(node2, ContentDB.new("", uint32.high, inMemory = true))
+      proto1 = StateNetwork.new(node1, ContentDB.new("", uint32.high, inMemory = true), sm1)
+      proto2 = StateNetwork.new(node2, ContentDB.new("", uint32.high, inMemory = true), sm2)
 
     check proto2.portalProtocol.addNode(node1.localNode) == Added
 
@@ -96,14 +98,17 @@ procSuite "State Content Network":
       trie = genesisToTrie("fluffy" / "tests" / "custom_genesis" / "chainid7.json")
       node1 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20302))
+      sm1 = StreamManager.new(node1)
       node2 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20303))
+      sm2 = StreamManager.new(node2)
       node3 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20304))
+      sm3 = StreamManager.new(node3)
 
-      proto1 = StateNetwork.new(node1, ContentDB.new("", uint32.high, inMemory = true))
-      proto2 = StateNetwork.new(node2, ContentDB.new("", uint32.high, inMemory = true))
-      proto3 = StateNetwork.new(node3, ContentDB.new("", uint32.high, inMemory = true))
+      proto1 = StateNetwork.new(node1, ContentDB.new("", uint32.high, inMemory = true), sm1)
+      proto2 = StateNetwork.new(node2, ContentDB.new("", uint32.high, inMemory = true), sm2)
+      proto3 = StateNetwork.new(node3, ContentDB.new("", uint32.high, inMemory = true), sm3)
 
     # Node1 knows about Node2, and Node2 knows about Node3 which hold all content
     check proto1.portalProtocol.addNode(node2.localNode) == Added
@@ -156,12 +161,13 @@ procSuite "State Content Network":
     let
       node1 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20302))
+      sm1 = StreamManager.new(node1)
       node2 = initDiscoveryNode(
         rng, PrivateKey.random(rng[]), localAddress(20303))
+      sm2 = StreamManager.new(node2)
 
-
-      proto1 = StateNetwork.new(node1, ContentDB.new("", uint32.high, inMemory = true))
-      proto2 = StateNetwork.new(node2, ContentDB.new("", uint32.high, inMemory = true))
+      proto1 = StateNetwork.new(node1, ContentDB.new("", uint32.high, inMemory = true), sm1)
+      proto2 = StateNetwork.new(node2, ContentDB.new("", uint32.high, inMemory = true), sm2)
 
     check (await node1.ping(node2.localNode)).isOk()
     check (await node2.ping(node1.localNode)).isOk()


### PR DESCRIPTION
Clean up a bit portal stream interaction with UtpDiscv5Protocol transaport. Improvements:

- encapsulate whole stream logic in `portal_stream` by introducing `StreamManager`.
- do not leak `portal_stream` constants to other parts of the app.
- use `getUserData` on utp router simplify callbacks passed to UtpDiscv5Protocol (they no longer need to capture opened streams`)
- move `contentQueue` to network, that way each network is responsible for each own content queue, where stream is producer of content and network is consumer, this allows different limits content limits per network.