### PR TITLE
Add missing import to aristo_blobify.nim

### DIFF
--- a/nimbus/db/aristo/aristo_blobify.nim
+++ b/nimbus/db/aristo/aristo_blobify.nim
@@ -11,7 +11,7 @@
 {.push raises: [].}
 
 import
-  std/[bitops, sequtils, sets],
+  std/[bitops, sequtils, sets, tables],
   eth/[common, trie/nibbles],
   results,
   stew/endians2,


### PR DESCRIPTION
I'm using Nimbus as an API, and without this import, compilation will fail due to:

```
undeclared field: 'keys' for type tables.
```

because it is referenced here:

https://github.com/status-im/nimbus-eth1/blob/cba5d166f42a75c58840e329fe202eb6f8dda97d/nimbus/db/aristo/aristo_blobify.nim#L193