### PR TITLE
Set disableMarchNative for Fluffy Dockerfile

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -40,13 +40,19 @@ if defined(windows):
 if defined(disableMarchNative):
   if defined(i386) or defined(amd64):
     if defined(macosx):
-      # https://support.apple.com/kb/SP777
-      # "macOS Mojave - Technical Specifications": EOL as of 2021-10 so macOS
-      # users on pre-Nehalem must be running either some Hackintosh, or using
-      # an unsupported macOS version beyond that most recently EOL'd. Nehalem
-      # supports instruction set extensions through SSE4.2 and POPCNT.
-      switch("passC", "-march=nehalem")
-      switch("passL", "-march=nehalem")
+      # https://support.apple.com/kb/sp803
+      # "macOS Catalina - Technical Specifications": EOL as of 2022-09
+      # https://support.apple.com/kb/sp833
+      # "macOS Big Sur - Technical Specifications" lists current oldest
+      # supported models: MacBook (2015 or later), MacBook Air (2013 or later),
+      # MacBook Pro (Late 2013 or later), Mac mini (2014 or later), iMac (2014
+      # or later), iMac Pro (2017 or later), Mac Pro (2013 or later).
+      #
+      # These all have Haswell or newer CPUs.
+      #
+      # This ensures AVX2, AES-NI, PCLMUL, BMI1, and BMI2 instruction set support.
+      switch("passC", "-march=haswell -mtune=generic")
+      switch("passL", "-march=haswell -mtune=generic")
     else:
       switch("passC", "-mssse3")
       switch("passL", "-mssse3")

--- a/fluffy/tools/docker/Dockerfile
+++ b/fluffy/tools/docker/Dockerfile
@@ -8,14 +8,16 @@ RUN apt-get update \
 ARG BRANCH_NAME=master
 ENV NPROC=2
 
+ENV NIMFLAGS_COMMON="-d:disableMarchNative --gcc.options.debug:'-g1' --clang.options.debug:'-gline-tables-only'"
+
 RUN git clone https://github.com/status-im/nimbus-eth1.git \
  && cd nimbus-eth1 \
  && git checkout ${BRANCH_NAME} \
  && git pull \
- && make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+ && make -j${NPROC} NIMFLAGS="${NIMFLAGS_COMMON} --parallelBuild:${NPROC}" V=1 update
 
 RUN cd nimbus-eth1 && \
-    make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" fluffy && \
+    make -j${NPROC} NIMFLAGS="${NIMFLAGS_COMMON} --parallelBuild:${NPROC}" fluffy && \
     mv build/fluffy /usr/bin/
 
 # --------------------------------- #


### PR DESCRIPTION
The Fluffy Dockerfile is used for Portal Hive. While one can manually edit the docker image used in Portal Hive in case if not being compatible, it isn't exactly user friendly. Enable disableMarchNative so that it is much less likely to be needed.

Also update the settings in disableMarchNative to the ones of the nimbus-eth2 repository