### PR TITLE
Time based forking

### DIFF
--- a/fluffy/tests/test_state_network.nim
+++ b/fluffy/tests/test_state_network.nim
@@ -24,8 +24,8 @@ proc genesisToTrie(filePath: string): HexaryTrie =
     quit(1)
 
   let sdb  = newStateDB(newMemoryDB(), false)
-  let map  = toForkToBlockNumber(cn.config)
-  let fork = map.toHardFork(0.toBlockNumber)
+  let map  = toForkTransitionTable(cn.config)
+  let fork = map.toHardFork(forkDeterminationInfo(0.toBlockNumber, cn.genesis.timestamp))
   discard toGenesisHeader(cn.genesis, sdb, fork)
 
   sdb.getTrie

--- a/newBlockchainTests.md
+++ b/newBlockchainTests.md
@@ -1095,8 +1095,9 @@ OK: 22/28 Fail: 0/28 Skip: 6/28
 + Transaction64Rule_d64e0.json                                    OK
 + Transaction64Rule_d64m1.json                                    OK
 + Transaction64Rule_d64p1.json                                    OK
++ Transaction64Rule_integerBoundaries.json                        OK
 ```
-OK: 13/13 Fail: 0/13 Skip: 0/13
+OK: 14/14 Fail: 0/14 Skip: 0/14
 ## stEIP150singleCodeGasPrices
 ```diff
 + RawBalanceGas.json                                              OK
@@ -3336,4 +3337,4 @@ OK: 0/3 Fail: 0/3 Skip: 3/3
 OK: 11/11 Fail: 0/11 Skip: 0/11
 
 ---TOTAL---
-OK: 2881/2986 Fail: 0/2986 Skip: 105/2986
+OK: 2882/2987 Fail: 0/2987 Skip: 105/2987

--- a/newGeneralStateTests.md
+++ b/newGeneralStateTests.md
@@ -617,8 +617,9 @@ OK: 22/28 Fail: 0/28 Skip: 6/28
 + Transaction64Rule_d64e0.json                                    OK
 + Transaction64Rule_d64m1.json                                    OK
 + Transaction64Rule_d64p1.json                                    OK
++ Transaction64Rule_integerBoundaries.json                        OK
 ```
-OK: 13/13 Fail: 0/13 Skip: 0/13
+OK: 14/14 Fail: 0/14 Skip: 0/14
 ## stEIP150singleCodeGasPrices
 ```diff
 + RawBalanceGas.json                                              OK
@@ -2858,4 +2859,4 @@ OK: 1/3 Fail: 0/3 Skip: 2/3
 OK: 11/11 Fail: 0/11 Skip: 0/11
 
 ---TOTAL---
-OK: 2506/2608 Fail: 0/2608 Skip: 102/2608
+OK: 2507/2609 Fail: 0/2609 Skip: 102/2609

--- a/nimbus/common/chain_config.nim
+++ b/nimbus/common/chain_config.nim
@@ -187,73 +187,89 @@ template to(a: string, b: type UInt256): UInt256 =
   # json_serialization decode table stuff
   UInt256.fromHex(a)
 
-macro fillTmpArray(conf, tmp: typed): untyped =
+macro fillArrayOfBlockNumberBasedForkOptionals(conf, tmp: typed): untyped =
   result = newStmtList()
   for i, x in forkBlockField:
     let fieldIdent = newIdentNode(x)
     result.add quote do:
-      `tmp`[`i`] = ForkOptional(
+      `tmp`[`i`] = BlockNumberBasedForkOptional(
         number  : `conf`.`fieldIdent`,
         name    : `x`)
 
-macro fillToBlockNumberArray(conf, arr: typed): untyped =
+macro fillArrayOfTimeBasedForkOptionals(conf, tmp: typed): untyped =
   result = newStmtList()
-  for fork, forkField in forkBlockNumber:
-    let
-      fieldIdent = newIdentNode(forkField)
-      forkIdent  = newIdentNode($HardFork(fork))
+  for i, x in forkTimeField:
+    let fieldIdent = newIdentNode(x)
     result.add quote do:
-      `arr`[`forkIdent`] = `conf`.`fieldIdent`
+      `tmp`[`i`] = TimeBasedForkOptional(
+        time    : `conf`.`fieldIdent`,
+        name    : `x`)
 
 # ------------------------------------------------------------------------------
 # Public functions
 # ------------------------------------------------------------------------------
 
-proc toForkToBlockNumber*(conf: ChainConfig): ForkToBlockNumber =
-  fillToBlockNumberArray(conf, result)
-  result[Frontier] = some(0.toBlockNumber)
-
-proc toHardFork*(forkToBlock: ForkToBlockNumber, number: BlockNumber): HardFork =
+proc toHardFork*(map: ForkTransitionTable, forkDeterminer: ForkDeterminationInfo): HardFork =
   for fork in countdown(HardFork.high, HardFork.low):
-    let forkBlock = forkToBlock[fork]
-    if forkBlock.isSome and number >= forkBlock.get:
+    if isGTETransitionThreshold(map, forkDeterminer, fork):
       return fork
 
   # should always have a match
   doAssert(false, "unreachable code")
 
+func forkDeterminationInfoForHeader*(header: BlockHeader): ForkDeterminationInfo =
+  # FIXME-Adam-mightAlsoNeedTTD?
+  forkDeterminationInfo(header.blockNumber, header.timestamp)
+
 proc validateChainConfig*(conf: ChainConfig): bool =
   result = true
 
-  var tmp: array[forkBlockField.len, ForkOptional]
-  fillTmpArray(conf, tmp)
+  # FIXME: factor this to remove the duplication between the
+  # block-based ones and the time-based ones.
 
-  var lastFork = tmp[0]
-  for i in 1..<tmp.len:
-    let cur = tmp[i]
+  var blockNumberBasedForkOptionals: array[forkBlockField.len, BlockNumberBasedForkOptional]
+  fillArrayOfBlockNumberBasedForkOptionals(conf, blockNumberBasedForkOptionals)
 
-    # Next one must be higher number
-    #if lastFork.number.isNone and cur.number.isSome:
-    #  error "Unsupported fork ordering",
-    #    lastFork=lastFork.name,
-    #    lastNumber=lastFork.number,
-    #    curFork=cur.name,
-    #    curNumber=cur.number
-    #  return false
+  var timeBasedForkOptionals: array[forkTimeField.len, TimeBasedForkOptional]
+  fillArrayOfTimeBasedForkOptionals(conf, timeBasedForkOptionals)
 
-    if lastFork.number.isSome and cur.number.isSome:
-      if lastFork.number.get > cur.number.get:
+  var lastBlockNumberBasedFork = blockNumberBasedForkOptionals[0]
+  for i in 1..<blockNumberBasedForkOptionals.len:
+    let cur = blockNumberBasedForkOptionals[i]
+
+    if lastBlockNumberBasedFork.number.isSome and cur.number.isSome:
+      if lastBlockNumberBasedFork.number.get > cur.number.get:
         error "Unsupported fork ordering",
-          lastFork=lastFork.name,
-          lastNumber=lastFork.number,
+          lastFork=lastBlockNumberBasedFork.name,
+          lastNumber=lastBlockNumberBasedFork.number,
           curFork=cur.name,
           curNumber=cur.number
         return false
 
     # If it was optional and not set, then ignore it
     if cur.number.isSome:
-      lastFork = cur
+      lastBlockNumberBasedFork = cur
 
+  # TODO: check to make sure the timestamps are all past the
+  # block numbers?
+
+  var lastTimeBasedFork = timeBasedForkOptionals[0]
+  for i in 1..<timeBasedForkOptionals.len:
+    let cur = timeBasedForkOptionals[i]
+
+    if lastTimeBasedFork.time.isSome and cur.time.isSome:
+      if lastTimeBasedFork.time.get > cur.time.get:
+        error "Unsupported fork ordering",
+          lastFork=lastTimeBasedFork.name,
+          lastTime=lastTimeBasedFork.time,
+          curFork=cur.name,
+          curTime=cur.time
+        return false
+
+    # If it was optional and not set, then ignore it
+    if cur.time.isSome:
+      lastTimeBasedFork = cur
+  
   if conf.clique.period.isSome or
      conf.clique.epoch.isSome:
     conf.consensusType = ConsensusType.POA

--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -48,9 +48,9 @@ type
     genesisHash: KeccakHash
     genesisHeader: BlockHeader
 
-    # map block number and ttd to
+    # map block number and ttd and time to
     # HardFork
-    forkToBlock: ForkToBlockNumber
+    forkTransitionTable: ForkTransitionTable
     blockToFork: BlockToForks
 
     # Eth wire protocol need this
@@ -79,8 +79,7 @@ type
 # Forward declarations
 # ------------------------------------------------------------------------------
 
-proc hardForkTransition*(com: CommonRef,
-  number: BlockNumber, td: Option[DifficultyInt]) {.gcsafe.}
+proc hardForkTransition*(com: CommonRef, forkDeterminer: ForkDeterminationInfo) {.gcsafe.}
 
 func cliquePeriod*(com: CommonRef): int
 
@@ -123,8 +122,8 @@ proc init(com      : CommonRef,
   com.db          = ChainDBRef.new(db)
   com.pruneTrie   = pruneTrie
   com.config      = config
-  com.forkToBlock = config.toForkToBlockNumber()
-  com.blockToFork = config.blockToForks(com.forkToBlock)
+  com.forkTransitionTable = config.toForkTransitionTable()
+  com.blockToFork = config.blockToForks(com.forkTransitionTable)
   com.networkId   = networkId
   com.syncProgress= SyncProgress()
 
@@ -133,7 +132,8 @@ proc init(com      : CommonRef,
   # set it before creating genesis block
   # TD need to be some(0.u256) because it can be the genesis
   # already at the MergeFork
-  com.hardForkTransition(0.toBlockNumber, some(0.u256))
+  let optionalGenesisTime = if genesis.isNil: none[EthTime]() else: some(genesis.timestamp)
+  com.hardForkTransition(ForkDeterminationInfo(blockNumber: 0.toBlockNumber, td: some(0.u256), time: optionalGenesisTime))
 
   # com.forkIds and com.blockZeroHash is set
   # by setForkId
@@ -149,6 +149,28 @@ proc init(com      : CommonRef,
   # Always initialise the PoW epoch cache even though it migh no be used
   com.pow = PowRef.new
   com.pos = CasperRef.new
+
+func matchesFork(com: CommonRef, fork: HardFork, number, td, time: UInt256): bool =
+  let x = com.blockToFork[fork]
+  x.toFork(x.data, number, td, time)
+
+proc getTd(com: CommonRef, blockHash: Hash256): Option[DifficultyInt] =
+  var td: DifficultyInt
+  if not com.db.getTd(blockHash, td):
+    # TODO: Is this really ok?
+    none[DifficultyInt]()
+  else:
+    some(td)
+
+proc needTdForHardForkDetermination(com: CommonRef): bool =
+  let t = com.forkTransitionTable.mergeForkTransitionThreshold
+  t.blockNumber.isNone and t.ttd.isSome
+
+proc getTdIfNecessary(com: CommonRef, blockHash: Hash256): Option[DifficultyInt] =
+  if needTdForHardForkDetermination(com):
+    getTd(com, blockHash)
+  else:
+    none[DifficultyInt]()
 
 # ------------------------------------------------------------------------------
 # Public constructors
@@ -193,7 +215,7 @@ proc clone*(com: CommonRef, db: TrieDatabaseRef): CommonRef =
     db           : ChainDBRef.new(db),
     pruneTrie    : com.pruneTrie,
     config       : com.config,
-    forkToBlock  : com.forkToBlock,
+    forkTransitionTable: com.forkTransitionTable,
     blockToFork  : com.blockToFork,
     forkIds      : com.forkIds,
     genesisHash  : com.genesisHash,
@@ -214,90 +236,47 @@ proc clone*(com: CommonRef): CommonRef =
 # Public functions
 # ------------------------------------------------------------------------------
 
-func toHardFork*(com: CommonRef, number: BlockNumber): HardFork =
-  ## doesn't do transition
-  ## only want to know a particular block number
-  ## belongs to which fork without considering TD or TTD
-  ## MergeFork: assume the MergeForkBlock isSome,
-  ## if there is a MergeFork, thus bypassing the TD >= TTD
-  ## comparison
-  toHardFork(com.forkToBlock, number)
+func toHardFork*(com: CommonRef, forkDeterminer: ForkDeterminationInfo): HardFork =
+  toHardFork(com.forkTransitionTable, forkDeterminer)
 
-proc hardForkTransition(com: CommonRef,
-     number: BlockNumber, td: Option[DifficultyInt])
+proc hardForkTransition(com: CommonRef, forkDeterminer: ForkDeterminationInfo)
       {.gcsafe, raises: [Defect, CatchableError].} =
   ## When consensus type already transitioned to POS,
   ## the storage can choose not to store TD anymore,
   ## at that time, TD is no longer needed to find a fork
   ## TD only needed during transition from POW/POA to POS.
   ## Same thing happen before London block, TD can be ignored.
+  let fork = toHardFork(com.forkTransitionTable, forkDeterminer)
+  com.currentFork = fork
+  com.consensusTransition(fork)
 
-  if td.isNone:
-    # fork transition ignoring TD
-    let fork = com.toHardFork(number)
-    com.currentFork = fork
-    com.consensusTransition(fork)
-    return
+proc hardForkTransition*(com: CommonRef,
+                         number: BlockNumber,
+                         td: Option[DifficultyInt],
+                         time: Option[EthTime])
+      {.gcsafe, raises: [Defect, CatchableError].} =
+  com.hardForkTransition(ForkDeterminationInfo(blockNumber: number, time: time, td: td))
 
-  # fork transition considering TD
-  let td = td.get()
-  for fork in countdown(HardFork.high, HardFork.low):
-    let x = com.blockToFork[fork]
-    if x.toFork(x.data, number, td):
-      com.currentFork = fork
-      com.consensusTransition(fork)
-      return
-
-  # should always have a match
-  doAssert(false, "unreachable code")
-
-proc hardForkTransition*(com: CommonRef, parentHash: Hash256,
-                         number: BlockNumber)
-                         {.gcsafe, raises: [Defect, CatchableError].} =
-
-  # if mergeForkBlock is present, it has higher
-  # priority than TTD
-  if com.config.mergeForkBlock.isSome or
-     com.config.terminalTotalDifficulty.isNone:
-    let fork = com.toHardFork(number)
-    com.currentFork = fork
-    com.consensusTransition(fork)
-    return
-
-  var td: DifficultyInt
-  if not com.db.getTd(parentHash, td):
-    # TODO: Is this really ok?
-    let fork = com.toHardFork(number)
-    com.currentFork = fork
-    com.consensusTransition(fork)
-    return
-
-  for fork in countdown(HardFork.high, HardFork.low):
-    let x = com.blockToFork[fork]
-    if x.toFork(x.data, number, td):
-      com.currentFork = fork
-      com.consensusTransition(fork)
-      return
-
-  # should always have a match
-  doAssert(false, "unreachable code")
+proc hardForkTransition*(com: CommonRef,
+                         parentHash: Hash256,
+                         number: BlockNumber,
+                         time: Option[EthTime])
+      {.gcsafe, raises: [Defect, CatchableError].} =
+  com.hardForkTransition(number, getTdIfNecessary(com, parentHash), time)
 
 proc hardForkTransition*(com: CommonRef, header: BlockHeader)
                         {.gcsafe, raises: [Defect, CatchableError].} =
 
-  com.hardForkTransition(header.parentHash, header.blockNumber)
+  com.hardForkTransition(header.parentHash, header.blockNumber, some(header.timestamp))
 
-func toEVMFork*(com: CommonRef, number: BlockNumber): EVMFork =
+func toEVMFork*(com: CommonRef, forkDeterminer: ForkDeterminationInfo): EVMFork =
   ## similar to toFork, but produce EVMFork
-  ## be aware that if MergeFork is not set in
-  ## chain config, this function probably give wrong
-  ## result because no TD is put into consideration
-  let fork = com.toHardFork(number)
+  let fork = com.toHardFork(forkDeterminer)
   ToEVMFork[fork]
 
 func isLondon*(com: CommonRef, number: BlockNumber): bool =
   # TODO: Fixme, use only London comparator
-  com.toHardFork(number) >= London
+  com.toHardFork(number.blockNumberToForkDeterminationInfo) >= London
 
 func forkGTE*(com: CommonRef, fork: HardFork): bool =
   com.currentFork >= fork
@@ -317,9 +296,9 @@ proc minerAddress*(com: CommonRef; header: BlockHeader): EthAddress
 
   account.value
 
-func forkId*(com: CommonRef, number: BlockNumber): ForkID {.gcsafe.} =
+func forkId*(com: CommonRef, forkDeterminer: ForkDeterminationInfo): ForkID {.gcsafe.} =
   ## EIP 2364/2124
-  let fork = com.toHardFork(number)
+  let fork = com.toHardFork(forkDeterminer)
   com.forkIds[fork]
 
 func isEIP155*(com: CommonRef, number: BlockNumber): bool =
@@ -455,7 +434,7 @@ proc setTTD*(com: CommonRef, ttd: Option[DifficultyInt]) =
   com.config.terminalTotalDifficulty = ttd
   # rebuild blockToFork
   # TODO: Fix me, only need to rebuild MergeFork comparator
-  com.blockToFork = com.config.blockToForks(com.forkToBlock)
+  com.blockToFork = com.config.blockToForks(com.forkTransitionTable)
 
 proc setFork*(com: CommonRef, fork: HardFork): Hardfork =
   ## useful for testing

--- a/nimbus/common/genesis.nim
+++ b/nimbus/common/genesis.nim
@@ -97,8 +97,8 @@ proc toGenesisHeader*(genesis: Genesis, fork: HardFork, db: TrieDatabaseRef = ni
 proc toGenesisHeader*(params: NetworkParams, db: TrieDatabaseRef = nil): BlockHeader
     {.raises: [Defect, RlpError].} =
   ## Generate the genesis block header from the `genesis` and `config` argument value.
-  let map  = toForkToBlockNumber(params.config)
-  let fork = map.toHardFork(0.toBlockNumber)
+  let map  = toForkTransitionTable(params.config)
+  let fork = map.toHardFork(forkDeterminationInfo(0.toBlockNumber, params.genesis.timestamp))
   toGenesisHeader(params.genesis, fork, db)
 
 

--- a/nimbus/common/hardforks.nim
+++ b/nimbus/common/hardforks.nim
@@ -8,7 +8,7 @@
 # those terms.
 
 import
-  std/options,
+  std/[options, times],
   eth/common,
   json_serialization,
   ../utils/utils,
@@ -47,12 +47,119 @@ type
     Shanghai
     Cancun
 
+const lastPurelyBlockNumberBasedFork* = GrayGlacier
+# MergeFork is special because of TTD.
+# Shanghai is special because for now it's a block/time hybrid.
+const firstPurelyTimeBasedFork* = Cancun 
+
+
+type
   CliqueOptions* = object
     epoch* : Option[int]
     period*: Option[int]
 
-  # if you add more fork block
-  # please update forkBlockField constant too
+  MergeForkTransitionThreshold* = object
+    blockNumber*: Option[BlockNumber]
+    ttd*: Option[DifficultyInt]
+
+  BlockNumberOrTimeTransitionThreshold* = object
+    blockNumber*: Option[BlockNumber]
+    time*: Option[EthTime]
+
+  ForkTransitionTable* = object
+    blockNumberThresholds*: array[Frontier..GrayGlacier, Option[BlockNumber]]
+    mergeForkTransitionThreshold*: MergeForkTransitionThreshold
+    shanghaiTransitionThreshold*: BlockNumberOrTimeTransitionThreshold
+    timeThresholds*: array[Cancun..Cancun, Option[EthTime]]
+
+  # Starting with Shanghai, forking is based on timestamp
+  # rather than block number. (Although it seems like
+  # temporarily we want to be able to specify Shanghai
+  # using *either* block number or timestamp.)
+  #
+  # I'm not sure what to call this type, but we used to pass
+  # just the block number into various places that need to
+  # determine which fork we're on, and now we need to pass
+  # around both block number and also time. And the config
+  # info for each individual fork will be either a block
+  # number or a time.
+  #
+  # Note that time and TD are optional. TD being optional
+  # is because it's perfectly fine, if mergeForkBlock is
+  # set, to not bother with TTD anymore. But I'm not sure
+  # it makes sense to allow time to be optional. See the
+  # comment below on blockNumberToForkDeterminationInfo.
+  ForkDeterminationInfo* = object
+    blockNumber*: BlockNumber
+    time*: Option[EthTime]
+    td*: Option[DifficultyInt]
+
+func blockNumberToForkDeterminationInfo*(n: BlockNumber): ForkDeterminationInfo =
+  # FIXME: All callers of this function are suspect; I'm guess we should
+  # always be using both block number and time. But we have a few places,
+  # like various tests, where we only have block number and the tests are
+  # meant for pre-Merge forks, so maybe those are okay.
+  ForkDeterminationInfo(blockNumber: n, time: none[EthTime](), td: none[DifficultyInt]())
+
+func forkDeterminationInfo*(n: BlockNumber, t: EthTime): ForkDeterminationInfo =
+  ForkDeterminationInfo(blockNumber: n, time: some(t), td: none[DifficultyInt]())
+
+# FIXME: Is this called anywhere?
+func forkDeterminationInfoIncludingTd*(n: BlockNumber, t: EthTime, td: DifficultyInt): ForkDeterminationInfo =
+  ForkDeterminationInfo(blockNumber: n, time: some(t), td: some(td))
+
+func adjustForNextBlock*(t: EthTime): EthTime =
+  # FIXME-Adam: what's the right thing to do here?
+  # How do we calculate "the timestamp for the block
+  # after this one"?
+  #
+  # If this makes no sense, what should the callers
+  # do instead?
+  fromUnix(t.toUnix + 12)
+
+func adjustForNextBlock*(f: ForkDeterminationInfo): ForkDeterminationInfo =
+  ForkDeterminationInfo(
+    blockNumber: f.blockNumber + 1,
+    time: f.time.map(adjustForNextBlock),
+    td: f.td
+  )
+
+# This function is awkward because there are various different ways now of
+# doing a hard-fork transition (block number, ttd, time, block number *or*
+# time). We used to have a simple array called forkToBlock that mapped each
+# HardFork to a BlockNumber; now we have this ForkTransitionTable, which
+# contains a couple of arrays and also special cases for MergeBlock and
+# Shanghai.
+func isGTETransitionThreshold*(map: ForkTransitionTable, forkDeterminer: ForkDeterminationInfo, fork: HardFork): bool =
+  if fork <= lastPurelyBlockNumberBasedFork:
+    map.blockNumberThresholds[fork].isSome and forkDeterminer.blockNumber >= map.blockNumberThresholds[fork].get
+  elif fork == MergeFork:
+    # MergeFork is a special case that can use either block number or ttd;
+    # block number takes precedence.
+    let t = map.mergeForkTransitionThreshold
+    if t.blockNumber.isSome:
+      forkDeterminer.blockNumber >= t.blockNumber.get
+    elif t.ttd.isSome and forkDeterminer.td.isSome:
+      forkDeterminer.td.get >= t.ttd.get
+    else:
+      false
+  elif fork == Shanghai:  
+    # For now, Shanghai is a special case that can use either block number or time.
+    let t = map.shanghaiTransitionThreshold
+    if t.blockNumber.isSome:
+      forkDeterminer.blockNumber >= t.blockNumber.get
+    elif t.time.isSome and forkDeterminer.time.isSome:
+      forkDeterminer.time.get >= t.time.get
+    else:
+      false
+  elif fork <= HardFork.high:
+    map.timeThresholds[fork].isSome and forkDeterminer.time.isSome and forkDeterminer.time.get >= map.timeThresholds[fork].get
+  else:
+    raise newException(Defect, "Why is this hard fork not in one of the above categories?")
+
+type
+  # If you add more fork blocks, please update
+  # forkBlockField/forkTimeField and toForkTransitionTable too.
   ChainConfig* = ref object
     chainId*            : ChainId
     homesteadBlock*     : Option[BlockNumber]
@@ -72,23 +179,33 @@ type
     arrowGlacierBlock*  : Option[BlockNumber]
     grayGlacierBlock*   : Option[BlockNumber]
     mergeForkBlock*     : Option[BlockNumber]
+    # Temporarily, Shanghai may be specified by either block number
+    # or time; later this may get changed to only use time.
     shanghaiBlock*      : Option[BlockNumber]
-    cancunBlock*        : Option[BlockNumber]
+    shanghaiTime*       : Option[EthTime]
+    # FIXME-Adam: Does it make sense to have both block and time
+    # for Cancun, too, for now?
+    cancunTime*         : Option[EthTime]
 
     clique*             : CliqueOptions
     terminalTotalDifficulty*: Option[UInt256]
     consensusType*
       {.dontSerialize.} : ConsensusType
 
-  ForkToBlockNumber* = array[HardFork, Option[BlockNumber]]
-  ForkOptional* = object
+  # These are used for checking that the values of the fields
+  # are in a valid order.
+  BlockNumberBasedForkOptional* = object
     name*: string
     number*: Option[BlockNumber]
+  TimeBasedForkOptional* = object
+    name*: string
+    time*: Option[EthTime]
+
 
 const
   # this table is used for generate
   # code at compile time to check
-  # the order of blok number in ChainConfig
+  # the order of block number in ChainConfig
   forkBlockField* = [
     "homesteadBlock",
     "daoForkBlock",
@@ -106,30 +223,41 @@ const
     "grayGlacierBlock",
     "mergeForkBlock",
     "shanghaiBlock",
-    "cancunBlock",
   ]
 
-  # this table is used to generate
-  # code to build fork to block number
-  # array
-  forkBlockNumber* = [
-    Homestead: "homesteadBlock",
-    DAOFork: "daoForkBlock",
-    Tangerine: "eip150Block",
-    Spurious: "eip158Block",
-    Byzantium: "byzantiumBlock",
-    Constantinople: "constantinopleBlock",
-    Petersburg: "petersburgBlock",
-    Istanbul: "istanbulBlock",
-    MuirGlacier: "muirGlacierBlock",
-    Berlin: "berlinBlock",
-    London: "londonBlock",
-    ArrowGlacier: "arrowGlacierBlock",
-    GrayGlacier: "grayGlacierBlock",
-    MergeFork: "mergeForkBlock",
-    Shanghai: "shanghaiBlock",
-    Cancun: "cancunBlock",
+  forkTimeField* = [
+    "shanghaiTime",
+    "cancunTime",
   ]
+
+func mergeForkTransitionThreshold(conf: ChainConfig): MergeForkTransitionThreshold =
+  MergeForkTransitionThreshold(blockNumber: conf.mergeForkBlock, ttd: conf.terminalTotalDifficulty)
+
+func shanghaiTransitionThreshold(conf: ChainConfig): BlockNumberOrTimeTransitionThreshold =
+  BlockNumberOrTimeTransitionThreshold(blockNumber: conf.shanghaiBlock, time: conf.shanghaiTime)
+
+proc toForkTransitionTable*(conf: ChainConfig): ForkTransitionTable =
+  # We used to auto-generate this code from a list of
+  # field names, but it doesn't seem worthwhile anymore
+  # (now that there's irregularity due to block-based vs
+  # timestamp-based forking).
+  result.blockNumberThresholds[Frontier      ] = some(0.toBlockNumber)
+  result.blockNumberThresholds[Homestead     ] = conf.homesteadBlock
+  result.blockNumberThresholds[DAOFork       ] = conf.daoForkBlock
+  result.blockNumberThresholds[Tangerine     ] = conf.eip150Block
+  result.blockNumberThresholds[Spurious      ] = conf.eip158Block
+  result.blockNumberThresholds[Byzantium     ] = conf.byzantiumBlock
+  result.blockNumberThresholds[Constantinople] = conf.constantinopleBlock
+  result.blockNumberThresholds[Petersburg    ] = conf.petersburgBlock
+  result.blockNumberThresholds[Istanbul      ] = conf.istanbulBlock
+  result.blockNumberThresholds[MuirGlacier   ] = conf.muirGlacierBlock
+  result.blockNumberThresholds[Berlin        ] = conf.berlinBlock
+  result.blockNumberThresholds[London        ] = conf.londonBlock
+  result.blockNumberThresholds[ArrowGlacier  ] = conf.arrowGlacierBlock
+  result.blockNumberThresholds[GrayGlacier   ] = conf.grayGlacierBlock
+  result.mergeForkTransitionThreshold          = conf.mergeForkTransitionThreshold
+  result.shanghaiTransitionThreshold           = conf.shanghaiTransitionThreshold
+  result.timeThresholds[Cancun] = conf.cancunTime
 
 # ------------------------------------------------------------------------------
 # Map HardFork to EVM/EVMC Fork
@@ -199,8 +327,24 @@ func toNextFork(n: Option[BlockNumber]): uint64 =
   else:
     0'u64
 
-func getNextFork(c: ChainConfig, fork: HardFork): uint64 =
-  let next: array[HardFork, uint64] = [
+# EIP-6122: ForkID now works with timestamps too.
+func toNextFork(t: Option[EthTime]): uint64 =
+  if t.isSome:
+    t.get.toUnix.uint64
+  else:
+    0'u64
+
+# Shanghai could be specified by either block number or time
+func toNextFork(n: Option[BlockNumber], t: Option[EthTime]): uint64 =
+  if n.isSome:
+    n.get.truncate(uint64)
+  elif t.isSome:
+    t.get.toUnix.uint64
+  else:
+    0'u64
+
+func arrayMappingHardForkToNextFork(c: ChainConfig): array[HardFork, uint64] =
+  return [
     0'u64,
     toNextFork(c.homesteadBlock),
     toNextFork(c.daoForkBlock),
@@ -216,10 +360,11 @@ func getNextFork(c: ChainConfig, fork: HardFork): uint64 =
     toNextFork(c.arrowGlacierBlock),
     toNextFork(c.grayGlacierBlock),
     toNextFork(c.mergeForkBlock),
-    toNextFork(c.shanghaiBlock),
-    toNextFork(c.cancunBlock),
+    toNextFork(c.shanghaiBlock, c.shanghaiTime),
+    toNextFork(c.cancunTime),
   ]
 
+func getNextFork(next: array[HardFork, uint64], fork: HardFork): uint64 =
   if fork == high(HardFork):
     result = 0
     return
@@ -230,9 +375,9 @@ func getNextFork(c: ChainConfig, fork: HardFork): uint64 =
       result = next[x]
       break
 
-func calculateForkId(c: ChainConfig, fork: HardFork,
+func calculateForkId(next: array[HardFork, uint64], fork: HardFork,
                      prevCRC: uint32, prevFork: uint64): ForkID =
-  result.nextFork = c.getNextFork(fork)
+  result.nextFork = getNextFork(next, fork)
 
   if result.nextFork != prevFork:
     result.crc = crc32(prevCRC, toBytesBE(prevFork))
@@ -241,11 +386,13 @@ func calculateForkId(c: ChainConfig, fork: HardFork,
 
 func calculateForkIds*(c: ChainConfig,
                       genesisCRC: uint32): array[HardFork, ForkID] =
+  let next = arrayMappingHardForkToNextFork(c)
+
   var prevCRC = genesisCRC
-  var prevFork = c.getNextFork(Frontier)
+  var prevFork = getNextFork(next, Frontier)
 
   for fork in HardFork:
-    result[fork] = calculateForkId(c, fork, prevCRC, prevFork)
+    result[fork] = calculateForkId(next, fork, prevCRC, prevFork)
     prevFork = result[fork].nextFork
     prevCRC = result[fork].crc
 
@@ -254,56 +401,104 @@ func calculateForkIds*(c: ChainConfig,
 # ------------------------------------------------------------------------------
 
 type
-  BlockToForkFunc* = proc(data, number, td: UInt256): bool
+  BlockToForkFunc* = proc(data, number, td, time: UInt256): bool
     {.gcsafe, noSideEffect, nimcall, raises: [Defect, CatchableError].}
 
   BlockToFork* = object
-    # `data` can be blockNumber or TTD
+    # `data` can be blockNumber or time or TTD
     data*  : UInt256
     toFork*: BlockToForkFunc
 
   BlockToForks* = array[HardFork, BlockToFork]
 
-func forkTrue(data, number, td: UInt256): bool
+func forkTrue(data, number, td, time: UInt256): bool
   {.gcsafe, nimcall, raises: [Defect, CatchableError].} =
   # frontier always return true
   true
 
-func forkFalse(data, number, td: UInt256): bool
+func forkFalse(data, number, td, time: UInt256): bool
   {.gcsafe, nimcall, raises: [Defect, CatchableError].} =
   # forkBlock.isNone always return false
   false
 
-func forkMaybe(data, number, td: UInt256): bool
+func blockNumberMaybe(data, number, td, time: UInt256): bool
   {.gcsafe, nimcall, raises: [Defect, CatchableError].} =
   # data is a blockNumber
   number >= data
 
-func mergeMaybe(data, number, td: UInt256): bool
+func mergeMaybe(data, number, td, time: UInt256): bool
   {.gcsafe, nimcall, raises: [Defect, CatchableError].} =
   # data is a TTD
   td >= data
 
-proc blockToForks*(conf: ChainConfig, map: ForkToBlockNumber): BlockToForks =
+func timeMaybe(data, number, td, time: UInt256): bool
+  {.gcsafe, nimcall, raises: [Defect, CatchableError].} =
+  # data is a time
+  time >= data
+
+func blockNumber_blockToFork(n: Option[BlockNumber]): BlockToFork =
+  if n.isSome:
+    result.data = n.get
+    result.toFork = blockNumberMaybe
+  else:
+    result.toFork = forkFalse
+
+func mergeFork_blockToFork(t: MergeForkTransitionThreshold): BlockToFork =
+  # special case for MergeFork
+  # if mergeForkBlock.isSome, it takes precedence over TTD
+  # if mergeForkBlock.isNone, compare TD with TTD
+  if t.blockNumber.isSome:
+    result.data = t.blockNumber.get
+    result.toFork = blockNumberMaybe
+  elif t.ttd.isSome:
+    result.data = t.ttd.get
+    result.toFork = mergeMaybe
+  else:
+    result.toFork = forkFalse
+
+func blockNumberOrTime_blockToFork(t: BlockNumberOrTimeTransitionThreshold): BlockToFork =
+  if t.blockNumber.isSome:
+    result.data = t.blockNumber.get
+    result.toFork = blockNumberMaybe
+  elif t.time.isSome:
+    result.data = t.time.get.toUnix.u256
+    result.toFork = timeMaybe
+  else:
+    result.toFork = forkFalse
+
+func time_blockToFork(t: Option[EthTime]): BlockToFork =
+  if t.isSome:
+    result.data = t.get.toUnix.u256
+    result.toFork = timeMaybe
+  else:
+    result.toFork = forkFalse
+
+# FIXME: is BlockToForks even necessary anymore? I feel like
+# we could just use the ForkTransitionTable, now that TTD is
+# part of it; just have callers call isGTETransitionThreshold
+# instead of the BlockToForkFunc.
+
+func blockToForks*(conf: ChainConfig, map: ForkTransitionTable): BlockToForks =
   # between Frontier and latest HardFork
   # can be a match or not
-  for fork, number in map:
-    if number.isSome:
-      result[fork].data = number.get()
-      result[fork].toFork = forkMaybe
-    else:
-      result[fork].toFork = forkFalse
+  for fork, n in map.blockNumberThresholds:
+    result[fork] = blockNumber_blockToFork(n)
 
-  # Frontier always return true
+  # Special cases, in between the old block-number-based ones and the new
+  # time-based ones.
+  result[MergeFork] = mergeFork_blockToFork(map.mergeForkTransitionThreshold)
+  result[Shanghai] = blockNumberOrTime_blockToFork(map.shanghaiTransitionThreshold)
+  
+  for fork, t in map.timeThresholds:
+    result[fork] = time_blockToFork(t)
+  
+  # There used to be a special case here for MergeFork, but now it's
+  # incorporated into mergeFork_blockToFork.
+  
+  # Frontier always return true.
+  # Is this special case necessary, given that Frontier's block number
+  # is always 0?
   result[Frontier].toFork = forkTrue
-
-  # special case for MergeFork
-  # if MergeForkBlock.isSome, it takes precedence over TTD
-  # if MergeForkBlock.isNone, compare TD with TTD
-  if map[MergeFork].isNone and
-     conf.terminalTotalDifficulty.isSome:
-    result[MergeFork].data = conf.terminalTotalDifficulty.get()
-    result[MergeFork].toFork = mergeMaybe
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/core/executor/process_transaction.nim
+++ b/nimbus/core/executor/process_transaction.nim
@@ -129,7 +129,10 @@ proc processTransaction*(
     {.gcsafe, raises: [Defect,CatchableError].} =
   ## Variant of `processTransaction()` with `*fork* derived
   ## from the `vmState` argument.
-  let fork = vmState.com.toEVMFork(header.blockNumber)
+  ##
+  ## FIXME-Adam: Hmm, I'm getting the block number and timestamp from
+  ## the header; is that incorrect?
+  let fork = vmState.com.toEVMFork(header.forkDeterminationInfoForHeader)
   vmState.processTransaction(tx, sender, header, fork)
 
 # ------------------------------------------------------------------------------

--- a/nimbus/core/pow/difficulty.nim
+++ b/nimbus/core/pow/difficulty.nim
@@ -172,7 +172,7 @@ template calcDifficultyGrayGlacier*(timeStamp: EthTime, parent: BlockHeader): Di
   makeDifficultyCalculator(11_400_000, timeStamp, parent)
 
 func calcDifficulty*(com: CommonRef, timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
-  let next = com.toHardFork(parent.blockNumber + bigOne)
+  let next = com.toHardFork(parent.forkDeterminationInfoForHeader.adjustForNextBlock)
   if next >= GrayGlacier:
     result = calcDifficultyGrayGlacier(timeStamp, parent)
   elif next >= ArrowGlacier:

--- a/nimbus/core/tx_pool/tx_chain.nim
+++ b/nimbus/core/tx_pool/tx_chain.nim
@@ -106,7 +106,7 @@ proc resetTxEnv(dh: TxChainRef; parent: BlockHeader; fee: Option[UInt256])
 
   # do hardfork transition before
   # BaseVMState querying any hardfork/consensus from CommonRef
-  dh.com.hardForkTransition(parent.blockHash, parent.blockNumber+1)
+  dh.com.hardForkTransition(parent.blockHash, parent.blockNumber+1, some(parent.timestamp.adjustForNextBlock))
   dh.prepareHeader(parent)
 
   # we don't consider PoS difficulty here
@@ -251,7 +251,7 @@ proc baseFee*(dh: TxChainRef): GasPrice =
 
 proc nextFork*(dh: TxChainRef): EVMFork =
   ## Getter, fork of next block
-  dh.com.toEVMFork(dh.txEnv.vmState.blockNumber)
+  dh.com.toEVMFork(dh.txEnv.vmState.forkDeterminationInfoForVMState)
 
 proc gasUsed*(dh: TxChainRef): GasInt =
   ## Getter, accumulated gas burned for collected blocks

--- a/nimbus/core/tx_pool/tx_chain/tx_basefee.nim
+++ b/nimbus/core/tx_pool/tx_chain/tx_basefee.nim
@@ -35,8 +35,9 @@ proc baseFeeGet*(com: CommonRef; parent: BlockHeader): GasPrice =
 
   # Note that the baseFee is calculated for the next header
   let
-    parentFork = com.toEVMFork(parent.blockNumber)
-    nextFork = com.toEVMFork(parent.blockNumber + 1)
+    forkDeterminer = forkDeterminationInfoForHeader(parent)
+    parentFork = com.toEVMFork(forkDeterminer)
+    nextFork = com.toEVMFork(forkDeterminer.adjustForNextBlock)
 
   if nextFork < FkLondon:
     return 0.GasPrice

--- a/nimbus/evm/state.nim
+++ b/nimbus/evm/state.nim
@@ -395,3 +395,9 @@ proc buildWitness*(vmState: BaseVMState): seq[byte]
   var wb = initWitnessBuilder(vmState.com.db.db, rootHash, flags)
   safeExecutor("buildWitness"):
     result = wb.buildWitness(mkeys)
+
+func forkDeterminationInfoForVMState*(vmState: BaseVMState): ForkDeterminationInfo =
+  # FIXME-Adam: Is this timestamp right? Note that up above in blockNumber we add 1;
+  # should timestamp be adding 12 or something?
+  # Also, can I get the TD? Do I need to?
+  forkDeterminationInfo(vmState.blockNumber, vmState.timestamp)

--- a/nimbus/evm/state_transactions.nim
+++ b/nimbus/evm/state_transactions.nim
@@ -32,7 +32,7 @@ proc setupTxContext*(vmState: BaseVMState, origin: EthAddress, gasPrice: GasInt,
     if forkOverride.isSome:
       forkOverride.get
     else:
-      vmState.com.toEVMFork(vmState.blockNumber)
+      vmState.com.toEVMFork(vmState.forkDeterminationInfoForVMState)
   vmState.gasCosts = vmState.fork.forkToSchedule
 
 

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -390,7 +390,7 @@ proc setupEthRpc*(
     var
       idx = 0
       prevGasUsed = GasInt(0)
-      fork = com.toEVMFork(header.blockNumber)
+      fork = com.toEVMFork(header.forkDeterminationInfoForHeader)
 
     for receipt in chainDB.getReceipts(header.receiptRoot):
       let gasUsed = receipt.cumulativeGasUsed - prevGasUsed

--- a/nimbus/sync/handlers.nim
+++ b/nimbus/sync/handlers.nim
@@ -363,7 +363,7 @@ method getStatus*(ctx: EthWireRef): EthState {.gcsafe.} =
     db = ctx.db
     com = ctx.chain.com
     bestBlock = db.getCanonicalHead()
-    forkId = com.forkId(bestBlock.blockNumber)
+    forkId = com.forkId(bestBlock.forkDeterminationInfoForHeader)
 
   EthState(
     totalDifficulty: db.headTotalDifficulty,

--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -90,13 +90,14 @@ proc rpcCallEvm*(call: RpcCallData, header: BlockHeader, com: CommonRef): CallRe
 
 proc rpcEstimateGas*(cd: RpcCallData, header: BlockHeader, com: CommonRef, gasCap: GasInt): GasInt =
   # Binary search the gas requirement, as it may be higher than the amount used
+  let timestamp = getTime().utc.toTime
   let topHeader = BlockHeader(
     parentHash: header.blockHash,
-    timestamp:  getTime().utc.toTime,
+    timestamp:  timestamp,
     gasLimit:   0.GasInt,          ## ???
     fee:        UInt256.none())    ## ???
   let vmState = BaseVMState.new(topHeader, com)
-  let fork    = com.toEVMFork(header.blockNumber)
+  let fork    = com.toEVMFork(forkDeterminationInfo(header.blockNumber, timestamp))
   let txGas   = gasFees[fork][GasTransaction] # txGas always 21000, use constants?
   var params  = toCallParams(vmState, cd, gasCap, header.fee)
 

--- a/nimbus/vm_state.nim
+++ b/nimbus/vm_state.nim
@@ -21,6 +21,7 @@ export
   vms.coinbase,
   vms.difficulty,
   vms.disableTracing,
+  vms.forkDeterminationInfoForVMState,
   vms.enableTracing,
   vms.tracingEnabled,
   vms.baseFee,

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -173,7 +173,7 @@ proc importBlock(tester: var Tester, com: CommonRef,
 
   let parentHeader = com.db.getBlockHeader(tb.header.parentHash)
   let td = some(com.db.getScore(tb.header.parentHash))
-  com.hardForkTransition(tb.header.blockNumber, td)
+  com.hardForkTransition(tb.header.blockNumber, td, some(tb.header.timestamp))
 
   tester.vmState = BaseVMState.new(
     parentHeader,

--- a/tests/test_custom_network.nim
+++ b/tests/test_custom_network.nim
@@ -237,7 +237,7 @@ proc genesisLoadRunner(noisy = true;
         params = params)
 
       check mcom.ttd.get == sSpcs.termTotalDff
-      check mcom.toHardFork(sSpcs.mergeFork.toBlockNumber) == MergeFork
+      check mcom.toHardFork(sSpcs.mergeFork.toBlockNumber.blockNumberToForkDeterminationInfo) == MergeFork
 
     test &"Construct persistent ChainDBRef on {tmpDir}, {persistPruneInfo}":
       if disablePersistentDB:
@@ -257,7 +257,7 @@ proc genesisLoadRunner(noisy = true;
           params = params)
 
         check dcom.ttd.get == sSpcs.termTotalDff
-        check dcom.toHardFork(sSpcs.mergeFork.toBlockNumber) == MergeFork
+        check dcom.toHardFork(sSpcs.mergeFork.toBlockNumber.blockNumberToForkDeterminationInfo) == MergeFork
 
     test "Initialise in-memory Genesis":
       mcom.initializeEmptyDb

--- a/tests/test_forkid.nim
+++ b/tests/test_forkid.nim
@@ -92,7 +92,7 @@ template runTest(network: untyped, name: string) =
       com    = CommonRef.new(newMemoryDB(), true, network, params)
 
     for x in `network IDs`:
-      let id = com.forkId(x.blockNumber.toBlockNumber)
+      let id = com.forkId(x.blockNumber.toBlockNumber.blockNumberToForkDeterminationInfo)
       check id.crc == x.id.crc
       check id.nextFork == x.id.nextFork
 

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -100,7 +100,7 @@ proc testFixtureIndexes(tester: Tester, testStatusIMPL: var TestStatus) =
 
   var gasUsed: GasInt
   let sender = tester.tx.getSender()
-  let fork = com.toEVMFork(tester.header.blockNumber)
+  let fork = com.toEVMFork(tester.header.forkDeterminationInfoForHeader)
 
   vmState.mutateStateDB:
     setupStateDB(tester.pre, db)

--- a/tools/common/helpers.nim
+++ b/tools/common/helpers.nim
@@ -49,7 +49,9 @@ func getChainConfig*(network: string, c: ChainConfig) =
     c.grayGlacierBlock    = number[HardFork.GrayGlacier]
     c.mergeForkBlock      = number[HardFork.MergeFork]
     c.shanghaiBlock       = number[HardFork.Shanghai]
-    c.cancunBlock         = number[HardFork.Cancun]
+    # FIXME-Adam: I don't understand how these tests are supposed
+    # to work. Will they specify timestamps for Shanghai/Cancun?
+    # c.cancunBlock         = number[HardFork.Cancun]
 
   c.daoForkSupport = false
   c.chainId = 1.ChainId

--- a/witnessBuilderBC.md
+++ b/witnessBuilderBC.md
@@ -1095,8 +1095,9 @@ OK: 28/28 Fail: 0/28 Skip: 0/28
 + Transaction64Rule_d64e0.json                                    OK
 + Transaction64Rule_d64m1.json                                    OK
 + Transaction64Rule_d64p1.json                                    OK
++ Transaction64Rule_integerBoundaries.json                        OK
 ```
-OK: 13/13 Fail: 0/13 Skip: 0/13
+OK: 14/14 Fail: 0/14 Skip: 0/14
 ## stEIP150singleCodeGasPrices
 ```diff
 + RawBalanceGas.json                                              OK
@@ -3336,4 +3337,4 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 OK: 11/11 Fail: 0/11 Skip: 0/11
 
 ---TOTAL---
-OK: 2986/2986 Fail: 0/2986 Skip: 0/2986
+OK: 2987/2987 Fail: 0/2987 Skip: 0/2987

--- a/witnessBuilderGST.md
+++ b/witnessBuilderGST.md
@@ -617,8 +617,9 @@ OK: 28/28 Fail: 0/28 Skip: 0/28
 + Transaction64Rule_d64e0.json                                    OK
 + Transaction64Rule_d64m1.json                                    OK
 + Transaction64Rule_d64p1.json                                    OK
++ Transaction64Rule_integerBoundaries.json                        OK
 ```
-OK: 13/13 Fail: 0/13 Skip: 0/13
+OK: 14/14 Fail: 0/14 Skip: 0/14
 ## stEIP150singleCodeGasPrices
 ```diff
 + RawBalanceGas.json                                              OK
@@ -2858,4 +2859,4 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 OK: 11/11 Fail: 0/11 Skip: 0/11
 
 ---TOTAL---
-OK: 2608/2608 Fail: 0/2608 Skip: 0/2608
+OK: 2609/2609 Fail: 0/2609 Skip: 0/2609


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth1/issues/1424

Replaced the ForkToBlockNumber array with a (more complicated) object called ForkTransitionTable that knows the difference between block-based forks, time-based forks, and the special cases like MergeFork and Shanghai (which IIUC needs to be doable via either block number or time, at least temporarily).

Created a type called ForkDeterminationInfo to represent the information needed to determine which hard fork a particular block is on. In the past all we needed was a block number; now we need to pass in both a block number and timestamp (and if mergeForkBlock isn't specified, maybe TD as well), so I created a type for it (though I don't love the name).

Several things are still unresolved. (See various places that say FIXME-Adam.) But I think this is progress.
