### PR TITLE
Add historical summaries to Portal beacon network

### DIFF
--- a/fluffy/network/beacon/beacon_chain_historical_summaries.nim
+++ b/fluffy/network/beacon/beacon_chain_historical_summaries.nim
@@ -1,5 +1,5 @@
-# Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# fluffy
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -25,8 +25,9 @@ type
   HistoricalSummaries* = HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT]
   HistoricalSummariesProof* = array[5, Digest]
   HistoricalSummariesWithProof* = object
-    historical_summaries: HistoricalSummaries
-    proof: HistoricalSummariesProof
+    finalized_slot*: Slot
+    historical_summaries*: HistoricalSummaries
+    proof*: HistoricalSummariesProof
 
 func buildProof*(
     state: ForkedHashedBeaconState): Result[HistoricalSummariesProof, string] =
@@ -47,3 +48,9 @@ func verifyProof*(
     leave = hash_tree_root(historical_summaries)
 
   verify_merkle_multiproof(@[leave], proof, @[gIndex], stateRoot)
+
+func verifyProof*(
+    summariesWithProof: HistoricalSummariesWithProof,
+    stateRoot: Digest): bool =
+  verifyProof(
+    summariesWithProof.historical_summaries, summariesWithProof.proof, stateRoot)

--- a/fluffy/network/beacon/beacon_content.nim
+++ b/fluffy/network/beacon/beacon_content.nim
@@ -1,5 +1,5 @@
 # Fluffy - Portal Network
-# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -36,6 +36,7 @@ type
     lightClientUpdate = 0x11
     lightClientFinalityUpdate = 0x12
     lightClientOptimisticUpdate = 0x13
+    historicalSummaries = 0x14
 
   # TODO: Consider how we will gossip bootstraps?
   # In consensus light client operation a node trusts only one bootstrap hash,
@@ -59,6 +60,8 @@ type
   LightClientOptimisticUpdateKey* = object
     optimisticSlot*: uint64 ## signature_slot of the update
 
+  HistoricalSummariesKey* = uint8
+
   ContentKey* = object
     case contentType*: ContentType
     of unused:
@@ -71,6 +74,8 @@ type
       lightClientFinalityUpdateKey*: LightClientFinalityUpdateKey
     of lightClientOptimisticUpdate:
       lightClientOptimisticUpdateKey*: LightClientOptimisticUpdateKey
+    of historicalSummaries:
+      historicalSummariesKey*: HistoricalSummariesKey
 
   # TODO:
   # ForkedLightClientUpdateBytesList can get pretty big and is send in one go.
@@ -266,4 +271,10 @@ func optimisticUpdateContentKey*(optimisticSlot: uint64): ContentKey =
     lightClientOptimisticUpdateKey: LightClientOptimisticUpdateKey(
       optimisticSlot: optimisticSlot
     )
+  )
+
+func historicalSummariesContentKey*(): ContentKey =
+  ContentKey(
+    contentType: historicalSummaries,
+    historicalSummariesKey: 0
   )

--- a/fluffy/tests/test_beacon_chain_historical_summaries.nim
+++ b/fluffy/tests/test_beacon_chain_historical_summaries.nim
@@ -1,5 +1,5 @@
-# Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# fluffy
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -18,7 +18,7 @@ import
   beacon_chain/../tests/mocking/mock_genesis,
   beacon_chain/../tests/consensus_spec/fixtures_utils,
 
-  ../network/history/experimental/beacon_chain_historical_summaries
+  ../network/beacon/beacon_chain_historical_summaries
 
 suite "Beacon Chain Historical Summaries":
   let


### PR DESCRIPTION
Will add bridge data injection + encoding test vectors + test vectors extraction in follow up PR(s).
Same for some general cleanup in beacon_network code + tests.