### PR TITLE
Move content offered log after socket close wait

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -834,9 +834,9 @@ proc offer(p: PortalProtocol, o: OfferRequest):
               socket.close()
               return err("Error writing requested data")
 
+    await socket.closeWait()
     debug "Content successfully offered"
 
-    await socket.closeWait()
     return ok(m.contentKeys)
   else:
     warn "Offer failed due to accept request failure ",

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -257,7 +257,9 @@ proc readContentOffer(
   else:
     # This means FIN didn't arrive yet, perhaps it got dropped but it might also
     # be still in flight. Closing the socket (= sending FIN) ourselves.
-    # Not waiting here for its ACK however, so no `closeWait`
+    # Not waiting here for its ACK however, so no `closeWait`. Underneath the
+    # socket will still wait for the FIN-ACK (or timeout) before it destroys the
+    # socket.
     socket.close()
 
   # TODO: This could currently create a backlog of content items to be validated


### PR DESCRIPTION
To be clear that the socket also got closed before this. Also explain that on socket close, the actual socket still waits for an ACK.

PR instead of https://github.com/status-im/nimbus-eth1/pull/1527

The early debug log, although technically correct,  could be confusing as a receiving end did not ACK yet any of the data. Wait with the log until socket got closed.