### PR TITLE
Fix Nim binaries cache key of main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
           runner.os == 'Windows'
         run: |
           echo '${{ github.workspace }}'"/external/mingw-${{ matrix.target.cpu }}/bin" >> $GITHUB_PATH
-          echo '${{ github.workspace }}'"/external/dlls-${{ matrix.target.cpu }}" >> $GITHUB_PATH          
+          echo '${{ github.workspace }}'"/external/dlls-${{ matrix.target.cpu }}" >> $GITHUB_PATH
 
       - name: Get latest nimbus-build-system commit hash
         id: versions
@@ -237,7 +237,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: NimBinCache
-          key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}'
+          key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}-${{ matrix.target.evmc }}'
 
       - name: Build Nim and Nimbus-eth1 dependencies
         run: |

--- a/.github/workflows/simulators.yml
+++ b/.github/workflows/simulators.yml
@@ -119,6 +119,11 @@ jobs:
           curl -L "$MINGW_URL" -o "external/mingw-amd64.zip"
           7z x -y "external/mingw-amd64.zip" -oexternal/mingw-amd64/
           mv external/mingw-amd64/**/* ./external/mingw-amd64
+
+      - name: Path to cached dependencies (Windows)
+        if: >
+          runner.os == 'Windows'
+        run: |
           echo '${{ github.workspace }}'"/external/mingw-amd64/bin" >> $GITHUB_PATH
 
       - name: Get latest nimbus-build-system commit hash


### PR DESCRIPTION
Why:
Multiple CI share the same cache key will fail to save the cached files.

Also:
Fix simulators CI path to cached llvm-mingw on windows.