### PR TITLE
Extended data Payload specs for the backend.

### DIFF
--- a/nimbus/db/aristo/README.md
+++ b/nimbus/db/aristo/README.md
@@ -267,13 +267,61 @@ A *Leaf* record path segment is compact encoded. So it has at least one byte.
 The first byte *P0* has bit 5 set, i.e. *P0 and 0x20* is non-zero (bit 4 is
 also set if the right nibble is the first part of the path.)
 
+If present, the serialisation of the payload field can be either for account
+data, for RLP encoded or for unstructured data as defined below.
+
+### Leaf record payload serialisation for account data
+
+        0 +-- ..  --+
+		  |         |                        -- nonce, 0 or 8 bytes
+		  +-- ..  --+--+
+		  |            |                     -- balance, 0, 8, or 32 bytes
+		  +-- ..  --+--+
+		  |         |                        -- storage ID, 0 or 8 bytes
+		  +-- ..  --+--+
+		  |            |                     -- code hash, 0, 8 or 32 bytes
+          +--+ .. --+--+
+          |  |                               -- bitmask(2)-word array
+          +--+
+
+        where each bitmask(2)-word array entry defines the length of
+		the preceeding data fields:
+		  00 -- field is missing
+		  01 -- field lengthh is 8 bytes
+		  10 -- field lengthh is 32 bytes
+
+Apparently, entries 0 and and 2 of the bitmask(2) word array cannot have the
+value 10 as they refer to the nonce and the storage ID data fields. So, joining
+the bitmask(2)-word array to a single byte, the maximum value of that byte is
+0x99.
+
+### Leaf record payload serialisation for RLP encoded data
+
+        0 +--+ .. --+
+		  |  |      |                        -- data, at least one byte
+		  +--+ .. --+
+          |  |                               -- marker byte
+          +--+
+
+        where the marker byte is 0xaa
+
+### Leaf record payload serialisation for unstructured data
+
+        0 +--+ .. --+
+		  |  |      |                        -- data, at least one byte
+		  +--+ .. --+
+          |  |                               -- marker byte
+          +--+
+
+        where the marker byte is 0xff
+
 ### Descriptor record serialisation
 
         0 +-- ..
           ...                                -- recycled vertexIDs
-          +--+--+--+--+--+--+--+--+--+
-          |                          |       -- bottom of unused vertexIDs
-          +--+--+--+--+--+--+--+--+--+
+          +--+--+--+--+--+--+--+--+
+          |                       |          -- bottom of unused vertexIDs
+          +--+--+--+--+--+--+--+--+
           || |                               -- marker(2) + unused(6)
           +--+
 

--- a/nimbus/db/aristo/aristo_check/check_be.nim
+++ b/nimbus/db/aristo/aristo_check/check_be.nim
@@ -43,7 +43,15 @@ proc toNodeBe(
   ## Similar to `toNode()` but fetching from the backend only
   case vtx.vType:
   of Leaf:
-    return ok NodeRef(vType: Leaf, lPfx: vtx.lPfx, lData: vtx.lData)
+    let node = NodeRef(vType: Leaf, lPfx: vtx.lPfx, lData: vtx.lData)
+    if vtx.lData.pType == AccountData:
+      let vid = vtx.lData.account.storageID
+      if vid.isValid:
+        let rc = db.getKeyBackend vid
+        if rc.isErr or not rc.value.isValid:
+          return err(vid)
+        node.key[0] = rc.value
+    return ok node
   of Branch:
     let node = NodeRef(vType: Branch, bVid: vtx.bVid)
     var missing: seq[VertexID]

--- a/nimbus/db/aristo/aristo_constants.nim
+++ b/nimbus/db/aristo/aristo_constants.nim
@@ -24,7 +24,7 @@ const
   EmptyVidSeq* = seq[VertexID].default
     ## Useful shortcut
 
-  VOID_CODE_KEY* = EMPTY_CODE_HASH.to(HashKey)
+  VOID_CODE_HASH* = EMPTY_CODE_HASH
     ## Equivalent of `nil` for `Account` object code hash
 
   VOID_HASH_KEY* = EMPTY_ROOT_HASH.to(HashKey)

--- a/nimbus/db/aristo/aristo_desc/aristo_error.nim
+++ b/nimbus/db/aristo/aristo_desc/aristo_error.nim
@@ -42,6 +42,12 @@ type
     DeblobLeafGotExtPrefix
     DeblobSizeGarbled
     DeblobWrongType
+    DeblobPayloadTooShortInt64
+    DeblobPayloadTooShortInt256
+    DeblobNonceLenUnsupported
+    DeblobBalanceLenUnsupported
+    DeblobStorageLenUnsupported
+    DeblobCodeLenUnsupported
 
     # Converter `asNode()`, currenly for unit tests only
     CacheMissingNodekeys

--- a/nimbus/db/aristo/aristo_desc/aristo_types_identifiers.nim
+++ b/nimbus/db/aristo/aristo_desc/aristo_types_identifiers.nim
@@ -168,8 +168,11 @@ func `==`*(a, b: HashKey): bool =
   ## Table/KeyedQueue mixin
   a.ByteArray32 == b.ByteArray32
 
-func read*[T: HashID|HashKey](rlp: var Rlp, W: type T): T
-    {.gcsafe, raises: [RlpError].} =
+func read*[T: HashID|HashKey](
+    rlp: var Rlp;
+    W: type T;
+      ): T
+      {.gcsafe, raises: [RlpError].} =
   rlp.read(Hash256).to(T)
 
 func append*(writer: var RlpWriter, val: HashID|HashKey) =

--- a/nimbus/db/aristo/aristo_hashify/hashify_helper.nim
+++ b/nimbus/db/aristo/aristo_hashify/hashify_helper.nim
@@ -29,7 +29,16 @@ proc toNode*(
   ## Convert argument vertex to node
   case vtx.vType:
   of Leaf:
-    return ok NodeRef(vType: Leaf, lPfx: vtx.lPfx, lData: vtx.lData)
+    let node = NodeRef(vType: Leaf, lPfx: vtx.lPfx, lData: vtx.lData)
+    # Need to resolve storage root for account leaf
+    if vtx.lData.pType == AccountData:
+      let vid = vtx.lData.account.storageID
+      if vid.isValid:
+        let key = db.getKey vid
+        if not key.isValid:
+          return err(@[vid])
+        node.key[0] = key
+    return ok node
   of Branch:
     let node = NodeRef(vType: Branch, bVid: vtx.bVid)
     var missing: seq[VertexID]

--- a/tests/test_aristo.nim
+++ b/tests/test_aristo.nim
@@ -265,11 +265,11 @@ when isMainModule:
 
   setErrorLevel()
 
-  when true and false:
+  when true: # and false:
     noisy.miscRunner()
 
   # Borrowed from `test_sync_snap.nim`
-  when true and false:
+  when true: # and false:
     for n,sam in snapTestList:
       noisy.transcodeRunner(sam)
     for n,sam in snapTestStorageList:

--- a/tests/test_aristo/test_helpers.nim
+++ b/tests/test_aristo/test_helpers.nim
@@ -153,7 +153,7 @@ proc to*(ua: seq[UndumpAccounts]; T: type seq[ProofTrieData]): T =
           leafTie: LeafTie(
             root:  rootVid,
             path:  it.accKey.to(HashKey).to(HashID)),
-          payload: PayloadRef(pType: BlobData, blob: it.accBlob))))
+          payload: PayloadRef(pType: RawData, rawBlob: it.accBlob))))
 
 proc to*(us: seq[UndumpStorages]; T: type seq[ProofTrieData]): T =
   var (rootKey, rootVid) = (VOID_HASH_KEY, VertexID(0))
@@ -170,7 +170,7 @@ proc to*(us: seq[UndumpStorages]; T: type seq[ProofTrieData]): T =
             leafTie: LeafTie(
               root:  rootVid,
               path:  it.slotHash.to(HashKey).to(HashID)),
-            payload: PayloadRef(pType: BlobData, blob: it.slotData))))
+            payload: PayloadRef(pType: RawData, rawBlob: it.slotData))))
     if 0 < result.len:
       result[^1].proof = s.data.proof
 

--- a/tests/test_aristo/test_transcode.nim
+++ b/tests/test_aristo/test_transcode.nim
@@ -89,7 +89,7 @@ proc test_transcodeAccounts*(
   var
     adb = AristoDbRef.init BackendNone
     count = -1
-  for (n, key,value) in rocky.walkAllDb():
+  for (n, key, value) in rocky.walkAllDb():
     if stopAfter < n:
       break
     count = n
@@ -112,10 +112,10 @@ proc test_transcodeAccounts*(
     else:
       case node.vType:
       of aristo_desc.Leaf:
-        let account = node.lData.blob.decode(Account)
-        node.lData = PayloadRef(pType: AccountData, account: account)
-        discard adb.hashToVtxID(VertexID(1), node.lData.account.storageRoot)
-        discard adb.hashToVtxID(VertexID(1), node.lData.account.codeHash)
+        let account = node.lData.rawBlob.decode(Account)
+        node.lData = PayloadRef(pType: LegacyAccount, legaAcc: account)
+        discard adb.hashToVtxID(VertexID(1), node.lData.legaAcc.storageRoot)
+        discard adb.hashToVtxID(VertexID(1), node.lData.legaAcc.codeHash)
       of aristo_desc.Extension:
         # key <-> vtx correspondence
         check node.key[0] == node0.key[0]
@@ -146,8 +146,9 @@ proc test_transcodeAccounts*(
     block:
       # `deblobify()` will always decode to `BlobData` type payload
       if node1.vType == aristo_desc.Leaf:
-        let account = node1.lData.blob.decode(Account)
-        node1.lData = PayloadRef(pType: AccountData, account: account)
+        # Node that deserialisation of the account stops at the RLP encoding
+        let account = node1.lData.rlpBlob.decode(Account)
+        node1.lData = PayloadRef(pType: LegacyAccount, legaAcc: account)
 
       if node != node1:
         check node == node1


### PR DESCRIPTION
why:
  For the main tree with root vertex ID 1, the leaf nodes hold the
  account data. These accounts may link to sub trees the storage root
  node ID of which must be registered here. There is no reverse key
  lookup on the backend.

note:
  These definitions are experimental. Also, there are some tests missing
  for validating Payload data conversions.