### PR TITLE
Use signature slot instead of attested header slot

### DIFF
--- a/fluffy/network/beacon_light_client/beacon_light_client_manager.nim
+++ b/fluffy/network/beacon_light_client/beacon_light_client_manager.nim
@@ -330,7 +330,7 @@ proc loop(self: LightClientManager) {.async.} =
           let finalizedSlot = start_slot(epoch(wallTime.slotOrZero()) - 2)
           await self.query(FinalityUpdate, finalizedSlot)
         of LcSyncKind.OptimisticUpdate:
-          let optimisticSlot = wallTime.slotOrZero() - 1
+          let optimisticSlot = wallTime.slotOrZero()
           await self.query(OptimisticUpdate, optimisticSlot)
 
     nextSyncTaskTime = wallTime + self.rng.nextLcSyncTaskDelay(

--- a/fluffy/tests/beacon_light_client_tests/test_beacon_light_client_content.nim
+++ b/fluffy/tests/beacon_light_client_tests/test_beacon_light_client_content.nim
@@ -170,7 +170,7 @@ suite "Beacon Light Client Content Encodings - Mainnet":
       let key = contentKey.value()
       withForkyObject(update):
         when lcDataFork > LightClientDataFork.None:
-          check forkyObject.attested_header.beacon.slot ==
+          check forkyObject.signature_slot ==
             key.lightClientOptimisticUpdateKey.optimisticSlot
 
       # re-encode content and content key

--- a/fluffy/tests/beacon_light_client_tests/test_beacon_light_client_network.nim
+++ b/fluffy/tests/beacon_light_client_tests/test_beacon_light_client_network.nim
@@ -90,7 +90,7 @@ procSuite "Beacon Light Client Content Network":
         lightClientOptimisticUpdateBytes, altair.LightClientOptimisticUpdate)
       optimisticUpdate = ForkedLightClientOptimisticUpdate(
         kind: LightClientDataFork.Altair, altairData: optimisticUpdateData)
-      optimisticHeaderSlot = optimisticUpdateData.attested_header.beacon.slot
+      optimisticHeaderSlot = optimisticUpdateData.signature_slot
 
       finalityUpdateKey = finalityUpdateContentKey(
         distinctBase(finalizedHeaderSlot)

--- a/fluffy/tools/beacon_chain_bridge/beacon_chain_bridge.nim
+++ b/fluffy/tools/beacon_chain_bridge/beacon_chain_bridge.nim
@@ -231,7 +231,7 @@ proc gossipLCOptimisticUpdate*(
   withForkyObject(update):
     when lcDataFork > LightClientDataFork.None:
       let
-        slot = forkyObject.attested_header.beacon.slot
+        slot = forkyObject.signature_slot
         contentKey = encode(optimisticUpdateContentKey(slot.uint64))
         forkDigest = forkDigestAtEpoch(
           forkDigests[], epoch(forkyObject.attested_header.beacon.slot), cfg)

--- a/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
+++ b/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
@@ -615,7 +615,7 @@ proc run(config: BeaconBridgeConf) {.raises: [CatchableError].} =
           update, slot = forkyObject.attested_header.beacon.slot
 
         let
-          slot = forkyObject.attested_header.beacon.slot
+          slot = forkyObject.signature_slot
           contentKey = encode(optimisticUpdateContentKey(slot.uint64))
           contentId = beacon_light_client_content.toContentId(contentKey)
           forkDigest = forkDigestAtEpoch(

--- a/fluffy/tools/eth_data_exporter/cl_data_exporter.nim
+++ b/fluffy/tools/eth_data_exporter/cl_data_exporter.nim
@@ -264,7 +264,7 @@ proc exportLCOptimisticUpdate*(
   withForkyObject(update):
     when lcDataFork > LightClientDataFork.None:
       let
-        slot = forkyObject.attested_header.beacon.slot
+        slot = forkyObject.signature_slot
         contentKey = encode(optimisticUpdateContentKey(slot.uint64))
         contentId = beacon_light_client_content.toContentId(contentKey)
         forkDigest = forkDigestAtEpoch(


### PR DESCRIPTION
Use signature slot instead of attested header slot in the OptimisticUpdate content key.