### PR TITLE
Optionally write all epoch accumulators when building accumulator

### DIFF
--- a/fluffy/data/history_data_parser.nim
+++ b/fluffy/data/history_data_parser.nim
@@ -206,14 +206,8 @@ proc readAccumulator*(file: string): Result[FinishedAccumulator, string] =
     err("Failed decoding accumulator: " & e.msg)
 
 
-proc readEpochAccumulator*(dataFile: string): Result[EpochAccumulator, string] =
-  let res = ? readJsonType(dataFile, EpochAccumulatorObject)
-
-  let encodedAccumulator =
-    try:
-      res.epochAccumulator.hexToSeqByte()
-    except ValueError as e:
-      return err("Invalid hex data for accumulator: " & e.msg)
+proc readEpochAccumulator*(file: string): Result[EpochAccumulator, string] =
+  let encodedAccumulator = ? readAllFile(file).mapErr(toString)
 
   try:
     ok(SSZ.decode(encodedAccumulator, EpochAccumulator))

--- a/fluffy/rpc/rpc_calls/rpc_portal_debug_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_debug_calls.nim
@@ -4,10 +4,8 @@ proc portal_history_storeContent(dataFile: string): bool
 proc portal_history_propagate(dataFile: string): bool
 proc portal_history_propagateHeaders(dataFile: string): bool
 proc portal_history_propagateBlock(dataFile: string, blockHash: string): bool
-proc portal_history_propagateAccumulatorData(
-    dataFile: string): bool
-proc portal_history_propagateEpochAccumulator(
-    dataFile: string): bool
+proc portal_history_propagateEpochAccumulator(dataFile: string): bool
+proc portal_history_propagateEpochAccumulators(path: string): bool
 proc portal_history_storeContentInNodeRange(
     dbPath: string, max: uint32, starting: uint32): bool
 proc portal_history_offerContentInNodeRange(
@@ -16,4 +14,3 @@ proc portal_history_depthContentPropagate(
     dbPath: string, max: uint32): bool
 proc portal_history_breadthContentPropagate(
     dbPath: string): bool
-

--- a/fluffy/rpc/rpc_portal_debug_api.nim
+++ b/fluffy/rpc/rpc_portal_debug_api.nim
@@ -64,21 +64,20 @@ proc installPortalDebugApiHandlers*(
     else:
       raise newException(ValueError, $res.error)
 
-  rpcServer.rpc("portal_" & network & "_propagateAccumulatorData") do(
-      dataFile: string) -> bool:
-    let res = await p.propagateAccumulatorData(dataFile)
-    if res.isOk():
-      return true
-    else:
-      raise newException(ValueError, $res.error)
-
   rpcServer.rpc("portal_" & network & "_propagateEpochAccumulator") do(
       dataFile: string) -> bool:
     let res = await p.propagateEpochAccumulator(dataFile)
     if res.isOk():
       return true
     else:
-      echo $res.error
+      raise newException(ValueError, $res.error)
+
+  rpcServer.rpc("portal_" & network & "_propagateEpochAccumulators") do(
+      path: string) -> bool:
+    let res = await p.propagateEpochAccumulators(path)
+    if res.isOk():
+      return true
+    else:
       raise newException(ValueError, $res.error)
 
   rpcServer.rpc("portal_" & network & "_storeContentInNodeRange") do(

--- a/fluffy/tests/test_accumulator.nim
+++ b/fluffy/tests/test_accumulator.nim
@@ -13,15 +13,15 @@ import
   unittest2, stint,
   eth/common/eth_types_rlp,
   ../data/history_data_parser,
-  ../network/history/[history_content, accumulator]
+  ../network/history/[history_content, accumulator],
+  ./test_helpers
 
 func buildProof(
-    epochAccumulators: seq[(ContentKey, EpochAccumulator)],
-    header: BlockHeader):
+    epochAccumulators: seq[EpochAccumulator], header: BlockHeader):
     Result[seq[Digest], string] =
   let
     epochIndex = getEpochIndex(header)
-    epochAccumulator = epochAccumulators[epochIndex][1]
+    epochAccumulator = epochAccumulators[epochIndex]
 
     headerRecordIndex = getHeaderRecordIndex(header, epochIndex)
     gIndex = GeneralizedIndex(epochSize*2*2 + (headerRecordIndex*2))
@@ -54,13 +54,9 @@ suite "Header Accumulator":
       headers.add(BlockHeader(
         blockNumber: i.stuint(256), difficulty: 1.stuint(256)))
 
-    let
-      accumulatorRes = buildAccumulator(headers)
-      epochAccumulators = buildAccumulatorData(headers)
-
+    let accumulatorRes = buildAccumulatorData(headers)
     check accumulatorRes.isOk()
-
-    let accumulator = accumulatorRes.get()
+    let (accumulator, epochAccumulators) = accumulatorRes.get()
 
     block: # Test valid headers
       for i in headersToTest:


### PR DESCRIPTION
- Can write epoch accumulators to files now with eth_data_exporter
- RPC requests to gossip epoch accumulators now uses these files instead of building on the fly
- Other build accumulator calls are adjusted and only used for tests and thus moved to testing folder