### PR TITLE
Fix bug in inCurrentEpoch and improve accumulator related tests

### DIFF
--- a/fluffy/network/history/accumulator.nim
+++ b/fluffy/network/history/accumulator.nim
@@ -109,7 +109,15 @@ func buildAccumulatorData*(headers: seq[BlockHeader]):
 ## against the Accumulator and the header proofs.
 
 func inCurrentEpoch*(blockNumber: uint64, a: Accumulator): bool =
-  blockNumber > uint64(a.historicalEpochs.len() * epochSize) - 1
+  # Note:
+  # Block numbers start at 0, so historical epochs are set as:
+  # 0 -> 8191 -> len = 1 * 8192
+  # 8192 -> 16383 -> len = 2 * 8192
+  # ...
+  # A block number is in the current epoch if it is bigger than the last block
+  # number in the last historical epoch. Which is the same as being equal or
+  # bigger than current length of historical epochs * epochSize.
+  blockNumber >= uint64(a.historicalEpochs.len() * epochSize)
 
 func inCurrentEpoch*(header: BlockHeader, a: Accumulator): bool =
   let blockNumber = header.blockNumber.truncate(uint64)

--- a/fluffy/tests/test_content_db.nim
+++ b/fluffy/tests/test_content_db.nim
@@ -8,7 +8,6 @@
 {.used.}
 
 import
-  std/algorithm,
   unittest2, stint,
   eth/keys,
   ../network/state/state_content,
@@ -81,10 +80,10 @@ suite "Content Database":
 
     db.del(u256(2))
     db.del(u256(1))
-    
+
     let realSize1 = db.realSize()
     let size5 = db.size()
-    
+
     check:
       size4 == size5
       # real size will be smaller as after del, there are free pages in sqlite

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -89,7 +89,7 @@ task test_portal_testnet, "Build test_portal_testnet":
 task testfluffy, "Run fluffy tests":
   # Need the nimbus_db_backend in state network tests as we need a Hexary to
   # start from, even though it only uses the MemoryDb.
-  test "fluffy/tests", "all_fluffy_tests", "-d:chronicles_log_level=ERROR -d:chronosStrictException -d:nimbus_db_backend=sqlite -d:PREFER_BLST_SHA256=false"
+  test "fluffy/tests", "all_fluffy_tests", "-d:chronicles_log_level=ERROR -d:chronosStrictException -d:nimbus_db_backend=sqlite -d:PREFER_BLST_SHA256=false -d:canonicalVerify=true"
 
 task testlcproxy, "Run light proxy tests":
   test "lc_proxy/tests", "test_proof_validation", "-d:chronicles_log_level=ERROR -d:chronosStrictException -d:nimbus_db_backend=sqlite -d:PREFER_BLST_SHA256=false"


### PR DESCRIPTION
- Fix negative wraparound / underflow in inCurrentEpoch
- Add tests in accumulator tests to verify the above
- Add header offer tests with accumulator that does and doesn't contain historical epochs
- Additional clean-up of history tests
- enable canonicalVerify in the tests