### PR TITLE
Fix vmflags for witness generation 1934.

### DIFF
--- a/nimbus/evm/state.nim
+++ b/nimbus/evm/state.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
Changes included in this PR:
- Fix issue where vmflags were being reset in the middle of processBlocksImpl. I needed these vmflags to work so I could enable witness generation in the test.
- Turned on witness generation and verification in the test_blockchain_json test. The witness generation was previously disabled. Note that witnesses generation is still disabled by default (in production) but can be enabled by setting the GenerateWitness vmflag.
- Fixed a minor issue where witness generation would fail for blocks with no transactions. The code has been updated to return an empty witness for a block that has no transactions. This should almost never happen in practice I'm guessing but probably a good idea to cover anyway.