### PR TITLE
Improvements to portal beacon network

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -180,7 +180,8 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
             beaconLightClientDb,
             streamManager,
             networkData.forks,
-            bootstrapRecords = bootstrapRecords)
+            bootstrapRecords = bootstrapRecords,
+            portalConfig = portalConfig)
 
         let lc = LightClient.new(
           lightClientNetwork, rng, networkData,


### PR DESCRIPTION
- Adjust beacon lc db to avoid requirement of pruning optimistic and finality updates
- Enable Portal config for beacon chain network to apply IP limits configs on routing table