### PR TITLE
Allow dataRadius as optional parameter in Portal ping JSON-RPC

### DIFF
--- a/fluffy/rpc/rpc_portal_api.nim
+++ b/fluffy/rpc/rpc_portal_api.nim
@@ -16,6 +16,11 @@ import
 
 export rpcserver
 
+type
+  FindNodeInfo = object
+    total: uint8
+    enrs: seq[Record]
+
 # Portal Network JSON-RPC impelentation as per specification:
 # https://github.com/ethereum/portal-network-specs/tree/master/jsonrpc
 
@@ -108,14 +113,17 @@ proc installPortalApiHandlers*(
       )
 
   rpcServer.rpc("portal_" & network & "FindNodes") do(
-      enr: Record, distances: seq[uint16]) -> seq[Record]:
+      enr: Record, distances: seq[uint16]) -> FindNodeInfo:
     let
       node = toNodeWithAddress(enr)
       nodes = await p.findNodes(node, distances)
     if nodes.isErr():
       raise newException(ValueError, $nodes.error)
     else:
-      return nodes.get().map(proc(n: Node): Record = n.record)
+      return FindNodeInfo(
+        total: 9,
+        enrs: nodes.get().map(proc(n: Node): Record = n.record)
+      )
 
   # TODO: This returns null values for the `none`s. Not sure what it should be
   # according to spec, no k:v pair at all?

--- a/fluffy/rpc/rpc_portal_api.nim
+++ b/fluffy/rpc/rpc_portal_api.nim
@@ -81,9 +81,12 @@ proc installPortalApiHandlers*(
       raise newException(ValueError, "Record not found in DHT lookup.")
 
   rpcServer.rpc("portal_" & network & "Ping") do(
-      enr: Record) -> tuple[enrSeq: uint64, dataRadius: UInt256]:
-    # TODO: Not fully according to spec:
-    # - Missing optional dataRadius parameter
+      enr: Record, dataRadius: Option[UInt256]) -> tuple[
+        enrSeq: uint64,
+        dataRadius: UInt256]:
+    # TODO: Optional appears to be broken, when the parameter is missing it
+    # fails. Providing null does work.
+    # TODO: The dataRadius value is ignored.
     let
       node = toNodeWithAddress(enr)
       pong = await p.ping(node)


### PR DESCRIPTION
However, ignore it currently, as it might be removed anyhow.

Originally wanted to merge this, and then remove it again or not depending on https://github.com/ethereum/portal-network-specs/pull/202.

However, options appear to be broken in nim-json-rpc, making them not so optional. So this will remain draft.