### PR TITLE
Add chronicles formatters for aristo db types

### DIFF
--- a/.github/workflows/fluffy.yml
+++ b/.github/workflows/fluffy.yml
@@ -1,3 +1,10 @@
+# Nimbus
+# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 name: fluffy CI
 on:
   push:
@@ -8,6 +15,7 @@ on:
       - '!fluffy/docs/**'
       - 'nimbus/rpc/hexstrings.nim'
       - 'nimbus/rpc/rpc_*.nim'
+      - 'nimbus/db/**'
       - 'vendor/**'
       - 'Makefile'
       - 'nimbus.nimble'
@@ -20,6 +28,7 @@ on:
       - '!fluffy/docs/**'
       - 'nimbus/rpc/hexstrings.nim'
       - 'nimbus/rpc/rpc_*.nim'
+      - 'nimbus/db/**'
       - 'vendor/**'
       - 'Makefile'
       - 'nimbus.nimble'

--- a/nimbus/db/aristo/aristo_desc/desc_identifiers.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_identifiers.nim
@@ -18,6 +18,7 @@ import
   std/[sequtils, strutils, hashes],
   eth/[common, trie/nibbles],
   stew/byteutils,
+  chronicles,
   results,
   stint
 
@@ -96,6 +97,13 @@ type
     ## tables.
     root*: VertexID                  ## Root ID for the sub-trie.
     key*: HashKey                     ## Merkle hash or encoded small node data
+
+# ------------------------------------------------------------------------------
+# Chronicles formatters
+# ------------------------------------------------------------------------------
+
+chronicles.formatIt(VertexID): $it
+chronicles.formatIt(QueueID): $it
 
 # ------------------------------------------------------------------------------
 # Private helpers


### PR DESCRIPTION
The Fluffy build is currently broken due to aristo db changes:

```
...
/home/deme/repos/nimbus-eth1/nimbus/db/aristo/aristo_init/memory_db.nim(89, 17) template/generic instantiation of `debug` from here
/home/deme/repos/nimbus-eth1/vendor/nim-chronicles/chronicles.nim(365, 10) template/generic instantiation of `log` from here
/home/deme/repos/nimbus-eth1/nimbus/db/aristo/aristo_init/memory_db.nim(89, 66) template/generic instantiation of `expandItIMPL` from here
/home/deme/repos/nimbus-eth1/vendor/nim-chronicles/chronicles/log_output.nim(748, 39) template/generic instantiation of `setProperty` from here
/home/deme/repos/nimbus-eth1/vendor/nim-chronicles/chronicles/log_output.nim(685, 10) template/generic instantiation of `[]=` from here
/home/deme/repos/nimbus-eth1/vendor/nim-chronicles/chronicles/log_output.nim(658, 17) template/generic instantiation of `writeField` from here
/home/deme/repos/nimbus-eth1/vendor/nim-json-serialization/json_serialization/writer.nim(73, 4) template/generic instantiation of `writeValue` from here
/home/deme/repos/nimbus-eth1/vendor/nim-json-serialization/json_serialization/writer.nim(249, 12) Error: fatal error: Failed to convert to JSON an unsupported type: VertexID
make: *** [Makefile:241: fluffy] Error 1
```

This is due to some types used in aristo not having a formatter and failing for JSON sink.

How was this not seen in CI?
The `db` directory was never added to the fluffy CI trigger paths when core_db import was added (used in history_network).
This was now added also in this PR.

Why aristo? 
`core_db` seems to import aristo.

Why no issue compiling Nimbus?
I'm assuming Nimbus never gets tested in CI compiling with a JSON sink.