### PR TITLE
Optimize EVM Mstore8 and memory.writePadded

### DIFF
--- a/nimbus/evm/interpreter/op_handlers/oph_memory.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_memory.nim
@@ -158,7 +158,7 @@ const
       reason = "MSTORE8: GasVeryLow + memory expansion")
 
     k.cpt.memory.extend(memPos, 1)
-    k.cpt.memory.write(memPos, [value.toByteArrayBE[31]])
+    k.cpt.memory.write(memPos, value.toByteArrayBE[31])
 
   # -------
 


### PR DESCRIPTION
- mstore8 operation is simplified using one byte writer
- refactor writePadded and avoid unecessary allocations

fix #67