### PR TITLE
Add possible historical_roots with proof structure

### DIFF
--- a/fluffy/network/history/experimental/beacon_chain_block_proof.nim
+++ b/fluffy/network/history/experimental/beacon_chain_block_proof.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022 Status Research & Development GmbH
+# Copyright (c) 2022-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -31,6 +31,9 @@
 # is currently in no way available over any of the consensus layer libp2p
 # protocols. Thus a light client cannot really be build using these proofs,
 # which makes it rather useless for now.
+# - The historical_roots could be put available on the network together with
+# a proof against the right state root. An example of this can be seen in
+# ./fluffy/network/history/experimental/beacon_chain_historical_roots.nim
 #
 # Caveat:
 #
@@ -68,9 +71,10 @@
 # TODO: Probably needs to make usage of forks instead of just bellatrix.
 #
 
-{.used.}
-
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import
   stew/results,

--- a/fluffy/network/history/experimental/beacon_chain_historical_roots.nim
+++ b/fluffy/network/history/experimental/beacon_chain_historical_roots.nim
@@ -1,0 +1,52 @@
+# Nimbus
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+#
+# Example of how the beacon state historical_roots field could be provided with
+# a Merkle proof that can be verified against the right state root.
+# These historical_roots with their proof could for example be provided over the
+# network and verified on the receivers end.
+#
+
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  stew/results,
+  beacon_chain/spec/forks,
+  beacon_chain/spec/datatypes/bellatrix
+
+export results
+
+type
+  HistoricalRoots* = HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
+  HistoricalRootsProof* = array[5, Digest]
+  HistoricalRootsWithProof* = object
+    historical_roots: HistoricalRoots
+    proof: HistoricalRootsProof
+
+func buildProof*(
+    state: ForkedHashedBeaconState): Result[HistoricalRootsProof, string] =
+  let gIndex = GeneralizedIndex(39) # 31 + 8 = 39
+
+  var proof: HistoricalRootsProof
+  withState(state):
+    ? forkyState.data.build_proof(gIndex, proof)
+
+  ok(proof)
+
+func verifyProof*(
+    historical_roots: HistoricalRoots,
+    proof: HistoricalRootsProof,
+    stateRoot: Digest): bool =
+  let
+    gIndex = GeneralizedIndex(39)
+    leave = hash_tree_root(historical_roots)
+
+  verify_merkle_multiproof(@[leave], proof, @[gIndex], stateRoot)

--- a/fluffy/tests/all_fluffy_tests.nim
+++ b/fluffy/tests/all_fluffy_tests.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
@@ -17,4 +17,5 @@ import
   ./test_content_db,
   ./test_discovery_rpc,
   ./test_bridge_parser,
-  ./test_beacon_chain_block_proof
+  ./test_beacon_chain_block_proof,
+  ./test_beacon_chain_historical_roots

--- a/fluffy/tests/test_beacon_chain_block_proof.nim
+++ b/fluffy/tests/test_beacon_chain_block_proof.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022 Status Research & Development GmbH
+# Copyright (c) 2022-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -7,7 +7,10 @@
 
 {.used.}
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import
   unittest2,

--- a/fluffy/tests/test_beacon_chain_historical_roots.nim
+++ b/fluffy/tests/test_beacon_chain_historical_roots.nim
@@ -1,0 +1,54 @@
+# Nimbus
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  unittest2,
+  beacon_chain/spec/forks,
+  beacon_chain/spec/datatypes/bellatrix,
+  beacon_chain/../tests/testblockutil,
+  # Mock helpers
+  beacon_chain/../tests/mocking/mock_genesis,
+
+  ../network/history/experimental/beacon_chain_historical_roots
+
+suite "Beacon Chain Historical Roots":
+  let
+    cfg = block:
+      var res = defaultRuntimeConfig
+      res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
+      res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
+      res
+    state = newClone(initGenesisState(cfg = cfg))
+  var cache = StateCache()
+
+  var blocks: seq[bellatrix.SignedBeaconBlock]
+  # Note:
+  # Adding 8192 blocks. First block is genesis block and not one of these.
+  # Then one extra block is needed to get the historical roots, block
+  # roots and state roots processed.
+  # index i = 0 is second block.
+  # index i = 8190 is 8192th block and last one that is part of the first
+  # historical root
+  for i in 0..<SLOTS_PER_HISTORICAL_ROOT:
+    blocks.add(addTestBlock(state[], cache, cfg = cfg).bellatrixData)
+
+  test "Historical Roots Proof":
+    let historical_roots = getStateField(state[], historical_roots)
+
+    let res = buildProof(state[])
+    check res.isOk()
+    let proof = res.get()
+
+    withState(state[]):
+      check verifyProof(historical_roots, proof, forkyState.root)


### PR DESCRIPTION
This is an example of how the beacon state historical_roots could be added with a proof to be able to provide on the network and verify by means of proof against the state root.