### PR TITLE
Switch to the new style of importing vendor packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ nimcache
 # Nimble user files
 nimble.develop
 nimble.paths
+
+# nimbus-build-system files
+nimbus-build-system.paths
+

--- a/config.nims
+++ b/config.nims
@@ -1,5 +1,11 @@
 import strutils
 
+--noNimblePath
+
+if getEnv("NIMBUS_BUILD_SYSTEM") == "yes" and
+   system.fileExists("nimbus-build-system.paths"):
+  include "nimbus-build-system.paths"
+
 if defined(release):
   switch("nimcache", "nimcache/release/$projectName")
 else:


### PR DESCRIPTION
In preparation of our migration to the new Nimble-based setup
and [nim-workspace][1], we switch to a new model where the vendor
packages are no longer imported through a locally generated Nimble
dir, but rather through an auto-generated `nimbus-build-system.paths`
file that features regular `--path:` statements.

This file will be imported only within the nimbus-build-system
environment in order to avoid any unwanted interference in working
copies based on the new Nimble setup.

[1]: https://github.com/status-im/nim-workspace