### PR TITLE
Adjust discv5_updateNodeInfo JSON-RPC to specify key and value

### DIFF
--- a/fluffy/rpc/rpc_discovery_api.nim
+++ b/fluffy/rpc/rpc_discovery_api.nim
@@ -30,10 +30,9 @@ proc installDiscoveryApiHandlers*(rpcServer: RpcServer|RpcProxy,
     return d.routingTable.getNodeInfo()
 
   rpcServer.rpc("discv5_updateNodeInfo") do(
-      kvPairs: seq[(string, string)]) -> NodeInfo:
-    # TODO: Not according to spec, as spec parameters are weird.
-    # It is currently as in
-    # https://ddht.readthedocs.io/en/latest/jsonrpc.html#discv5-updatenodeinfo
+      kvPairs: seq[tuple[key: string, value: string]]) -> NodeInfo:
+    # TODO: Not according to spec, as spec only allows socket address.
+    # portal-specs PR has been created with suggested change as is here.
     let enrFields = kvPairs.map(
       proc(n: (string, string)): (string, seq[byte]) {.raises: [ValueError].} =
         (n[0], hexToSeqByte(n[1]))


### PR DESCRIPTION
Accompanying spec PR: https://github.com/ethereum/portal-network-specs/pull/207

The current version was not following the spec, but also not the above spec PR, as a nameless tuple basically required the parameter to look like:

```json
{
  "params": [
    [
      {
        "Field0": "0xabcd",
        "Field1": "0xffff"
      },
      {
        "Field0": "0xffff",
        "Field1": "0xffff"
      }
    ]
  ]
}
```

Which now becomes:

```json
{
  "params": [
    [
      {
        "key": "0xabcd",
        "value": "0xffff"
      },
      {
        "key": "0xffff",
        "value": "0xffff"
      }
    ]
  ]
}
```

I don't think there is some way to define a Nim type that results in something like:
```json
{
  "params": [
    [
      {
        "0xabcd": "0xffff"
      },
      {
        "0xffff": "0xffff"
      }
    ]
  ]
}
```

I think that requires custom parsing of the `JsonNode`, so going with the more verbose version.