### PR TITLE
Move BlockHeaderWithProof content to content key selector 0

### DIFF
--- a/fluffy/eth_data/history_data_seeding.nim
+++ b/fluffy/eth_data/history_data_seeding.nim
@@ -181,8 +181,8 @@ proc historyPropagateHeadersWithProof*(
       let
         content = headerWithProof.get()
         contentKey = ContentKey(
-          contentType: blockHeaderWithProof,
-          blockHeaderWithProofKey: BlockKey(blockHash: header.blockHash()))
+          contentType: blockHeader,
+          blockHeaderKey: BlockKey(blockHash: header.blockHash()))
         encKey = history_content.encode(contentKey)
         contentId = history_content.toContentId(encKey)
         encodedContent = SSZ.encode(content)

--- a/fluffy/network/history/history_content.nim
+++ b/fluffy/network/history/history_content.nim
@@ -32,7 +32,6 @@ type
     blockBody = 0x01
     receipts = 0x02
     epochAccumulator = 0x03
-    blockHeaderWithProof = 0x04
 
   BlockKey* = object
     blockHash*: BlockHash
@@ -50,8 +49,6 @@ type
       receiptsKey*: BlockKey
     of epochAccumulator:
       epochAccumulatorKey*: EpochAccumulatorKey
-    of blockHeaderWithProof:
-      blockHeaderWithProofKey*: BlockKey
 
 func init*(
     T: type ContentKey, contentType: ContentType,
@@ -70,10 +67,6 @@ func init*(
     ContentKey(
       contentType: contentType,
       epochAccumulatorKey: EpochAccumulatorKey(epochHash: hash))
-  of blockHeaderWithProof:
-    ContentKey(
-      contentType: contentType,
-      blockHeaderWithProofKey: BlockKey(blockHash: hash))
 
 func encode*(contentKey: ContentKey): ByteList =
   ByteList.init(SSZ.encode(contentKey))
@@ -111,8 +104,6 @@ func `$`*(x: ContentKey): string =
   of epochAccumulator:
     let key = x.epochAccumulatorKey
     res.add("epochHash: " & $key.epochHash)
-  of blockHeaderWithProof:
-    res.add($x.blockHeaderWithProofKey)
 
   res.add(")")
 

--- a/fluffy/scripts/test_portal_testnet.nim
+++ b/fluffy/scripts/test_portal_testnet.nim
@@ -52,8 +52,8 @@ proc buildHeadersWithProof*(
       let
         content = ? buildHeaderWithProof(header, epochAccumulator)
         contentKey = ContentKey(
-          contentType: blockHeaderWithProof,
-          blockHeaderWithProofKey: BlockKey(blockHash: header.blockHash()))
+          contentType: blockHeader,
+          blockHeaderKey: BlockKey(blockHash: header.blockHash()))
 
       blockHeadersWithProof.add(
         (encode(contentKey).asSeq(), SSZ.encode(content)))

--- a/fluffy/scripts/test_portal_testnet.nim
+++ b/fluffy/scripts/test_portal_testnet.nim
@@ -19,7 +19,8 @@ import
     history_data_json_store,
     history_data_ssz_e2s],
   ../network/history/[history_content, accumulator],
-  ../seed_db
+  ../seed_db,
+  ../tests/test_history_util
 
 type
   FutureCallback[A] = proc (): Future[A] {.gcsafe, raises: [Defect].}
@@ -41,24 +42,6 @@ type
       defaultValue: 7000
       desc: "Port of the JSON-RPC service of the bootstrap (first) node"
       name: "base-rpc-port" .}: uint16
-
-proc buildHeadersWithProof*(
-    blockHeaders: seq[BlockHeader],
-    epochAccumulator: EpochAccumulatorCached):
-    Result[seq[(seq[byte], seq[byte])], string] =
-  var blockHeadersWithProof: seq[(seq[byte], seq[byte])]
-  for header in blockHeaders:
-    if header.isPreMerge():
-      let
-        content = ? buildHeaderWithProof(header, epochAccumulator)
-        contentKey = ContentKey(
-          contentType: blockHeader,
-          blockHeaderKey: BlockKey(blockHash: header.blockHash()))
-
-      blockHeadersWithProof.add(
-        (encode(contentKey).asSeq(), SSZ.encode(content)))
-
-  ok(blockHeadersWithProof)
 
 proc connectToRpcServers(config: PortalTestnetConf):
     Future[seq[RpcClient]] {.async.} =

--- a/fluffy/tests/portal_spec_tests/mainnet/all_fluffy_portal_spec_tests.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/all_fluffy_portal_spec_tests.nim
@@ -10,6 +10,7 @@
 import
   ./test_portal_wire_encoding,
   ./test_history_content,
+  ./test_headers_with_proof,
   ./test_header_content,
   ./test_state_content,
   ./test_accumulator_root

--- a/fluffy/tests/portal_spec_tests/mainnet/test_headers_with_proof.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_headers_with_proof.nim
@@ -1,0 +1,97 @@
+# Nimbus
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  unittest2, stew/byteutils,
+  eth/common/eth_types_rlp,
+  ../../../network_metadata,
+  ../../../eth_data/[history_data_json_store, history_data_ssz_e2s],
+  ../../../network/history/[history_content, history_network, accumulator],
+  ../../test_history_util
+
+type
+  JsonHeaderContent* = object
+    content_key*: string
+    content_value*: string
+
+  JsonHeaderContentTable* = Table[string, JsonHeaderContent]
+
+suite "Headers with Proof":
+  test "HeaderWithProof Decoding and Verifying":
+    const dataFile =
+      "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/1000001-1000010.json"
+
+    let accumulator =
+      try:
+        SSZ.decode(finishedAccumulator, FinishedAccumulator)
+      except SszError as err:
+        raiseAssert "Invalid baked-in accumulator: " & err.msg
+
+    let res = readJsonType(dataFile, JsonHeaderContentTable)
+    check res.isOk()
+    let headerContent = res.get()
+
+    for k, v in headerContent:
+      let
+        # TODO: strange assignment failure when using try/except ValueError
+        # for the hexToSeqByte() here.
+        contentKey = decodeSsz(
+          v.content_key.hexToSeqByte(), ContentKey)
+        contentValue = decodeSsz(
+          v.content_value.hexToSeqByte(), BlockHeaderWithProof)
+
+      check:
+        contentKey.isOk()
+        contentValue.isOk()
+
+      let blockHeaderWithProof = contentValue.get()
+
+      let res = decodeRlp(blockHeaderWithProof.header.asSeq(), BlockHeader)
+      check res.isOk()
+      let header = res.get()
+
+      check accumulator.verifyHeader(header, blockHeaderWithProof.proof).isOk()
+
+  test "HeaderWithProof Building and Encoding":
+    const
+      headerFile = "./vendor/portal-spec-tests/tests/mainnet/history/headers/1000001-1000010.e2s"
+      accumulatorFile = "./vendor/portal-spec-tests/tests/mainnet/history/accumulator/epoch-accumulator-00122.ssz"
+      headersWithProofFile = "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/1000001-1000010.json"
+
+    let
+      blockHeaders = readBlockHeaders(headerFile).valueOr:
+        raiseAssert "Invalid header file: " & headerFile
+      epochAccumulator = readEpochAccumulatorCached(accumulatorFile).valueOr:
+        raiseAssert "Invalid epoch accumulator file: " & accumulatorFile
+      blockHeadersWithProof =
+        buildHeadersWithProof(blockHeaders, epochAccumulator).valueOr:
+          raiseAssert "Could not build headers with proof"
+
+    let res = readJsonType(headersWithProofFile, JsonHeaderContentTable)
+    check res.isOk()
+    let headerContent = res.get()
+
+    # Go over all content keys and headers with generated proofs and compare
+    # them with the ones from the test vectors.
+    for i, (headerContentKey, headerWithProof) in blockHeadersWithProof:
+      let
+        blockNumber = blockHeaders[i].blockNumber
+        contentKey =
+          headerContent[blockNumber.toString()].content_key.hexToSeqByte()
+        contentValue =
+          headerContent[blockNumber.toString()].content_value.hexToSeqByte()
+
+      check:
+        contentKey == headerContentKey
+        contentValue == headerWithProof

--- a/fluffy/tests/test_history_network.nim
+++ b/fluffy/tests/test_history_network.nim
@@ -70,7 +70,7 @@ proc headersToContentInfo(
       headerHash = header.blockHash()
       blockKey = BlockKey(blockHash: headerHash)
       contentKey = encode(ContentKey(
-        contentType: blockHeaderWithProof, blockHeaderWithProofKey: blockKey))
+        contentType: blockHeader, blockHeaderKey: blockKey))
       contentInfo = ContentInfo(
         contentKey: contentKey, content: SSZ.encode(headerWithProof))
     contentInfos.add(contentInfo)
@@ -119,7 +119,7 @@ procSuite "History Content Network":
         headerHash = header.blockHash()
         blockKey = BlockKey(blockHash: headerHash)
         contentKey = ContentKey(
-          contentType: blockHeaderWithProof, blockHeaderWithProofKey: blockKey)
+          contentType: blockHeader, blockHeaderKey: blockKey)
         encKey = encode(contentKey)
         contentId = toContentId(contentKey)
       historyNode2.portalProtocol().storeContent(

--- a/fluffy/tests/test_history_util.nim
+++ b/fluffy/tests/test_history_util.nim
@@ -1,0 +1,36 @@
+# Nimbus
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  stew/results,
+  eth/common/eth_types_rlp,
+  ../network/history/[history_content, accumulator]
+
+export results, accumulator, history_content
+
+proc buildHeadersWithProof*(
+    blockHeaders: seq[BlockHeader],
+    epochAccumulator: EpochAccumulatorCached):
+    Result[seq[(seq[byte], seq[byte])], string] =
+  var blockHeadersWithProof: seq[(seq[byte], seq[byte])]
+  for header in blockHeaders:
+    if header.isPreMerge():
+      let
+        content = ? buildHeaderWithProof(header, epochAccumulator)
+        contentKey = ContentKey(
+          contentType: blockHeader,
+          blockHeaderKey: BlockKey(blockHash: header.blockHash()))
+
+      blockHeadersWithProof.add(
+        (encode(contentKey).asSeq(), SSZ.encode(content)))
+
+  ok(blockHeadersWithProof)

--- a/fluffy/tools/bridge/beacon_chain_bridge.nim
+++ b/fluffy/tools/bridge/beacon_chain_bridge.nim
@@ -231,7 +231,7 @@ proc run() {.raises: [Exception, Defect].} =
               blockhash = history_content.`$`hash
 
             block: # gossip header
-              let contentKey = ContentKey.init(blockHeaderWithProof, hash)
+              let contentKey = ContentKey.init(blockHeader, hash)
               let encodedContentKey = contentKey.encode.asSeq()
 
               try:


### PR DESCRIPTION
- Remove as content type with content key selector 4
- Replace regular block header with BlockHeaderWithProof at content key selector 0

This is equivalent of spec change PR https://github.com/ethereum/portal-network-specs/pull/177