### PR TITLE
bump `nim-eth` for `eip4844` support

### DIFF
--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -132,6 +132,9 @@ func validateBlockHeaderBytes*(
 
   let header = ? decodeRlp(bytes, BlockHeader)
 
+  if header.excessDataGas.isSome:
+    return err("EIP-4844 not yet implemented")
+
   if header.withdrawalsRoot.isSome:
     return err("Withdrawals not yet implemented")
 

--- a/nimbus/core/eip4844.nim
+++ b/nimbus/core/eip4844.nim
@@ -1,0 +1,21 @@
+# Nimbus
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+import
+  stew/results,
+  ../common/common
+
+# https://eips.ethereum.org/EIPS/eip-4844
+func validateEip4844Header*(
+    com: CommonRef, header: BlockHeader
+): Result[void, string] {.raises: [Defect].} =
+  if header.excessDataGas.isSome:
+    return err("EIP-4844 not yet implemented")
+  return ok()

--- a/nimbus/core/validate.nim
+++ b/nimbus/core/validate.nim
@@ -13,7 +13,7 @@ import
   ../db/accounts_cache,
   ".."/[transaction, common/common],
   ".."/[vm_state, vm_types, errors],
-  "."/[dao, gaslimit, withdrawals],
+  "."/[dao, eip4844, gaslimit, withdrawals],
   ./pow/[difficulty, header],
   ./pow,
   chronicles,
@@ -129,7 +129,10 @@ proc validateHeader(com: CommonRef; header, parentHeader: BlockHeader;
     if checkSealOK:
       return pow.validateSeal(header)
 
-  com.validateWithdrawals(header)
+  ? com.validateWithdrawals(header)
+  ? com.validateEip4844Header(header)
+
+  ok()
 
 func validateUncle(currBlock, uncle, uncleParent: BlockHeader):
                                                Result[void,string] =

--- a/nimbus/sync/legacy.nim
+++ b/nimbus/sync/legacy.nim
@@ -17,7 +17,7 @@ import
   eth/p2p/[private/p2p_types, peer_pool],
   stew/byteutils,
   "."/[protocol, types],
-  ../core/[chain, clique/clique_sealer, gaslimit, withdrawals],
+  ../core/[chain, clique/clique_sealer, eip4844, gaslimit, withdrawals],
   ../core/pow/difficulty,
   ../constants,
   ../utils/utils,
@@ -236,6 +236,12 @@ proc validateHeader(ctx: LegacySyncRef, header: BlockHeader,
   res = com.validateWithdrawals(header)
   if res.isErr:
     trace "validate withdrawals error",
+      msg=res.error
+    return false
+
+  res = com.validateEip4844Header(header)
+  if res.isErr:
+    trace "validate eip4844 error",
       msg=res.error
     return false
 

--- a/nimbus/utils/debug.nim
+++ b/nimbus/utils/debug.nim
@@ -49,6 +49,8 @@ proc debug*(h: BlockHeader): string =
     result.add "fee            : " & $h.fee.get()   & "\n"
   if h.withdrawalsRoot.isSome:
     result.add "withdrawalsRoot: " & $h.withdrawalsRoot.get() & "\n"
+  if h.excessDataGas.isSome:
+    result.add "excessDataGas:   " & $h.excessDataGas.get() & "\n"
   result.add "blockHash      : " & $blockHash(h) & "\n"
 
 proc dumpAccount(stateDB: AccountsCache, address: EthAddress): JsonNode =

--- a/tests/replay/pp.nim
+++ b/tests/replay/pp.nim
@@ -56,7 +56,7 @@ proc pp*(h: BlockHeader; sep = " "): string =
     &"stateRoot={h.stateRoot.pp}{sep}" &
     &"baseFee={h.baseFee}{sep}" &
     &"withdrawalsRoot={h.withdrawalsRoot.get(EMPTY_ROOT_HASH)}{sep}" &
-    &"excessDataGas={h.excessDataGas.get(GasInt(0))}"
+    &"excessDataGas={h.excessDataGas.get(0.u256)}"
 
 proc pp*(g: Genesis; sep = " "): string =
   "" &

--- a/tests/replay/pp.nim
+++ b/tests/replay/pp.nim
@@ -55,7 +55,8 @@ proc pp*(h: BlockHeader; sep = " "): string =
     &"receiptRoot={h.receiptRoot.pp}{sep}" &
     &"stateRoot={h.stateRoot.pp}{sep}" &
     &"baseFee={h.baseFee}{sep}" &
-    &"withdrawalsRoot={h.withdrawalsRoot.get(EMPTY_ROOT_HASH)}"
+    &"withdrawalsRoot={h.withdrawalsRoot.get(EMPTY_ROOT_HASH)}{sep}" &
+    &"excessDataGas={h.excessDataGas.get(GasInt(0))}"
 
 proc pp*(g: Genesis; sep = " "): string =
   "" &


### PR DESCRIPTION
The `BlockHeader` structure in `nim-eth` was updated with support for EIP-4844 (danksharding). To enable the `nim-eth` bump, the ingress of `BlockHeader` structures has been hardened to reject headers that have the new `excessDataGas` field until proper EIP4844 support exists. https://github.com/status-im/nim-eth/pull/570