### PR TITLE
Remove ChaindId from BlockKey and update test vectors

### DIFF
--- a/fluffy/data/history_data_parser.nim
+++ b/fluffy/data/history_data_parser.nim
@@ -83,7 +83,7 @@ func readBlockData*(
       $blockData.number & ": " & e.msg)
 
   let contentKeyType =
-    BlockKey(chainId: 1'u16, blockHash: blockHash)
+    BlockKey(blockHash: blockHash)
 
   try:
     # If wanted the hash for the corresponding header can be verified

--- a/fluffy/network/history/history_content.nim
+++ b/fluffy/network/history/history_content.nim
@@ -18,12 +18,13 @@ import
 export ssz_serialization, common_types, hash
 
 ## Types and calls for history network content keys
+
 const
-  # Maximum content key size comes from:
-  # 34 bytes for ssz serialized BlockKey
-  # 1 byte for contentType
-  # TODO it would be nice to caluclate it somehow from the object definition (macro?)
-  maxContentKeySize* = 35
+  # Maximum content key size:
+  # - 32 bytes for SSZ serialized `BlockKey`
+  # - 1 byte for `ContentType`
+  # TODO: calculate it somehow from the object definition (macro?)
+  maxContentKeySize* = 33
 
 type
   ContentType* = enum
@@ -34,7 +35,6 @@ type
     masterAccumulator = 0x04
 
   BlockKey* = object
-    chainId*: uint16
     blockHash*: BlockHash
 
   EpochAccumulatorKey* = object
@@ -85,7 +85,7 @@ func `$`*(x: BlockHash): string =
   "0x" & x.data.toHex()
 
 func `$`*(x: BlockKey): string =
-  "blockHash: " & $x.blockHash & ", chainId: " & $x.chainId
+  "blockHash: " & $x.blockHash
 
 func `$`*(x: ContentKey): string =
   var res = "(type: " & $x.contentType & ", "

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -203,7 +203,7 @@ proc installEthApiHandlers*(
     ## Returns BlockObject or nil when no block was found.
     let
       blockHash = data.toHash()
-      blockRes = await historyNetwork.getBlock(1'u16, blockHash)
+      blockRes = await historyNetwork.getBlock(blockHash)
 
     if blockRes.isNone():
       return none(BlockObject)
@@ -222,7 +222,7 @@ proc installEthApiHandlers*(
 
     let
       blockNumber = fromHex(UInt256, quantityTag)
-      blockResult = await historyNetwork.getBlock(1'u16, blockNumber)
+      blockResult = await historyNetwork.getBlock(blockNumber)
 
     if blockResult.isOk():
       let maybeBlock = blockResult.get()
@@ -244,7 +244,7 @@ proc installEthApiHandlers*(
     ## Returns integer of the number of transactions in this block.
     let
       blockHash = data.toHash()
-      blockRes = await historyNetwork.getBlock(1'u16, blockHash)
+      blockRes = await historyNetwork.getBlock(blockHash)
 
     if blockRes.isNone():
       raise newException(ValueError, "Could not find block with requested hash")
@@ -273,7 +273,7 @@ proc installEthApiHandlers*(
     else:
       let hash = filterOptions.blockHash.unsafeGet()
 
-      let headerOpt = await historyNetwork.getBlockHeader(1'u16, hash)
+      let headerOpt = await historyNetwork.getBlockHeader(hash)
       if headerOpt.isNone():
         raise newException(ValueError,
           "Could not find header with requested hash")
@@ -285,8 +285,8 @@ proc installEthApiHandlers*(
         # are no assumptions about usage of concurrent queries on portal
         # wire protocol level
         let
-          bodyOpt = await historyNetwork.getBlockBody(1'u16, hash, header)
-          receiptsOpt = await historyNetwork.getReceipts(1'u16, hash, header)
+          bodyOpt = await historyNetwork.getBlockBody(hash, header)
+          receiptsOpt = await historyNetwork.getReceipts(hash, header)
 
         if bodyOpt.isSome() and receiptsOpt.isSome():
           let

--- a/fluffy/tests/test_history_content.nim
+++ b/fluffy/tests/test_history_content.nim
@@ -23,16 +23,16 @@ suite "History ContentKey Encodings":
     # Output
     const
       contentKeyHex =
-        "000f00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+        "00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
       contentId =
-        "15025167517633317571792618561170587584740338038067807801482118109695980329625"
+        "28281392725701906550238743427348001871342819822834514257505083923073246729726"
       # or
       contentIdHexBE =
-        "2137f185b713a60dd1190e650d01227b4f94ecddc9c95478e2c591c40557da99"
+        "3e86b3767b57402ea72e369ae0496ce47cc15be685bec3b4726b9f316e3895fe"
 
     let contentKey = ContentKey(
       contentType: blockHeader,
-      blockHeaderKey: BlockKey(chainId: 15'u16, blockHash: blockHash))
+      blockHeaderKey: BlockKey(blockHash: blockHash))
 
     let encoded = encode(contentKey)
     check encoded.asSeq.toHex == contentKeyHex
@@ -56,16 +56,16 @@ suite "History ContentKey Encodings":
     # Output
     const
       contentKeyHex =
-        "011400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+        "01d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
       contentId =
-        "12834862124958403129911294156243112356210437741210740000860318140844473844426"
+        "106696502175825986237944249828698290888857178633945273402044845898673345165419"
       # or
       contentIdHexBE =
-        "1c6046475f0772132774ab549173ca8487bea031ce539cad8e990c08df5802ca"
+        "ebe414854629d60c58ddd5bf60fd72e41760a5f7a463fdcb169f13ee4a26786b"
 
     let contentKey = ContentKey(
       contentType: blockBody,
-      blockBodyKey: BlockKey(chainId: 20'u16, blockHash: blockHash))
+      blockBodyKey: BlockKey(blockHash: blockHash))
 
     let encoded = encode(contentKey)
     check encoded.asSeq.toHex == contentKeyHex
@@ -89,16 +89,16 @@ suite "History ContentKey Encodings":
     # Output
     const
       contentKeyHex =
-        "020400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+        "02d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
       contentId =
-        "76995449220721979583200368506411933662679656077191192504502358532083948020658"
+        "76230538398907151249589044529104962263309222250374376758768131420767496438948"
       # or
       contentIdHexBE =
-        "aa39e1423e92f5a667ace5b79c2c98adbfd79c055d891d0b9c49c40f816563b2"
+        "a888f4aafe9109d495ac4d4774a6277c1ada42035e3da5e10a04cc93247c04a4"
 
     let contentKey = ContentKey(
       contentType: receipts,
-      receiptsKey: BlockKey(chainId: 4'u16, blockHash: blockHash))
+      receiptsKey: BlockKey(blockHash: blockHash))
 
     let encoded = encode(contentKey)
     check encoded.asSeq.toHex == contentKeyHex

--- a/fluffy/tests/test_history_network.nim
+++ b/fluffy/tests/test_history_network.nim
@@ -63,7 +63,7 @@ proc headersToContentInfo(headers: seq[BlockHeader]): seq[ContentInfo] =
   for h in headers:
     let
       headerHash = h.blockHash()
-      bk = BlockKey(chainId: 1'u16, blockHash: headerHash)
+      bk = BlockKey(blockHash: headerHash)
       ck = encode(ContentKey(contentType: blockHeader, blockHeaderKey: bk))
       headerEncoded = rlp.encode(h)
       ci = ContentInfo(contentKey: ck, content: headerEncoded)
@@ -96,7 +96,7 @@ procSuite "History Content Network":
     for h in headers:
       let
         headerHash = h.blockHash()
-        blockKey = BlockKey(chainId: 1'u16, blockHash: headerHash)
+        blockKey = BlockKey(blockHash: headerHash)
         contentKey = ContentKey(
           contentType: blockHeader, blockHeaderKey: blockKey)
         contentId = toContentId(contentKey)
@@ -116,7 +116,7 @@ procSuite "History Content Network":
       (await historyNode2.portalProtocol().ping(historyNode1.localNode())).isOk()
 
     for i in 0..lastBlockNumber:
-      let blockResponse = await historyNode1.historyNetwork.getBlock(1'u16, u256(i))
+      let blockResponse = await historyNode1.historyNetwork.getBlock(u256(i))
 
       check blockResponse.isOk()
 

--- a/fluffy/tools/eth_data_exporter.nim
+++ b/fluffy/tools/eth_data_exporter.nim
@@ -294,7 +294,7 @@ proc writeBlocksToDb(config: ExporterConf, client: RpcClient) =
     let
       blck = downloadBlock(i, client)
       blockHash = blck.header.blockHash()
-      contentKeyType = BlockKey(chainId: 1, blockHash: blockHash)
+      contentKeyType = BlockKey(blockHash: blockHash)
       headerKey = encode(ContentKey(
         contentType: blockHeader, blockHeaderKey: contentKeyType))
       bodyKey = encode(ContentKey(


### PR DESCRIPTION
ChainId got remove in Portal specs and test vectors are updated in PR: https://github.com/ethereum/portal-network-specs/pull/167

Will remove network usage (and thus content key) of Master Accumulator in seperate PR

