### PR TITLE
Add new portal JSON-RPC OfferReal as Offer is doing gossip now

### DIFF
--- a/fluffy/data/history_data_seeding.nim
+++ b/fluffy/data/history_data_seeding.nim
@@ -52,7 +52,7 @@ proc propagateEpochAccumulator*(
       # Note: The file actually holds the SSZ encoded accumulator, but we need
       # to decode as we need the root for the content key.
       encodedAccumulator = SSZ.encode(accumulator)
-    info "Gossiping epoch accumulator", rootHash
+    info "Gossiping epoch accumulator", rootHash, contentKey = encKey
 
     p.storeContent(
       encKey,

--- a/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
@@ -16,6 +16,8 @@ proc portal_stateFindContent(enr: Record, contentKey: string): tuple[
 proc portal_stateFindContentFull(enr: Record, contentKey: string): tuple[
   content: Option[string],
   enrs: Option[seq[Record]]]
+proc portal_stateOfferReal(
+  enr: Record, contentKey: string, contentValue: string): bool
 proc portal_stateOffer(contentKey: string, contentValue: string): int
 proc portal_stateRecursiveFindNodes(nodeId: NodeId): seq[Record]
 proc portal_stateRecursiveFindContent(contentKey: string): string
@@ -40,6 +42,8 @@ proc portal_historyFindContent(enr: Record, contentKey: string): tuple[
 proc portal_historyFindContentFull(enr: Record, contentKey: string): tuple[
   content: Option[string],
   enrs: Option[seq[Record]]]
+proc portal_historyOfferReal(
+  enr: Record, contentKey: string, contentValue: string): bool
 proc portal_historyOffer(contentKey: string, contentValue: string): int
 proc portal_historyRecursiveFindNodes(nodeId: NodeId): seq[Record]
 proc portal_historyRecursiveFindContent(contentKey: string): string

--- a/fluffy/rpc/rpc_portal_api.nim
+++ b/fluffy/rpc/rpc_portal_api.nim
@@ -168,6 +168,22 @@ proc installPortalApiHandlers*(
           none(string),
           some(foundContent.nodes.map(proc(n: Node): Record = n.record)))
 
+  rpcServer.rpc("portal_" & network & "OfferReal") do(
+      enr: Record, contentKey: string, contentValue: string) -> bool:
+    # Note: unspecified RPC, but the spec took over the Offer call to actually
+    # do gossip. This should be adjusted.
+    let
+      node = toNodeWithAddress(enr)
+      key = hexToSeqByte(contentKey)
+      content = hexToSeqByte(contentValue)
+      contentInfo = ContentInfo(contentKey: ByteList.init(key), content: content)
+      res = await p.offer(node, @[contentInfo])
+
+    if res.isOk():
+      return true
+    else:
+      raise newException(ValueError, $res.error)
+
   rpcServer.rpc("portal_" & network & "Offer") do(
       contentKey: string, contentValue: string) -> int:
     let


### PR DESCRIPTION
The portal_*Offer call was changed in the specs to actually do gossip. Make it no longer possible to test purely an offer with one node. Add OfferReal call for now until spec potentially gets adjusted.

Also Add some Node information logging for FindContent and Offer to be able to better debug failures and interoperability.