### PR TITLE
Fix issue where invalid / not validated would get gossiped

### DIFF
--- a/fluffy/rpc/rpc_calls/rpc_portal_debug_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_debug_calls.nim
@@ -2,6 +2,7 @@
 proc portal_history_store(contentKey: string, content: string): bool
 proc portal_history_storeContent(dataFile: string): bool
 proc portal_history_propagate(dataFile: string): bool
+proc portal_history_propagateHeaders(dataFile: string): bool
 proc portal_history_propagateBlock(dataFile: string, blockHash: string): bool
 proc portal_history_propagateAccumulatorData(
     dataFile: string): bool
@@ -12,7 +13,7 @@ proc portal_history_storeContentInNodeRange(
 proc portal_history_offerContentInNodeRange(
     dbPath: string, nodeId: NodeId, max: uint32, starting: uint32): int
 proc portal_history_depthContentPropagate(
-  dbPath: string, max: uint32): bool
+    dbPath: string, max: uint32): bool
 proc portal_history_breadthContentPropagate(
-  dbPath: string): bool
+    dbPath: string): bool
 

--- a/fluffy/rpc/rpc_portal_debug_api.nim
+++ b/fluffy/rpc/rpc_portal_debug_api.nim
@@ -48,6 +48,14 @@ proc installPortalDebugApiHandlers*(
     else:
       raise newException(ValueError, $res.error)
 
+  rpcServer.rpc("portal_" & network & "_propagateHeaders") do(
+      dataFile: string) -> bool:
+    let res = await p.historyPropagateHeaders(dataFile)
+    if res.isOk():
+      return true
+    else:
+      raise newException(ValueError, $res.error)
+
   rpcServer.rpc("portal_" & network & "_propagateBlock") do(
       dataFile: string, blockHash: string) -> bool:
     let res = await p.historyPropagateBlock(dataFile, blockHash)


### PR DESCRIPTION
Also requires us to split header data propagation from block body and receipts propagation as the now fixed bug would allow for more data to be gossiped even when data does not get validated (which requires the headers).