### PR TITLE
Get rid of HexQuantityStr and HexDataStr usage

### DIFF
--- a/nimbus/evm/async/data_sources/json_rpc_data_source.nim
+++ b/nimbus/evm/async/data_sources/json_rpc_data_source.nim
@@ -136,7 +136,6 @@ type
 proc fetchAccountAndSlots*(rpcClient: RpcClient, address: EthAddress, slots: seq[UInt256], blockNumber: common.BlockNumber): Future[(Account, AccountProof, seq[StorageProof])] {.async.} =
   let t0 = now()
   debug "Got to fetchAccountAndSlots", address=address, slots=slots, blockNumber=blockNumber
-  #let blockNumberHexStr: HexQuantityStr = encodeQuantity(blockNumber)
   let blockNumberUint64 = blockNumber.truncate(uint64)
   let a = web3.Address(address)
   let bid = blockId(blockNumber.truncate(uint64))

--- a/nimbus/rpc/debug.nim
+++ b/nimbus/rpc/debug.nim
@@ -9,7 +9,9 @@
 
 import
   std/json,
-  json_rpc/rpcserver, rpc_utils,
+  json_rpc/rpcserver, 
+  ./rpc_utils,
+  ./rpc_types,
   ../tracer, ../vm_types,
   ../common/common,
   ../beacon/web3_eth_conv,
@@ -63,7 +65,7 @@ proc setupDebugRpc*(com: CommonRef, rpcsrv: RpcServer) =
 
     result = traceTransaction(com, blockHeader, blockBody, txDetails.index, flags)
 
-  rpcsrv.rpc("debug_dumpBlockStateByNumber") do(quantityTag: string) -> JsonNode:
+  rpcsrv.rpc("debug_dumpBlockStateByNumber") do(quantityTag: BlockTag) -> JsonNode:
     ## Retrieves the state that corresponds to the block number and returns
     ## a list of accounts (including storage and code).
     ##
@@ -89,7 +91,7 @@ proc setupDebugRpc*(com: CommonRef, rpcsrv: RpcServer) =
 
     result = dumpBlockState(com, header, body)
 
-  rpcsrv.rpc("debug_traceBlockByNumber") do(quantityTag: string, options: Option[TraceOptions]) -> JsonNode:
+  rpcsrv.rpc("debug_traceBlockByNumber") do(quantityTag: BlockTag, options: Option[TraceOptions]) -> JsonNode:
     ## The traceBlock method will return a full stack trace of all invoked opcodes of all transaction
     ## that were included included in this block.
     ##
@@ -119,7 +121,7 @@ proc setupDebugRpc*(com: CommonRef, rpcsrv: RpcServer) =
 
     result = traceBlock(com, header, body, flags)
 
-  rpcsrv.rpc("debug_setHead") do(quantityTag: string) -> bool:
+  rpcsrv.rpc("debug_setHead") do(quantityTag: BlockTag) -> bool:
     ## Sets the current head of the local chain by block number.
     ## Note, this is a destructive action and may severely damage your chain.
     ## Use with extreme caution.

--- a/nimbus/rpc/rpc_types.nim
+++ b/nimbus/rpc/rpc_types.nim
@@ -18,3 +18,7 @@ export
 
 type
   FilterLog* = eth_api_types.LogObject
+
+  # BlockTag instead of BlockId:
+  # prevent type clash with eth2 BlockId in fluffy/verified_proxy
+  BlockTag* = eth_api_types.RtBlockIdentifier

--- a/premix/parser.nim
+++ b/premix/parser.nim
@@ -14,7 +14,17 @@ import
   stint, stew/byteutils
 
 import ../nimbus/transaction, ../nimbus/utils/ec_recover
-from web3/ethhexstrings import encodeQuantity
+
+template stripLeadingZeros(value: string): string =
+  var cidx = 0
+  # ignore the last character so we retain '0' on zero value
+  while cidx < value.len - 1 and value[cidx] == '0':
+    cidx.inc
+  value[cidx .. ^1]
+
+func encodeQuantity(value: SomeUnsignedInt): string =
+  var hValue = value.toHex.stripLeadingZeros
+  result = "0x" & hValue.toLowerAscii
 
 func hexToInt*(s: string, T: typedesc[SomeInteger]): T =
   var i = 0


### PR DESCRIPTION
Both types are not safe and require validation/conversion from rpc implementer.
This PR change it to safer types and delegate the conversion and validation to the rpc library.