### PR TITLE
Quickfix for possible IndexError in state network recursive gossip

### DIFF
--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -187,6 +187,11 @@ proc recursiveGossipAccountTrieNode(
         nibbles = decodedKey.accountTrieNodeKey.path.unpackNibbles()
         proof = decodedValue.proof
 
+      # When nibbles is empty this means the root node was received. Recursive
+      # gossiping is finished.
+      if nibbles.len() == 0:
+        return
+
       discard nibbles.pop()
       discard (distinctBase proof).pop()
       let


### PR DESCRIPTION
This would currently manifest sometimes in state gossip test in CI or locally. But could occur on fluffy binary in case state network  is enable and data is gossiped.