### PR TITLE
Bump nim-web3 and others

### DIFF
--- a/fluffy/rpc/portal_rpc_client.nim
+++ b/fluffy/rpc/portal_rpc_client.nim
@@ -1,12 +1,12 @@
 # Nimbus
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  std/os,
+  std/[os, json],
   json_rpc/rpcclient,
   json_rpc/errors, # TODO: should be exported in json_rpc/clients/httpclient
   ./rpc_types, rpc_discovery_api # for the PongResponse

--- a/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
@@ -1,3 +1,10 @@
+# Nimbus
+# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 ## Portal State Network json-rpc calls
 proc portal_stateNodeInfo(): NodeInfo
 proc portal_stateRoutingTableInfo(): RoutingTableInfo
@@ -6,8 +13,7 @@ proc portal_stateAddEnrs(enrs: seq[Record]): bool
 proc portal_stateGetEnr(nodeId: NodeId): Record
 proc portal_stateDeleteEnr(nodeId: NodeId): bool
 proc portal_stateLookupEnr(nodeId: NodeId): Record
-proc portal_statePing(enr: Record): tuple[
-  enrSeq: uint64, customPayload: string]
+proc portal_statePing(enr: Record): PingResult
 proc portal_stateFindNodes(enr: Record): seq[Record]
 proc portal_stateFindContent(enr: Record, contentKey: string): JsonNode
 proc portal_stateOffer(
@@ -26,8 +32,7 @@ proc portal_historyAddEnrs(enrs: seq[Record]): bool
 proc portal_historyGetEnr(nodeId: NodeId): Record
 proc portal_historyDeleteEnr(nodeId: NodeId): bool
 proc portal_historyLookupEnr(nodeId: NodeId): Record
-proc portal_historyPing(enr: Record): tuple[
-  enrSeq: uint64, customPayload: string]
+proc portal_historyPing(enr: Record): PingResult
 proc portal_historyFindNodes(enr: Record): seq[Record]
 proc portal_historyFindContent(enr: Record, contentKey: string): JsonNode
 proc portal_historyOffer(
@@ -46,8 +51,7 @@ proc portal_beaconAddEnrs(enrs: seq[Record]): bool
 proc portal_beaconGetEnr(nodeId: NodeId): Record
 proc portal_beaconDeleteEnr(nodeId: NodeId): bool
 proc portal_beaconLookupEnr(nodeId: NodeId): Record
-proc portal_beaconPing(enr: Record): tuple[
-  enrSeq: uint64, customPayload: string]
+proc portal_beaconPing(enr: Record): PingResult
 proc portal_beaconFindNodes(enr: Record): seq[Record]
 proc portal_beaconFindContent(enr: Record, contentKey: string): JsonNode
 proc portal_beaconOffer(

--- a/fluffy/rpc/rpc_discovery_api.nim
+++ b/fluffy/rpc/rpc_discovery_api.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -21,6 +21,8 @@ type
     recipientIP: string
     recipientPort: uint16
 
+PongResponse.useDefaultSerializationIn JrpcConv
+
 proc installDiscoveryApiHandlers*(rpcServer: RpcServer|RpcProxy,
     d: discv5_protocol.Protocol) =
   ## Discovery v5 JSON-RPC API such as defined here:
@@ -30,7 +32,7 @@ proc installDiscoveryApiHandlers*(rpcServer: RpcServer|RpcProxy,
     return d.routingTable.getNodeInfo()
 
   rpcServer.rpc("discv5_updateNodeInfo") do(
-      kvPairs: seq[tuple[key: string, value: string]]) -> NodeInfo:
+      kvPairs: seq[(string, string)]) -> NodeInfo:
     # TODO: Not according to spec, as spec only allows socket address.
     # portal-specs PR has been created with suggested change as is here.
     let enrFields = kvPairs.map(

--- a/fluffy/rpc/rpc_types.nim
+++ b/fluffy/rpc/rpc_types.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -8,6 +8,7 @@
 {.push raises: [].}
 
 import
+  stint,
   json_rpc/jsonmarshal,
   stew/[results, byteutils],
   eth/p2p/discoveryv5/[routing_table, enr, node]
@@ -22,6 +23,12 @@ type
   RoutingTableInfo* = object
     localNodeId*: NodeId
     buckets*: seq[seq[NodeId]]
+
+  PingResult* = tuple[enrSeq: uint64, dataRadius: UInt256]
+
+NodeInfo.useDefaultSerializationIn JrpcConv
+RoutingTableInfo.useDefaultSerializationIn JrpcConv
+(string,string).useDefaultSerializationIn JrpcConv
 
 func getNodeInfo*(r: RoutingTable): NodeInfo =
   NodeInfo(enr: r.localNode.record, nodeId: r.localNode.id)
@@ -50,49 +57,61 @@ func toNodeWithAddress*(enr: Record): Node {.raises: [ValueError].} =
   else:
     node
 
-func `%`*(value: Record): JsonNode =
-  newJString(value.toURI())
+proc writeValue*(w: var JsonWriter[JrpcConv], v: Record)
+      {.gcsafe, raises: [IOError].} =
+  w.writeValue(v.toURI())
 
-func fromJson*(n: JsonNode, argName: string, result: var Record)
-    {.raises: [ValueError].} =
-  n.kind.expect(JString, argName)
-  if not fromURI(result, n.getStr()):
-    raise newException(ValueError, "Invalid ENR")
+proc readValue*(r: var JsonReader[JrpcConv], val: var Record)
+       {.gcsafe, raises: [IOError, JsonReaderError].} =
+  if not fromURI(val, r.parseString()):
+    r.raiseUnexpectedValue("Invalid ENR")
 
-func `%`*(value: NodeId): JsonNode =
-  %("0x" & value.toHex())
+proc writeValue*(w: var JsonWriter[JrpcConv], v: NodeId)
+      {.gcsafe, raises: [IOError].} =
+  w.writeValue("0x" & v.toHex())
 
-func `%`*(value: Opt[NodeId]): JsonNode =
-  if value.isSome():
-    %("0x" & value.get().toHex())
+proc writeValue*(w: var JsonWriter[JrpcConv], v: Opt[NodeId])
+      {.gcsafe, raises: [IOError].} =
+  if v.isSome():
+    w.writeValue("0x" & v.get().toHex())
   else:
-    %("0x")
+    w.writeValue("0x")
 
-func `%`*(value: Opt[seq[byte]]): JsonNode =
-  if value.isSome():
-    %(value.get().to0xHex())
+proc readValue*(r: var JsonReader[JrpcConv], val: var NodeId)
+       {.gcsafe, raises: [IOError, JsonReaderError].} =
+  try:
+    val = NodeId.fromHex(r.parseString())
+  except ValueError as exc:
+    r.raiseUnexpectedValue("NodeId parser error: " & exc.msg)
+
+proc writeValue*(w: var JsonWriter[JrpcConv], v: Opt[seq[byte]])
+      {.gcsafe, raises: [IOError].} =
+  if v.isSome():
+    w.writeValue(v.get().to0xHex())
   else:
-    %("0x")
+    w.writeValue("0x")
 
-func fromJson*(n: JsonNode, argName: string, result: var NodeId)
-    {.raises: [ValueError].} =
-  n.kind.expect(JString, argName)
+proc readValue*(r: var JsonReader[JrpcConv], val: var seq[byte])
+       {.gcsafe, raises: [IOError, JsonReaderError].} =
+  try:
+    val = hexToSeqByte(r.parseString())
+  except ValueError as exc:
+    r.raiseUnexpectedValue("seq[byte] parser error: " & exc.msg)
 
-  # TODO: fromHex (and thus parse) call seems to let pass several invalid
-  # UInt256.
-  result = UInt256.fromHex(n.getStr())
+proc writeValue*(w: var JsonWriter[JrpcConv], v: PingResult)
+      {.gcsafe, raises: [IOError].} =
+  w.beginRecord()
+  w.writeField("enrSeq", v.enrSeq)
+  w.writeField("dataRadius", "0x" & v.dataRadius.toHex)
+  w.endRecord()
 
-# TODO: This one should go to nim-json-rpc but before we can do that we will
-# have to update the vendor module to the current latest.
-func fromJson*(n: JsonNode, argName: string, result: var uint16)
-    {.raises: [ValueError].} =
-  n.kind.expect(JInt, argName)
-  let asInt = n.getBiggestInt()
-  if asInt < 0:
-    raise newException(
-      ValueError, "JSON-RPC input is an unexpected negative value")
-  if asInt > BiggestInt(uint16.high()):
-    raise newException(
-      ValueError, "JSON-RPC input is too large for uint32")
-
-  result = uint16(asInt)
+proc readValue*(r: var JsonReader[JrpcConv], val: var PingResult)
+       {.gcsafe, raises: [IOError, SerializationError].} =
+  try:
+    for field in r.readObjectFields():
+      case field:
+      of "enrSeq": val.enrSeq = r.parseInt(uint64)
+      of "dataRadius": val.dataRadius = UInt256.fromHex(r.parseString())
+      else: discard
+  except ValueError as exc:
+    r.raiseUnexpectedValue("PingResult parser error: " & exc.msg)

--- a/fluffy/tests/test_discovery_rpc.nim
+++ b/fluffy/tests/test_discovery_rpc.nim
@@ -1,5 +1,5 @@
 # Nimbus - Portal Network
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -48,7 +48,8 @@ procSuite "Discovery RPC":
 
   asyncTest "Get local node info":
     let tc = await setupTest(rng)
-    let resp = await tc.client.call("discv5_nodeInfo", %[])
+    let jsonBytes = await tc.client.call("discv5_nodeInfo", %[])
+    let resp = JrpcConv.decode(jsonBytes.string, JsonNode)
 
     check:
       resp.contains("nodeId")

--- a/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
+++ b/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
@@ -669,7 +669,9 @@ proc run(config: BeaconBridgeConf) {.raises: [CatchableError].} =
       waitFor (RpcHttpClient(web3Client.get())).connect(config.web3Url.get().web3Url)
 
   info "Listening to incoming network requests"
-  network.initBeaconSync(cfg, forkDigests, genesisBlockRoot, getBeaconTime)
+  network.registerProtocol(
+    PeerSync, PeerSync.NetworkState.init(
+      cfg, forkDigests, genesisBlockRoot, getBeaconTime))
   network.addValidator(
     getBeaconBlocksTopic(forkDigests.phase0),
     proc (signedBlock: phase0.SignedBeaconBlock): errors.ValidationResult =

--- a/hive_integration/nodocker/engine/auths_tests.nim
+++ b/hive_integration/nodocker/engine/auths_tests.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -14,6 +14,7 @@ import
   chronicles,
   nimcrypto/[hmac],
   web3/engine_api_types,
+  web3/conversions,
   json_rpc/[rpcclient],
   ./types
 
@@ -22,6 +23,9 @@ const
   defaultJwtTokenSecretBytes = "secretsecretsecretsecretsecretse"
   maxTimeDriftSeconds        = 60'i64
   defaultProtectedHeader     = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+
+createRpcSigsFromNim(RpcClient):
+  proc engine_exchangeTransitionConfigurationV1(transitionConfiguration: TransitionConfigurationV1): TransitionConfigurationV1
 
 proc base64urlEncode(x: auto): string =
   base64.encode(x, safe = true).replace("=", "")
@@ -62,7 +66,7 @@ template genAuthTest(procName: untyped, timeDriftSeconds: int64, customAuthSecre
     let client = getClient(env, token)
 
     try:
-      discard waitFor client.call("engine_exchangeTransitionConfigurationV1", %[%tConf])
+      discard waitFor client.engine_exchangeTransitionConfigurationV1(tConf)
       testCond authOk:
         error "Authentication was supposed to fail authentication but passed"
     except CatchableError:

--- a/hive_integration/nodocker/engine/cancun/helpers.nim
+++ b/hive_integration/nodocker/engine/cancun/helpers.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -208,19 +208,19 @@ proc verifyBeaconRootStorage*(client: RpcClient, payload: ExecutionPayload): boo
     error "verifyBeaconRootStorage", msg=r.error
     return false
 
-  if r.get != payload.timestamp.uint64.u256:
+  if r.get.u256 != payload.timestamp.uint64.u256:
     error "verifyBeaconRootStorage storage 1",
       expect=payload.timestamp.uint64.u256,
-      get=r.get
+      get=r.get.u256
     return false
 
   # Verify the beacon root key
   r = client.storageAt(precompileAddress, beaconRootKey, blockNumber)
   let parentBeaconBlockRoot = timestampToBeaconRoot(payload.timestamp)
-  if parentBeaconBlockRoot != beaconRoot(r.get):
+  if parentBeaconBlockRoot != r.get:
     error "verifyBeaconRootStorage storage 2",
       expect=parentBeaconBlockRoot.toHex,
-      get=beaconRoot(r.get).toHex
+      get=r.get.toHex
     return false
 
   return true

--- a/hive_integration/nodocker/engine/helper.nim
+++ b/hive_integration/nodocker/engine/helper.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -25,6 +25,6 @@ proc txInPayload*(payload: ExecutionPayload, txHash: common.Hash256): bool =
 proc checkPrevRandaoValue*(client: RpcClient, expectedPrevRandao: common.Hash256, blockNumber: uint64): bool =
   let storageKey = blockNumber.u256
   let r = client.storageAt(prevRandaoContractAddr, storageKey)
-  let expected = UInt256.fromBytesBE(expectedPrevRandao.data)
+  let expected = FixedBytes[32](expectedPrevRandao.data)
   r.expectStorageEqual(expected)
   return true

--- a/hive_integration/nodocker/engine/types.nim
+++ b/hive_integration/nodocker/engine/types.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -85,9 +85,6 @@ func timestampToBeaconRoot*(timestamp: Quantity): FixedBytes[32] =
   # Generates a deterministic hash from the timestamp
   let h = keccakHash(timestamp.uint64.toBytesBE)
   FixedBytes[32](h.data)
-
-func beaconRoot*(x: UInt256): FixedBytes[32] =
-  FixedBytes[32](x.toByteArrayBE)
 
 proc randomBytes*(_: type common.Hash256): common.Hash256 =
   doAssert randomBytes(result.data) == 32
@@ -248,7 +245,7 @@ template expectHash*(res: untyped, hash: common.Hash256) =
   testCond s.blockHash == hash:
     error "Unexpected expectHash", expect=hash.short, get=s.blockHash.short
 
-template expectStorageEqual*(res: untyped, expectedValue: UInt256) =
+template expectStorageEqual*(res: untyped, expectedValue: FixedBytes[32]) =
   testCond res.isOk:
     error "expectStorageEqual", msg=res.error
   testCond res.get == expectedValue:

--- a/hive_integration/nodocker/engine/withdrawals/wd_base_spec.nim
+++ b/hive_integration/nodocker/engine/withdrawals/wd_base_spec.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -162,12 +162,12 @@ proc verifyContractsStorage(ws: WDBaseSpec, env: TestEnv): Result[void, string] 
 
   if latestPayloadNumber.truncate(int) >= ws.forkHeight:
     # Shanghai
-    r.expectStorageEqual(WARM_COINBASE_ADDRESS, 100.u256)    # WARM_STORAGE_READ_COST
-    p.expectStorageEqual(PUSH0_ADDRESS, latestPayloadNumber) # tx succeeded
+    r.expectStorageEqual(WARM_COINBASE_ADDRESS, 100.u256.w3FixedBytes)    # WARM_STORAGE_READ_COST
+    p.expectStorageEqual(PUSH0_ADDRESS, latestPayloadNumber.w3FixedBytes) # tx succeeded
   else:
     # Pre-Shanghai
-    r.expectStorageEqual(WARM_COINBASE_ADDRESS, 2600.u256) # COLD_ACCOUNT_ACCESS_COST
-    p.expectStorageEqual(PUSH0_ADDRESS, 0.u256)            # tx must've failed
+    r.expectStorageEqual(WARM_COINBASE_ADDRESS, 2600.u256.w3FixedBytes) # COLD_ACCOUNT_ACCESS_COST
+    p.expectStorageEqual(PUSH0_ADDRESS, 0.u256.w3FixedBytes)            # tx must've failed
 
   ok()
 

--- a/hive_integration/nodocker/engine/withdrawals/wd_history.nim
+++ b/hive_integration/nodocker/engine/withdrawals/wd_history.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -14,7 +14,8 @@ import
   json_rpc/[rpcclient],
   stew/[byteutils, results],
   ../engine_client,
-  ../../../nimbus/utils/utils
+  ../../../nimbus/utils/utils,
+  ../../../nimbus/beacon/web3_eth_conv
 
 type
   Withdrawals* = ref object
@@ -93,7 +94,7 @@ proc verifyWithdrawals*(wh: WDHistory, blockNumber: uint64, rpcBlock: Option[UIn
               client.storageAt(account, 0.u256, rpcBlock.get)
             else:
               client.storageAt(account, 0.u256)
-    s.expectStorageEqual(account, 0.u256)
+    s.expectStorageEqual(account, 0.u256.w3FixedBytes)
   ok()
 
 # Create a new copy of the withdrawals history

--- a/hive_integration/nodocker/pyspec/pyspec_sim.nim
+++ b/hive_integration/nodocker/pyspec/pyspec_sim.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -101,7 +101,7 @@ proc validatePostState(node: JsonNode, t: TestEnv): bool =
           echo sRes.error
           return false
 
-        if val != sRes.value:
+        if val.w3FixedBytes != sRes.value:
           echo "storage recieved from account 0x",
             account.toHex,
             " at slot 0x",

--- a/nimbus/beacon/web3_eth_conv.nim
+++ b/nimbus/beacon/web3_eth_conv.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -86,6 +86,9 @@ func u64*(x: Option[Web3Quantity]): Option[uint64] =
 func u256*(x: Web3Quantity): UInt256 =
   u256(x.uint64)
 
+func u256*(x: FixedBytes[32]): UInt256 =
+  UInt256.fromBytesBE(x.bytes)
+
 func ethTime*(x: Web3Quantity): common.EthTime =
   common.EthTime(x)
 
@@ -103,7 +106,7 @@ func ethHashes*(list: openArray[Web3Hash]): seq[common.Hash256] =
 func ethHashes*(list: Option[seq[Web3Hash]]): Option[seq[common.Hash256]] =
   if list.isNone: none(seq[common.Hash256])
   else: some ethHashes(list.get)
-  
+
 func ethAddr*(x: Web3Address): common.EthAddress =
   EthAddress x
 
@@ -217,6 +220,9 @@ func w3Qty*(x: Option[uint64]): Option[Web3Quantity] =
 
 func w3Qty*(x: uint64): Web3Quantity =
   Web3Quantity(x)
+
+func w3FixedBytes*(x: UInt256): FixedBytes[32] =
+  FixedBytes[32](x.toBytesBE)
 
 func w3ExtraData*(x: common.Blob): Web3ExtraData =
   Web3ExtraData x

--- a/nimbus/evm/async/data_sources/json_rpc_data_source.nim
+++ b/nimbus/evm/async/data_sources/json_rpc_data_source.nim
@@ -25,16 +25,19 @@ import
   ../../../sync/protocol,
   ../../../db/[core_db, distinct_tries, incomplete_db, storage_types],
   ../data_sources,
-  ../../../beacon/web3_eth_conv
+  ../../../beacon/web3_eth_conv,
+  web3/conversions,
+  web3
 
 when defined(legacy_eth66_enabled):
   import
     ../../../sync/protocol/eth66 as proto_eth66
   from ../../../sync/protocol/eth66 import getNodeData
 
-from web3 import Web3, BlockHash, BlockObject, FixedBytes, Address, ProofResponse, StorageProof, newWeb3, fromJson, fromHex, eth_getBlockByHash, eth_getBlockByNumber, eth_getCode, eth_getProof, blockId, `%`
-
 export AsyncOperationFactory, AsyncDataSource
+
+type
+  BlockHeader = eth_types.BlockHeader
 
 var durationSpentDoingFetches*: times.Duration
 var fetchCounter*: int

--- a/nimbus/rpc/common.nim
+++ b/nimbus/rpc/common.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -28,6 +28,9 @@ type
     enode : string # Enode string
     ip    : string # address string
     ports : NodePorts
+
+NodePorts.useDefaultSerializationIn JrpcConv
+NodeInfo.useDefaultSerializationIn JrpcConv
 
 proc setupCommonRpc*(node: EthereumNode, conf: NimbusConf, server: RpcServer) =
   server.rpc("web3_clientVersion") do() -> string:

--- a/nimbus/rpc/debug.nim
+++ b/nimbus/rpc/debug.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -9,7 +9,7 @@
 
 import
   std/json,
-  json_rpc/rpcserver, 
+  json_rpc/rpcserver,
   ./rpc_utils,
   ./rpc_types,
   ../tracer, ../vm_types,
@@ -26,6 +26,8 @@ type
     disableStack: Option[bool]
     disableState: Option[bool]
     disableStateDiff: Option[bool]
+
+TraceOptions.useDefaultSerializationIn JrpcConv
 
 proc isTrue(x: Option[bool]): bool =
   result = x.isSome and x.get() == true

--- a/nimbus/tracer.nim
+++ b/nimbus/tracer.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -65,7 +65,7 @@ proc captureAccount(n: JsonNode, db: LedgerRef, address: EthAddress, name: strin
   let codeHash = db.getCodeHash(address)
   let storageRoot = db.getStorageRoot(address)
 
-  jaccount["nonce"] = %(nonce.Web3Quantity)
+  jaccount["nonce"] = %(conversions.`$`(nonce.Web3Quantity))
   jaccount["balance"] = %("0x" & balance.toHex)
 
   let code = db.getCode(address)

--- a/nimbus_verified_proxy/nimbus_verified_proxy.nim
+++ b/nimbus_verified_proxy/nimbus_verified_proxy.nim
@@ -126,7 +126,9 @@ proc run(config: VerifiedProxyConf) {.raises: [CatchableError].} =
   verifiedProxy.installEthApiHandlers()
 
   info "Listening to incoming network requests"
-  network.initBeaconSync(cfg, forkDigests, genesisBlockRoot, getBeaconTime)
+  network.registerProtocol(
+    PeerSync, PeerSync.NetworkState.init(
+      cfg, forkDigests, genesisBlockRoot, getBeaconTime))
   network.addValidator(
     getBeaconBlocksTopic(forkDigests.phase0),
     proc (signedBlock: phase0.SignedBeaconBlock): ValidationResult =

--- a/premix/downloader.nim
+++ b/premix/downloader.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Copyright (c) 2020-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -36,12 +36,14 @@ proc request*(
     params: JsonNode,
     client: Option[RpcClient] = none[RpcClient]()): JsonNode =
   if client.isSome():
-    result = waitFor client.unsafeGet().call(methodName, params)
+    let res = waitFor client.unsafeGet().call(methodName, params)
+    result = JrpcConv.decode(res.string, JsonNode)
   else:
     var client = newRpcHttpClient()
     #client.httpMethod(MethodPost)
     waitFor client.connect("127.0.0.1", Port(8545), false)
-    result = waitFor client.call(methodName, params)
+    let res = waitFor client.call(methodName, params)
+    result = JrpcConv.decode(res.string, JsonNode)
     waitFor client.close()
 
 proc requestBlockBody(


### PR DESCRIPTION
Bump nim-json-rpc and nimbus-eth2 too.
Reason: both nim-json-rpc and nim-web3 migrate from stdlib/json to nim-json-serialization