### PR TITLE
Implement safe and finalized tag for eth_getBlockByNumber

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -265,7 +265,8 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
       rpcHttpServerWithProxy.installPortalApiHandlers(
         stateNetwork.get().portalProtocol, "state")
     if historyNetwork.isSome():
-      rpcHttpServerWithProxy.installEthApiHandlers(historyNetwork.get())
+      rpcHttpServerWithProxy.installEthApiHandlers(
+        historyNetwork.get(), beaconLightClient)
       rpcHttpServerWithProxy.installPortalApiHandlers(
         historyNetwork.get().portalProtocol, "history")
       rpcHttpServerWithProxy.installPortalDebugApiHandlers(

--- a/fluffy/network/beacon_light_client/beacon_light_client.nim
+++ b/fluffy/network/beacon_light_client/beacon_light_client.nim
@@ -32,7 +32,7 @@ type
     cfg: RuntimeConfig
     forkDigests: ref ForkDigests
     getBeaconTime*: GetBeaconTimeFn
-    store: ref ForkedLightClientStore
+    store*: ref ForkedLightClientStore
     processor*: ref LightClientProcessor
     manager: LightClientManager
     onFinalizedHeader*, onOptimisticHeader*: LightClientHeaderCallback


### PR DESCRIPTION
Only available when running the beacon LC and the portal beacon network.