### PR TITLE
Adjust portal FindContent JSON-RPC according to latest specs

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -182,6 +182,7 @@ type
     case kind*: FoundContentKind
     of Content:
       content*: seq[byte]
+      utpTransfer*: bool
     of Nodes:
       nodes*: seq[Node]
 
@@ -651,7 +652,8 @@ proc findContent*(p: PortalProtocol, dst: Node, contentKey: ByteList):
           debug "Socket read fully",
             socketKey = socket.socketKey
           socket.destroy()
-          return ok(FoundContent(src: dst, kind: Content, content: content))
+          return ok(FoundContent(
+            src: dst, kind: Content, content: content, utpTransfer: true))
         else :
           debug "Socket read time-out",
             socketKey = socket.socketKey
@@ -667,7 +669,9 @@ proc findContent*(p: PortalProtocol, dst: Node, contentKey: ByteList):
         socket.close()
         raise exc
     of contentType:
-      return ok(FoundContent(src: dst, kind: Content, content: m.content.asSeq()))
+      return ok(FoundContent(
+        src: dst,
+        kind: Content, content: m.content.asSeq(), utpTransfer: false))
     of enrsType:
       let records = recordsFromBytes(m.enrs)
       if records.isOk():

--- a/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
@@ -9,13 +9,7 @@ proc portal_stateLookupEnr(nodeId: NodeId): Record
 proc portal_statePing(enr: Record): tuple[
   enrSeq: uint64, customPayload: string]
 proc portal_stateFindNodes(enr: Record): seq[Record]
-proc portal_stateFindContent(enr: Record, contentKey: string): tuple[
-  connectionId: Option[string],
-  content: Option[string],
-  enrs: Option[seq[Record]]]
-proc portal_stateFindContentFull(enr: Record, contentKey: string): tuple[
-  content: Option[string],
-  enrs: Option[seq[Record]]]
+proc portal_stateFindContent(enr: Record, contentKey: string): JsonNode
 proc portal_stateOffer(
   enr: Record, contentKey: string, contentValue: string): string
 proc portal_stateRecursiveFindNodes(nodeId: NodeId): seq[Record]
@@ -35,13 +29,7 @@ proc portal_historyLookupEnr(nodeId: NodeId): Record
 proc portal_historyPing(enr: Record): tuple[
   enrSeq: uint64, customPayload: string]
 proc portal_historyFindNodes(enr: Record): seq[Record]
-proc portal_historyFindContent(enr: Record, contentKey: string): tuple[
-  connectionId: Option[string],
-  content: Option[string],
-  enrs: Option[seq[Record]]]
-proc portal_historyFindContentFull(enr: Record, contentKey: string): tuple[
-  content: Option[string],
-  enrs: Option[seq[Record]]]
+proc portal_historyFindContent(enr: Record, contentKey: string): JsonNode
 proc portal_historyOffer(
   enr: Record, contentKey: string, contentValue: string): string
 proc portal_historyRecursiveFindNodes(nodeId: NodeId): seq[Record]
@@ -61,13 +49,7 @@ proc portal_beaconLightClientLookupEnr(nodeId: NodeId): Record
 proc portal_beaconLightClientPing(enr: Record): tuple[
   enrSeq: uint64, customPayload: string]
 proc portal_beaconLightClientFindNodes(enr: Record): seq[Record]
-proc portal_beaconLightClientFindContent(enr: Record, contentKey: string): tuple[
-  connectionId: Option[string],
-  content: Option[string],
-  enrs: Option[seq[Record]]]
-proc portal_beaconLightClientFindContentFull(enr: Record, contentKey: string): tuple[
-  content: Option[string],
-  enrs: Option[seq[Record]]]
+proc portal_beaconLightClientFindContent(enr: Record, contentKey: string): JsonNode
 proc portal_beaconLightClientOffer(
   enr: Record, contentKey: string, contentValue: string): string
 proc portal_beaconLightClientRecursiveFindNodes(nodeId: NodeId): seq[Record]


### PR DESCRIPTION
Also remove the FindContentFull unspecced JSON-RPC as the new FindContent specification replaces this functionality basically.

Accompanying spec change: https://github.com/ethereum/portal-network-specs/pull/206