### PR TITLE
fix macro assembler and reenable disabled tests

### DIFF
--- a/nimbus/evm/state_transactions.nim
+++ b/nimbus/evm/state_transactions.nim
@@ -9,7 +9,6 @@
 # according to those terms.
 
 import
-  std/sets,
   chronos,
   eth/common/eth_types,
   ../constants,

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -27,9 +27,9 @@ cliBuilder:
           ./test_filters,
           ./test_op_arith,
           ./test_op_bit,
-          # ./test_op_env,
+          ./test_op_env,
           ./test_op_memory,
-          # ./test_op_misc,
+          ./test_op_misc,
           ./test_op_custom,
           ./test_state_db,
           ./test_difficulty,
@@ -45,5 +45,5 @@ cliBuilder:
           ./test_pow,
           ./test_configuration,
           ./test_keyed_queue_rlp,
-          # ./test_txpool,
+          ./test_txpool,
           ./test_merge

--- a/tests/test_op_arith.nim
+++ b/tests/test_op_arith.nim
@@ -2,8 +2,6 @@ import macro_assembler, unittest2
 
 proc opArithMain*() =
   suite "Arithmetic Opcodes":
-    let (vmState, chainDB) = initDatabase()
-
     assembler:
       title: "ADD_1"
       code:
@@ -297,7 +295,7 @@ proc opArithMain*() =
 
         SDIV
       stack:   "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000" # half of the hi bits are set
-      fork: constantinople
+      fork: Constantinople
 
     assembler: # SUB OP
       title: "SUB_1"

--- a/tests/test_op_bit.nim
+++ b/tests/test_op_bit.nim
@@ -2,8 +2,6 @@ import macro_assembler, unittest2
 
 proc opBitMain*() =
   suite "Bitwise Opcodes":
-    let (vmState, chainDB) = initDatabase()
-
     assembler: # AND OP
       title: "AND_1"
       code:
@@ -114,7 +112,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000001"
         PUSH1 "0x00"
         SHL
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000001"
 
     assembler: # SHL OP
@@ -123,7 +121,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000001"
         PUSH1 "0x01"
         SHL
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000002"
 
     assembler: # SHL OP
@@ -132,7 +130,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000001"
         PUSH1 "0xff"
         SHL
-      fork: constantinople
+      fork: Constantinople
       stack: "0x8000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SHL OP
@@ -141,7 +139,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000001"
         PUSH2 "0x0100"
         SHL
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SHL OP
@@ -150,7 +148,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000001"
         PUSH2 "0x0101"
         SHL
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SHL OP
@@ -159,7 +157,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0x00"
         SHL
-      fork: constantinople
+      fork: Constantinople
       stack: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 
     assembler: # SHL OP
@@ -168,7 +166,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0x01"
         SHL
-      fork: constantinople
+      fork: Constantinople
       stack: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE"
 
     assembler: # SHL OP
@@ -177,7 +175,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0xff"
         SHL
-      fork: constantinople
+      fork: Constantinople
       stack: "0x8000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SHL OP
@@ -186,7 +184,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH2 "0x0100"
         SHL
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SHL OP
@@ -195,7 +193,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000000"
         PUSH1 "0x01"
         SHL
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SHL OP
@@ -204,7 +202,7 @@ proc opBitMain*() =
         PUSH32 "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0x01"
         SHL
-      fork: constantinople
+      fork: Constantinople
       stack: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE"
 
     assembler: # SHR OP
@@ -213,7 +211,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000001"
         PUSH1 "0x00"
         SHR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000001"
 
     assembler: # SHR OP
@@ -222,7 +220,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000001"
         PUSH1 "0x01"
         SHR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SHR OP
@@ -231,7 +229,7 @@ proc opBitMain*() =
         PUSH32 "0x8000000000000000000000000000000000000000000000000000000000000000"
         PUSH1 "0x01"
         SHR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x4000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SHR OP
@@ -240,7 +238,7 @@ proc opBitMain*() =
         PUSH32 "0x8000000000000000000000000000000000000000000000000000000000000000"
         PUSH1 "0xff"
         SHR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000001"
 
     assembler: # SHR OP
@@ -249,7 +247,7 @@ proc opBitMain*() =
         PUSH32 "0x8000000000000000000000000000000000000000000000000000000000000000"
         PUSH2 "0x0100"
         SHR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SHR OP
@@ -258,7 +256,7 @@ proc opBitMain*() =
         PUSH32 "0x8000000000000000000000000000000000000000000000000000000000000000"
         PUSH2 "0x0101"
         SHR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SHR OP
@@ -267,7 +265,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0x00"
         SHR
-      fork: constantinople
+      fork: Constantinople
       stack: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 
     assembler: # SHR OP
@@ -276,7 +274,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0x01"
         SHR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 
     assembler: # SHR OP
@@ -285,7 +283,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0xff"
         SHR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000001"
 
     assembler: # SHR OP
@@ -294,7 +292,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH2 "0x0100"
         SHR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SHR OP
@@ -303,7 +301,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000000"
         PUSH1 "0x01"
         SHR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SAR OP
@@ -312,7 +310,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000001"
         PUSH1 "0x00"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000001"
 
     assembler: # SAR OP
@@ -321,7 +319,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000001"
         PUSH1 "0x01"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SAR OP
@@ -330,7 +328,7 @@ proc opBitMain*() =
         PUSH32 "0x8000000000000000000000000000000000000000000000000000000000000000"
         PUSH1 "0x01"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0xC000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SAR OP
@@ -339,7 +337,7 @@ proc opBitMain*() =
         PUSH32 "0x8000000000000000000000000000000000000000000000000000000000000000"
         PUSH1 "0xff"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 
     assembler: # SAR OP
@@ -348,7 +346,7 @@ proc opBitMain*() =
         PUSH32 "0x8000000000000000000000000000000000000000000000000000000000000000"
         PUSH2 "0x0100"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 
     assembler: # SAR OP
@@ -357,7 +355,7 @@ proc opBitMain*() =
         PUSH32 "0x8000000000000000000000000000000000000000000000000000000000000000"
         PUSH2 "0x0101"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 
     assembler: # SAR OP
@@ -366,7 +364,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0x00"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 
     assembler: # SAR OP
@@ -375,7 +373,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0x01"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 
     assembler: # SAR OP
@@ -384,7 +382,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0xff"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 
     assembler: # SAR OP
@@ -393,7 +391,7 @@ proc opBitMain*() =
         PUSH32 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH2 "0x0100"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 
     assembler: # SAR OP
@@ -402,7 +400,7 @@ proc opBitMain*() =
         PUSH32 "0x0000000000000000000000000000000000000000000000000000000000000000"
         PUSH1 "0x01"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SAR OP
@@ -411,7 +409,7 @@ proc opBitMain*() =
         PUSH32 "0x4000000000000000000000000000000000000000000000000000000000000000"
         PUSH1 "0xfe"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000001"
 
     assembler: # SAR OP
@@ -420,7 +418,7 @@ proc opBitMain*() =
         PUSH32 "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0xf8"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x000000000000000000000000000000000000000000000000000000000000007F"
 
     assembler: # SAR OP
@@ -429,7 +427,7 @@ proc opBitMain*() =
         PUSH32 "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0xfe"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000001"
 
     assembler: # SAR OP
@@ -438,7 +436,7 @@ proc opBitMain*() =
         PUSH32 "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH1 "0xff"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SAR OP
@@ -447,7 +445,7 @@ proc opBitMain*() =
         PUSH32 "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         PUSH2 "0x0100"
         SAR
-      fork: constantinople
+      fork: Constantinople
       stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # ISZERO OP
@@ -657,4 +655,3 @@ proc opBitMain*() =
 
 when isMainModule:
   opBitMain()
-

--- a/tests/test_op_custom.nim
+++ b/tests/test_op_custom.nim
@@ -1,11 +1,10 @@
 import
-  macro_assembler, unittest2,
+  macro_assembler,
+  unittest2,
   eth/common
 
 proc opCustomMain*() =
   suite "Custom Opcodes Test":
-    let (vmState, chainDB) = initDatabase()
-
     assembler: # CALLDATASIZE OP
       title: "CALLDATASIZE_1"
       data:
@@ -192,7 +191,7 @@ proc opCustomMain*() =
         Address
         Balance
       stack: "0x00000000000000000000000000000000000000000000000000000000000f4434"
-      fork: berlin
+      fork: Berlin
       gasused: 102
 
     assembler: # ORIGIN OP
@@ -254,7 +253,7 @@ proc opCustomMain*() =
       code:
         Push1 "0x00"
         Blockhash
-      stack: "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+      stack: "0xc3bd2d00745c03048a5616146a96f5ff78e54efb9e5b04af208cdaff6f3830ee"
 
     # current block coinbase/miner
     assembler: # COINBASE OP
@@ -268,7 +267,7 @@ proc opCustomMain*() =
       title: "TIMESTAMP_1"
       code:
         TimeStamp
-      stack: "0x0000000000000000000000000000000000000000000000000000000000000001"
+      stack: "0x0000000000000000000000000000000000000000000000000000000000001234"
 
     # current block number
     assembler: # NUMBER OP
@@ -282,7 +281,7 @@ proc opCustomMain*() =
       title: "DIFFICULTY_1"
       code:
         Difficulty
-      stack: "0x0000000000000000000000000000000000000000000000000000000400800000"
+      stack: "0x00000000000000000000000000000000000000000000000000000000000003eb"
 
     # tx gas price
     assembler: # GASPRICE OP

--- a/tests/test_op_memory.nim
+++ b/tests/test_op_memory.nim
@@ -1,9 +1,9 @@
-import macro_assembler, unittest2, macros, strutils
+import
+  std/[macros, strutils],
+  macro_assembler, unittest2
 
 proc opMemoryMain*() =
   suite "Memory Opcodes":
-    let (vmState, chainDB) = initDatabase()
-
     assembler: # PUSH1 OP
       title: "PUSH1"
       code:
@@ -516,152 +516,124 @@ proc opMemoryMain*() =
         SSTORE
       success: false
       stack: "0x22"
-  #[
+
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_1"
       code: "60006000556000600055"
-      fork: constantinople
-      # assertEquals(412, program.getResult().getGasUsed())
-      # assertEquals(0, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 412
 
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_2"
       code: "60006000556001600055"
-      fork: constantinople
-      # assertEquals(20212, program.getResult().getGasUsed())
-      # assertEquals(0, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 20212
 
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_3"
       code: "60016000556000600055"
-      fork: constantinople
-      # assertEquals(20212, program.getResult().getGasUsed())
-      # assertEquals(19800, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 20212
 
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_4"
       code: "60016000556002600055"
-      fork: constantinople
-      # assertEquals(20212, program.getResult().getGasUsed())
-      # assertEquals(0, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 20212
 
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_5"
       code: "60016000556001600055"
-      fork: constantinople
-      # assertEquals(20212, program.getResult().getGasUsed())
-      # assertEquals(0, program.getResult().getFutureRefund())
-
+      fork: Constantinople
+      gasUsed: 20212
+#[
     # Sets Storage row on "cow" address:
     # 0: 1
     # private void setStorageToOne(VM vm) {
     #       # Sets storage value to 1 and commits
     #           code: "60006000556001600055"
-    #           fork: constantinople
+    #           fork: Constantinople
     #       invoke.getRepository().commit()
     #       invoke.setOrigRepository(invoke.getRepository())
 
-    setStorageToOne(vm)
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_6"
       code: "60006000556000600055"
-      fork: constantinople
-      # assertEquals(5212, program.getResult().getGasUsed())
-      # assertEquals(15000, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 5212
 
-    setStorageToOne(vm)
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_7"
       code: "60006000556001600055"
-      fork: constantinople
-      # assertEquals(5212, program.getResult().getGasUsed())
-      # assertEquals(4800, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 5212
 
-    setStorageToOne(vm)
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_8"
       code: "60006000556002600055"
-      fork: constantinople
-      # assertEquals(5212, program.getResult().getGasUsed())
-      # assertEquals(0, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 5212
 
-    setStorageToOne(vm)
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_9"
       code: "60026000556000600055"
-      fork: constantinople
-      # assertEquals(5212, program.getResult().getGasUsed())
-      # assertEquals(15000, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 5212
 
-    setStorageToOne(vm)
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_10"
       code: "60026000556003600055"
-      fork: constantinople
-      # assertEquals(5212, program.getResult().getGasUsed())
-      # assertEquals(0, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 5212
 
-    setStorageToOne(vm)
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_11"
       code: "60026000556001600055"
-      fork: constantinople
-      # assertEquals(5212, program.getResult().getGasUsed())
-      # assertEquals(4800, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 5212
 
-    setStorageToOne(vm)
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_12"
       code: "60026000556002600055"
-      fork: constantinople
-      # assertEquals(5212, program.getResult().getGasUsed())
-      # assertEquals(0, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 5212
 
-    setStorageToOne(vm)
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_13"
       code: "60016000556000600055"
-      fork: constantinople
-      # assertEquals(5212, program.getResult().getGasUsed())
-      # assertEquals(15000, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 5212
 
-    setStorageToOne(vm)
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_14"
       code: "60016000556002600055"
-      fork: constantinople
-      # assertEquals(5212, program.getResult().getGasUsed())
-      # assertEquals(0, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 5212
 
-    setStorageToOne(vm)
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_15"
       code: "60016000556001600055"
-      fork: constantinople
-      # assertEquals(412, program.getResult().getGasUsed())
-      # assertEquals(0, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 412
 
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_16"
       code: "600160005560006000556001600055"
-      fork: constantinople
-      # assertEquals(40218, program.getResult().getGasUsed())
-      # assertEquals(19800, program.getResult().getFutureRefund())
+      fork: Constantinople
+      gasUsed: 40218
 
-    setStorageToOne(vm)
     assembler: # SSTORE EIP1283
       title: "SSTORE_NET_17"
       code: "600060005560016000556000600055"
-      fork: constantinople
-      # assertEquals(10218, program.getResult().getGasUsed())
-      # assertEquals(19800, program.getResult().getFutureRefund())
-  ]#
+      fork: Constantinople
+      gasUsed: 10218
+]#
     assembler: # SLOAD OP
       title: "SLOAD_1"
       code:
         PUSH1 "0xAA"
         SLOAD
-      stack: "0x0000000000000000000000000000000000000000000000000000000000000022"
+      stack: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
     assembler: # SLOAD OP
       title: "SLOAD_2"
@@ -707,7 +679,7 @@ proc opMemoryMain*() =
         SLOAD
         PC
       stack:
-        "0x0000000000000000000000000000000000000000000000000000000000000022"
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
         "0x0000000000000000000000000000000000000000000000000000000000000008"
       memory:
         "0x00"

--- a/tests/test_op_misc.nim
+++ b/tests/test_op_misc.nim
@@ -1,11 +1,10 @@
 import
-  macro_assembler, unittest2, macros,
-  stew/byteutils, eth/common
+  macro_assembler,
+  unittest2,
+  eth/common
 
 proc opMiscMain*() =
   suite "Misc Opcodes":
-    let (vmState, chainDB) = initDatabase()
-
     assembler: # LOG0 OP
       title: "Log0"
       code:

--- a/tests/test_txpool/helpers.nim
+++ b/tests/test_txpool/helpers.nim
@@ -39,7 +39,6 @@ export
   tx_packer.packerVmExec,
   tx_recover.recoverItem,
   tx_tabs.TxTabsRef,
-  tx_tabs.any,
   tx_tabs.decAccount,
   tx_tabs.dispose,
   tx_tabs.eq,

--- a/tests/test_txpool2.nim
+++ b/tests/test_txpool2.nim
@@ -1,6 +1,6 @@
 import
-  std/[strutils, math, tables, times],
-  eth/[keys, trie/hexary],
+  std/[math, tables, times],
+  eth/[keys],
   stew/[byteutils, results], unittest2,
   ../nimbus/db/state_db,
   ../nimbus/core/chain,


### PR DESCRIPTION
now macro assembler support merge fork, shanghai, etc without using ugly hack. also each assembler test have their own `setup` section that can access `vmState` and perform various custom setup.

fix #1339
fix #1447