### PR TITLE
Make accumulator finite at merge block

### DIFF
--- a/fluffy/network/history/history_content.nim
+++ b/fluffy/network/history/history_content.nim
@@ -38,7 +38,7 @@ type
     blockHash*: BlockHash
 
   EpochAccumulatorKey* = object
-    epochHash*: Digest
+    epochHash*: Digest # TODO: Perhaps this should be called epochRoot in the spec instead
 
   MasterAccumulatorKeyType* = enum
     latest = 0x00 # An SSZ Union None

--- a/fluffy/tests/portal_spec_tests/mainnet/all_fluffy_portal_spec_tests.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/all_fluffy_portal_spec_tests.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
@@ -8,12 +8,8 @@
 {. warning[UnusedImport]:off .}
 
 import
-  ./test_portal_wire_protocol,
-  ./test_state_distance,
-  ./test_state_network,
-  ./test_accumulator,
-  ./test_history_validation,
-  ./test_history_network,
-  ./test_content_db,
-  ./test_discovery_rpc,
-  ./test_bridge_parser
+  ./test_portal_wire_encoding,
+  ./test_history_content,
+  ./test_header_content,
+  ./test_state_content,
+  ./test_accumulator_root

--- a/fluffy/tests/portal_spec_tests/mainnet/test_accumulator_root.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_accumulator_root.nim
@@ -1,0 +1,50 @@
+# Nimbus
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+{.push raises: [Defect].}
+
+import
+  unittest2, stint, stew/byteutils,
+  eth/common/eth_types_rlp,
+  ../../../data/history_data_parser,
+  ../../../network/history/[history_content, accumulator]
+
+suite "Header Accumulator Root":
+  test "Header Accumulator Update":
+    const
+      hashTreeRoots = [
+        "53521984da4bbdbb011fe8a1473bf71bdf1040b14214a05cd1ce6932775bc7fa",
+        "ae48c6d4e1b0a68324f346755645ba7e5d99da3dd1c38a9acd10e2fe4f43cfb4",
+        "52f7bd6204be2d98cb9d09aa375b4355140e0d65744ce7b2f3ea34d8e6453572"]
+
+      dataFile = "./fluffy/tests/blocks/mainnet_blocks_1-2.json"
+
+    let blockDataRes = readJsonType(dataFile, BlockDataTable)
+
+    check blockDataRes.isOk()
+    let blockData = blockDataRes.get()
+
+    var headers: seq[BlockHeader]
+    # Len of headers from blockdata + genesis header
+    headers.setLen(blockData.len() + 1)
+
+    headers[0] = getGenesisHeader()
+
+    for k, v in blockData.pairs:
+      let res = v.readBlockHeader()
+      check res.isOk()
+      let header = res.get()
+      headers[header.blockNumber.truncate(int)] = header
+
+    var accumulator: Accumulator
+
+    for i, hash in hashTreeRoots:
+      updateAccumulator(accumulator, headers[i])
+
+      check accumulator.hash_tree_root().data.toHex() == hashTreeRoots[i]

--- a/fluffy/tests/portal_spec_tests/mainnet/test_header_content.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_header_content.nim
@@ -11,7 +11,7 @@
 
 import
   unittest2, stew/byteutils,
-  ../network/header/header_content
+  ../../../network/header/header_content
 
 suite "Header Gossip ContentKey Encodings":
   test "BlockHeader":

--- a/fluffy/tests/portal_spec_tests/mainnet/test_history_content.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_history_content.nim
@@ -9,7 +9,8 @@
 
 import
   unittest2, stew/byteutils, stint,
-  ../network/history/history_content
+  ssz_serialization, ssz_serialization/[proofs, merkleization],
+  ../../../network/history/[history_content, accumulator]
 
 # According to test vectors:
 # https://github.com/ethereum/portal-network-specs/blob/master/content-keys-test-vectors.md#history-network-keys

--- a/fluffy/tests/portal_spec_tests/mainnet/test_portal_wire_encoding.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_portal_wire_encoding.nim
@@ -9,7 +9,7 @@
 
 import
   unittest2, stint, stew/[byteutils, results], eth/p2p/discoveryv5/enr,
-  ../network/wire/messages
+  ../../../network/wire/messages
 
 # According to test vectors:
 # https://github.com/ethereum/portal-network-specs/blob/master/portal-wire-test-vectors.md

--- a/fluffy/tests/portal_spec_tests/mainnet/test_state_content.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_state_content.nim
@@ -9,7 +9,7 @@
 
 import
   unittest2, stew/byteutils,
-  ../network/state/state_content
+  ../../../network/state/state_content
 
 # According to test vectors:
 # https://github.com/ethereum/portal-network-specs/blob/master/content-keys-test-vectors.md#state-network-keys

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -89,7 +89,10 @@ task test_portal_testnet, "Build test_portal_testnet":
 task testfluffy, "Run fluffy tests":
   # Need the nimbus_db_backend in state network tests as we need a Hexary to
   # start from, even though it only uses the MemoryDb.
-  test "fluffy/tests", "all_fluffy_tests", "-d:chronicles_log_level=ERROR -d:chronosStrictException -d:nimbus_db_backend=sqlite -d:PREFER_BLST_SHA256=false -d:canonicalVerify=true"
+  test "fluffy/tests/portal_spec_tests/mainnet", "all_fluffy_portal_spec_tests", "-d:chronicles_log_level=ERROR -d:chronosStrictException -d:nimbus_db_backend=sqlite -d:PREFER_BLST_SHA256=false -d:canonicalVerify=true"
+  # Running tests with a low `mergeBlockNumber` to make the tests faster.
+  # Using the real mainnet merge block number is not realistic for these tests.
+  test "fluffy/tests", "all_fluffy_tests", "-d:chronicles_log_level=ERROR -d:chronosStrictException -d:nimbus_db_backend=sqlite -d:PREFER_BLST_SHA256=false -d:canonicalVerify=true -d:mergeBlockNumber:38130"
 
 task testlcproxy, "Run light proxy tests":
   test "lc_proxy/tests", "test_proof_validation", "-d:chronicles_log_level=ERROR -d:chronosStrictException -d:nimbus_db_backend=sqlite -d:PREFER_BLST_SHA256=false"


### PR DESCRIPTION
- Let accumulator finish its last pre merge epoch (hash_tree_root on incomplete epoch).
- Adjust code to use isPreMerge and remove isCurrentEpoch
- Split up tests to a set that runs with a mainnet merge block number and a set that runs with a testing value.