### PR TITLE
Use separeate client and server in lcproxy

### DIFF
--- a/lc_proxy/rpc/rpc_eth_lc_api.nim
+++ b/lc_proxy/rpc/rpc_eth_lc_api.nim
@@ -8,44 +8,63 @@
 {.push raises: [Defect].}
 
 import
-  json_rpc/[rpcproxy, rpcserver],
-  web3/conversions,
-  ../../nimbus/rpc/[hexstrings, rpc_types],
+  stint,
+  chronicles,
+  json_rpc/[rpcserver, rpcclient],
+  web3,
+  web3/ethhexstrings,
   beacon_chain/eth1/eth1_monitor,
   beacon_chain/spec/forks
 
-export rpcproxy, forks
+export forks
+
+logScope:
+  topics = "light_proxy"
 
 template encodeQuantity(value: UInt256): HexQuantityStr =
-  HexQuantityStr("0x" & value.toHex())
+  hexQuantityStr("0x" & value.toHex())
 
-proc encodeQuantity(q: Quantity): hexstrings.HexQuantityStr =
-  return hexstrings.encodeQuantity(distinctBase(q))
+template encodeQuantity(value: Quantity): HexQuantityStr =
+  hexQuantityStr(encodeQuantity(value.uint64))
 
 type LightClientRpcProxy* = ref object
-  proxy*: RpcProxy
+  client*: RpcClient
+  server*: RpcHttpServer
   executionPayload*: Opt[ExecutionPayloadV1]
 
 proc installEthApiHandlers*(lcProxy: LightClientRpcProxy) =
   template payload(): Opt[ExecutionPayloadV1] = lcProxy.executionPayload
 
-  lcProxy.proxy.rpc("eth_blockNumber") do() -> HexQuantityStr:
+  lcProxy.server.rpc("eth_blockNumber") do() -> HexQuantityStr:
     ## Returns the number of most recent block.
     if payload.isNone:
       raise newException(ValueError, "Syncing")
 
     return encodeQuantity(payload.get.blockNumber)
 
-  lcProxy.proxy.rpc("eth_getBlockByNumber") do(
-      quantityTag: string, fullTransactions: bool) -> Option[rpc_types.BlockObject]:
-    ## Returns information about a block by number.
+  # TODO quantity tag should be better typed
+  lcProxy.server.rpc("eth_getBalance") do(address: Address, quantityTag: string) -> HexQuantityStr:
     if payload.isNone:
       raise newException(ValueError, "Syncing")
 
     if quantityTag != "latest":
+      # TODO for now we support only latest block, as its semanticly most streight
+      # forward i.e it is last received and valid ExecutionPayloadV1.
+      # Ultimatly we could keep track of n last valid payload and support number
+      # queries for this set of blocks
+      # `Pending` coud be mapped to some optimisc header with block fetched on demand
       raise newException(ValueError, "Only latest block is supported")
 
-    if fullTransactions:
-      raise newException(ValueError, "Transaction bodies not supported")
+    # When requesting state for `latest` block number, we need to translate
+    # `latest` to actual block number as `latest` on proxy and on data provider
+    # can mean different blocks and ultimatly piece received piece of state
+    # must by validated against correct state root
+    let blockNumber = payload.get.blockNumber.uint64
 
-    return some rpc_types.BlockObject(number: some(encodeQuantity(payload.get.blockNumber)))
+    info "Forwarding get_Balance", executionBn = blockNumber
+
+    # TODO this could be realised by eth_getProof as it return also balance
+    # of the account
+    let b = await lcProxy.client.eth_getBalance(address, blockId(blockNumber))
+
+    return encodeQuantity(b)


### PR DESCRIPTION
small pr to use separate client and server in proxy as:
- in some calls we will need to change `quantityTag` argument to receive correct block against which we will validate proof
- some call can be realized by other calls i.e `eth_getBalance` can be realized by `eth_getProof`

