### PR TITLE
use axplicit 127.0.0.1 instead of localhost string for rpc related tests

### DIFF
--- a/hive_integration/nodocker/engine/auths_tests.nim
+++ b/hive_integration/nodocker/engine/auths_tests.nim
@@ -3,7 +3,7 @@ import
   test_env,
   unittest2,
   chronicles,
-  nimcrypto/[hmac, utils],
+  nimcrypto/[hmac],
   json_rpc/[rpcclient],
   ./types
 
@@ -28,7 +28,7 @@ proc getClient(t: TestEnv, token: string): RpcHttpClient =
     @[("Authorization", "Bearer " & token)]
 
   let client = newRpcHttpClient(getHeaders = authHeaders)
-  waitFor client.connect("localhost", t.conf.rpcPort, false)
+  waitFor client.connect("127.0.0.1", t.conf.rpcPort, false)
   return client
 
 template genAuthTest(procName: untyped, timeDriftSeconds: int64, customAuthSecretBytes: string, authOK: bool) =

--- a/hive_integration/nodocker/engine/engine_client.nim
+++ b/hive_integration/nodocker/engine/engine_client.nim
@@ -6,8 +6,7 @@ import
   json_rpc/[rpcclient, errors, jsonmarshal],
   ../../../tests/rpcclient/eth_api,
   ../../../premix/parser,
-  ../../../nimbus/rpc/hexstrings,
-  ../../../premix/parser
+  ../../../nimbus/rpc/hexstrings
 
 import web3/engine_api as web3_engine_api
 

--- a/hive_integration/nodocker/engine/engine_sim.nim
+++ b/hive_integration/nodocker/engine/engine_sim.nim
@@ -1,6 +1,5 @@
 import
   "."/[types, test_env, engine_tests, auths_tests],
-  unittest2,
   ../sim_utils
 
 proc combineTests(): seq[TestSpec] =

--- a/hive_integration/nodocker/engine/helper.nim
+++ b/hive_integration/nodocker/engine/helper.nim
@@ -1,10 +1,9 @@
 import
-  std/[typetraits, json],
+  std/[typetraits],
   nimcrypto/sysrand,
   test_env,
-  eth/[common,  rlp, keys],
+  eth/[common, rlp, keys],
   json_rpc/[rpcclient],
-  ../../../nimbus/rpc/hexstrings,
   ../../../nimbus/transaction
 
 import eth/common/eth_types as common_eth_types

--- a/hive_integration/nodocker/engine/test_env.nim
+++ b/hive_integration/nodocker/engine/test_env.nim
@@ -1,5 +1,5 @@
 import
-  std/[os, json, times, math],
+  std/[os, times, math],
   eth/keys,
   eth/p2p as eth_p2p,
   stew/[results, byteutils],
@@ -99,7 +99,7 @@ proc setupELClient*(t: TestEnv, chainFile: string, enableAuth: bool) =
               else:
                 @[]
 
-  t.rpcServer = newRpcHttpServer(["localhost:" & $t.conf.rpcPort], hooks)
+  t.rpcServer = newRpcHttpServer(["127.0.0.1:" & $t.conf.rpcPort], hooks)
   t.sealingEngine = SealingEngineRef.new(
     t.chainRef, t.ctx, t.conf.engineSigner,
     txPool, EngineStopped
@@ -120,7 +120,7 @@ proc setupELClient*(t: TestEnv, chainFile: string, enableAuth: bool) =
   t.rpcServer.start()
 
   t.rpcClient = newRpcHttpClient()
-  waitFor t.rpcClient.connect("localhost", t.conf.rpcPort, false)
+  waitFor t.rpcClient.connect("127.0.0.1", t.conf.rpcPort, false)
   t.gHeader = t.com.genesisHeader
 
   let kRes = PrivateKey.fromHex(vaultKeyHex)

--- a/hive_integration/nodocker/pyspec/test_env.nim
+++ b/hive_integration/nodocker/pyspec/test_env.nim
@@ -62,7 +62,7 @@ proc setupELClient*(t: TestEnv, conf: ChainConfig, node: JsonNode) =
   doAssert(t.com.db.getCanonicalHead().blockHash == genesisHeader.blockHash)
 
   let txPool  = TxPoolRef.new(t.com, engineSigner)
-  t.rpcServer = newRpcHttpServer(["localhost:8545"])
+  t.rpcServer = newRpcHttpServer(["127.0.0.1:8545"])
   t.sealingEngine = SealingEngineRef.new(
     t.chainRef, t.ctx, engineSigner,
     txPool, EngineStopped
@@ -76,7 +76,7 @@ proc setupELClient*(t: TestEnv, conf: ChainConfig, node: JsonNode) =
   t.rpcServer.start()
 
   t.rpcClient = newRpcHttpClient()
-  waitFor t.rpcClient.connect("localhost", 8545.Port, false)
+  waitFor t.rpcClient.connect("127.0.0.1", 8545.Port, false)
 
 proc stopELClient*(t: TestEnv) =
   waitFor t.rpcClient.close()

--- a/nimbus/rpc/engine_api.nim
+++ b/nimbus/rpc/engine_api.nim
@@ -166,11 +166,10 @@ proc handle_newPayload(sealingEngine: SealingEngineRef, api: EngineApiRef, com: 
 
   # We have an existing parent, do some sanity checks to avoid the beacon client
   # triggering too early
-  let
-    td  = db.getScore(header.parentHash)
-    ttd = com.ttd.get(high(common.BlockNumber))
+  let ttd = com.ttd.get(high(common.BlockNumber))
 
   when payload is ExecutionPayloadV1:
+    let td  = db.getScore(header.parentHash)
     if (not com.forkGTE(MergeFork)) and td < ttd:
       warn "Ignoring pre-merge payload",
         number = header.blockNumber, hash = blockHash, td, ttd

--- a/tests/test_merge.nim
+++ b/tests/test_merge.nim
@@ -90,7 +90,7 @@ proc runTest(steps: Steps) =
   com.initializeEmptyDb()
 
   var
-    rpcServer = newRpcSocketServer(["localhost:" & $conf.rpcPort])
+    rpcServer = newRpcSocketServer(["127.0.0.1:" & $conf.rpcPort])
     client = newRpcSocketClient()
     txPool = TxPoolRef.new(com, conf.engineSigner)
     sealingEngine = SealingEngineRef.new(
@@ -104,7 +104,7 @@ proc runTest(steps: Steps) =
 
   sealingEngine.start()
   rpcServer.start()
-  waitFor client.connect("localhost", conf.rpcPort)
+  waitFor client.connect("127.0.0.1", conf.rpcPort)
 
   suite "Engine API tests":
     for i, step in steps.list:

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -170,7 +170,7 @@ proc rpcMain*() =
     # Create Ethereum RPCs
     let RPC_PORT = 8545
     var
-      rpcServer = newRpcSocketServer(["localhost:" & $RPC_PORT])
+      rpcServer = newRpcSocketServer(["127.0.0.1:" & $RPC_PORT])
       client = newRpcSocketClient()
       txPool = TxPoolRef.new(com, conf.engineSigner)
 
@@ -179,7 +179,7 @@ proc rpcMain*() =
 
     # Begin tests
     rpcServer.start()
-    waitFor client.connect("localhost", Port(RPC_PORT))
+    waitFor client.connect("127.0.0.1", Port(RPC_PORT))
 
     # TODO: add more tests here
     test "web3_clientVersion":


### PR DESCRIPTION
on windows, using "localhost" for rpc test is very slow. both pyspec_sim and engine_sim will need more than one hour. while on linux and macos only few minutes.