### PR TITLE
More witness fixes

### DIFF
--- a/nimbus/db/ledger/accounts_cache.nim
+++ b/nimbus/db/ledger/accounts_cache.nim
@@ -664,11 +664,6 @@ func update(wd: var WitnessData, acc: RefAccount) =
       wd.storageKeys.incl k
 
   for k, v in acc.overlayStorage:
-    if v.isZero and k notin wd.storageKeys:
-      continue
-    if v.isZero and k in wd.storageKeys:
-      wd.storageKeys.excl k
-      continue
     wd.storageKeys.incl k
 
 func witnessData(acc: RefAccount): WitnessData =

--- a/nimbus/db/ledger/accounts_cache.nim
+++ b/nimbus/db/ledger/accounts_cache.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/ledger/accounts_ledger.nim
+++ b/nimbus/db/ledger/accounts_ledger.nim
@@ -707,11 +707,6 @@ proc update(wd: var WitnessData, acc: AccountRef) =
       wd.storageKeys.incl k
 
   for k, v in acc.overlayStorage:
-    if v.isZero and k notin wd.storageKeys:
-      continue
-    if v.isZero and k in wd.storageKeys:
-      wd.storageKeys.excl k
-      continue
     wd.storageKeys.incl k
 
 proc witnessData(acc: AccountRef): WitnessData =

--- a/nimbus/rpc/experimental.nim
+++ b/nimbus/rpc/experimental.nim
@@ -75,8 +75,7 @@ proc getBlockProofs*(
     let address = keyData.address
     var slots = newSeq[UInt256]()
 
-    if not keyData.storageKeys.isNil and accDB.accountExists(address) and
-        accDB.getStorageRoot(address) != EMPTY_ROOT_HASH:
+    if not keyData.storageKeys.isNil and accDB.accountExists(address):
       for slotData in keyData.storageKeys.keys:
         slots.add(fromBytesBE(UInt256, slotData.storageSlot))
 

--- a/stateless/witness_from_tree.nim
+++ b/stateless/witness_from_tree.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Copyright (c) 2020-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -166,7 +166,7 @@ proc writeHashNode(wb: var WitnessBuilder, node: openArray[byte], depth: int, st
 
 proc writeShortRlp(wb: var WitnessBuilder, node: openArray[byte], depth: int, storageMode: bool)
     {.gcsafe, raises: [IOError].} =
-  doAssert(node.len < 32 and depth >= 9 and storageMode)
+  doAssert(node.len < 32 and storageMode)
   wb.writeByte(HashNodeType)
   wb.writeByte(ShortRlpPrefix)
   wb.writeByte(node.len)

--- a/tests/test_rpc_getproofs_track_state_changes.nim
+++ b/tests/test_rpc_getproofs_track_state_changes.nim
@@ -1,0 +1,172 @@
+# Nimbus
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  std/[json, os, tables],
+  unittest2,
+  web3/eth_api,
+  json_rpc/[rpcclient, rpcserver],
+  stew/byteutils,
+  ../nimbus/core/chain,
+  ../nimbus/common/common,
+  ../nimbus/rpc,
+  ../../nimbus/db/[ledger, core_db],
+  ../../nimbus/db/[core_db/persistent, storage_types],
+  ../stateless/[witness_verification, witness_types],
+  ./rpc/experimental_rpc_client
+
+type
+  Hash256 = eth_types.Hash256
+
+func ethAddr*(x: Address): EthAddress =
+  EthAddress x
+
+template toHash256(hash: untyped): Hash256 =
+  fromHex(Hash256, hash.toHex())
+
+
+proc checkAndValidateWitnessAgainstProofs(
+    db: CoreDbRef,
+    parentStateRoot: Hash256,
+    expectedStateRoot: Hash256,
+    witness: seq[byte],
+    proofs: seq[ProofResponse],
+    stateDB: LedgerRef,
+    i: uint64) =
+
+  let
+    verifyWitnessResult = verifyWitness(expectedStateRoot, witness, {wfNoFlag})
+
+  check verifyWitnessResult.isOk()
+  let witnessData = verifyWitnessResult.value()
+
+  check:
+    witness.len() > 0
+    proofs.len() > 0
+    witnessData.len() > 0
+
+  for proof in proofs:
+    let
+      address = proof.address.ethAddr()
+      balance = proof.balance
+      nonce = proof.nonce.uint64
+      codeHash = proof.codeHash.toHash256()
+      storageHash = proof.storageHash.toHash256()
+      slotProofs = proof.storageProof
+
+    if witnessData.contains(address):
+      let
+        storageData = witnessData[address].storage
+        code = witnessData[address].code
+
+      check:
+        witnessData[address].account.balance == balance
+        witnessData[address].account.nonce == nonce
+        witnessData[address].account.codeHash == codeHash
+
+      for slotProof in slotProofs:
+        if storageData.contains(slotProof.key):
+          check storageData[slotProof.key] == slotProof.value
+
+      #if code.len() > 0:
+      stateDB.setCode(address, code)
+
+    # stateDB.setBalance(address, balance)
+    # stateDB.setNonce(address, nonce)
+
+    # for slotProof in slotProofs:
+    #   stateDB.setStorage(address, slotProof.key, slotProof.value)
+
+    # # the account doesn't exist due to a self destruct
+    # if (codeHash == ZERO_HASH256 and storageHash == ZERO_HASH256) or
+    #     (balance == 0 and nonce == 0 and codeHash == EMPTY_SHA3 and storageHash == EMPTY_ROOT_HASH):
+    #   stateDB.selfDestruct(address)
+
+    # the account doesn't exist due to a self destruct
+    if (codeHash == ZERO_HASH256 and storageHash == ZERO_HASH256):
+      stateDB.selfDestruct(address)
+    elif (balance == 0 and nonce == 0 and codeHash == EMPTY_SHA3 and storageHash == EMPTY_ROOT_HASH):
+      stateDB.setBalance(address, balance)
+      stateDB.setNonce(address, nonce)
+      stateDB.clearStorage(address)
+    else:
+      stateDB.setBalance(address, balance)
+      stateDB.setNonce(address, nonce)
+      for slotProof in slotProofs:
+        stateDB.setStorage(address, slotProof.key, slotProof.value)
+
+    stateDB.persist(clearEmptyAccount = i >= 2_675_000, clearCache = false) # vmState.determineFork >= FkSpurious
+
+    check stateDB.getBalance(address) == balance
+    check stateDB.getNonce(address) == nonce
+
+    if codeHash == ZERO_HASH256 or codeHash == EMPTY_SHA3:
+      check stateDB.getCode(address).len() == 0
+      check stateDB.getCodeHash(address) == EMPTY_SHA3
+    else:
+      check stateDB.getCodeHash(address) == codeHash
+
+    if storageHash == ZERO_HASH256 or storageHash == EMPTY_ROOT_HASH:
+      check stateDB.getStorageRoot(address) == EMPTY_ROOT_HASH
+    else:
+      check stateDB.getStorageRoot(address) == storageHash
+
+  check stateDB.rootHash == expectedStateRoot
+
+
+proc rpcExperimentalJsonMain*() =
+
+  suite "rpc getProofs track state changes tests":
+
+    let
+      RPC_HOST = "127.0.0.1"
+      RPC_PORT = 0 # let the OS choose a port
+
+    var client = newRpcHttpClient()
+
+    waitFor client.connect(RPC_HOST, Port(8545), secure = false)
+
+    test "Test track the changes introduced in every block":
+
+      let com = CommonRef.new(
+        newCoreDbRef(LegacyDbPersistent, "."), false)
+
+      com.initializeEmptyDb()
+      com.db.compensateLegacySetup()
+
+      let startBlock = 190_000 # 116_525
+      let endBlock = 200_000
+      let blockHeader = waitFor client.eth_getBlockByNumber(blockId(startBlock.uint64), false)
+
+      var stateDB = AccountsCache.init(com.db, blockHeader.stateRoot.toHash256(), false)
+
+      for i in startBlock..endBlock:
+        let
+          blockNum = blockId(i.uint64)
+          parentHeader = waitFor client.eth_getBlockByNumber(blockId(i.uint64 - 1), false)
+          blockHeader = waitFor client.eth_getBlockByNumber(blockId(i.uint64), false)
+          witness = waitFor client.exp_getWitnessByBlockNumber(blockNum, true)
+          proofs = waitFor client.exp_getProofsByBlockNumber(blockNum, true)
+        checkAndValidateWitnessAgainstProofs(
+          com.db, parentHeader.stateRoot.toHash256(), blockHeader.stateRoot.toHash256(), witness, proofs, stateDB, i.uint64)
+
+        if i mod 10000 == 0:
+          let blockHeader = waitFor client.eth_getBlockByNumber(blockNum, false)
+
+          for p in proofs:
+            let address = p.address.ethAddr
+            discard stateDB.accountExists(address)
+
+          stateDB.persist(clearEmptyAccount = i >= 2_675_000, clearCache = true) # vmState.determineFork >= FkSpurious
+
+          echo "Block Number = ", i, " Current State Root = ", stateDB.rootHash
+          echo "Expected block stateRoot: ", blockHeader.stateRoot
+          doAssert blockHeader.stateRoot.toHash256() == stateDB.rootHash
+
+
+when isMainModule:
+  rpcExperimentalJsonMain()

--- a/tests/test_tools_build.nim
+++ b/tests/test_tools_build.nim
@@ -28,4 +28,5 @@ import
   ../tools/t8n/t8n,
   ../tools/t8n/t8n_test,
   ../tools/evmstate/evmstate,
-  ../tools/evmstate/evmstate_test
+  ../tools/evmstate/evmstate_test,
+  ./test_rpc_getproofs_track_state_changes

--- a/tests/test_tools_build.nim
+++ b/tests/test_tools_build.nim
@@ -1,5 +1,5 @@
 # nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license: [LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT
 #   * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
After improving the tests for the exp_getProofsByBlockNumber endpoint to validate the list of state updates against a local test state, I discovered the following issues which are fixed in this PR:
- State roots didn't match for some of the tests and further investigation showed that not all the state updates were coming through in the block proofs. Values were not being returned when a storage slot was updated back to a zero value.
- AccountCache code has been updated to allow zero value storage slots in the witness cache data.
- Storage slots are now not returned if the account doesn't exist (for example due to a self destruct)
- exp_getProofsByBlockNumber endpoint refactored to build the list of proofs directly from the MultikeyRef. This was required to return the zero value slots which don't get returned in the block witness due to how the witness is built from the state tries. For zero value storage slots there is no leaf because it is deleted during the call to persist. I believe the block witness doesn't need to store zero value storage slots because this is the default value for a slot.