### PR TITLE
Fix potential overflow error on toPC

### DIFF
--- a/nimbus/utils/prettify.nim
+++ b/nimbus/utils/prettify.nim
@@ -62,8 +62,13 @@ proc toPC*(
   let
     sign = if num < 0: "-" else: ""
     preTruncated = (num.abs * multiplier) + roundUp
+
   if int.high.float <= preTruncated:
     return "NaN"
+  # `intToStr` will do `abs` which throws overflow exception when value of low()
+  if preTruncated.int <= int.low():
+    return "NaN"
+
   result = sign & preTruncated.int.intToStr(minDigits) & "%"
   when 0 < digitsAfterDot:
     result.insert(".", result.len - minDigits)


### PR DESCRIPTION
Hit an overflow error when running nimbus-eth1:
```
/home/deme/repos/nimbus-eth1/nimbus/nimbus.nim(490) nimbus
/home/deme/repos/nimbus-eth1/nimbus/nimbus.nim(463) process
/home/deme/repos/nimbus-eth1/vendor/nim-chronos/chronos/asyncloop.nim(295) poll
/home/deme/repos/nimbus-eth1/nimbus/sync/snap/worker/ticker.nim(138) runLogTicker
/home/deme/repos/nimbus-eth1/nimbus/sync/snap/worker/ticker.nim(108) pc99
/home/deme/repos/nimbus-eth1/nimbus/utils/prettify.nim(67) toPC
/home/deme/repos/nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/pure/strutils.nim(1057) nsuIntToStr
/home/deme/repos/nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/system/integerops.nim(15) raiseOverflow
/home/deme/repos/nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/system/fatal.nim(54) sysFatal
Error: unhandled exception: over- or underflow [OverflowDefect]
```

From a look at the code, it seems to me that this would hit on int.low() value for `preTruncated.int`, hence the additional check on that as fix.

One might want to rework that toPC code to avoid these oddities. Consider this a quick fix.