### PR TITLE
State network content retrieval

### DIFF
--- a/fluffy/network/state/state_content.nim
+++ b/fluffy/network/state/state_content.nim
@@ -152,16 +152,28 @@ func toContentId*(contentKey: ByteList): ContentId =
 func toContentId*(contentKey: ContentKey): ContentId =
   toContentId(encode(contentKey))
 
-func offerContentToEncodedRetrievalContent*(offerContent: OfferContentValue): seq[byte] =
+func offerContentToRetrievalContent*(offerContent: OfferContentValue): RetrievalContentValue =
   case offerContent.contentType:
     of unused:
-      raiseAssert "Gossiping content with unused content type"
+      raiseAssert "Converting content with unused content type"
     of accountTrieNode:
-      SSZ.encode(AccountTrieNodeRetrieval(node: offerContent.accountTrieNode.proof[^1])) # TODO implement properly
+      RetrievalContentValue(contentType: accountTrieNode, accountTrieNode: AccountTrieNodeRetrieval(node: offerContent.accountTrieNode.proof[^1])) # TODO implement properly
     of contractTrieNode:
-      SSZ.encode(ContractTrieNodeRetrieval(node: offerContent.contractTrieNode.storageProof[^1])) # TODO implement properly
+      RetrievalContentValue(contentType: contractTrieNode, contractTrieNode: ContractTrieNodeRetrieval(node: offerContent.contractTrieNode.storageProof[^1])) # TODO implement properly
     of contractCode:
-      SSZ.encode(ContractCodeRetrieval(code: offerContent.contractCode.code))
+      RetrievalContentValue(contentType: contractCode, contractCode: ContractCodeRetrieval(code: offerContent.contractCode.code))
+
+func encode*(content: RetrievalContentValue): seq[byte] =
+  case content.contentType:
+    of unused:
+      raiseAssert "Encoding content with unused content type"
+    of accountTrieNode:
+      SSZ.encode(content.accountTrieNode)
+    of contractTrieNode:
+      SSZ.encode(content.contractTrieNode)
+    of contractCode:
+      SSZ.encode(content.contractCode)
+
 
 func packNibbles*(nibbles: seq[byte]): Nibbles =
   doAssert(nibbles.len() <= MAX_UNPACKED_NIBBLES_LEN, "Can't pack more than 64 nibbles")

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -202,7 +202,7 @@ proc processContentLoop(n: StateNetwork) {.async.} =
             error "Received offered content with invalid content key", contentKey
             continue
         if validateContent(decodedKey, decodedValue):
-          let valueForRetrieval = decodedValue.offerContentToEncodedRetrievalContent()
+          let valueForRetrieval = decodedValue.offerContentToRetrievalContent().encode()
 
           n.portalProtocol.storeContent(contentKey, contentId, valueForRetrieval)
 


### PR DESCRIPTION
### What was the problem?
State network spec states that there are two distinct flavors of each data type:
1) Offer data that is gossiped via `Offer/Accept`
2) Retrieval data that is stored locally and provided via `Find/Found Content`

We already had data types for gossip as well as basic gossip implemented for `Account Trie Node`. We lacked types describing retrieval data, as well as ways to convert Offer data into Retrieval data.

### How this PR fixes that
By implementing ADTs describing this two flavours: `OfferContentValue`, `RetrievalContentValue`. Which allowed to implement functions that work on one and convert it into another: `offerContentToRetrievalContent`. Which allowed us to modify offer data into retrieval data right before storing it into local DB.
This PR also fixes gossip test. That is now checks if the next node in gossip chain stored it's gossiped data in retrieval format.

### Bonus
This PR also gets rid of multiple encoding/decoding calls by moving decoding operation into separate step, and then operating mainly on decoded data. Except for gossip function, as it needs both encoded and decoded data. Encoded is for `ContractCodeOffer` as it is not being modified when gossiped. And decoded is for the rest of the types.