### PR TITLE
bump `nim-eth` for `withdrawalsRoot` support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,11 @@ nimcache
 *.generated.nim
 /dist
 
+/all_test.md
+
 # Nimble user files
 nimble.develop
 nimble.paths
 
 # nimbus-build-system files
 nimbus-build-system.paths
-

--- a/TransactionTests.md
+++ b/TransactionTests.md
@@ -21,12 +21,36 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + dataTx_bcValidBlockTestFrontier.json                            OK
 ```
 OK: 9/9 Fail: 0/9 Skip: 0/9
+## ttEIP1559
+```diff
++ GasLimitPriceProductOverflow.json                               OK
++ GasLimitPriceProductOverflowtMinusOne.json                      OK
++ GasLimitPriceProductPlusOneOverflow.json                        OK
++ maxFeePerGas00prefix.json                                       OK
++ maxFeePerGas32BytesValue.json                                   OK
++ maxFeePerGasOverflow.json                                       OK
++ maxPriorityFeePerGas00prefix.json                               OK
++ maxPriorityFeePerGasOverflow.json                               OK
++ maxPriorityFeePerGass32BytesValue.json                          OK
+```
+OK: 9/9 Fail: 0/9 Skip: 0/9
 ## ttEIP2028
 ```diff
 + DataTestInsufficientGas2028.json                                OK
 + DataTestSufficientGas2028.json                                  OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
+## ttEIP2930
+```diff
++ accessListAddressGreaterThan20.json                             OK
++ accessListAddressLessThan20.json                                OK
++ accessListAddressPrefix00.json                                  OK
++ accessListStorage0x0001.json                                    OK
++ accessListStorage32Bytes.json                                   OK
++ accessListStorageOver32Bytes.json                               OK
++ accessListStoragePrefix00.json                                  OK
+```
+OK: 7/7 Fail: 0/7 Skip: 0/7
 ## ttGasLimit
 ```diff
 + NotEnoughGasLimit.json                                          OK
@@ -189,6 +213,8 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + RLPNonceWithFirstZeros.json                                     OK
 + RLPTransactionGivenAsArray.json                                 OK
 + RLPValueWithFirstZeros.json                                     OK
++ RLP_04_maxFeePerGas32BytesValue.json                            OK
++ RLP_09_maxFeePerGas32BytesValue.json                            OK
 + RLPgasLimitWithFirstZeros.json                                  OK
 + RLPgasPriceWithFirstZeros.json                                  OK
 + TRANSCT_HeaderGivenAsArray_0.json                               OK
@@ -233,7 +259,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + aMaliciousRLP.json                                              OK
 + tr201506052141PYTHON.json                                       OK
 ```
-OK: 57/57 Fail: 0/57 Skip: 0/57
+OK: 59/59 Fail: 0/59 Skip: 0/59
 
 ---TOTAL---
-OK: 190/190 Fail: 0/190 Skip: 0/190
+OK: 208/208 Fail: 0/208 Skip: 0/208

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -157,6 +157,9 @@ func validateBlockHeaderBytes*(
 
   let header = ? decodeRlp(bytes, BlockHeader)
 
+  if header.withdrawalsRoot.isSome:
+    return err("Withdrawals not yet implemented")
+
   if not (header.blockHash() == hash):
     err("Block header hash does not match")
   else:

--- a/newBlockchainTests.md
+++ b/newBlockchainTests.md
@@ -1,5 +1,12 @@
 newBlockchainTests
 ===
+## bcArrowGlacierToMerge
+```diff
++ difficultyFormula.json                                          OK
++ powToPosBlockRejection.json                                     OK
++ powToPosTest.json                                               OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## bcBerlinToLondon
 ```diff
 + BerlinToLondonTransition.json                                   OK
@@ -29,6 +36,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + baseFee.json                                                    OK
 + besuBaseFeeBug.json                                             OK
 + burnVerify.json                                                 OK
++ burnVerifyLondon.json                                           OK
 + checkGasLimit.json                                              OK
 + feeCap.json                                                     OK
 + gasLimit20m.json                                                OK
@@ -40,21 +48,29 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + lowDemand.json                                                  OK
 + medDemand.json                                                  OK
 + tips.json                                                       OK
++ tipsLondon.json                                                 OK
 + transFail.json                                                  OK
 + transType.json                                                  OK
 + valCausesOOF.json                                               OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
+OK: 21/21 Fail: 0/21 Skip: 0/21
 ## bcEIP158ToByzantium
 ```diff
 + ByzantiumTransition.json                                        OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
+## bcEIP3675
+```diff
++ timestampPerBlock.json                                          OK
++ tipInsideBlock.json                                             OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## bcExample
 ```diff
 + basefeeExample.json                                             OK
++ mergeExample.json                                               OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## bcExploitTest
 ```diff
   DelegateCallSpam.json                                           Skip
@@ -266,6 +282,7 @@ OK: 96/96 Fail: 0/96 Skip: 0/96
 + RefundOverflow.json                                             OK
 + RefundOverflow2.json                                            OK
 + SuicidesMixingCoinbase.json                                     OK
++ SuicidesMixingCoinbase2.json                                    OK
 + TransactionFromCoinbaseHittingBlockGasLimit1.json               OK
 + TransactionFromCoinbaseNotEnoughFounds.json                     OK
 + TransactionNonceCheck.json                                      OK
@@ -299,6 +316,7 @@ OK: 96/96 Fail: 0/96 Skip: 0/96
 + extcodehashEmptySuicide.json                                    OK
 + logRevert.json                                                  OK
 + multimpleBalanceInstruction.json                                OK
++ random.json                                                     OK
 + randomStatetest123.json                                         OK
 + randomStatetest136.json                                         OK
 + randomStatetest160.json                                         OK
@@ -344,7 +362,7 @@ OK: 96/96 Fail: 0/96 Skip: 0/96
 + transactionFromSelfDestructedContract.json                      OK
 + txCost-sec73.json                                               OK
 ```
-OK: 87/88 Fail: 0/88 Skip: 1/88
+OK: 89/90 Fail: 0/90 Skip: 1/90
 ## bcTotalDifficultyTest
 ```diff
 + lotsOfBranchesOverrideAtTheEnd.json                             OK
@@ -405,6 +423,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 ## bcUncleTest
 ```diff
 + EqualUncleInTwoDifferentBlocks.json                             OK
++ EqualUncleInTwoDifferentBlocks2.json                            OK
 + InChainUncle.json                                               OK
 + InChainUncleFather.json                                         OK
 + InChainUncleGrandPa.json                                        OK
@@ -427,7 +446,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + uncleHeaderWithGeneration0.json                                 OK
 + uncleWithSameBlockNumber.json                                   OK
 ```
-OK: 22/22 Fail: 0/22 Skip: 0/22
+OK: 23/23 Fail: 0/23 Skip: 0/23
 ## bcValidBlockTest
 ```diff
 + ExtraData32.json                                                OK
@@ -730,8 +749,9 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + callcodecallcodecallcode_111_SuicideEnd.json                    OK
 + callcodecallcodecallcode_111_SuicideMiddle.json                 OK
   callcodecallcodecallcode_ABCB_RECURSIVE.json                    Skip
++ touchAndGo.json                                                 OK
 ```
-OK: 72/79 Fail: 0/79 Skip: 7/79
+OK: 73/80 Fail: 0/80 Skip: 7/80
 ## stCallCreateCallCodeTest
 ```diff
   Call1024BalanceTooLow.json                                      Skip
@@ -1006,6 +1026,7 @@ OK: 51/52 Fail: 0/52 Skip: 1/52
 + CREATE_HighNonceMinus1.json                                     OK
 + CREATE_empty000CreateinInitCode_Transaction.json                OK
 + CodeInConstructor.json                                          OK
++ CreateAddressWarmAfterFail.json                                 OK
 + CreateCollisionResults.json                                     OK
 + CreateCollisionToEmpty.json                                     OK
 + CreateOOGFromCallRefunds.json                                   OK
@@ -1019,12 +1040,14 @@ OK: 51/52 Fail: 0/52 Skip: 1/52
 + CreateOOGafterInitCodeRevert2.json                              OK
 + CreateOOGafterMaxCodesize.json                                  OK
 + CreateResults.json                                              OK
++ CreateTransactionHighNonce.json                                 OK
 + TransactionCollisionToEmpty.json                                OK
 + TransactionCollisionToEmptyButCode.json                         OK
 + TransactionCollisionToEmptyButNonce.json                        OK
 + createFailResult.json                                           OK
++ createLargeResult.json                                          OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
+OK: 44/44 Fail: 0/44 Skip: 0/44
 ## stDelegatecallTestHomestead
 ```diff
   Call1024BalanceTooLow.json                                      Skip
@@ -1128,12 +1151,13 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + lowGasPriceOldTypes.json                                        OK
 + outOfFunds.json                                                 OK
 + outOfFundsOldTypes.json                                         OK
++ senderBalance.json                                              OK
 + tipTooHigh.json                                                 OK
 + transactionIntinsicBug.json                                     OK
 + typeTwoBerlin.json                                              OK
 + valCausesOOF.json                                               OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
+OK: 13/13 Fail: 0/13 Skip: 0/13
 ## stEIP158Specific
 ```diff
 + CALL_OneVCallSuicide.json                                       OK
@@ -1175,11 +1199,12 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + indexesOmitExample.json                                         OK
 + invalidTr.json                                                  OK
 + labelsExample.json                                              OK
++ mergeTest.json                                                  OK
 + rangesExample.json                                              OK
 + solidityExample.json                                            OK
 + yulExample.json                                                 OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
+OK: 12/12 Fail: 0/12 Skip: 0/12
 ## stExtCodeHash
 ```diff
 + callToNonExistent.json                                          OK
@@ -1457,6 +1482,7 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 ## stPreCompiledContracts
 ```diff
 + blake2B.json                                                    OK
++ delegatecall09Undefined.json                                    OK
 + idPrecomps.json                                                 OK
 + identity_to_bigger.json                                         OK
 + identity_to_smaller.json                                        OK
@@ -1465,7 +1491,7 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + precompsEIP2929.json                                            OK
 + sec80.json                                                      OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
+OK: 9/9 Fail: 0/9 Skip: 0/9
 ## stPreCompiledContracts2
 ```diff
 + CALLBlake2f.json                                                OK
@@ -1533,6 +1559,7 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + CallEcrecoverS_prefixed0.json                                   OK
 + CallEcrecoverUnrecoverableKey.json                              OK
 + CallEcrecoverV_prefixed0.json                                   OK
++ CallEcrecover_Overflow.json                                     OK
 + CallIdentitiy_0.json                                            OK
 + CallIdentitiy_1.json                                            OK
 + CallIdentity_1_nonzeroValue.json                                OK
@@ -1562,13 +1589,15 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + CallSha256_4.json                                               OK
 + CallSha256_4_gas99.json                                         OK
 + CallSha256_5.json                                               OK
++ ecrecoverShortBuff.json                                         OK
++ ecrecoverWeirdV.json                                            OK
 + modexpRandomInput.json                                          OK
 + modexp_0_0_0_20500.json                                         OK
 + modexp_0_0_0_22000.json                                         OK
 + modexp_0_0_0_25000.json                                         OK
 + modexp_0_0_0_35000.json                                         OK
 ```
-OK: 99/99 Fail: 0/99 Skip: 0/99
+OK: 102/102 Fail: 0/102 Skip: 0/102
 ## stQuadraticComplexityTest
 ```diff
   Call1MB1024Calldepth.json                                       Skip
@@ -2772,6 +2801,7 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + currentAccountBalance.json                                      OK
 + doubleSelfdestructTest.json                                     OK
 + doubleSelfdestructTest2.json                                    OK
++ doubleSelfdestructTouch.json                                    OK
 + extcodecopy.json                                                OK
 + return0.json                                                    OK
 + return1.json                                                    OK
@@ -2786,7 +2816,7 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + suicideSendEtherToMe.json                                       OK
 + testRandomTest.json                                             OK
 ```
-OK: 56/66 Fail: 0/66 Skip: 10/66
+OK: 57/67 Fail: 0/67 Skip: 10/67
 ## stTimeConsuming
 ```diff
   CALLBlake2f_MaxRounds.json                                      Skip
@@ -3306,4 +3336,4 @@ OK: 0/3 Fail: 0/3 Skip: 3/3
 OK: 11/11 Fail: 0/11 Skip: 0/11
 
 ---TOTAL---
-OK: 2859/2964 Fail: 0/2964 Skip: 105/2964
+OK: 2881/2986 Fail: 0/2986 Skip: 105/2986

--- a/newGeneralStateTests.md
+++ b/newGeneralStateTests.md
@@ -271,8 +271,9 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + callcodecallcodecallcode_111_SuicideEnd.json                    OK
 + callcodecallcodecallcode_111_SuicideMiddle.json                 OK
   callcodecallcodecallcode_ABCB_RECURSIVE.json                    Skip
++ touchAndGo.json                                                 OK
 ```
-OK: 72/79 Fail: 0/79 Skip: 7/79
+OK: 73/80 Fail: 0/80 Skip: 7/80
 ## stCallCreateCallCodeTest
 ```diff
   Call1024BalanceTooLow.json                                      Skip
@@ -547,6 +548,7 @@ OK: 51/52 Fail: 0/52 Skip: 1/52
 + CREATE_HighNonceMinus1.json                                     OK
 + CREATE_empty000CreateinInitCode_Transaction.json                OK
 + CodeInConstructor.json                                          OK
++ CreateAddressWarmAfterFail.json                                 OK
 + CreateCollisionResults.json                                     OK
 + CreateCollisionToEmpty.json                                     OK
 + CreateOOGFromCallRefunds.json                                   OK
@@ -560,12 +562,14 @@ OK: 51/52 Fail: 0/52 Skip: 1/52
 + CreateOOGafterInitCodeRevert2.json                              OK
 + CreateOOGafterMaxCodesize.json                                  OK
 + CreateResults.json                                              OK
++ CreateTransactionHighNonce.json                                 OK
 + TransactionCollisionToEmpty.json                                OK
 + TransactionCollisionToEmptyButCode.json                         OK
 + TransactionCollisionToEmptyButNonce.json                        OK
 + createFailResult.json                                           OK
++ createLargeResult.json                                          OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
+OK: 44/44 Fail: 0/44 Skip: 0/44
 ## stDelegatecallTestHomestead
 ```diff
   Call1024BalanceTooLow.json                                      Skip
@@ -669,12 +673,13 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + lowGasPriceOldTypes.json                                        OK
 + outOfFunds.json                                                 OK
 + outOfFundsOldTypes.json                                         OK
++ senderBalance.json                                              OK
 + tipTooHigh.json                                                 OK
 + transactionIntinsicBug.json                                     OK
 + typeTwoBerlin.json                                              OK
 + valCausesOOF.json                                               OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
+OK: 13/13 Fail: 0/13 Skip: 0/13
 ## stEIP158Specific
 ```diff
 + CALL_OneVCallSuicide.json                                       OK
@@ -716,11 +721,12 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + indexesOmitExample.json                                         OK
 + invalidTr.json                                                  OK
 + labelsExample.json                                              OK
++ mergeTest.json                                                  OK
 + rangesExample.json                                              OK
 + solidityExample.json                                            OK
 + yulExample.json                                                 OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
+OK: 12/12 Fail: 0/12 Skip: 0/12
 ## stExtCodeHash
 ```diff
 + callToNonExistent.json                                          OK
@@ -998,6 +1004,7 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 ## stPreCompiledContracts
 ```diff
 + blake2B.json                                                    OK
++ delegatecall09Undefined.json                                    OK
 + idPrecomps.json                                                 OK
 + identity_to_bigger.json                                         OK
 + identity_to_smaller.json                                        OK
@@ -1006,7 +1013,7 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + precompsEIP2929.json                                            OK
 + sec80.json                                                      OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
+OK: 9/9 Fail: 0/9 Skip: 0/9
 ## stPreCompiledContracts2
 ```diff
 + CALLBlake2f.json                                                OK
@@ -1074,6 +1081,7 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + CallEcrecoverS_prefixed0.json                                   OK
 + CallEcrecoverUnrecoverableKey.json                              OK
 + CallEcrecoverV_prefixed0.json                                   OK
++ CallEcrecover_Overflow.json                                     OK
 + CallIdentitiy_0.json                                            OK
 + CallIdentitiy_1.json                                            OK
 + CallIdentity_1_nonzeroValue.json                                OK
@@ -1103,13 +1111,15 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + CallSha256_4.json                                               OK
 + CallSha256_4_gas99.json                                         OK
 + CallSha256_5.json                                               OK
++ ecrecoverShortBuff.json                                         OK
++ ecrecoverWeirdV.json                                            OK
 + modexpRandomInput.json                                          OK
 + modexp_0_0_0_20500.json                                         OK
 + modexp_0_0_0_22000.json                                         OK
 + modexp_0_0_0_25000.json                                         OK
 + modexp_0_0_0_35000.json                                         OK
 ```
-OK: 99/99 Fail: 0/99 Skip: 0/99
+OK: 102/102 Fail: 0/102 Skip: 0/102
 ## stQuadraticComplexityTest
 ```diff
   Call1MB1024Calldepth.json                                       Skip
@@ -2313,6 +2323,7 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + currentAccountBalance.json                                      OK
 + doubleSelfdestructTest.json                                     OK
 + doubleSelfdestructTest2.json                                    OK
++ doubleSelfdestructTouch.json                                    OK
 + extcodecopy.json                                                OK
 + return0.json                                                    OK
 + return1.json                                                    OK
@@ -2327,7 +2338,7 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + suicideSendEtherToMe.json                                       OK
 + testRandomTest.json                                             OK
 ```
-OK: 56/66 Fail: 0/66 Skip: 10/66
+OK: 57/67 Fail: 0/67 Skip: 10/67
 ## stTimeConsuming
 ```diff
   CALLBlake2f_MaxRounds.json                                      Skip
@@ -2847,4 +2858,4 @@ OK: 1/3 Fail: 0/3 Skip: 2/3
 OK: 11/11 Fail: 0/11 Skip: 0/11
 
 ---TOTAL---
-OK: 2495/2597 Fail: 0/2597 Skip: 102/2597
+OK: 2506/2608 Fail: 0/2608 Skip: 102/2608

--- a/nimbus/debug.nim
+++ b/nimbus/debug.nim
@@ -1,3 +1,13 @@
+# Nimbus
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
 import
   std/[options, times],
   eth/common,
@@ -19,22 +29,24 @@ proc `$`(data: Blob): string =
   data.toHex
 
 proc debug*(h: BlockHeader): string =
-  result.add "parentHash : " & $h.parentHash  & "\n"
-  result.add "ommersHash : " & $h.ommersHash  & "\n"
-  result.add "coinbase   : " & $h.coinbase    & "\n"
-  result.add "stateRoot  : " & $h.stateRoot   & "\n"
-  result.add "txRoot     : " & $h.txRoot      & "\n"
-  result.add "receiptRoot: " & $h.receiptRoot & "\n"
-  result.add "bloom      : " & $h.bloom       & "\n"
-  result.add "difficulty : " & $h.difficulty  & "\n"
-  result.add "blockNumber: " & $h.blockNumber & "\n"
-  result.add "gasLimit   : " & $h.gasLimit    & "\n"
-  result.add "gasUsed    : " & $h.gasUsed     & "\n"
-  result.add "timestamp  : " & $h.timestamp.toUnix   & "\n"
-  result.add "extraData  : " & $h.extraData   & "\n"
-  result.add "mixDigest  : " & $h.mixDigest   & "\n"
-  result.add "nonce      : " & $h.nonce       & "\n"
-  result.add "fee.isSome : " & $h.fee.isSome  & "\n"
+  result.add "parentHash     : " & $h.parentHash  & "\n"
+  result.add "ommersHash     : " & $h.ommersHash  & "\n"
+  result.add "coinbase       : " & $h.coinbase    & "\n"
+  result.add "stateRoot      : " & $h.stateRoot   & "\n"
+  result.add "txRoot         : " & $h.txRoot      & "\n"
+  result.add "receiptRoot    : " & $h.receiptRoot & "\n"
+  result.add "bloom          : " & $h.bloom       & "\n"
+  result.add "difficulty     : " & $h.difficulty  & "\n"
+  result.add "blockNumber    : " & $h.blockNumber & "\n"
+  result.add "gasLimit       : " & $h.gasLimit    & "\n"
+  result.add "gasUsed        : " & $h.gasUsed     & "\n"
+  result.add "timestamp      : " & $h.timestamp.toUnix   & "\n"
+  result.add "extraData      : " & $h.extraData   & "\n"
+  result.add "mixDigest      : " & $h.mixDigest   & "\n"
+  result.add "nonce          : " & $h.nonce       & "\n"
+  result.add "fee.isSome     : " & $h.fee.isSome  & "\n"
   if h.fee.isSome:
-    result.add "fee        : " & $h.fee.get()   & "\n"
-  result.add "blockHash  : " & $blockHash(h) & "\n"
+    result.add "fee            : " & $h.fee.get()   & "\n"
+  if h.withdrawalsRoot.isSome:
+    result.add "withdrawalsRoot: " & $h.withdrawalsRoot.get() & "\n"
+  result.add "blockHash      : " & $blockHash(h) & "\n"

--- a/nimbus/p2p/validate.nim
+++ b/nimbus/p2p/validate.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -15,8 +15,7 @@ import
   ../transaction,
   ../utils/[difficulty, header, pow],
   ".."/[vm_state, vm_types, forks, errors],
-  ./dao,
-  ./gaslimit,
+  "."/[dao, gaslimit, withdrawals],
   chronicles,
   eth/[common, rlp],
   nimcrypto/utils,
@@ -129,7 +128,7 @@ proc validateHeader(db: BaseChainDB; header, parentHeader: BlockHeader;
     if checkSealOK:
       return pow.validateSeal(header)
 
-  result = ok()
+  db.validateWithdrawals(header)
 
 func validateUncle(currBlock, uncle, uncleParent: BlockHeader):
                                                Result[void,string] =

--- a/nimbus/p2p/withdrawals.nim
+++ b/nimbus/p2p/withdrawals.nim
@@ -1,0 +1,22 @@
+# Nimbus
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+import
+  stew/results,
+  eth/common,
+  ../db/db_chain
+
+# https://eips.ethereum.org/EIPS/eip-4895
+func validateWithdrawals*(
+    c: BaseChainDB, header: BlockHeader
+): Result[void, string] {.raises: [Defect].} =
+  if header.withdrawalsRoot.isSome:
+    return err("Withdrawals not yet implemented")
+  return ok()

--- a/nimbus/sync/fast.nim
+++ b/nimbus/sync/fast.nim
@@ -1,5 +1,5 @@
 # nim-eth
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at
 #     https://opensource.org/licenses/MIT).
@@ -17,7 +17,7 @@ import
   eth/p2p/[private/p2p_types, peer_pool],
   stew/byteutils,
   "."/[protocol, types],
-  ../p2p/[chain, clique/clique_sealer, gaslimit],
+  ../p2p/[chain, clique/clique_sealer, gaslimit, withdrawals],
   ../db/db_chain,
   ../utils/difficulty,
   ".."/[constants, utils]
@@ -198,7 +198,7 @@ proc validateHeader(ctx: FastSyncCtx, header: BlockHeader, height = none(BlockNu
         period
       return false
 
-  let res = db.validateGasLimitOrBaseFee(header, parentHeader)
+  var res = db.validateGasLimitOrBaseFee(header, parentHeader)
   if res.isErr:
     trace "validate gaslimit error",
       msg=res.error
@@ -212,6 +212,12 @@ proc validateHeader(ctx: FastSyncCtx, header: BlockHeader, height = none(BlockNu
         height=height.get(),
         parentNumber=parentHeader.blockNumber
       return false
+
+  res = db.validateWithdrawals(header)
+  if res.isErr:
+    trace "validate withdrawals error",
+      msg=res.error
+    return false
 
   return true
 

--- a/tests/replay/pp.nim
+++ b/tests/replay/pp.nim
@@ -1,6 +1,6 @@
 
 # Nimbus
-# Copyright (c) 2018-2019 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -54,7 +54,8 @@ proc pp*(h: BlockHeader; sep = " "): string =
     &"txRoot={h.txRoot.pp}{sep}" &
     &"receiptRoot={h.receiptRoot.pp}{sep}" &
     &"stateRoot={h.stateRoot.pp}{sep}" &
-    &"baseFee={h.baseFee}"
+    &"baseFee={h.baseFee}{sep}" &
+    &"withdrawalsRoot={h.withdrawalsRoot.get(EMPTY_ROOT_HASH)}"
 
 proc pp*(g: Genesis; sep = " "): string =
   "" &

--- a/witnessBuilderBC.md
+++ b/witnessBuilderBC.md
@@ -1,5 +1,12 @@
 witnessBuilderBC
 ===
+## bcArrowGlacierToMerge
+```diff
++ difficultyFormula.json                                          OK
++ powToPosBlockRejection.json                                     OK
++ powToPosTest.json                                               OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## bcBerlinToLondon
 ```diff
 + BerlinToLondonTransition.json                                   OK
@@ -29,6 +36,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + baseFee.json                                                    OK
 + besuBaseFeeBug.json                                             OK
 + burnVerify.json                                                 OK
++ burnVerifyLondon.json                                           OK
 + checkGasLimit.json                                              OK
 + feeCap.json                                                     OK
 + gasLimit20m.json                                                OK
@@ -40,21 +48,29 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + lowDemand.json                                                  OK
 + medDemand.json                                                  OK
 + tips.json                                                       OK
++ tipsLondon.json                                                 OK
 + transFail.json                                                  OK
 + transType.json                                                  OK
 + valCausesOOF.json                                               OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
+OK: 21/21 Fail: 0/21 Skip: 0/21
 ## bcEIP158ToByzantium
 ```diff
 + ByzantiumTransition.json                                        OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
+## bcEIP3675
+```diff
++ timestampPerBlock.json                                          OK
++ tipInsideBlock.json                                             OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## bcExample
 ```diff
 + basefeeExample.json                                             OK
++ mergeExample.json                                               OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## bcExploitTest
 ```diff
 + DelegateCallSpam.json                                           OK
@@ -266,6 +282,7 @@ OK: 96/96 Fail: 0/96 Skip: 0/96
 + RefundOverflow.json                                             OK
 + RefundOverflow2.json                                            OK
 + SuicidesMixingCoinbase.json                                     OK
++ SuicidesMixingCoinbase2.json                                    OK
 + TransactionFromCoinbaseHittingBlockGasLimit1.json               OK
 + TransactionFromCoinbaseNotEnoughFounds.json                     OK
 + TransactionNonceCheck.json                                      OK
@@ -299,6 +316,7 @@ OK: 96/96 Fail: 0/96 Skip: 0/96
 + extcodehashEmptySuicide.json                                    OK
 + logRevert.json                                                  OK
 + multimpleBalanceInstruction.json                                OK
++ random.json                                                     OK
 + randomStatetest123.json                                         OK
 + randomStatetest136.json                                         OK
 + randomStatetest160.json                                         OK
@@ -344,7 +362,7 @@ OK: 96/96 Fail: 0/96 Skip: 0/96
 + transactionFromSelfDestructedContract.json                      OK
 + txCost-sec73.json                                               OK
 ```
-OK: 88/88 Fail: 0/88 Skip: 0/88
+OK: 90/90 Fail: 0/90 Skip: 0/90
 ## bcTotalDifficultyTest
 ```diff
 + lotsOfBranchesOverrideAtTheEnd.json                             OK
@@ -405,6 +423,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 ## bcUncleTest
 ```diff
 + EqualUncleInTwoDifferentBlocks.json                             OK
++ EqualUncleInTwoDifferentBlocks2.json                            OK
 + InChainUncle.json                                               OK
 + InChainUncleFather.json                                         OK
 + InChainUncleGrandPa.json                                        OK
@@ -427,7 +446,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + uncleHeaderWithGeneration0.json                                 OK
 + uncleWithSameBlockNumber.json                                   OK
 ```
-OK: 22/22 Fail: 0/22 Skip: 0/22
+OK: 23/23 Fail: 0/23 Skip: 0/23
 ## bcValidBlockTest
 ```diff
 + ExtraData32.json                                                OK
@@ -730,8 +749,9 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + callcodecallcodecallcode_111_SuicideEnd.json                    OK
 + callcodecallcodecallcode_111_SuicideMiddle.json                 OK
 + callcodecallcodecallcode_ABCB_RECURSIVE.json                    OK
++ touchAndGo.json                                                 OK
 ```
-OK: 79/79 Fail: 0/79 Skip: 0/79
+OK: 80/80 Fail: 0/80 Skip: 0/80
 ## stCallCreateCallCodeTest
 ```diff
 + Call1024BalanceTooLow.json                                      OK
@@ -1006,6 +1026,7 @@ OK: 52/52 Fail: 0/52 Skip: 0/52
 + CREATE_HighNonceMinus1.json                                     OK
 + CREATE_empty000CreateinInitCode_Transaction.json                OK
 + CodeInConstructor.json                                          OK
++ CreateAddressWarmAfterFail.json                                 OK
 + CreateCollisionResults.json                                     OK
 + CreateCollisionToEmpty.json                                     OK
 + CreateOOGFromCallRefunds.json                                   OK
@@ -1019,12 +1040,14 @@ OK: 52/52 Fail: 0/52 Skip: 0/52
 + CreateOOGafterInitCodeRevert2.json                              OK
 + CreateOOGafterMaxCodesize.json                                  OK
 + CreateResults.json                                              OK
++ CreateTransactionHighNonce.json                                 OK
 + TransactionCollisionToEmpty.json                                OK
 + TransactionCollisionToEmptyButCode.json                         OK
 + TransactionCollisionToEmptyButNonce.json                        OK
 + createFailResult.json                                           OK
++ createLargeResult.json                                          OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
+OK: 44/44 Fail: 0/44 Skip: 0/44
 ## stDelegatecallTestHomestead
 ```diff
 + Call1024BalanceTooLow.json                                      OK
@@ -1128,12 +1151,13 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + lowGasPriceOldTypes.json                                        OK
 + outOfFunds.json                                                 OK
 + outOfFundsOldTypes.json                                         OK
++ senderBalance.json                                              OK
 + tipTooHigh.json                                                 OK
 + transactionIntinsicBug.json                                     OK
 + typeTwoBerlin.json                                              OK
 + valCausesOOF.json                                               OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
+OK: 13/13 Fail: 0/13 Skip: 0/13
 ## stEIP158Specific
 ```diff
 + CALL_OneVCallSuicide.json                                       OK
@@ -1175,11 +1199,12 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + indexesOmitExample.json                                         OK
 + invalidTr.json                                                  OK
 + labelsExample.json                                              OK
++ mergeTest.json                                                  OK
 + rangesExample.json                                              OK
 + solidityExample.json                                            OK
 + yulExample.json                                                 OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
+OK: 12/12 Fail: 0/12 Skip: 0/12
 ## stExtCodeHash
 ```diff
 + callToNonExistent.json                                          OK
@@ -1457,6 +1482,7 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 ## stPreCompiledContracts
 ```diff
 + blake2B.json                                                    OK
++ delegatecall09Undefined.json                                    OK
 + idPrecomps.json                                                 OK
 + identity_to_bigger.json                                         OK
 + identity_to_smaller.json                                        OK
@@ -1465,7 +1491,7 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + precompsEIP2929.json                                            OK
 + sec80.json                                                      OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
+OK: 9/9 Fail: 0/9 Skip: 0/9
 ## stPreCompiledContracts2
 ```diff
 + CALLBlake2f.json                                                OK
@@ -1533,6 +1559,7 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + CallEcrecoverS_prefixed0.json                                   OK
 + CallEcrecoverUnrecoverableKey.json                              OK
 + CallEcrecoverV_prefixed0.json                                   OK
++ CallEcrecover_Overflow.json                                     OK
 + CallIdentitiy_0.json                                            OK
 + CallIdentitiy_1.json                                            OK
 + CallIdentity_1_nonzeroValue.json                                OK
@@ -1562,13 +1589,15 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + CallSha256_4.json                                               OK
 + CallSha256_4_gas99.json                                         OK
 + CallSha256_5.json                                               OK
++ ecrecoverShortBuff.json                                         OK
++ ecrecoverWeirdV.json                                            OK
 + modexpRandomInput.json                                          OK
 + modexp_0_0_0_20500.json                                         OK
 + modexp_0_0_0_22000.json                                         OK
 + modexp_0_0_0_25000.json                                         OK
 + modexp_0_0_0_35000.json                                         OK
 ```
-OK: 99/99 Fail: 0/99 Skip: 0/99
+OK: 102/102 Fail: 0/102 Skip: 0/102
 ## stQuadraticComplexityTest
 ```diff
 + Call1MB1024Calldepth.json                                       OK
@@ -2772,6 +2801,7 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + currentAccountBalance.json                                      OK
 + doubleSelfdestructTest.json                                     OK
 + doubleSelfdestructTest2.json                                    OK
++ doubleSelfdestructTouch.json                                    OK
 + extcodecopy.json                                                OK
 + return0.json                                                    OK
 + return1.json                                                    OK
@@ -2786,7 +2816,7 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + suicideSendEtherToMe.json                                       OK
 + testRandomTest.json                                             OK
 ```
-OK: 66/66 Fail: 0/66 Skip: 0/66
+OK: 67/67 Fail: 0/67 Skip: 0/67
 ## stTimeConsuming
 ```diff
 + CALLBlake2f_MaxRounds.json                                      OK
@@ -3306,4 +3336,4 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 OK: 11/11 Fail: 0/11 Skip: 0/11
 
 ---TOTAL---
-OK: 2964/2964 Fail: 0/2964 Skip: 0/2964
+OK: 2986/2986 Fail: 0/2986 Skip: 0/2986

--- a/witnessBuilderGST.md
+++ b/witnessBuilderGST.md
@@ -271,8 +271,9 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + callcodecallcodecallcode_111_SuicideEnd.json                    OK
 + callcodecallcodecallcode_111_SuicideMiddle.json                 OK
 + callcodecallcodecallcode_ABCB_RECURSIVE.json                    OK
++ touchAndGo.json                                                 OK
 ```
-OK: 79/79 Fail: 0/79 Skip: 0/79
+OK: 80/80 Fail: 0/80 Skip: 0/80
 ## stCallCreateCallCodeTest
 ```diff
 + Call1024BalanceTooLow.json                                      OK
@@ -547,6 +548,7 @@ OK: 52/52 Fail: 0/52 Skip: 0/52
 + CREATE_HighNonceMinus1.json                                     OK
 + CREATE_empty000CreateinInitCode_Transaction.json                OK
 + CodeInConstructor.json                                          OK
++ CreateAddressWarmAfterFail.json                                 OK
 + CreateCollisionResults.json                                     OK
 + CreateCollisionToEmpty.json                                     OK
 + CreateOOGFromCallRefunds.json                                   OK
@@ -560,12 +562,14 @@ OK: 52/52 Fail: 0/52 Skip: 0/52
 + CreateOOGafterInitCodeRevert2.json                              OK
 + CreateOOGafterMaxCodesize.json                                  OK
 + CreateResults.json                                              OK
++ CreateTransactionHighNonce.json                                 OK
 + TransactionCollisionToEmpty.json                                OK
 + TransactionCollisionToEmptyButCode.json                         OK
 + TransactionCollisionToEmptyButNonce.json                        OK
 + createFailResult.json                                           OK
++ createLargeResult.json                                          OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
+OK: 44/44 Fail: 0/44 Skip: 0/44
 ## stDelegatecallTestHomestead
 ```diff
 + Call1024BalanceTooLow.json                                      OK
@@ -669,12 +673,13 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + lowGasPriceOldTypes.json                                        OK
 + outOfFunds.json                                                 OK
 + outOfFundsOldTypes.json                                         OK
++ senderBalance.json                                              OK
 + tipTooHigh.json                                                 OK
 + transactionIntinsicBug.json                                     OK
 + typeTwoBerlin.json                                              OK
 + valCausesOOF.json                                               OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
+OK: 13/13 Fail: 0/13 Skip: 0/13
 ## stEIP158Specific
 ```diff
 + CALL_OneVCallSuicide.json                                       OK
@@ -716,11 +721,12 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + indexesOmitExample.json                                         OK
 + invalidTr.json                                                  OK
 + labelsExample.json                                              OK
++ mergeTest.json                                                  OK
 + rangesExample.json                                              OK
 + solidityExample.json                                            OK
 + yulExample.json                                                 OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
+OK: 12/12 Fail: 0/12 Skip: 0/12
 ## stExtCodeHash
 ```diff
 + callToNonExistent.json                                          OK
@@ -998,6 +1004,7 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 ## stPreCompiledContracts
 ```diff
 + blake2B.json                                                    OK
++ delegatecall09Undefined.json                                    OK
 + idPrecomps.json                                                 OK
 + identity_to_bigger.json                                         OK
 + identity_to_smaller.json                                        OK
@@ -1006,7 +1013,7 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + precompsEIP2929.json                                            OK
 + sec80.json                                                      OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
+OK: 9/9 Fail: 0/9 Skip: 0/9
 ## stPreCompiledContracts2
 ```diff
 + CALLBlake2f.json                                                OK
@@ -1074,6 +1081,7 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + CallEcrecoverS_prefixed0.json                                   OK
 + CallEcrecoverUnrecoverableKey.json                              OK
 + CallEcrecoverV_prefixed0.json                                   OK
++ CallEcrecover_Overflow.json                                     OK
 + CallIdentitiy_0.json                                            OK
 + CallIdentitiy_1.json                                            OK
 + CallIdentity_1_nonzeroValue.json                                OK
@@ -1103,13 +1111,15 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + CallSha256_4.json                                               OK
 + CallSha256_4_gas99.json                                         OK
 + CallSha256_5.json                                               OK
++ ecrecoverShortBuff.json                                         OK
++ ecrecoverWeirdV.json                                            OK
 + modexpRandomInput.json                                          OK
 + modexp_0_0_0_20500.json                                         OK
 + modexp_0_0_0_22000.json                                         OK
 + modexp_0_0_0_25000.json                                         OK
 + modexp_0_0_0_35000.json                                         OK
 ```
-OK: 99/99 Fail: 0/99 Skip: 0/99
+OK: 102/102 Fail: 0/102 Skip: 0/102
 ## stQuadraticComplexityTest
 ```diff
 + Call1MB1024Calldepth.json                                       OK
@@ -2313,6 +2323,7 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + currentAccountBalance.json                                      OK
 + doubleSelfdestructTest.json                                     OK
 + doubleSelfdestructTest2.json                                    OK
++ doubleSelfdestructTouch.json                                    OK
 + extcodecopy.json                                                OK
 + return0.json                                                    OK
 + return1.json                                                    OK
@@ -2327,7 +2338,7 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + suicideSendEtherToMe.json                                       OK
 + testRandomTest.json                                             OK
 ```
-OK: 66/66 Fail: 0/66 Skip: 0/66
+OK: 67/67 Fail: 0/67 Skip: 0/67
 ## stTimeConsuming
 ```diff
 + CALLBlake2f_MaxRounds.json                                      OK
@@ -2847,4 +2858,4 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 OK: 11/11 Fail: 0/11 Skip: 0/11
 
 ---TOTAL---
-OK: 2597/2597 Fail: 0/2597 Skip: 0/2597
+OK: 2608/2608 Fail: 0/2608 Skip: 0/2608


### PR DESCRIPTION
The `BlockHeader` structure in `nim-eth` was updated with support for EIP-4895 (withdrawals). To enable the `nim-eth` bump, the ingress of `BlockHeader` structures has been hardened to reject headers that have the new `withdrawalsRoot` field until proper withdrawals support exists. https://github.com/status-im/nim-eth/pull/562