### PR TITLE
Make fluffy rpc portal call compatible with spec

### DIFF
--- a/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
@@ -1,35 +1,35 @@
 ## Portal State Network json-rpc calls
-proc portal_state_nodeInfo(): NodeInfo
-proc portal_state_routingTableInfo(): RoutingTableInfo
-proc portal_state_lookupEnr(nodeId: NodeId): Record
-proc portal_state_addEnrs(enrs: seq[Record]): bool
-proc portal_state_ping(enr: Record): tuple[
+proc portal_stateNodeInfo(): NodeInfo
+proc portal_stateRoutingTableInfo(): RoutingTableInfo
+proc portal_stateLookupEnr(nodeId: NodeId): Record
+proc portal_stateAddEnrs(enrs: seq[Record]): bool
+proc portal_statePing(enr: Record): tuple[
   seqNum: uint64, customPayload: string]
-proc portal_state_findNodes(enr: Record): seq[Record]
-proc portal_state_findContentRaw(enr: Record, contentKey: string): tuple[
+proc portal_stateFindNodes(enr: Record): seq[Record]
+proc portal_stateFindContentRaw(enr: Record, contentKey: string): tuple[
   connectionId: Option[string],
   content: Option[string],
   enrs: Option[seq[Record]]]
-proc portal_state_findContent(enr: Record, contentKey: string): tuple[
+proc portal_stateFindContent(enr: Record, contentKey: string): tuple[
   content: Option[string],
   enrs: Option[seq[Record]]]
-proc portal_state_offer(enr: Record, contentKey: string): bool
-proc portal_state_recursiveFindNodes(): seq[Record]
+proc portal_stateOffer(enr: Record, contentKey: string): bool
+proc portal_stateRecursiveFindNodes(): seq[Record]
 
 ## Portal History Network json-rpc calls
-proc portal_history_nodeInfo(): NodeInfo
-proc portal_history_routingTableInfo(): RoutingTableInfo
-proc portal_history_lookupEnr(nodeId: NodeId): Record
-proc portal_history_addEnrs(enrs: seq[Record]): bool
-proc portal_history_ping(enr: Record): tuple[
+proc portal_historyNodeInfo(): NodeInfo
+proc portal_historyRoutingTableInfo(): RoutingTableInfo
+proc portal_historyLookupEnr(nodeId: NodeId): Record
+proc portal_historyAddEnrs(enrs: seq[Record]): bool
+proc portal_historyPing(enr: Record): tuple[
   seqNum: uint64, customPayload: string]
-proc portal_history_findNodes(enr: Record): seq[Record]
-proc portal_history_findContentRaw(enr: Record, contentKey: string): tuple[
+proc portal_historyFindNodes(enr: Record): seq[Record]
+proc portal_historyFindContentRaw(enr: Record, contentKey: string): tuple[
   connectionId: Option[string],
   content: Option[string],
   enrs: Option[seq[Record]]]
-proc portal_history_findContent(enr: Record, contentKey: string): tuple[
+proc portal_historyFindContent(enr: Record, contentKey: string): tuple[
   content: Option[string],
   enrs: Option[seq[Record]]]
-proc portal_history_offer(enr: Record, contentKey: string): bool
-proc portal_history_recursiveFindNodes(): seq[Record]
+proc portal_historyOffer(enr: Record, contentKey: string): bool
+proc portal_historyRecursiveFindNodes(): seq[Record]

--- a/fluffy/rpc/rpc_portal_api.nim
+++ b/fluffy/rpc/rpc_portal_api.nim
@@ -29,20 +29,20 @@ proc installPortalApiHandlers*(
   ## will look something similar as what exists here now:
   ## https://github.com/ethereum/portal-network-specs/pull/88
 
-  rpcServer.rpc("portal_" & network & "_nodeInfo") do() -> NodeInfo:
+  rpcServer.rpc("portal_" & network & "NodeInfo") do() -> NodeInfo:
     return p.routingTable.getNodeInfo()
 
-  rpcServer.rpc("portal_" & network & "_routingTableInfo") do() -> RoutingTableInfo:
+  rpcServer.rpc("portal_" & network & "RoutingTableInfo") do() -> RoutingTableInfo:
     return getRoutingTableInfo(p.routingTable)
 
-  rpcServer.rpc("portal_" & network & "_lookupEnr") do(nodeId: NodeId) -> Record:
+  rpcServer.rpc("portal_" & network & "LookupEnr") do(nodeId: NodeId) -> Record:
     let lookup = await p.resolve(nodeId)
     if lookup.isSome():
       return lookup.get().record
     else:
       raise newException(ValueError, "Record not found in DHT lookup.")
 
-  rpcServer.rpc("portal_" & network & "_addEnrs") do(enrs: seq[Record]) -> bool:
+  rpcServer.rpc("portal_" & network & "AddEnrs") do(enrs: seq[Record]) -> bool:
     for enr in enrs:
       let nodeRes = newNode(enr)
       if nodeRes.isOk():
@@ -52,7 +52,7 @@ proc installPortalApiHandlers*(
 
     return true
 
-  rpcServer.rpc("portal_" & network & "_ping") do(
+  rpcServer.rpc("portal_" & network & "Ping") do(
       enr: Record) -> tuple[seqNum: uint64, customPayload: string]:
     let
       node = toNodeWithAddress(enr)
@@ -64,7 +64,7 @@ proc installPortalApiHandlers*(
       let p = pong.get()
       return (p.enrSeq, p.customPayload.asSeq().toHex())
 
-  rpcServer.rpc("portal_" & network & "_findNodes") do(
+  rpcServer.rpc("portal_" & network & "FindNodes") do(
       enr: Record, distances: seq[uint16]) -> seq[Record]:
     let
       node = toNodeWithAddress(enr)
@@ -78,7 +78,7 @@ proc installPortalApiHandlers*(
   # according to spec, no k:v pair at all?
   # Note: `*_findContentRaw` is actually `*_findContent` call according to
   # WIP Portal JSON-RPC API specification. Not sure about the best naming here.
-  rpcServer.rpc("portal_" & network & "_findContentRaw") do(
+  rpcServer.rpc("portal_" & network & "FindContentRaw") do(
       enr: Record, contentKey: string) -> tuple[
         connectionId: Option[string],
         content: Option[string],
@@ -116,7 +116,7 @@ proc installPortalApiHandlers*(
               records.get(), node, enrsResultLimit).map(
                 proc(n: Node): Record = n.record)))
 
-  rpcServer.rpc("portal_" & network & "_findContent") do(
+  rpcServer.rpc("portal_" & network & "FindContent") do(
       enr: Record, contentKey: string) -> tuple[
         content: Option[string], enrs: Option[seq[Record]]]:
     let
@@ -138,7 +138,7 @@ proc installPortalApiHandlers*(
           none(string),
           some(foundContent.nodes.map(proc(n: Node): Record = n.record)))
 
-  rpcServer.rpc("portal_" & network & "_offer") do(
+  rpcServer.rpc("portal_" & network & "Offer") do(
       enr: Record, contentKey: string) -> bool:
     # Only allow 1 content key for now
     let
@@ -150,6 +150,6 @@ proc installPortalApiHandlers*(
     else:
       return true
 
-  rpcServer.rpc("portal_" & network & "_recursiveFindNodes") do() -> seq[Record]:
+  rpcServer.rpc("portal_" & network & "RecursiveFindNodes") do() -> seq[Record]:
     let discovered = await p.queryRandom()
     return discovered.map(proc(n: Node): Record = n.record)


### PR DESCRIPTION
Make naming of portal rpc calls compatible with spec - https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/portal-network-specs/assembled-spec/jsonrpc/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false

`debug` call are left as it is, as those are internal and naming with `_` more naturally maps to namespaces of different networks