### PR TITLE
Use rpcProxy in lc proxy

### DIFF
--- a/nimbus/rpc/cors.nim
+++ b/nimbus/rpc/cors.nim
@@ -14,8 +14,7 @@ import
   chronos/apps/http/[httptable, httpserver],
   json_rpc/rpcserver,
   httputils,
-  websock/websock as ws,
-  ../config
+  websock/websock as ws
 
 proc sameOrigin(a, b: Uri): bool =
   a.hostname == b.hostname and


### PR DESCRIPTION
-use fixed cors logic - this enables serving requests from browser calls
-use RpcProxy - to forward missing methods necessary for metamask to work. Not sure why I did not use it initially, probably I thought that most methods won't be forwarded directly so there is no use case for it, but ultimately it makes nice temporary solution to make it work