### PR TITLE
Lower the content deletion fraction and other contentdb clean-up

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -1115,7 +1115,7 @@ proc traceContentLookup*(p: PortalProtocol, target: ByteList, targetId: UInt256)
   seen.incl(p.baseProtocol.localNode.id) # No need to discover our own node
   for node in closestNodes:
     seen.incl(node.id)
-  
+
   # Local node should be part of the responses
   responses["0x" & $p.localNode.id] = TraceResponse(
     durationMs: 0,
@@ -1223,10 +1223,10 @@ proc traceContentLookup*(p: PortalProtocol, target: ByteList, targetId: UInt256)
 
       of Content:
         let duration = chronos.milliseconds(now(chronos.Moment) - ts)
-        
+
         # cancel any pending queries as the content has been found
         for f in pendingQueries:
-          f.cancel()
+          f.cancelSoon()
         portal_lookup_content_requests.observe(requestAmount)
 
         let distance = p.routingTable.distance(content.src.id, targetId)


### PR DESCRIPTION
- The current setting of 0.25 was very big. Set to 0.05, which is potentially still large. This change did expose some issues with the current implementation and especially testing.
- General clean-up, renaming for consistency, and re-ordering/restructuring/deletion of some code.
- Fixed several typos
- ...