### PR TITLE
upgrade github actions/cache and actions/checkout to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout nimbus-eth1
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Derive environment variables
         shell: bash
@@ -130,7 +130,7 @@ jobs:
       - name: Restore rocksdb from cache (Macos/Linux)
         if: runner.os != 'Windows'
         id: rocksdb-cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: rocks-db-cache-${{ matrix.target.cpu }}
           key: 'rocksdb-v2-${{ matrix.target.os }}-${{ matrix.target.cpu }}'
@@ -170,7 +170,7 @@ jobs:
       - name: Restore Nim DLLs dependencies (Windows) from cache
         if: runner.os == 'Windows'
         id: windows-dlls-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: external/dlls-${{ matrix.target.cpu }}
           # according to docu, idle caches are kept for up to 7 days
@@ -209,11 +209,11 @@ jobs:
             git ls-remote "https://github.com/$1" "${2:-HEAD}" | cut -f 1
           }
           nbsHash=$(getHash status-im/nimbus-build-system)
-          echo "::set-output name=nimbus_build_system::$nbsHash"
+          echo "nimbus_build_system=$nbsHash" >> $GITHUB_OUTPUT
 
       - name: Restore prebuilt Nim from cache
         id: nim-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: NimBinCache
           key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}'


### PR DESCRIPTION
Also change ::set-output usage to $GITHUB_OUTPUT.
This commit goal is to eliminate warnings in github actions summary page.