### PR TITLE
Storage of block witnesses

### DIFF
--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -206,6 +206,11 @@ type
       defaultValueDesc: ""
       name: "verify-from" }: Option[uint64]
 
+    generateWitness* {.
+      desc: "Enable experimental generation and storage of block witnesses"
+      defaultValue: false
+      name: "generate-witness" }: bool
+
     evm* {.
       desc: "Load alternative EVM from EVMC-compatible shared library" & sharedLibText
       defaultValue: ""

--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -207,6 +207,7 @@ type
       name: "verify-from" }: Option[uint64]
 
     generateWitness* {.
+      hidden
       desc: "Enable experimental generation and storage of block witnesses"
       defaultValue: false
       name: "generate-witness" }: bool

--- a/nimbus/core/chain/chain_desc.nim
+++ b/nimbus/core/chain/chain_desc.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -32,6 +32,10 @@ type
 
     extraValidation: bool ##\
       ## Trigger extra validation, currently within `persistBlocks()`
+      ## function only.
+
+    generateWitness: bool ##\
+      ## Enable generation of block witness, currently within `persistBlocks()`
       ## function only.
 
     verifyFrom: BlockNumber ##\
@@ -101,6 +105,10 @@ proc extraValidation*(c: ChainRef): bool =
   ## Getter
   c.extraValidation
 
+proc generateWitness*(c: ChainRef): bool =
+  ## Getter
+  c.generateWitness
+
 proc verifyFrom*(c: ChainRef): BlockNumber =
   ## Getter
   c.verifyFrom
@@ -124,6 +132,11 @@ proc `extraValidation=`*(c: ChainRef; extraValidation: bool) =
   ## Setter. If set `true`, the assignment value `extraValidation` enables
   ## extra block chain validation.
   c.extraValidation = extraValidation
+
+proc `generateWitness=`*(c: ChainRef; generateWitness: bool) =
+  ## Setter. If set `true`, the assignment value `generateWitness` enables
+  ## block witness generation.
+  c.generateWitness = generateWitness
 
 proc `verifyFrom=`*(c: ChainRef; verifyFrom: BlockNumber) =
   ## Setter. The  assignment value `verifyFrom` defines the first block where

--- a/nimbus/core/chain/persist_blocks.nim
+++ b/nimbus/core/chain/persist_blocks.nim
@@ -147,8 +147,7 @@ proc persistBlocksImpl(c: ChainRef; headers: openArray[BlockHeader];
 
       dbTx.rollback()
 
-      let blockHash = c.db.getBlockHash(header.blockNumber)
-      c.db.setBlockWitness(blockHash, witness)
+      c.db.setBlockWitness(header.blockHash(), witness)
 
 
     if NoPersistHeader notin flags:

--- a/nimbus/db/core_db/core_apps_legacy.nim
+++ b/nimbus/db/core_db/core_apps_legacy.nim
@@ -734,6 +734,12 @@ proc haveBlockAndState*(db: CoreDbRef, headerHash: Hash256): bool =
   # see if stateRoot exists
   db.exists(header.stateRoot)
 
+proc getBlockWitness*(db: CoreDbRef, blockHash: Hash256): seq[byte] {.gcsafe.} =
+  db.kvt.get(blockHashToBlockWitnessKey(blockHash).toOpenArray)
+
+proc setBlockWitness*(db: CoreDbRef, blockHash: Hash256, witness: seq[byte]) =
+  db.kvt.put(blockHashToBlockWitnessKey(blockHash).toOpenArray, witness)
+
 # ------------------------------------------------------------------------------
 # End
 # ------------------------------------------------------------------------------

--- a/nimbus/db/core_db/core_apps_legacy.nim
+++ b/nimbus/db/core_db/core_apps_legacy.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/core_db/core_apps_newapi.nim
+++ b/nimbus/db/core_db/core_apps_newapi.nim
@@ -921,6 +921,21 @@ proc haveBlockAndState*(db: CoreDbRef, headerHash: Hash256): bool =
   # see if stateRoot exists
   db.exists(header.stateRoot)
 
+proc getBlockWitness*(db: CoreDbRef, blockHash: Hash256): seq[byte] {.gcsafe.} =
+  let data = db.newKvt(Shared)
+               .get(blockHashToBlockWitnessKey(blockHash).toOpenArray).valueOr:
+    if error.error != KvtNotFound:
+      warn logTxt "getBlockWitness()", blockHash, action="get()", error=($$error)
+    return
+
+  return data
+
+proc setBlockWitness*(db: CoreDbRef, blockHash: Hash256, witness: seq[byte]) =
+  let witnessKey = blockHashToBlockWitnessKey blockHash
+  db.newKvt.put(witnessKey.toOpenArray, witness).isOkOr:
+    warn logTxt "setBlockWitness()", witnessKey, action="put()", error=($$error)
+    return
+
 # ------------------------------------------------------------------------------
 # End
 # ------------------------------------------------------------------------------

--- a/nimbus/db/ledger/accounts_cache.nim
+++ b/nimbus/db/ledger/accounts_cache.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/storage_types.nim
+++ b/nimbus/db/storage_types.nim
@@ -31,6 +31,7 @@ type
     snapSyncAccount
     snapSyncStorageSlot
     snapSyncStateRoot
+    blockHashToBlockWitness
 
   DbKey* = object
     # The first byte stores the key type. The rest are key-specific values
@@ -128,6 +129,11 @@ proc snapSyncStateRootKey*(h: openArray[byte]): DbKey {.inline.} =
   result.data[0] = byte ord(snapSyncStateRoot)
   result.data[1 .. 32] = h
   result.dataEndPos = uint8 sizeof(h)
+
+proc blockHashToBlockWitnessKey*(h: Hash256): DbKey {.inline.} =
+  result.data[0] = byte ord(blockHashToBlockWitness)
+  result.data[1 .. 32] = h.data
+  result.dataEndPos = uint8 32
 
 template toOpenArray*(k: DbKey): openArray[byte] =
   k.data.toOpenArray(0, int(k.dataEndPos))

--- a/nimbus/db/storage_types.nim
+++ b/nimbus/db/storage_types.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -91,6 +91,7 @@ proc basicServices(nimbus: NimbusNode,
     nimbus.chainRef.extraValidation = 0 < verifyFrom
     nimbus.chainRef.verifyFrom = verifyFrom
 
+  nimbus.chainRef.generateWitness = conf.generateWitness
   nimbus.beaconEngine = BeaconEngineRef.new(nimbus.txPool, nimbus.chainRef)
 
 proc manageAccounts(nimbus: NimbusNode, conf: NimbusConf) =

--- a/nimbus/rpc/experimental.nim
+++ b/nimbus/rpc/experimental.nim
@@ -47,7 +47,7 @@ proc getBlockWitness*(
     flags = if vmState.fork >= FKSpurious: {wfEIP170} else: {}
   vmState.generateWitness = true # Enable saving witness data
 
-  var dbTx = vmState.com.db.beginTransaction()
+  let dbTx = vmState.com.db.beginTransaction()
   defer: dbTx.dispose()
 
   # Execute the block of transactions and collect the keys of the touched account state

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -55,4 +55,5 @@ cliBuilder:
           ./test_beacon/test_skeleton,
           ./test_overflow,
           ./test_getproof_json,
-          ./test_rpc_experimental_json
+          ./test_rpc_experimental_json,
+          ./test_persistblock_witness_json

--- a/tests/test_configuration.nim
+++ b/tests/test_configuration.nim
@@ -306,5 +306,21 @@ proc configurationMain*() =
       check conf.dataDir.string == defaultDataDir()
       check conf.keyStore.string == "banana"
 
+    test "generate-witness default":
+      let conf = makeTestConfig()
+      check conf.generateWitness == false
+
+    test "generate-witness enabled":
+      let conf = makeConfig(@["--generate-witness"])
+      check conf.generateWitness == true
+
+    test "generate-witness equals true":
+      let conf = makeConfig(@["--generate-witness=true"])
+      check conf.generateWitness == true
+
+    test "generate-witness equals false":
+      let conf = makeConfig(@["--generate-witness=false"])
+      check conf.generateWitness == false
+
 when isMainModule:
   configurationMain()

--- a/tests/test_persistblock_witness_json.nim
+++ b/tests/test_persistblock_witness_json.nim
@@ -1,0 +1,69 @@
+# Nimbus
+# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  std/[json, os, tables, strutils],
+  unittest2,
+  stew/byteutils,
+  ./test_helpers,
+  ../nimbus/core/chain,
+  ../nimbus/common/common,
+  ../stateless/[witness_verification, witness_types]
+
+# use tracerTestGen.nim to generate additional test data
+proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus) =
+  var
+    blockNumber = UInt256.fromHex(node["blockNumber"].getStr())
+    memoryDB    = newCoreDbRef LegacyDbMemory
+    config      = chainConfigForNetwork(MainNet)
+    com         = CommonRef.new(memoryDB, config, pruneTrie = false)
+    state       = node["state"]
+
+  for k, v in state:
+    let key = hexToSeqByte(k)
+    let value = hexToSeqByte(v.getStr())
+    memoryDB.kvt.put(key, value)
+
+  let
+    parentNumber = blockNumber - 1
+    parent = com.db.getBlockHeader(parentNumber)
+    header = com.db.getBlockHeader(blockNumber)
+    headerHash = header.blockHash
+    blockBody = com.db.getBlockBody(headerHash)
+    chain = newChain(com)
+    headers = @[header]
+    bodies = @[blockBody]
+
+  chain.generateWitness = true # Enable code to generate and store witness in the db
+
+  # it's ok if setHead fails here because of missing ancestors
+  discard com.db.setHead(parent, true)
+  let validationResult = chain.persistBlocks(headers, bodies)
+  check validationResult == ValidationResult.OK
+
+  let
+    blockHash = memoryDB.getBlockHash(blockNumber)
+    witness = memoryDB.getBlockWitness(blockHash)
+    verifyWitnessResult = verifyWitness(parent.stateRoot, witness, {wfNoFlag})
+
+  check verifyWitnessResult.isOk()
+  let witnessData = verifyWitnessResult.value()
+
+  if blockBody.transactions.len() > 0:
+    check:
+      witness.len() > 0
+      witnessData.len() > 0
+
+proc persistBlockWitnessJsonMain*() =
+  suite "persist block json tests":
+    jsonTest("PersistBlockTests", testFixture)
+  #var testStatusIMPL: TestStatus
+  #let n = json.parseFile("tests" / "fixtures" / "PersistBlockTests" / "block420301.json")
+  #testFixture(n, testStatusIMPL)
+
+when isMainModule:
+  persistBlockWitnessJsonMain()

--- a/tests/test_persistblock_witness_json.nim
+++ b/tests/test_persistblock_witness_json.nim
@@ -47,7 +47,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus) =
 
   let
     blockHash = memoryDB.getBlockHash(blockNumber)
-    witness = memoryDB.getBlockWitness(blockHash)
+    witness = memoryDB.getBlockWitness(blockHash).value()
     verifyWitnessResult = verifyWitness(parent.stateRoot, witness, {wfNoFlag})
 
   check verifyWitnessResult.isOk()

--- a/tests/test_rpc_experimental_json.nim
+++ b/tests/test_rpc_experimental_json.nim
@@ -100,8 +100,6 @@ proc rpcExperimentalJsonMain*() =
 
   suite "rpc experimental json tests":
 
-    # The commented out json files below are failing due to hitting the RPC client and
-    # server defaultMaxRequestLength. Currently the limit is set to around 128kb.
     let importFiles = [
       "block97.json",
       "block98.json",


### PR DESCRIPTION
It would be good to get some early feedback on this change. 

I've added a new flag to Nimbus `--generate-witness` which will enable generation and storage of block witnesses in the database. The feature is disabled by default. The block witness is stored in the database by block hash and is persisted during the persistBlocks proc.