### PR TITLE
fix EIP-3860 bugs

### DIFF
--- a/nimbus/core/validate.nim
+++ b/nimbus/core/validate.nim
@@ -259,7 +259,7 @@ proc validateTransaction*(
     debug "invalid tx: Eip1559 Tx type detected before London"
     return false
 
-  if fork >= FkShanghai and tx.contractCreation and tx.payload.len >= EIP3860_MAX_INITCODE_SIZE:
+  if fork >= FkShanghai and tx.contractCreation and tx.payload.len > EIP3860_MAX_INITCODE_SIZE:
     debug "invalid tx: initcode size exceeds maximum"
     return false
 

--- a/nimbus/errors.nim
+++ b/nimbus/errors.nim
@@ -68,3 +68,7 @@ type
 
   VmStateError* = object of VMError
     ## VM state error relay
+
+  InitcodeError* = object of EVMError
+    ## Error to signal inicode size > EIP3860_MAX_INITCODE_SIZE
+    

--- a/nimbus/evm/interpreter/op_handlers/oph_create.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_create.nim
@@ -94,7 +94,8 @@ const
     # EIP-3860
     if k.cpt.fork >= FkShanghai and memLen > EIP3860_MAX_INITCODE_SIZE:
       trace "Initcode size exceeds maximum", initcodeSize = memLen
-      return
+      raise newException(InitcodeError,
+        &"CREATE: have {memLen}, max {EIP3860_MAX_INITCODE_SIZE}")
 
     let gasParams = GasParams(
       kind:              Create,
@@ -171,8 +172,9 @@ const
     # EIP-3860
     if k.cpt.fork >= FkShanghai and memLen > EIP3860_MAX_INITCODE_SIZE:
       trace "Initcode size exceeds maximum", initcodeSize = memLen
-      return
-    
+      raise newException(InitcodeError,
+        &"CREATE2: have {memLen}, max {EIP3860_MAX_INITCODE_SIZE}")
+
     let gasParams = GasParams(
       kind:              Create,
       cr_currentMemSize: k.cpt.memory.len,
@@ -183,7 +185,7 @@ const
     gasCost = gasCost + k.cpt.gasCosts[Create2].m_handler(0, 0, memLen)
 
     k.cpt.gasMeter.consumeGas(
-      gasCost, reason = &"CREATE: GasCreate + {memLen} * memory expansion")
+      gasCost, reason = &"CREATE2: GasCreate + {memLen} * memory expansion")
     k.cpt.memory.extend(memPos, memLen)
     k.cpt.returnData.setLen(0)
 
@@ -206,7 +208,7 @@ const
     var createMsgGas = k.cpt.gasMeter.gasRemaining
     if k.cpt.fork >= FkTangerine:
       createMsgGas -= createMsgGas div 64
-    k.cpt.gasMeter.consumeGas(createMsgGas, reason = "CREATE")
+    k.cpt.gasMeter.consumeGas(createMsgGas, reason = "CREATE2")
 
     when evmc_enabled:
       let

--- a/nimbus/transaction.nim
+++ b/nimbus/transaction.nim
@@ -123,7 +123,7 @@ proc validate*(tx: Transaction, fork: EVMFork) =
   if tx.intrinsicGas(fork) > tx.gasLimit:
     raise newException(ValidationError, "Insufficient gas")
 
-  if fork >= FkShanghai and tx.contractCreation and tx.payload.len >= EIP3860_MAX_INITCODE_SIZE:
+  if fork >= FkShanghai and tx.contractCreation and tx.payload.len > EIP3860_MAX_INITCODE_SIZE:
     raise newException(ValidationError, "Initcode size exceeds max")
 
   # check signature validity


### PR DESCRIPTION
Both CREATE and CREATE2 should raise exception if initcode len exceeds max because it will burn gas. Using `return` will not burn gas.

```text
3. If length of initcode to CREATE or CREATE2 instructions exceeds MAX_INITCODE_SIZE, instruction execution exceptionally aborts (as if it runs out of gas).
```

Bugs in tx validation seems mistyped.

They were discovered when I run tests from ethereum/tests. And then found these bugs, and bugs in the tests vectors too.