### PR TITLE
consensus-sim: importing blocks individually instead of concatenating…

### DIFF
--- a/hive_integration/nodocker/consensus/consensus_sim.nim
+++ b/hive_integration/nodocker/consensus/consensus_sim.nim
@@ -26,7 +26,13 @@ proc processChainData(cd: ChainData): TestStatus =
     )
 
   com.initializeEmptyDb()
-  discard importRlpBlock(cd.blocksRlp, com, "consensus_sim")
+
+  for bytes in cd.blocksRlp:
+    # ignore return value here
+    # because good blocks maybe interleaved with
+    # bad blocks
+    discard importRlpBlock(bytes, com, "consensus_sim")
+
   let head = com.db.getCanonicalHead()
   let blockHash = "0x" & head.blockHash.data.toHex
   if blockHash == cd.lastBlockHash:

--- a/hive_integration/nodocker/consensus/extract_consensus_data.nim
+++ b/hive_integration/nodocker/consensus/extract_consensus_data.nim
@@ -15,10 +15,12 @@ import
   ../../../nimbus/common/chain_config
 
 type
+  Blob = seq[byte]
+  
   ChainData* = object
     params*: NetworkParams
     lastBlockHash*: string
-    blocksRlp*: seq[byte]
+    blocksRlp*: seq[Blob]
 
 const genFields = [
   "nonce",


### PR DESCRIPTION
… them.

This is a workaround following hive example, because one of the test case withdrawalsAmountBounds.json, have bad blocks between good blocks. And that bad blocks contains big int too big to fit in uint64 of withdrawal amount field.

Clients who still importing concatenated blocks cannot pass all tests.