### PR TITLE
Adjust cron schedule for Fluffy nightly Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,16 @@
 name: Nimbus CI
 on:
   push:
-    paths-ignore: ['doc/**', 'docs/**', '**/*.md', 'hive_integration/**',
-      'fluffy/**', '.github/workflows/fluffy.yml',
-      'nimbus_verified_proxy/**', '.github/workflows/nimbus_verified_proxy.yml',
-      ]
+    paths-ignore:
+      - 'doc/**'
+      - 'docs/**'
+      - '**/*.md'
+      'hive_integration/**'
+      'fluffy/**'
+      '.github/workflows/fluffy*.yml'
+      'nimbus_verified_proxy/**'
+      '.github/workflows/nimbus_verified_proxy.yml'
+
   # Disable `pull_request`.  Experimenting with using only `push` for PRs.
   #pull_request:
   #  paths-ignore: ['doc/**', 'docs/**', '**/*.md', 'hive_integration/**']

--- a/.github/workflows/fluffy.yml
+++ b/.github/workflows/fluffy.yml
@@ -1,11 +1,11 @@
-# Nimbus
+# Fluffy
 # Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-name: fluffy CI
+name: Fluffy CI
 on:
   push:
     paths:

--- a/.github/workflows/fluffy_docs.yml
+++ b/.github/workflows/fluffy_docs.yml
@@ -1,4 +1,11 @@
-name: fluffy docs CI
+# Fluffy
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+name: Fluffy docs CI
 
 on:
   push:

--- a/.github/workflows/fluffy_nightly_docker.yml
+++ b/.github/workflows/fluffy_nightly_docker.yml
@@ -1,7 +1,14 @@
+# Fluffy
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 name: Fluffy nightly Docker build
 on:
   schedule:
-    - cron: "30 3 * * *"
+    - cron: "30 0 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
With this schedule the new fluffy Docker build should be available before public portal-hive tests are run. Else, we get an extra day of delay to see the results of the current latest.