### PR TITLE
Add clientInfo to ENR for easier testnet debugging

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -147,6 +147,9 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
     d = newProtocol(
       netkey,
       extIp, none(Port), extUdpPort,
+      # Note: The addition of clientInfo to the ENR is a temporary measure to
+      # easily identify & debug the clients used in the testnet.
+      localEnrFields = {"c": clientInfoShort},
       bootstrapRecords = bootstrapRecords,
       bindIp = bindIp, bindPort = udpPort,
       enrAutoUpdate = config.enrAutoUpdate,

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -147,9 +147,10 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
     d = newProtocol(
       netkey,
       extIp, none(Port), extUdpPort,
-      # Note: The addition of clientInfo to the ENR is a temporary measure to
-      # easily identify & debug the clients used in the testnet.
-      localEnrFields = {"c": clientInfoShort},
+      # Note: The addition of default clientInfo to the ENR is a temporary
+      # measure to easily identify & debug the clients used in the testnet.
+      # Might make this into a, default off, cli option.
+      localEnrFields = {"c": enrClientInfoShort},
       bootstrapRecords = bootstrapRecords,
       bindIp = bindIp, bindPort = udpPort,
       enrAutoUpdate = config.enrAutoUpdate,

--- a/fluffy/version.nim
+++ b/fluffy/version.nim
@@ -9,6 +9,7 @@
 
 import
   std/strutils,
+  stew/byteutils,
   metrics
 
 const
@@ -37,6 +38,9 @@ const
   compileYear = CompileDate[0 ..< 4]  # YYYY-MM-DD (UTC)
   copyrightBanner* =
     "Copyright (c) 2021-" & compileYear & " Status Research & Development GmbH"
+
+  # Short debugging indentifier for ENR
+  clientInfoShort* = toBytes("f-" & gitRevision)
 
 func getNimGitHash*(): string =
   const gitPrefix = "git hash: "

--- a/fluffy/version.nim
+++ b/fluffy/version.nim
@@ -39,8 +39,8 @@ const
   copyrightBanner* =
     "Copyright (c) 2021-" & compileYear & " Status Research & Development GmbH"
 
-  # Short debugging indentifier for ENR
-  clientInfoShort* = toBytes("f-" & gitRevision)
+  # Short debugging identifier to be placed in the ENR
+  enrClientInfoShort* = toBytes("f")
 
 func getNimGitHash*(): string =
   const gitPrefix = "git hash: "


### PR DESCRIPTION
As mentioned in the code, this is a temporary measure, as we probably do not want this information that easily searchable in the DHT for security reasons.