### PR TITLE
Adjust storage capacity option

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -38,10 +38,8 @@ const
   defaultAdminListenAddressDesc = $defaultAdminListenAddress
   defaultDataDirDesc = defaultDataDir()
   defaultClientConfigDesc = $(defaultClientConfig.httpUri)
-  # 100mb seems a bit smallish we may consider increasing defaults after some
-  # network measurements
-  defaultStorageSize* = uint32(1000 * 1000 * 100)
-  defaultStorageSizeDesc* = $defaultStorageSize
+  defaultStorageCapacity* = 2000'u32 # 2 GB default
+  defaultStorageCapacityDesc* = $defaultStorageCapacity
 
   defaultTableIpLimitDesc* =
     $defaultPortalProtocolConfig.tableIpLimits.tableIpLimit
@@ -220,12 +218,12 @@ type
 
     # TODO maybe it is worth defining minimal storage size and throw error if
     # value provided is smaller than minimum
-    storageSize* {.
-      desc: "Maximum amount (in bytes) of content which will be stored " &
+    storageCapacityMB* {.
+      desc: "Maximum amount (in megabytes) of content which will be stored " &
             "in the local database."
-      defaultValue: defaultStorageSize
-      defaultValueDesc: $defaultStorageSizeDesc
-      name: "storage-size" .}: uint32
+      defaultValue: defaultStorageCapacity
+      defaultValueDesc: $defaultStorageCapacityDesc
+      name: "storage-capacity" .}: uint64
 
     trustedBlockRoot* {.
       desc: "Recent trusted finalized block root to initialize the consensus light client from. " &

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -129,7 +129,7 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
   let
     db = ContentDB.new(config.dataDir / "db" / "contentdb_" &
       d.localNode.id.toBytesBE().toOpenArray(0, 8).toHex(),
-      maxSize = config.storageSize)
+      storageCapacity = config.storageCapacityMB * 1_000_000)
 
     portalConfig = PortalProtocolConfig.init(
       config.tableIpLimit,


### PR DESCRIPTION
- Rename storage-size to storage capacity
- Change type to uint64 to avoid potential wrap around
- Change to MB instead of KB and set default to 2GB