### PR TITLE
Remove contentSize and contentCount from history network log

### DIFF
--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -779,8 +779,6 @@ proc statusLogLoop(n: HistoryNetwork) {.async.} =
       info "History network status",
         radius = radiusPercentage.toString(10) & "%",
         dbSize = $(n.contentDB.size() div 1000) & "kb",
-        contentSize = $(n.contentDB.contentSize() div 1000) & "kb",
-        contentCount = n.contentDB.contentCount(),
         routingTableNodes = n.portalProtocol.routingTable.len()
 
       await sleepAsync(60.seconds)


### PR DESCRIPTION
These are quite expensive database operations, especially the contentSize one, and are not that necessary to log periodically considering dbSize is already logged and is the more important one. ContentSize is mostly useful to see the database overhead, which we could also add through some json rpc debug call if needed.