### PR TITLE
refactor touched accounts, selfdestruct, and log

### DIFF
--- a/nimbus/core/executor/process_transaction.nim
+++ b/nimbus/core/executor/process_transaction.nim
@@ -87,11 +87,11 @@ proc processTransactionImpl(
       vmState.cumulativeGasUsed += gasBurned
       result = ok(gasBurned)
 
-  vmState.clearSelfDestructsAndEmptyAccounts(fork, miner)
-
   if vmState.generateWitness:
     vmState.stateDB.collectWitnessData()
-  vmState.stateDB.persist(clearCache = false)
+  vmState.stateDB.persist(
+    clearEmptyAccount = fork >= FkSpurious,
+    clearCache = false)
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/nimbus/core/validate.nim
+++ b/nimbus/core/validate.nim
@@ -17,8 +17,12 @@ import
   ./pow/[difficulty, header],
   ./pow,
   chronicles,
-  nimcrypto/utils,
   stew/[objects, results]
+
+# chronicles stuff
+when loggingEnabled or enabledLogLevel >= NONE:
+  import
+    nimcrypto/utils
 
 from stew/byteutils
   import nil

--- a/nimbus/evm/state_transactions.nim
+++ b/nimbus/evm/state_transactions.nim
@@ -52,10 +52,6 @@ proc postExecComputation(c: Computation) =
     if c.fork < FkLondon:
       # EIP-3529: Reduction in refunds
       c.refundSelfDestruct()
-    shallowCopy(c.vmState.selfDestructs, c.selfDestructs)
-    shallowCopy(c.vmState.logEntries, c.logEntries)
-    c.vmState.touchedAccounts.incl c.touchedAccounts
-
   c.vmState.status = c.isSuccess
 
 proc execComputation*(c: Computation)

--- a/nimbus/evm/types.nim
+++ b/nimbus/evm/types.nim
@@ -46,12 +46,9 @@ type
     blockDifficulty*: UInt256
     flags*         : set[VMFlag]
     tracer*        : TransactionTracer
-    logEntries*    : seq[Log]
     receipts*      : seq[Receipt]
     stateDB*       : AccountsCache
     cumulativeGasUsed*: GasInt
-    touchedAccounts*: HashSet[EthAddress]
-    selfDestructs* : HashSet[EthAddress]
     txOrigin*      : EthAddress
     txGasPrice*    : GasInt
     gasCosts*      : GasCosts
@@ -89,9 +86,6 @@ type
     output*:                seq[byte]
     returnData*:            seq[byte]
     error*:                 Error
-    touchedAccounts*:       HashSet[EthAddress]
-    selfDestructs*:         HashSet[EthAddress]
-    logEntries*:            seq[Log]
     savePoint*:             SavePoint
     instr*:                 Op
     opIndex*:               int

--- a/nimbus/transaction/call_common.nim
+++ b/nimbus/transaction/call_common.nim
@@ -264,7 +264,7 @@ proc finishRunningComputation(host: TransactionHost, call: CallParams): CallResu
   shallowCopy(result.output, c.output)
   result.contractAddress = if call.isCreate: c.msg.contractAddress
                            else: default(HostAddress)
-  shallowCopy(result.logEntries, c.logEntries)
+  result.logEntries = host.vmState.stateDB.logEntries()
   result.stack = c.stack
   result.memory = c.memory
 

--- a/nimbus/transaction/host_services.nim
+++ b/nimbus/transaction/host_services.nim
@@ -220,15 +220,7 @@ proc selfDestruct(host: TransactionHost, address, beneficiary: HostAddress) {.sh
     # This must come after sending to the beneficiary in case the
     # contract named itself as the beneficiary.
     db.setBalance(address, 0.u256)
-
-  # TODO: Calling via `computation` is necessary to make some tests pass.
-  # Here's one that passes only with this:
-  #   tests/fixtures/eth_tests/GeneralStateTests/stRandom2/randomStatetest487.json
-  # We can't keep using `computation` though.
-  host.computation.touchedAccounts.incl(beneficiary)
-  host.computation.selfDestructs.incl(address)
-  #host.touchedAccounts.incl(beneficiary)
-  #host.selfDestructs.incl(address)
+    db.selfDestruct(address)
 
 template call(host: TransactionHost, msg: EvmcMessage): EvmcResult =
   # `call` is special.  The C stack usage must be kept small for deeply nested
@@ -266,13 +258,7 @@ proc emitLog(host: TransactionHost, address: HostAddress,
     copyMem(log.data[0].addr, data, data_size.int)
 
   log.address = address
-
-  # TODO: Calling via `computation` is necessary to makes some tests pass.
-  # Here's one that passes only with this:
-  #   tests/fixtures/eth_tests/GeneralStateTests/stRandom2/randomStatetest583.json
-  # We can't keep using `computation` though.
-  host.computation.logEntries.add(log)
-  #host.logEntries.add(log)
+  host.vmState.stateDB.addlogEntry(log)
 
 proc accessAccount(host: TransactionHost, address: HostAddress): EvmcAccessStatus {.show.} =
   host.vmState.mutateStateDB:

--- a/nimbus/transaction/host_types.nim
+++ b/nimbus/transaction/host_types.nim
@@ -59,9 +59,6 @@ type
     code*:            seq[byte]
     cachedTxContext*: bool
     txContext*:       EvmcTxContext
-    logEntries*:      seq[Log]
-    touchedAccounts*: HashSet[EthAddress]
-    selfDestructs*:   HashSet[EthAddress]
     depth*:           int
     saveComputation*: seq[Computation]
     hostInterface*:   ptr evmc_host_interface

--- a/nimbus/utils/debug.nim
+++ b/nimbus/utils/debug.nim
@@ -9,7 +9,7 @@
 # according to those terms.
 
 import
-  std/[options, times, json, strutils, sets],
+  std/[options, times, json, strutils],
   ../common/common,
   stew/byteutils,
   ../vm_state,
@@ -98,12 +98,9 @@ proc debug*(vms: BaseVMState): string =
   result.add "prevRandao       : " & $vms.prevRandao          & "\n"
   result.add "blockDifficulty  : " & $vms.blockDifficulty     & "\n"
   result.add "flags            : " & $vms.flags               & "\n"
-  result.add "logEntries.len   : " & $vms.logEntries.len      & "\n"
   result.add "receipts.len     : " & $vms.receipts.len        & "\n"
   result.add "stateDB.root     : " & $vms.stateDB.rootHash    & "\n"
   result.add "cumulativeGasUsed: " & $vms.cumulativeGasUsed   & "\n"
-  result.add "touchedAccs.len  : " & $vms.touchedAccounts.len & "\n"
-  result.add "selfDestructs.len: " & $vms.selfDestructs.len   & "\n"
   result.add "txOrigin         : " & $vms.txOrigin            & "\n"
   result.add "txGasPrice       : " & $vms.txGasPrice          & "\n"
   result.add "fork             : " & $vms.fork                & "\n"

--- a/nimbus/vm_computation.nim
+++ b/nimbus/vm_computation.nim
@@ -44,7 +44,6 @@ export
   vmc.isError,
   vmc.isOriginComputation,
   vmc.isSuccess,
-  vmc.isSelfDestructed,
   vmc.merge,
   vmc.newComputation,
   vmc.prepareTracer,

--- a/nimbus/vm_internals.nim
+++ b/nimbus/vm_internals.nim
@@ -94,7 +94,6 @@ export
   bChp.isError,
   bChp.isOriginComputation,
   bChp.isSuccess,
-  bChp.isSelfDestructed,
   bChp.merge,
   bChp.newComputation,
   bChp.prepareTracer,

--- a/nimbus/vm_state.nim
+++ b/nimbus/vm_state.nim
@@ -18,7 +18,6 @@ export
   vms.`$`,
   vms.blockNumber,
   vms.buildWitness,
-  vms.clearSelfDestructsAndEmptyAccounts,
   vms.coinbase,
   vms.determineFork,
   vms.difficulty,

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -350,7 +350,7 @@ proc verifyAsmResult(vmState: BaseVMState, com: CommonRef, boa: Assembler, asmRe
       error "storage has different value", key=key, expected=val, actual=value
       return false
 
-  let logs = vmState.logEntries
+  let logs = vmState.getAndClearLogEntries()
   if logs.len != boa.logs.len:
     error "different logs len", expected=boa.logs.len, actual=logs.len
     return false

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -87,7 +87,7 @@ proc testFixtureIndexes(tester: Tester, testStatusIMPL: var TestStatus) =
     let obtainedHash = vmState.readOnlyStateDB.rootHash
     check obtainedHash == tester.expectedHash
     let logEntries = vmState.getAndClearLogEntries()
-    let actualLogsHash = hashLogEntries(logEntries)
+    let actualLogsHash = rlpHash(logEntries)
     check(tester.expectedLogs == actualLogsHash)
     if tester.debugMode:
       let success = tester.expectedLogs == actualLogsHash and obtainedHash == tester.expectedHash

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -7,7 +7,7 @@
 
 import
   std/[os, macros, json, strformat, strutils, tables],
-  stew/byteutils, net, eth/[keys, rlp, p2p], unittest2,
+  stew/byteutils, net, eth/[keys, p2p], unittest2,
   testutils/markdown_reports,
   ../nimbus/[constants, config, transaction, errors],
   ../nimbus/db/accounts_cache,
@@ -137,9 +137,6 @@ proc verifyStateDB*(wantedState: JsonNode, stateDB: ReadOnlyStateDB) =
       raise newException(ValidationError, &"{ac} balanceDiff {wantedBalance.toHex} != {actualBalance.toHex}")
     if wantedNonce != actualNonce:
       raise newException(ValidationError, &"{ac} nonceDiff {wantedNonce.toHex} != {actualNonce.toHex}")
-
-proc hashLogEntries*(logs: seq[Log]): Hash256 =
-  keccakHash(rlp.encode(logs))
 
 proc setupEthNode*(
     conf: NimbusConf, ctx: EthContext,

--- a/tools/common/state_clearing.nim
+++ b/tools/common/state_clearing.nim
@@ -31,9 +31,6 @@ proc coinbaseStateClearing*(vmState: BaseVMState,
     if touched:
       db.addBalance(miner, 0.u256)
 
-    if fork >= FkSpurious:
-      db.deleteAccountIfEmpty(miner)
-
     # db.persist is an important step when using accounts_cache
     # it will affect the account storage's location
     # during the next call to `getComittedStorage`
@@ -41,4 +38,6 @@ proc coinbaseStateClearing*(vmState: BaseVMState,
 
     # do not clear cache, we need the cache when constructing
     # post state
-    db.persist(clearCache = false)
+    db.persist(
+      clearEmptyAccount = fork >= FkSpurious,
+      clearCache = false)

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -215,7 +215,7 @@ proc runExecution(ctx: var StateContext, conf: StateConf, pre: JsonNode): StateR
 
   vmState.mutateStateDB:
     setupStateDB(pre, db)
-    db.persist() # settle accounts storage
+    db.persist(clearEmptyAccount = false) # settle accounts storage
 
   defer:
     ctx.verifyResult(vmState)

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -220,7 +220,6 @@ proc exec(ctx: var TransContext,
 
     vmState.mutateStateDB:
       db.addBalance(ctx.env.currentCoinbase, mainReward)
-      db.persist(clearCache = false)
 
   let miner = ctx.env.currentCoinbase
   let fork = vmState.com.toEVMFork
@@ -411,7 +410,7 @@ proc transitionAction*(ctx: var TransContext, conf: T8NConf) =
 
     vmState.mutateStateDB:
       db.setupAlloc(ctx.alloc)
-      db.persist(clearCache = false)
+      db.persist(clearEmptyAccount = false, clearCache = false)
 
     let res = exec(ctx, vmState, conf.stateReward, header)
 


### PR DESCRIPTION
simplify EVM and delegete those things to accounts cache. also no more manual state clearing, accounts cache will be responsible for both collecting touched account and perform state clearing.