### PR TITLE
Allow EVM dispatcher to use different GasCostKind for each fork

### DIFF
--- a/nimbus/evm/interpreter/gas_costs.nim
+++ b/nimbus/evm/interpreter/gas_costs.nim
@@ -866,6 +866,31 @@ gasCosts(FkBerlin, berlin, BerlinGasCosts)
 gasCosts(FkLondon, london, LondonGasCosts)
 gasCosts(FkShanghai, shanghai, ShanghaiGasCosts)
 
+type
+  OpGck* = array[Op, GasCostKind]
+
+func opGck(gc: GasCosts): OpGck {.compileTime.} =
+  for op, x in gc:
+    result[op] = x.kind
+
+# Map fork to GasCostKind
+# used in op_dispatcher.nim
+const forkToGck*: array[EVMFork, OpGck] = [
+  opGck BaseGasCosts          , # FkFrontier
+  opGck HomesteadGasCosts     , # FkHomestead
+  opGck TangerineGasCosts     , # kTangerine
+  opGck SpuriousGasCosts      , # FkSpurious
+  opGck SpuriousGasCosts      , # FkByzantium
+  opGck ConstantinopleGasCosts, # FkConstantinople
+  opGck SpuriousGasCosts      , # FkPetersburg
+  opGck IstanbulGasCosts      , # FkIstanbul
+  opGck BerlinGasCosts        , # FkBerlin
+  opGck LondonGasCosts        , # FkLondon
+  opGck LondonGasCosts        , # FkParis
+  opGck ShanghaiGasCosts      , # FkShanghai
+  opGck ShanghaiGasCosts      , # FkCancun
+  ]
+
 proc forkToSchedule*(fork: EVMFork): GasCosts =
   if fork < FkHomestead:
     BaseGasCosts

--- a/nimbus/evm/interpreter/op_dispatcher.nim
+++ b/nimbus/evm/interpreter/op_dispatcher.nim
@@ -83,12 +83,13 @@ proc toCaseStmt(forkArg, opArg, k: NimNode): NimNode =
     var forkCaseSubExpr = nnkCaseStmt.newTree(branchOnFork)
     for fork in EVMFork:
       let asFork = quote do: EVMFork(`fork`)
+      let gcTable = forkToGck[fork]
 
       let branchStmt = block:
         if op == Stop:
           quote do:
             handleStopDirective(`k`)
-        elif BaseGasCosts[op].kind == GckFixed:
+        elif gcTable[op] == GckFixed:
           quote do:
             handleFixedGasCostsDirective(`asFork`,`asOp`,`k`)
         else:

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -212,13 +212,20 @@ proc runExecution(ctx: var StateContext, conf: StateConf, pre: JsonNode): StateR
     if conf.jsonEnabled:
       writeRootHashToStderr(vmState)
 
-  let rc = vmState.processTransaction(
-                ctx.tx, sender, ctx.header, fork)
-  if rc.isOk:
-    gasUsed = rc.value
-
-  let miner = ctx.header.coinbase
-  coinbaseStateClearing(vmState, miner, fork)
+  try:
+    let rc = vmState.processTransaction(
+                  ctx.tx, sender, ctx.header, fork)
+    if rc.isOk:
+      gasUsed = rc.value
+  
+    let miner = ctx.header.coinbase
+    coinbaseStateClearing(vmState, miner, fork)
+  except CatchableError as ex:
+    echo "FATAL: ", ex.msg
+    quit(QuitFailure)
+  except AssertionDefect as ex:
+    echo "FATAL: ", ex.msg
+    quit(QuitFailure)
 
 proc toTracerFlags(conf: Stateconf): set[TracerFlags] =
   result = {


### PR DESCRIPTION
Why?
Some opcodes such as labeled EIP-2929 changed their behavior from fixed gas cost to dynamic gas cost.

This changes together with #1715 and #1717 will make the new EVM tracer to produce trace result identical to geth.

Fix #1721 