### PR TITLE
Working on making vm2 async. (Not done yet.)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,10 @@ test: | build deps
 	$(ENV_SCRIPT) nim test_rocksdb $(NIM_PARAMS) nimbus.nims
 	$(ENV_SCRIPT) nim test $(NIM_PARAMS) nimbus.nims
 
+# FIXME-howDoIMakeASubSuite
+test-evm: | build deps
+	$(ENV_SCRIPT) nim test_evm $(NIM_PARAMS) nimbus.nims
+
 # Primitive reproducibility test.
 #
 # On some platforms, with some GCC versions, it may not be possible to get a

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -66,6 +66,10 @@ task test, "Run tests":
 task test_rocksdb, "Run rocksdb tests":
   test "tests/db", "test_kvstore_rocksdb", "-d:chronicles_log_level=ERROR -d:unittest2DisableParamFiltering"
 
+# FIXME-howDoIMakeASubSuite
+task test_evm, "Run EVM tests":
+  test "tests", "evm_tests", "-d:chronicles_log_level=ERROR -d:unittest2DisableParamFiltering"
+
 task fluffy, "Build fluffy":
   buildBinary "fluffy", "fluffy/", "-d:chronicles_log_level=TRACE -d:chronosStrictException -d:PREFER_BLST_SHA256=false"
 

--- a/nimbus/transaction/call_common.nim
+++ b/nimbus/transaction/call_common.nim
@@ -8,6 +8,7 @@
 
 import
   eth/common/eth_types, stint, options, stew/ranges/ptr_arith,
+  chronos,
   ".."/[vm_types, vm_state, vm_computation, vm_state_transactions],
   ".."/[vm_internals, vm_precompiles, vm_gas_costs],
   ".."/[db/accounts_cache, forks],
@@ -196,7 +197,7 @@ when defined(evmc_enabled):
       {.gcsafe.}:
         callResult.release(callResult)
 
-proc runComputation*(call: CallParams): CallResult =
+proc runComputation*(call: CallParams): Future[CallResult] {.async.} =
   let host = setupHost(call)
   let c = host.computation
 
@@ -212,7 +213,7 @@ proc runComputation*(call: CallParams): CallResult =
   when defined(evmc_enabled):
     doExecEvmc(host, call)
   else:
-    execComputation(host.computation)
+    await execComputation(host.computation)
 
   # EIP-3529: Reduction in refunds
   let MaxRefundQuotient = if host.vmState.fork >= FkLondon:

--- a/nimbus/vm2/computation.nim
+++ b/nimbus/vm2/computation.nim
@@ -21,6 +21,7 @@ import
   ./transaction_tracer,
   ./types,
   chronicles,
+  chronos,
   eth/[common, keys],
   options,
   sets
@@ -221,7 +222,7 @@ proc writeContract*(c: Computation) =
 
 template chainTo*(c, toChild: Computation, after: untyped) =
   c.child = toChild
-  c.continuation = proc() =
+  c.continuation = proc(): Future[void] =
     after
 
 proc merge*(c, child: Computation) =

--- a/nimbus/vm2/interpreter/op_handlers/oph_arithmetic.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_arithmetic.nim
@@ -295,7 +295,8 @@ const
      info: "Addition operation",
      exec: (prep: vm2OpIgnore,
             run:  addOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Mul,         ##  0x02, Multiplication
      forks: Vm2OpAllForks,
@@ -303,7 +304,8 @@ const
      info: "Multiplication operation",
      exec: (prep: vm2OpIgnore,
             run:  mulOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Sub,         ## 0x03, Subtraction
      forks: Vm2OpAllForks,
@@ -311,7 +313,8 @@ const
      info: "Subtraction operation",
      exec: (prep: vm2OpIgnore,
             run:  subOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Div,         ## 0x04, Division
      forks: Vm2OpAllForks,
@@ -319,7 +322,8 @@ const
      info: "Integer division operation",
      exec: (prep: vm2OpIgnore,
             run:  divideOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Sdiv,        ## 0x05, Signed division
      forks: Vm2OpAllForks,
@@ -327,7 +331,8 @@ const
      info: "Signed integer division operation (truncated)",
      exec: (prep: vm2OpIgnore,
             run:  sdivOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Mod,         ## 0x06, Modulo
      forks: Vm2OpAllForks,
@@ -335,7 +340,8 @@ const
      info: "Modulo remainder operation",
      exec: (prep: vm2OpIgnore,
             run:  moduloOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Smod,        ## 0x07, Signed modulo
      forks: Vm2OpAllForks,
@@ -343,7 +349,8 @@ const
      info: "Signed modulo remainder operation",
      exec: (prep: vm2OpIgnore,
             run:  smodOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Addmod,      ## 0x08, Modulo addition, Intermediate
                           ## computations do not roll over at 2^256
@@ -352,7 +359,8 @@ const
      info: "Modulo addition operation",
      exec: (prep: vm2OpIgnore,
             run:  addmodOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Mulmod,      ## 0x09, Modulo multiplication, Intermediate
                           ## computations do not roll over at 2^256
@@ -361,7 +369,8 @@ const
      info: "Modulo multiplication operation",
      exec: (prep: vm2OpIgnore,
             run:  mulmodOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Exp,         ## 0x0a, Exponentiation
      forks: Vm2OpAllForks,
@@ -369,7 +378,8 @@ const
      info: "Exponentiation operation",
      exec: (prep: vm2OpIgnore,
             run:  expOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: SignExtend,  ## 0x0b, Extend 2's complemet length
      forks: Vm2OpAllForks,
@@ -377,7 +387,8 @@ const
      info: "Extend length of two’s complement signed integer",
      exec: (prep: vm2OpIgnore,
             run:  signExtendOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Lt,          ## 0x10, Less-than
      forks: Vm2OpAllForks,
@@ -385,7 +396,8 @@ const
      info: "Less-than comparison",
      exec: (prep: vm2OpIgnore,
             run:  ltOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Gt,          ## 0x11, Greater-than
      forks: Vm2OpAllForks,
@@ -393,7 +405,8 @@ const
      info: "Greater-than comparison",
      exec: (prep: vm2OpIgnore,
             run:  gtOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Slt,         ## 0x12, Signed less-than
      forks: Vm2OpAllForks,
@@ -401,7 +414,8 @@ const
      info: "Signed less-than comparison",
      exec: (prep: vm2OpIgnore,
             run:  sltOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Sgt,         ## 0x13, Signed greater-than
      forks: Vm2OpAllForks,
@@ -409,7 +423,8 @@ const
      info: "Signed greater-than comparison",
      exec: (prep: vm2OpIgnore,
             run:  sgtOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Eq,          ## 0x14, Equality
      forks: Vm2OpAllForks,
@@ -417,7 +432,8 @@ const
      info: "Equality comparison",
      exec: (prep: vm2OpIgnore,
             run:  eqOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: IsZero,      ## 0x15, Not operator
      forks: Vm2OpAllForks,
@@ -425,7 +441,8 @@ const
      info: "Simple not operator (Note: real Yellow Paper description)",
      exec: (prep: vm2OpIgnore,
             run:  isZeroOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: And,         ## 0x16, AND
      forks: Vm2OpAllForks,
@@ -433,7 +450,8 @@ const
      info: "Bitwise AND operation",
      exec: (prep: vm2OpIgnore,
             run:  andOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Or,          ## 0x17, OR
      forks: Vm2OpAllForks,
@@ -441,7 +459,8 @@ const
      info: "Bitwise OR operation",
      exec: (prep: vm2OpIgnore,
             run:  orOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Xor,         ## 0x18, XOR
      forks: Vm2OpAllForks,
@@ -449,7 +468,8 @@ const
      info: "Bitwise XOR operation",
      exec: (prep: vm2OpIgnore,
             run:  xorOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Not,         ## 0x19, NOT
      forks: Vm2OpAllForks,
@@ -457,7 +477,8 @@ const
      info: "Bitwise NOT operation",
      exec: (prep: vm2OpIgnore,
             run:  notOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Byte,        ## 0x1a, Retrieve byte
      forks: Vm2OpAllForks,
@@ -465,7 +486,8 @@ const
      info: "Retrieve single byte from word",
      exec: (prep: vm2OpIgnore,
             run:  byteOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     # Constantinople's new opcodes
 
@@ -475,7 +497,8 @@ const
      info: "Shift left",
      exec: (prep: vm2OpIgnore,
             run:  shlOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Shr,         ## 0x1c, Shift right logical
      forks: Vm2OpConstantinopleAndLater,
@@ -483,7 +506,8 @@ const
      info: "Logical shift right",
      exec: (prep: vm2OpIgnore,
             run:  shrOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Sar,         ## 0x1d, Shift right arithmetic
      forks: Vm2OpConstantinopleAndLater,
@@ -491,7 +515,8 @@ const
      info: "Arithmetic shift right",
      exec: (prep: vm2OpIgnore,
             run:  sarOp,
-            post: vm2OpIgnore))]
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers)]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/vm2/interpreter/op_handlers/oph_blockdata.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_blockdata.nim
@@ -86,7 +86,8 @@ const
      info: "Get the hash of one of the 256 most recent complete blocks",
      exec: (prep: vm2OpIgnore,
             run:  blockhashOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Coinbase,        ## 0x41, Beneficiary address
      forks: Vm2OpAllForks,
@@ -94,7 +95,8 @@ const
      info: "Get the block's beneficiary address",
      exec: (prep: vm2OpIgnore,
             run:  coinBaseOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Timestamp,       ## 0x42, Block timestamp.
      forks: Vm2OpAllForks,
@@ -102,7 +104,8 @@ const
      info: "Get the block's timestamp",
      exec: (prep: vm2OpIgnore,
             run:  timestampOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Number,          ## 0x43, Block number
      forks: Vm2OpAllForks,
@@ -110,7 +113,8 @@ const
      info: "Get the block's number",
      exec: (prep: vm2OpIgnore,
             run:  blocknumberOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Difficulty,      ## 0x44, Block difficulty
      forks: Vm2OpAllForks,
@@ -118,7 +122,8 @@ const
      info: "Get the block's difficulty",
      exec: (prep: vm2OpIgnore,
             run:  difficultyOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: GasLimit,        ## 0x45, Block gas limit
      forks: Vm2OpAllForks,
@@ -126,7 +131,8 @@ const
      info: "Get the block's gas limit",
      exec: (prep: vm2OpIgnore,
             run:  gasLimitOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: ChainIdOp,       ## 0x46, EIP-155 chain identifier
      forks: Vm2OpIstanbulAndLater,
@@ -134,7 +140,8 @@ const
      info: "Get current chain’s EIP-155 unique identifier",
      exec: (prep: vm2OpIgnore,
             run:  chainIdOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: SelfBalance,     ## 0x47, Contract balance.
      forks: Vm2OpIstanbulAndLater,
@@ -142,7 +149,8 @@ const
      info: "Get current contract's balance",
      exec: (prep: vm2OpIgnore,
             run:  selfBalanceOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: BaseFee,         ## 0x48, EIP-1559 Block base fee.
      forks: Vm2OpLondonAndLater,
@@ -150,7 +158,8 @@ const
      info: "Get current block's EIP-1559 base fee",
      exec: (prep: vm2OpIgnore,
             run:  baseFeeOp,
-            post: vm2OpIgnore))]
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers)]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/vm2/interpreter/op_handlers/oph_call.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_call.nim
@@ -161,6 +161,8 @@ proc execSubCall(k: var Vm2Ctx; childMsg: Message; memPos, memLen: int) =
     if actualOutputSize > 0:
       c.memory.write(memPos, child.output.toOpenArray(0, actualOutputSize - 1))
 
+    newCompletedVoidFuture()
+
 # ------------------------------------------------------------------------------
 # Private, op handlers implementation
 # ------------------------------------------------------------------------------
@@ -426,7 +428,8 @@ const
      info: "Message-Call into an account",
      exec: (prep: vm2OpIgnore,
             run: callOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: CallCode,     ## 0xf2, Message-Call with alternative code
      forks: Vm2OpAllForks,
@@ -434,7 +437,8 @@ const
      info: "Message-call into this account with alternative account's code",
      exec: (prep: vm2OpIgnore,
             run: callCodeOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: DelegateCall, ## 0xf4, CallCode with persisting sender and value
      forks: Vm2OpHomesteadAndLater,
@@ -443,7 +447,8 @@ const
            "code but persisting the current values for sender and value.",
      exec: (prep: vm2OpIgnore,
             run: delegateCallOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: StaticCall,   ## 0xfa, Static message-call into an account
      forks: Vm2OpByzantiumAndLater,
@@ -451,7 +456,8 @@ const
      info: "Static message-call into an account",
      exec: (prep: vm2OpIgnore,
             run: staticCallOp,
-            post: vm2OpIgnore))]
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers)]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/vm2/interpreter/op_handlers/oph_create.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_create.nim
@@ -57,6 +57,8 @@ proc execSubCreate(k: var Vm2Ctx; childMsg: Message;
     elif not child.error.burnsGas: # Means return was `REVERT`.
       # From create, only use `outputData` if child returned with `REVERT`.
       c.returnData = child.output
+    
+    newCompletedVoidFuture()
 
 # ------------------------------------------------------------------------------
 # Private, op handlers implementation
@@ -188,7 +190,8 @@ const
      info: "Create a new account with associated code",
      exec: (prep: vm2OpIgnore,
             run: createOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Create2,   ## 0xf5, Create using keccak256
      forks: Vm2OpConstantinopleAndLater,
@@ -196,7 +199,8 @@ const
      info: "Behaves identically to CREATE, except using keccak256",
      exec: (prep: vm2OpIgnore,
             run: create2Op,
-            post: vm2OpIgnore))]
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers)]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/vm2/interpreter/op_handlers/oph_envinfo.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_envinfo.nim
@@ -273,7 +273,8 @@ const
      info: "Get address of currently executing account",
      exec: (prep: vm2OpIgnore,
             run:  addressOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Balance,         ## 0x31, Balance
      forks: Vm2OpAllForks - Vm2OpBerlinAndLater,
@@ -281,7 +282,8 @@ const
      info: "Get balance of the given account",
      exec: (prep: vm2OpIgnore,
             run:  balanceOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Balance,         ## 0x31, Balance for Berlin and later
      forks: Vm2OpBerlinAndLater,
@@ -289,7 +291,8 @@ const
      info: "EIP2929: Get balance of the given account",
      exec: (prep: vm2OpIgnore,
             run:  balanceEIP2929Op,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Origin,          ## 0x32, Origination address
      forks: Vm2OpAllForks,
@@ -297,7 +300,8 @@ const
      info: "Get execution origination address",
      exec: (prep: vm2OpIgnore,
             run:  originOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Caller,          ## 0x33, Caller address
      forks: Vm2OpAllForks,
@@ -305,7 +309,8 @@ const
      info: "Get caller address",
      exec: (prep: vm2OpIgnore,
             run:  callerOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: CallValue,       ## 0x34, Execution deposited value
      forks: Vm2OpAllForks,
@@ -314,7 +319,8 @@ const
            "responsible for this execution",
      exec: (prep: vm2OpIgnore,
             run:  callValueOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: CallDataLoad,    ## 0x35, Input data
      forks: Vm2OpAllForks,
@@ -322,7 +328,8 @@ const
      info: "Get input data of current environment",
      exec: (prep: vm2OpIgnore,
             run:  callDataLoadOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: CallDataSize,    ## 0x36, Size of input data
      forks: Vm2OpAllForks,
@@ -330,7 +337,8 @@ const
      info: "Get size of input data in current environment",
      exec: (prep: vm2OpIgnore,
             run:  callDataSizeOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: CallDataCopy,    ## 0x37, Copy input data to memory.
      forks: Vm2OpAllForks,
@@ -338,7 +346,8 @@ const
      info: "Copy input data in current environment to memory",
      exec: (prep: vm2OpIgnore,
             run:  callDataCopyOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: CodeSize,       ## 0x38, Size of code
      forks: Vm2OpAllForks,
@@ -346,7 +355,8 @@ const
      info: "Get size of code running in current environment",
      exec: (prep: vm2OpIgnore,
             run:  codeSizeOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: CodeCopy,       ## 0x39, Copy code to memory.
      forks: Vm2OpAllForks,
@@ -354,7 +364,8 @@ const
      info: "Copy code running in current environment to memory",
      exec: (prep: vm2OpIgnore,
             run:  codeCopyOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: GasPrice,       ## 0x3a, Gas price
      forks: Vm2OpAllForks,
@@ -362,7 +373,8 @@ const
      info: "Get price of gas in current environment",
      exec: (prep: vm2OpIgnore,
             run:  gasPriceOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: ExtCodeSize,    ## 0x3b, Account code size
      forks: Vm2OpAllForks - Vm2OpBerlinAndLater,
@@ -370,7 +382,8 @@ const
      info: "Get size of an account's code",
      exec: (prep: vm2OpIgnore,
             run:  extCodeSizeOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: ExtCodeSize,    ## 0x3b, Account code size for Berlin and later
      forks: Vm2OpBerlinAndLater,
@@ -378,7 +391,8 @@ const
      info: "EIP2929: Get size of an account's code",
      exec: (prep: vm2OpIgnore,
             run:  extCodeSizeEIP2929Op,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: ExtCodeCopy,    ## 0x3c, Account code copy to memory.
      forks: Vm2OpAllForks - Vm2OpBerlinAndLater,
@@ -386,7 +400,8 @@ const
      info: "Copy an account's code to memory",
      exec: (prep: vm2OpIgnore,
             run:  extCodeCopyOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: ExtCodeCopy,    ## 0x3c, Account Code-copy for Berlin and later
      forks: Vm2OpBerlinAndLater,
@@ -394,7 +409,8 @@ const
      info: "EIP2929: Copy an account's code to memory",
      exec: (prep: vm2OpIgnore,
             run:  extCodeCopyEIP2929Op,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: ReturnDataSize, ## 0x3d, Previous call output data size
      forks: Vm2OpByzantiumAndLater,
@@ -403,7 +419,8 @@ const
            "from the current environment",
      exec: (prep: vm2OpIgnore,
             run:  returnDataSizeOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: ReturnDataCopy, ## 0x3e, Previous call output data copy to memory
      forks: Vm2OpByzantiumAndLater,
@@ -411,7 +428,8 @@ const
      info: "Copy output data from the previous call to memory",
      exec: (prep: vm2OpIgnore,
             run:  returnDataCopyOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: ExtCodeHash,    ## 0x3f, Contract hash
      forks: Vm2OpConstantinopleAndLater - Vm2OpBerlinAndLater,
@@ -419,7 +437,8 @@ const
      info: "Returns the keccak256 hash of a contract’s code",
      exec: (prep: vm2OpIgnore,
             run:  extCodeHashOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: ExtCodeHash,    ## 0x3f, Contract hash for berlin and later
      forks: Vm2OpBerlinAndLater,
@@ -427,7 +446,8 @@ const
      info: "EIP2929: Returns the keccak256 hash of a contract’s code",
      exec: (prep: vm2OpIgnore,
             run:  extCodeHashEIP2929Op,
-            post: vm2OpIgnore))]
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers)]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/vm2/interpreter/op_handlers/oph_gen_handlers.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_gen_handlers.nim
@@ -104,7 +104,10 @@ macro genOphList*(runHandler: static[OphNumToTextFn];
                     nnkPar.newTree(
                       "prep".asIdent("vm2OpIgnore"),
                       "run".asIdent(n.runHandler),
-                      "post".asIdent("vm2OpIgnore"))))
+                      "post".asIdent("vm2OpIgnore"))),
+                  nnkExprColonExpr.newTree(
+                    newIdentNode("asyncHandlers"),
+                    newIdentNode("vm2NoAsyncOpHandlers")))
 
   # => const <varName>*: seq[Vm2OpExec] = @[ <records> ]
   result = nnkStmtList.newTree(

--- a/nimbus/vm2/interpreter/op_handlers/oph_hash.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_hash.nim
@@ -66,7 +66,8 @@ const
      info: "Compute Keccak-256 hash",
      exec: (prep: vm2OpIgnore,
             run:  sha3Op,
-            post: vm2OpIgnore))]
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers)]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/vm2/interpreter/op_handlers/oph_sysops.nim
+++ b/nimbus/vm2/interpreter/op_handlers/oph_sysops.nim
@@ -148,7 +148,8 @@ const
      info: "Halt execution returning output data",
      exec: (prep: vm2OpIgnore,
             run: returnOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Revert,       ## 0xfd, Halt and revert state changes
      forks: Vm2OpByzantiumAndLater,
@@ -157,7 +158,8 @@ const
            "and remaining gas",
      exec: (prep: vm2OpIgnore,
             run: revertOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: Invalid,      ## 0xfe, invalid instruction.
      forks: Vm2OpAllForks,
@@ -165,7 +167,8 @@ const
      info: "Designated invalid instruction",
      exec: (prep: vm2OpIgnore,
             run: invalidOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: SelfDestruct, ## 0xff, Halt execution, prep for later deletion
      forks: Vm2OpAllForks - Vm2OpTangerineAndLater,
@@ -173,7 +176,8 @@ const
      info: "Halt execution and register account for later deletion",
      exec: (prep: vm2OpIgnore,
             run:  selfDestructOp,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: SelfDestruct, ## 0xff, EIP150: self destruct, Tangerine
      forks: Vm2OpTangerineAndLater - Vm2OpSpuriousAndLater,
@@ -181,7 +185,8 @@ const
      info: "EIP150: Halt execution and register account for later deletion",
      exec: (prep: vm2OpIgnore,
             run:  selfDestructEIP150Op,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: SelfDestruct, ## 0xff, EIP161: self destruct, Spurious and later
      forks: Vm2OpSpuriousAndLater - Vm2OpBerlinAndLater,
@@ -189,7 +194,8 @@ const
      info: "EIP161: Halt execution and register account for later deletion",
      exec: (prep: vm2OpIgnore,
             run:  selfDestructEIP161Op,
-            post: vm2OpIgnore)),
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers),
 
     (opCode: SelfDestruct, ## 0xff, EIP2929: self destruct, Berlin and later
      forks: Vm2OpBerlinAndLater,
@@ -197,7 +203,8 @@ const
      info: "EIP2929: Halt execution and register account for later deletion",
      exec: (prep: vm2OpIgnore,
             run:  selfDestructEIP2929Op,
-            post: vm2OpIgnore))]
+            post: vm2OpIgnore),
+     asyncHandlers: vm2NoAsyncOpHandlers)]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/vm2/state_transactions.nim
+++ b/nimbus/vm2/state_transactions.nim
@@ -31,6 +31,7 @@ import
   ./state,
   ./types,
   chronicles,
+  chronos,
   eth/common,
   eth/common/eth_types,
   options,
@@ -56,12 +57,13 @@ proc refundGas*(c: Computation, tx: Transaction, sender: EthAddress) =
     db.addBalance(sender, c.gasMeter.gasRemaining.u256 * tx.gasPrice.u256)
 
 
-proc execComputation*(c: Computation) =
+proc execComputation*(c: Computation): Future[void] {.async.} =
   if not c.msg.isCreate:
     c.vmState.mutateStateDB:
       db.incNonce(c.msg.sender)
 
-  c.execCallOrCreate()
+  # This is one place where we used to call the synchronous version.
+  await c.asyncExecCallOrCreate()
 
   if c.isSuccess:
     if c.fork < FkLondon:

--- a/nimbus/vm2/types.nim
+++ b/nimbus/vm2/types.nim
@@ -11,6 +11,7 @@
 import
   tables, eth/common,
   options, json, sets,
+  chronos,
   ./stack,  ./memory, ./code_stream, ../forks,
   ./interpreter/[gas_costs, op_codes],
   # TODO - will be hidden at a lower layer
@@ -81,7 +82,7 @@ type
     instr*:                 Op
     opIndex*:               int
     parent*, child*:        Computation
-    continuation*:          proc() {.gcsafe.}
+    continuation*:          proc(): Future[void] {.gcsafe.}
 
   Error* = ref object
     info*:                  string
@@ -112,3 +113,13 @@ type
     value*:            UInt256
     data*:             seq[byte]
     flags*:            MsgFlags
+
+# AARDVARK - This is very obviously not the right place for this;
+# that's why I'm putting it here. This must already exist elsewhere.
+# Either find the existing one, or create it in the chronos
+# library, or learn why it's a bad idea.
+# -- Adam
+proc newCompletedVoidFuture*(): Future[void] =
+  let f = newFuture[void]("vm2/types/newCompletedVoidFuture()")
+  f.complete()
+  f

--- a/nimbus/vm_computation.nim
+++ b/nimbus/vm_computation.nim
@@ -24,7 +24,9 @@ else:
     ./vm2/interpreter_dispatch as vmi
   export
     vmi.execCallOrCreate,
-    vmi.executeOpcodes
+    vmi.executeOpcodes,
+    vmi.asyncExecCallOrCreate,
+    vmi.asyncExecuteOpcodes
 
 export
   vmc.accountExists,

--- a/nimbus/vm_internals.nim
+++ b/nimbus/vm_internals.nim
@@ -128,6 +128,8 @@ else:
     bChp.writeContract,
     cVmc.execCallOrCreate,
     cVmc.executeOpcodes,
+    cVmc.asyncExecCallOrCreate,
+    cVmc.asyncExecuteOpcodes,
     eGmt.consumeGas,
     eGmt.init,
     eGmt.refundGas,

--- a/tests/evm_tests.nim
+++ b/tests/evm_tests.nim
@@ -1,0 +1,23 @@
+# Nimbus
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ../test_macro
+
+{. warning[UnusedImport]:off .}
+
+# FIXME-howDoIMakeASubSuite: I have no idea whether creating this
+# file is a reasonable thing to do. I just want to gather a bunch
+# of EVM tests in one place. And I want to be able to gradually
+# add to this test suite. --Adam
+
+cliBuilder:
+  import  ./test_op_arith,
+          ./test_op_bit,
+          ./test_op_env,
+          ./test_op_memory,
+          ./test_op_misc,
+          ./test_op_custom

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -7,7 +7,7 @@
 
 import
   std/[strformat, strutils, json, os, tables, macros, options],
-  unittest2, stew/byteutils,
+  unittest2, stew/byteutils, chronos,
   eth/[trie/db, common, keys],
 
   ../nimbus/[vm_computation,
@@ -43,7 +43,8 @@ template doTest(fixture: JsonNode; vmState: BaseVMState; fork: Fork, address: Pr
       payload: if dataStr.len > 0: dataStr.hexToSeqByte else: @[]
     )
     let tx = signTransaction(unsignedTx, privateKey, ChainId(1), false)
-    let fixtureResult = testCallEvm(tx, tx.getSender, vmState, fork)
+    # FIXME-eventuallyPropagateAsyncFurtherUpward
+    let fixtureResult = waitFor(testCallEvm(tx, tx.getSender, vmState, fork))
 
     if expectedErr:
       check fixtureResult.isError


### PR DESCRIPTION
This code is not even close to being ready for use.

"make test" should still work, though.

What's in here:

  - There's a duplicated async version of the vm2 inner loop. (Search for UGLY-duplicatedForAsync.) I'm not happy with how much duplication there is, and maybe there's some clever macro I could write to make code that works for both sync and async, but doing macros-on-macros strikes me as a little bit too much magic for now, especially since I'm currently struggling with compiler bugs.

  - The asyncness has been propagated upward, to the point where I can at least run it through some tests. (I cut the propagation along other paths, though. Search for FIXME-eventuallyPropagateAsyncFurtherUpward.)

  - I've got a basic test sub-suite that just runs a few of the EVM-specific tests. (Run "make test-evm".) I'm wondering whether was an easier way for me to create a sub-suite of tests. (See FIXME-howDoIMakeASubSuite.)

  - In the implementation of each opcode, we can now (optionally) specify an asynchronous handler. (Search for asyncHandlers.)

  - And the thing that's broken because I encountered that Nim compiler bug is in op_handlers.nim; there are a few lines of code in there that you can uncomment to see the bug. What's *supposed* to happen is that if asyncHandlers is present, its "run" proc gets put into runAsynchronously in the vmOpHandlersRec structure. But for some reason that I don't understand, that's not working. Anyway, the idea is that when the async version of the EVM is running an opcode that has an asynchronous handler, it should run that instead of the synchronous handler. That should allow us to implement asynchronous handlers for the few opcodes that need them, while still allowing us to have a fully-synchronous version of the EVM (which might be useful for performance comparisons, until/unless we become satisfied that we don't need it).