### PR TITLE
Remove yield usage from portal stream and protocol

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -609,19 +609,11 @@ proc findContent*(p: PortalProtocol, dst: Node, contentKey: ByteList):
         return err("Trying to connect to node with unknown address")
 
       # uTP protocol uses BE for all values in the header, incl. connection id
-      let connFuture = p.stream.connectTo(
+      let connectionResult =
+        await p.stream.connectTo(
           nodeAddress.unsafeGet(),
           uint16.fromBytesBE(m.connectionId)
         )
-
-      yield connFuture
-
-      var connectionResult: Result[UtpSocket[NodeAddress], string]
-
-      if connFuture.completed():
-        connectionResult = connFuture.read()
-      else:
-        raise connFuture.error
 
       if connectionResult.isErr():
         debug "uTP connection error while trying to find content",


### PR DESCRIPTION
This yield usage was added back here (https://github.com/status-im/nimbus-eth1/pull/1107) as suggested fix for a socket leak on `connectTo` cancellations.

Never really liked the usage of yield there as a fix as yield sounds to me as something only to be used as chronos internal (that is, in the context of async), and perhaps even causes other issues?
Not sure if it really was necessary back then, but when testing right now it appears to be fine with `await`. 

(There is still a leak uTP socket leak currently in fluffy but it is not occurring on cancellation of `connectTo`).


