### PR TITLE
EVM embrace more EVMC types

### DIFF
--- a/nimbus/evm/evmc_api.nim
+++ b/nimbus/evm/evmc_api.nim
@@ -33,7 +33,7 @@ type
 
   nimbus_message* = object
     kind*        : evmc_call_kind
-    flags*       : uint32
+    flags*       : evmc_flags
     depth*       : int32
     gas*         : int64
     recipient*   : EthAddress

--- a/nimbus/evm/interpreter/op_handlers/oph_call.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_call.nim
@@ -142,7 +142,7 @@ proc staticCallParams(c: Computation):  LocalParams =
 
   result.value           = 0.u256
   result.sender          = c.msg.contractAddress
-  result.flags           = emvcStatic
+  result.flags.incl        EVMC_STATIC
   result.contractAddress = result.codeAddress
 
   result.updateStackAndParams(c)
@@ -196,7 +196,7 @@ const
     ## 0xf1, Message-Call into an account
     let cpt = k.cpt
 
-    if emvcStatic == cpt.msg.flags and cpt.stack[^3, UInt256] > 0.u256:
+    if EVMC_STATIC in cpt.msg.flags and cpt.stack[^3, UInt256] > 0.u256:
       raise newException(
         StaticContextError,
         "Cannot modify state while inside of a STATICCALL context")
@@ -248,7 +248,7 @@ const
             msg = new(nimbus_message)
             c   = cpt
           msg[] = nimbus_message(
-            kind        : evmcCall.ord.evmc_call_kind,
+            kind        : EVMC_CALL,
             depth       : (cpt.msg.depth + 1).int32,
             gas         : childGasLimit,
             sender      : p.sender,
@@ -257,7 +257,7 @@ const
             input_data  : cpt.memory.readPtr(p.memInPos),
             input_size  : p.memInLen.uint,
             value       : toEvmc(p.value),
-            flags       : p.flags.uint32
+            flags       : p.flags
           )
           c.execSubCall(msg, p)
         else:
@@ -265,7 +265,7 @@ const
             memPos = p.memOutPos,
             memLen = p.memOutLen,
             childMsg = Message(
-              kind:            evmcCall,
+              kind:            EVMC_CALL,
               depth:           cpt.msg.depth + 1,
               gas:             childGasLimit,
               sender:          p.sender,
@@ -327,7 +327,7 @@ const
             msg = new(nimbus_message)
             c   = cpt
           msg[] = nimbus_message(
-            kind        : evmcCallCode.ord.evmc_call_kind,
+            kind        : EVMC_CALLCODE,
             depth       : (cpt.msg.depth + 1).int32,
             gas         : childGasLimit,
             sender      : p.sender,
@@ -336,7 +336,7 @@ const
             input_data  : cpt.memory.readPtr(p.memInPos),
             input_size  : p.memInLen.uint,
             value       : toEvmc(p.value),
-            flags       : p.flags.uint32
+            flags       : p.flags
           )
           c.execSubCall(msg, p)
         else:
@@ -344,7 +344,7 @@ const
             memPos = p.memOutPos,
             memLen = p.memOutLen,
             childMsg = Message(
-              kind:            evmcCallCode,
+              kind:            EVMC_CALLCODE,
               depth:           cpt.msg.depth + 1,
               gas:             childGasLimit,
               sender:          p.sender,
@@ -401,7 +401,7 @@ const
             msg = new(nimbus_message)
             c   = cpt
           msg[] = nimbus_message(
-            kind        : evmcDelegateCall.ord.evmc_call_kind,
+            kind        : EVMC_DELEGATECALL,
             depth       : (cpt.msg.depth + 1).int32,
             gas         : childGasLimit,
             sender      : p.sender,
@@ -410,7 +410,7 @@ const
             input_data  : cpt.memory.readPtr(p.memInPos),
             input_size  : p.memInLen.uint,
             value       : toEvmc(p.value),
-            flags       : p.flags.uint32
+            flags       : p.flags
           )
           c.execSubCall(msg, p)
         else:
@@ -418,7 +418,7 @@ const
             memPos = p.memOutPos,
             memLen = p.memOutLen,
             childMsg = Message(
-              kind:            evmcDelegateCall,
+              kind:            EVMC_DELEGATECALL,
               depth:           cpt.msg.depth + 1,
               gas:             childGasLimit,
               sender:          p.sender,
@@ -476,7 +476,7 @@ const
             msg = new(nimbus_message)
             c   = cpt
           msg[] = nimbus_message(
-            kind        : evmcCall.ord.evmc_call_kind,
+            kind        : EVMC_CALL,
             depth       : (cpt.msg.depth + 1).int32,
             gas         : childGasLimit,
             sender      : p.sender,
@@ -485,7 +485,7 @@ const
             input_data  : cpt.memory.readPtr(p.memInPos),
             input_size  : p.memInLen.uint,
             value       : toEvmc(p.value),
-            flags       : p.flags.uint32
+            flags       : p.flags
           )
           c.execSubCall(msg, p)
         else:
@@ -493,7 +493,7 @@ const
             memPos = p.memOutPos,
             memLen = p.memOutLen,
             childMsg = Message(
-              kind:            evmcCall,
+              kind:            EVMC_CALL,
               depth:           cpt.msg.depth + 1,
               gas:             childGasLimit,
               sender:          p.sender,

--- a/nimbus/evm/interpreter/op_handlers/oph_create.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_create.nim
@@ -140,7 +140,7 @@ const
         msg = new(nimbus_message)
         c   = cpt
       msg[] = nimbus_message(
-        kind: evmcCreate.ord.evmc_call_kind,
+        kind: EVMC_CREATE,
         depth: (cpt.msg.depth + 1).int32,
         gas: createMsgGas,
         sender: cpt.msg.contractAddress,
@@ -153,7 +153,7 @@ const
     else:
       cpt.execSubCreate(
         childMsg = Message(
-          kind:   evmcCreate,
+          kind:   EVMC_CREATE,
           depth:  cpt.msg.depth + 1,
           gas:    createMsgGas,
           sender: cpt.msg.contractAddress,
@@ -222,7 +222,7 @@ const
         msg = new(nimbus_message)
         c   = cpt
       msg[] = nimbus_message(
-        kind: evmcCreate2.ord.evmc_call_kind,
+        kind: EVMC_CREATE2,
         depth: (cpt.msg.depth + 1).int32,
         gas: createMsgGas,
         sender: cpt.msg.contractAddress,
@@ -236,7 +236,7 @@ const
       cpt.execSubCreate(
         salt = salt,
         childMsg = Message(
-          kind:   evmcCreate2,
+          kind:   EVMC_CREATE2,
           depth:  cpt.msg.depth + 1,
           gas:    createMsgGas,
           sender: cpt.msg.contractAddress,

--- a/nimbus/evm/interpreter/op_handlers/oph_helpers.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_helpers.nim
@@ -20,7 +20,6 @@ import
   ../gas_costs,
   eth/common,
   eth/common/eth_types,
-  macros,
   stint
 
 when defined(evmc_enabled):
@@ -64,7 +63,7 @@ proc gasEip2929AccountCheck*(c: Computation; address: EthAddress, slot: UInt256)
 
 template checkInStaticContext*(c: Computation) =
   ## Verify static context in handler function, raise an error otherwise
-  if emvcStatic == c.msg.flags:
+  if EVMC_STATIC in c.msg.flags:
     # TODO: if possible, this check only appear
     # when fork >= FkByzantium
     raise newException(

--- a/nimbus/evm/interpreter/op_handlers/oph_memory.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_memory.nim
@@ -21,7 +21,6 @@ import
   ../../stack,
   ../../types,
   ../gas_costs,
-  ../gas_meter,
   ../op_codes,
   ../utils/utils_numeric,
   ./oph_defs,
@@ -33,6 +32,7 @@ import
 
 when not defined(evmc_enabled):
   import
+    ../gas_meter,
     ../../state,
     ../../../db/accounts_cache
 

--- a/nimbus/evm/interpreter/op_handlers/oph_sysops.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_sysops.nim
@@ -64,7 +64,7 @@ const
     k.cpt.memory.extend(pos, len)
     k.cpt.output = k.cpt.memory.read(pos, len)
     # setError(msg, false) will signal cheap revert
-    k.cpt.setError("REVERT opcode executed", false)
+    k.cpt.setError(EVMC_REVERT, "REVERT opcode executed", false)
 
 
   invalidOp: Vm2OpFn = proc(k: var Vm2Ctx) =

--- a/nimbus/evm/message.nim
+++ b/nimbus/evm/message.nim
@@ -11,4 +11,4 @@
 import ./types
 
 proc isCreate*(message: Message): bool =
-  message.kind in {evmcCreate, evmcCreate2}
+  message.kind in {EVMC_CREATE, EVMC_CREATE2}

--- a/nimbus/evm/state.nim
+++ b/nimbus/evm/state.nim
@@ -35,7 +35,6 @@ proc init(
       asyncFactory: AsyncOperationFactory = AsyncOperationFactory(maybeDataSource: none[AsyncDataSource]()))
     {.gcsafe.} =
   ## Initialisation helper
-  self.prevHeaders = @[]
   self.parent = parent
   self.timestamp = timestamp
   self.gasLimit = gasLimit
@@ -296,17 +295,6 @@ method getAncestorHash*(
     result = db.headerHash(blockNumber.truncate(uint64))
   else:
     result = db.getBlockHash(blockNumber)
-
-  #TODO: should we use deque here?
-  # someday we may revive this code when
-  # we already have working miner
-  when false:
-    let idx = ancestorDepth.toInt
-    if idx >= vmState.prevHeaders.len:
-      return
-
-    var header = vmState.prevHeaders[idx]
-    result = header.hash
 
 proc readOnlyStateDB*(vmState: BaseVMState): ReadOnlyStateDB {.inline.} =
   ReadOnlyStateDB(vmState.stateDB)

--- a/nimbus/evm/tracer/legacy_tracer.nim
+++ b/nimbus/evm/tracer/legacy_tracer.nim
@@ -37,16 +37,6 @@ iterator storage(ctx: LegacyTracer, compDepth: int): UInt256 =
   for key in ctx.storageKeys[compDepth]:
     yield key
 
-template stripLeadingZeros(value: string): string =
-  var cidx = 0
-  # ignore the last character so we retain '0' on zero value
-  while cidx < value.len - 1 and value[cidx] == '0':
-    cidx.inc
-  value[cidx .. ^1]
-
-proc encodeHexInt(x: SomeInteger): JsonNode =
-  %("0x" & x.toHex.stripLeadingZeros.toLowerAscii)
-
 proc newLegacyTracer*(flags: set[TracerFlags]): LegacyTracer =
   let trace = newJObject()
 

--- a/nimbus/evm/types.nim
+++ b/nimbus/evm/types.nim
@@ -17,6 +17,14 @@ import
   ../db/accounts_cache,
   ../common/[common, evmforks]
 
+# this import not guarded by `when defined(evmc_enabled)`
+# because we want to use evmc types such as evmc_call_kind
+# and evmc_flags
+import
+  evmc/evmc
+
+export evmc
+
 {.push raises: [].}
 
 when defined(evmc_enabled):
@@ -35,27 +43,26 @@ type
     ClearCache
 
   BaseVMState* = ref object of RootObj
-    prevHeaders*   : seq[BlockHeader]
-    com*           : CommonRef
-    gasPool*       : GasInt
-    parent*        : BlockHeader
-    timestamp*     : EthTime
-    gasLimit*      : GasInt
-    fee*           : Option[UInt256]
-    prevRandao*    : Hash256
-    blockDifficulty*: UInt256
-    flags*         : set[VMFlag]
-    tracer*        : TracerRef
-    receipts*      : seq[Receipt]
-    stateDB*       : AccountsCache
+    com*              : CommonRef
+    gasPool*          : GasInt
+    parent*           : BlockHeader
+    timestamp*        : EthTime
+    gasLimit*         : GasInt
+    fee*              : Option[UInt256]
+    prevRandao*       : Hash256
+    blockDifficulty*  : UInt256
+    flags*            : set[VMFlag]
+    tracer*           : TracerRef
+    receipts*         : seq[Receipt]
+    stateDB*          : AccountsCache
     cumulativeGasUsed*: GasInt
-    txOrigin*      : EthAddress
-    txGasPrice*    : GasInt
+    txOrigin*         : EthAddress
+    txGasPrice*       : GasInt
     txVersionedHashes*: VersionedHashes
-    gasCosts*      : GasCosts
-    fork*          : EVMFork
-    minerAddress*  : EthAddress
-    asyncFactory*  : AsyncOperationFactory
+    gasCosts*         : GasCosts
+    fork*             : EVMFork
+    minerAddress*     : EthAddress
+    asyncFactory*     : AsyncOperationFactory
 
   Computation* = ref object
     # The execution computation
@@ -82,23 +89,17 @@ type
     continuation*:          proc() {.gcsafe, raises: [CatchableError].}
 
   Error* = ref object
-    info*:                  string
-    burnsGas*:              bool
+    statusCode*: evmc_status_code
+    info*      : string
+    burnsGas*  : bool
 
   GasMeter* = object
     gasRefunded*: GasInt
     gasRemaining*: GasInt
 
-  CallKind* = enum
-    evmcCall         = 0, # CALL
-    evmcDelegateCall = 1, # DELEGATECALL
-    evmcCallCode     = 2, # CALLCODE
-    evmcCreate       = 3, # CREATE
-    evmcCreate2      = 4  # CREATE2
+  CallKind* = evmc_call_kind
 
-  MsgFlags* = enum
-    emvcNoFlags  = 0
-    emvcStatic   = 1
+  MsgFlags* = evmc_flags
 
   Message* = ref object
     kind*:             CallKind

--- a/nimbus/transaction/evmc_host_glue.nim
+++ b/nimbus/transaction/evmc_host_glue.nim
@@ -83,11 +83,11 @@ proc accessStorage(p: evmc_host_context, address: var evmc_address,
 
 proc getTransientStorage(p: evmc_host_context, address: var evmc_address,
                 key: var evmc_bytes32): evmc_bytes32
-    {.cdecl, raises: [RlpError].} =
+    {.cdecl, raises: [].} =
   toHost(p).getTransientStorage(address.fromEvmc, key.flip256.fromEvmc).toEvmc.flip256
 
 proc setTransientStorage(p: evmc_host_context, address: var evmc_address,
-                key, value: var evmc_bytes32) {.cdecl, raises: [RlpError].} =
+                key, value: var evmc_bytes32) {.cdecl, raises: [].} =
   toHost(p).setTransientStorage(address.fromEvmc, key.flip256.fromEvmc, value.flip256.fromEvmc)
 
 let hostInterface = evmc_host_interface(

--- a/nimbus/transaction/evmc_vm_glue.nim
+++ b/nimbus/transaction/evmc_vm_glue.nim
@@ -9,7 +9,7 @@
 {.push raises: [].}
 
 import
-  ./host_types, evmc/evmc, stew/ranges/ptr_arith,
+  ./host_types, evmc/evmc,
   ".."/[vm_types, vm_computation, vm_state_transactions]
 
 proc evmcReleaseResult(result: var evmc_result) {.cdecl.} =
@@ -56,9 +56,7 @@ proc evmcExecute(vm: ptr evmc_vm, hostInterface: ptr evmc_host_interface,
 
   return evmc_result(
     # Standard EVMC result, if a bit generic.
-    status_code: if c.isSuccess:            EVMC_SUCCESS
-                 elif not c.error.burnsGas: EVMC_REVERT
-                 else:                      EVMC_FAILURE,
+    status_code: c.statusCode,
     # Gas left is required to be zero when not `EVMC_SUCCESS` or `EVMC_REVERT`.
     gas_left:    if result.status_code notin {EVMC_SUCCESS, EVMC_REVERT}: 0'i64
                  else: c.gasMeter.gasRemaining.int64,

--- a/nimbus/transaction/host_call_nested.nim
+++ b/nimbus/transaction/host_call_nested.nim
@@ -43,7 +43,7 @@ proc afterExecCreateEvmcNested(host: TransactionHost, child: Computation,
     res.status_code = EVMC_SUCCESS
     res.create_address = child.msg.contractAddress.toEvmc
   else:
-    res.status_code = if child.shouldBurnGas: EVMC_FAILURE else: EVMC_REVERT
+    res.status_code = child.statusCode
     if child.output.len > 0:
       # TODO: can we move the ownership of seq to raw pointer?
       res.output_size = child.output.len.uint
@@ -65,7 +65,7 @@ proc beforeExecCallEvmcNested(host: TransactionHost,
                        host.computation.msg.contractAddress,
     value: m.value.fromEvmc,
     data: @(makeOpenArray(m.inputData, m.inputSize.int)),
-    flags: if m.isStatic: emvcStatic else: emvcNoFlags,
+    flags: m.flags,
   )
   return newComputation(host.vmState, childMsg)
 
@@ -78,7 +78,7 @@ proc afterExecCallEvmcNested(host: TransactionHost, child: Computation,
     host.computation.merge(child)
     res.status_code = EVMC_SUCCESS
   else:
-    res.status_code = if child.shouldBurnGas: EVMC_FAILURE else: EVMC_REVERT
+    res.status_code = child.statusCode
 
   if child.output.len > 0:
     # TODO: can we move the ownership of seq to raw pointer?

--- a/nimbus/transaction/host_services.nim
+++ b/nimbus/transaction/host_services.nim
@@ -9,7 +9,7 @@
 #{.push raises: [].}
 
 import
-  sets, times, stint, chronicles,
+  times, stint, chronicles,
   eth/common/eth_types, ../db/accounts_cache,
   ../common/[evmforks, common],
   ".."/[vm_state, vm_computation, vm_internals, vm_gas_costs],

--- a/nimbus/transaction/host_types.nim
+++ b/nimbus/transaction/host_types.nim
@@ -88,9 +88,6 @@ template flip256*(word256: evmc_uint256be): evmc_uint256be =
 template isCreate*(kind: EvmcCallKind): bool =
   kind in {EVMC_CREATE, EVMC_CREATE2}
 
-template isStatic*(msg: EvmcMessage): bool =
-  EVMC_STATIC in msg.flags
-
 template isZero*(n: evmc_bytes32): bool =
   n == default(evmc_bytes32)
 

--- a/nimbus/vm_computation.nim
+++ b/nimbus/vm_computation.nim
@@ -8,9 +8,6 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-
-# The VM computation module suffers from a circular include/import dependency.
-# After fixing this wrapper should be re-factored.
 import
   ./evm/computation as vmc,
   ./evm/interpreter_dispatch as vmi
@@ -57,6 +54,8 @@ export
   vmc.traceOpCodeEnded,
   vmc.traceOpCodeStarted,
   vmc.tracingEnabled,
-  vmc.writeContract
+  vmc.writeContract,
+  vmc.statusCode,
+  vmc.errorOpt
 
 # End


### PR DESCRIPTION
Also embed evmc_status_code to computation.error, and make the tracer produce cleaner output. No more "Revert opcode executed" error message. We can distinguish error code between REVERT and FAILURE in a more cleaner way.