### PR TITLE
introduce runtime EIPs management

### DIFF
--- a/nimbus/common/eips.nim
+++ b/nimbus/common/eips.nim
@@ -8,46 +8,75 @@
 # those terms.
 
 import
+  stew/bitseqs,
   ./hardforks
-
-#[
-   * - [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153) - Transient Storage Opcodes (`experimental`)
-   * - [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) - EIP-1559 Fee Market
-   * - [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) - VM simple subroutines (`experimental`)
-   * - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS12-381 precompiles (`experimental`)
-   * - [EIP-2565](https://eips.ethereum.org/EIPS/eip-2565) - ModExp Gas Cost
-   * - [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) - Typed Transactions
-   * - [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) - Gas cost increases for state access opcodes
-   * - [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) - Access List Transaction Type
-   * - [EIP-3198](https://eips.ethereum.org/EIPS/eip-3198) - BASEFEE opcode
-   * - [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529) - Reduction in refunds
-   * - [EIP-3540](https://eips.ethereum.org/EIPS/eip-3541) - EVM Object Format (EOF) v1 (`experimental`)
-   * - [EIP-3541](https://eips.ethereum.org/EIPS/eip-3541) - Reject new contracts starting with the 0xEF byte
-   *   [EIP-3651](https://eips.ethereum.org/EIPS/eip-3651) - Warm COINBASE (`experimental`)
-   * - [EIP-3670](https://eips.ethereum.org/EIPS/eip-3670) - EOF - Code Validation (`experimental`)
-   * - [EIP-3855](https://eips.ethereum.org/EIPS/eip-3855) - PUSH0 instruction (`experimental`)
-   * - [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860) - Limit and meter initcode (`experimental`)
-   * - [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) - Supplant DIFFICULTY opcode with PREVRANDAO (Merge)
-   *   [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895) - Beacon chain push withdrawals as operations (`experimental`)
-   * - [EIP-5133](https://eips.ethereum.org/EIPS/eip-5133) - Delaying Difficulty Bomb to mid-September 2022
-]#
 
 type
   EIP* = enum
-    EIP3541
-    EIP3670
-    EIP1559
-    EIP2537
-    EIP4895
+    EIP3540 # EVM Object Format (EOF) v1
+    EIP3651 # Warm COINBASE
+    EIP3670 # EOF - Code Validation
+    EIP3855 # PUSH0 instruction
+    EIP3860 # Limit and meter initcode
+    EIP4200 # EOF - Static relative jumps
+    EIP4750 # EOF - Functions
+    EIP4895 # Beacon chain push withdrawals as operations
+    EIP5450 # EOF - Stack Validation
 
-  ForkToEIP* = array[HardFork, set[EIP]]
+template len(x: type EIP): int =
+  1+EIP.high.int
+
+type
+  EipSet* = BitArray[EIP.len]
+  ForkToEIP* = array[HardFork, EipSet]
+
+proc incl*(x: var EipSet, y: EipSet) =
+  for i in 0..<x.bytes.len:
+    x.bytes[i] = x.bytes[i] or y.bytes[i]
+
+proc incl*(x: var EipSet, y: EIP) =
+  x.setBit(y.int)
+
+proc incl*(x: var EipSet, y: openArray[EIP]) =
+  for z in y:
+    x.incl z
+
+proc excl*(x: var EipSet, y: EipSet) =
+  for i in 0..<x.bytes.len:
+    x.bytes[i] = x.bytes[i] and not y.bytes[i]
+
+proc excl*(x: var EipSet, y: EIP) =
+  x.clearBit(y.int)
+
+proc excl*(x: var EipSet, y: openArray[EIP]) =
+  for z in y:
+    x.excl z
+
+func contains*(x: EipSet, y: EIP): bool =
+  x[y.int]
+
+func eipSet*(y: openArray[EIP]): EipSet =
+  for z in y:
+    result.incl z
+
+func eipSet*(y: varargs[EIP]): EipSet =
+  for z in y:
+    result.incl z
 
 func makeForkToEIP(): ForkToEIP {.compileTime.} =
   var map: ForkToEIP
 
-  # example:
-  # map[London]   = {EIP1559}
-  # map[Shanghai] = {EIP3541,EIP3670}
+  map[Shanghai] = eipSet(
+    EIP3540, # EVM Object Format (EOF) v1
+    EIP3651, # Warm COINBASE
+    EIP3670, # EOF - Code Validation
+    EIP3855, # PUSH0 instruction
+    EIP3860, # Limit and meter initcode
+    EIP4200, # EOF - Static relative jumps
+    EIP4750, # EOF - Functions
+    EIP4895, # Beacon chain push withdrawals as operations
+    EIP5450, # EOF - Stack Validation
+  )
 
   # the latest fork will accumulate most EIPs
   for fork in HardFork:


### PR DESCRIPTION
the EVMC interface become a barrier when talking about runtime EIP configuration. It only works on the EVM host side but currently there is no way to tell the EVM about which EIP(s) should be switch on or off.

related issue ethereum/evmc#453
