### PR TITLE
Update Nimbus codebase to use the new nim-rocksdb API.

### DIFF
--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -16,6 +16,7 @@
 import
   std/[tables, os],
   eth/common,
+  rocksdb/lib/librocksdb,
   rocksdb,
   stew/endians2,
   ../../aristo_desc,
@@ -23,17 +24,18 @@ import
 
 type
   RdbInst* = object
-    store*: RocksDBInstance          ## Rocks DB database handler
+    dbOpts*: DbOptionsRef
+    store*: RocksDbReadWriteRef      ## Rocks DB database handler
     basePath*: string                ## Database directory
 
     # Low level Rocks DB access for bulk store
-    envOpt*: rocksdb_envoptions_t
-    impOpt*: rocksdb_ingestexternalfileoptions_t
+    envOpt*: ptr rocksdb_envoptions_t
+    impOpt*: ptr rocksdb_ingestexternalfileoptions_t
 
   RdbKey* = array[1 + sizeof VertexID, byte]
     ## Sub-table key, <pfx> + VertexID
 
-  RdbTabs* = array[StorageType,Table[uint64,Blob]]
+  RdbTabs* = array[StorageType, Table[uint64,Blob]]
     ## Combined table for caching data to be stored/updated
 
 const

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
@@ -16,6 +16,7 @@
 import
   std/os,
   chronicles,
+  rocksdb/lib/librocksdb,
   rocksdb,
   results,
   ../../aristo_desc,
@@ -61,14 +62,18 @@ proc init*(
   except OSError, IOError:
     return err((RdbBeCantCreateTmpDir, ""))
 
-  let rc = rdb.store.init(
-    dbPath=dataDir, dbBackuppath=backupsDir, readOnly=false,
-    maxOpenFiles=openMax)
+  let dbOpts = defaultDbOptions()
+  dbOpts.setMaxOpenFiles(openMax)
+
+  let rc = openRocksDb(dataDir, dbOpts)
   if rc.isErr:
     let error = RdbBeDriverInitError
     debug logTxt "driver failed", dataDir, backupsDir, openMax,
       error, info=rc.error
     return err((RdbBeDriverInitError, rc.error))
+
+  rdb.dbOpts = dbOpts
+  rdb.store = rc.get()
 
   # The following is a default setup (subject to change)
   rdb.impOpt = rocksdb_ingestexternalfileoptions_create()

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_put.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_put.nim
@@ -135,8 +135,9 @@ proc commit(
     if not csError.isNil:
       return err((RdbBeFinishSstWriter, $csError))
 
+    var sstPath = session.sstPath.cstring
     rdb.store.cPtr.rocksdb_ingest_external_file(
-      [session.sstPath].allocCStringArray, 1, rdb.impOpt, cast[cstringArray](csError.addr))
+      cast[cstringArray](sstPath.addr), 1, rdb.impOpt, cast[cstringArray](csError.addr))
     if not csError.isNil:
       return err((RdbBeIngestSstWriter, $csError))
 

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_put.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_put.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_walk.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_walk.nim
@@ -17,6 +17,7 @@ import
   std/sequtils,
   eth/common,
   stew/endians2,
+  rocksdb/lib/librocksdb,
   rocksdb,
   ../init_common,
   ./rdb_desc
@@ -49,8 +50,13 @@ iterator walk*(
   ## Walk over all key-value pairs of the database.
   ##
   ## Non-decodable entries are stepped over and ignored.
-  let rit = rdb.store.db.rocksdb_create_iterator(rdb.store.readOptions)
-  defer: rit.rocksdb_iter_destroy()
+
+  let
+    readOptions = rocksdb_readoptions_create()
+    rit = rdb.store.cPtr.rocksdb_create_iterator(readOptions)
+  defer:
+    rit.rocksdb_iter_destroy()
+    readOptions.rocksdb_readoptions_destroy()
 
   rit.rocksdb_iter_seek_to_first()
 
@@ -91,8 +97,12 @@ iterator walk*(
       # Unsupported
       break walkBody
 
-    let rit = rdb.store.db.rocksdb_create_iterator(rdb.store.readOptions)
-    defer: rit.rocksdb_iter_destroy()
+    let
+      readOptions = rocksdb_readoptions_create()
+      rit = rdb.store.cPtr.rocksdb_create_iterator(readOptions)
+    defer:
+      rit.rocksdb_iter_destroy()
+      readOptions.rocksdb_readoptions_destroy()
 
     var
       kLen: csize_t

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_walk.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_walk.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/core_db/backend/legacy_rocksdb.nim
+++ b/nimbus/db/core_db/backend/legacy_rocksdb.nim
@@ -60,7 +60,7 @@ proc newLegacyPersistentCoreDbRef*(path: string): CoreDbRef =
     raise (ref ResultDefect)(msg: msg)
 
   proc done() =
-    backend.rdb.store.close()
+    backend.rdb.close()
 
   LegaPersDbRef(rdb: backend.rdb).init(LegacyDbPersistent, backend.trieDB, done)
 

--- a/nimbus/db/kvstore_rocksdb.nim
+++ b/nimbus/db/kvstore_rocksdb.nim
@@ -12,7 +12,8 @@
 
 import
   std/os,
-  rocksdb, stew/results,
+  stew/results,
+  rocksdb,
   eth/db/kvstore
 
 export results, kvstore
@@ -21,8 +22,17 @@ const maxOpenFiles = 512
 
 type
   RocksStoreRef* = ref object of RootObj
-    store*: RocksDBInstance
+    dbOpts*: DbOptionsRef
+    store*: RocksDbRef
     tmpDir*: string
+    backupEngine: BackupEngineRef
+
+template canWrite(db: RocksStoreRef): bool =
+  (db.store of RocksDbReadWriteRef)
+
+template validateCanWrite(db: RocksStoreRef) =
+  if not db.canWrite():
+    raiseAssert "Unimplemented"
 
 proc get*(db: RocksStoreRef, key: openArray[byte], onData: kvstore.DataProc): KvResult[bool] =
   db.store.get(key, onData)
@@ -31,26 +41,40 @@ proc find*(db: RocksStoreRef, prefix: openArray[byte], onFind: kvstore.KeyValueP
   raiseAssert "Unimplemented"
 
 proc put*(db: RocksStoreRef, key, value: openArray[byte]): KvResult[void] =
-  db.store.put(key, value)
+  db.validateCanWrite()
+  db.store.RocksDbReadWriteRef.put(key, value)
 
 proc contains*(db: RocksStoreRef, key: openArray[byte]): KvResult[bool] =
-  db.store.contains(key)
+  db.store.keyExists(key)
 
 proc del*(db: RocksStoreRef, key: openArray[byte]): KvResult[bool] =
-  db.store.del(key)
+  db.validateCanWrite()
+  let db = db.store.RocksDbReadWriteRef
+
+  let existsRes = db.keyExists(key)
+  if existsRes.isErr() or existsRes.get() == false:
+    return existsRes
+
+  let delRes = db.delete(key)
+  if delRes.isErr():
+    return err(delRes.error())
+
+  ok(true)
 
 proc clear*(db: RocksStoreRef): KvResult[bool] =
-  db.store.clear()
+  raiseAssert "Unimplemented"
 
 proc close*(db: RocksStoreRef) =
-  db.store.close
+  db.store.close()
 
 proc init*(
-    T: type RocksStoreRef, basePath: string, name: string,
+    T: type RocksStoreRef,
+    basePath: string,
+    name: string,
     readOnly = false): KvResult[T] =
+
   let
     dataDir = basePath / name / "data"
-    # tmpDir = basePath / name / "tmp" -- notused
     backupsDir = basePath / name / "backups"
 
   try:
@@ -59,9 +83,20 @@ proc init*(
   except OSError, IOError:
     return err("rocksdb: cannot create database directory")
 
-  var store: RocksDBInstance
-  if (let v = store.init(
-      dataDir, backupsDir, readOnly, maxOpenFiles = maxOpenFiles); v.isErr):
-    return err(v.error)
+  let backupRes = openBackupEngine(backupsDir)
+  if backupRes.isErr():
+    return err(backupRes.error())
 
-  ok(T(store: store))
+  let dbOpts = defaultDbOptions()
+  dbOpts.setMaxOpenFiles(maxOpenFiles)
+
+  if readOnly:
+    let res = openRocksDbReadOnly(dataDir, dbOpts)
+    if res.isErr():
+      return err(res.error())
+    ok(T(dbOpts: dbOpts, store: res.get(), backupEngine: backupRes.get()))
+  else:
+    let res = openRocksDb(dataDir, dbOpts)
+    if res.isErr():
+      return err(res.error())
+    ok(T(dbOpts: dbOpts, store: res.get(), backupEngine: backupRes.get()))

--- a/nimbus/db/kvstore_rocksdb.nim
+++ b/nimbus/db/kvstore_rocksdb.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_desc.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_desc.nim
@@ -15,16 +15,18 @@
 
 import
   std/os,
+  rocksdb/lib/librocksdb,
   rocksdb
 
 type
   RdbInst* = object
-    store*: RocksDBInstance          ## Rocks DB database handler
+    dbOpts*: DbOptionsRef
+    store*: RocksDbReadWriteRef      ## Rocks DB database handler
     basePath*: string                ## Database directory
 
     # Low level Rocks DB access for bulk store
-    envOpt*: rocksdb_envoptions_t
-    impOpt*: rocksdb_ingestexternalfileoptions_t
+    envOpt*: ptr rocksdb_envoptions_t
+    impOpt*: ptr rocksdb_ingestexternalfileoptions_t
 
 const
   BaseFolder* = "nimbus"         # Same as for Legacy DB

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_init.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_init.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_init.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_init.nim
@@ -16,6 +16,7 @@
 import
   std/os,
   chronicles,
+  rocksdb/lib/librocksdb,
   rocksdb,
   results,
   ../../kvt_desc,
@@ -61,14 +62,18 @@ proc init*(
   except OSError, IOError:
     return err((RdbBeCantCreateTmpDir, ""))
 
-  let rc = rdb.store.init(
-    dbPath=dataDir, dbBackuppath=backupsDir, readOnly=false,
-    maxOpenFiles=openMax)
+  let dbOpts = defaultDbOptions()
+  dbOpts.setMaxOpenFiles(openMax)
+
+  let rc = openRocksDb(dataDir, dbOpts)
   if rc.isErr:
     let error = RdbBeDriverInitError
     debug logTxt "driver failed", dataDir, backupsDir, openMax,
       error, info=rc.error
     return err((RdbBeDriverInitError, rc.error))
+
+  rdb.dbOpts = dbOpts
+  rdb.store = rc.get()
 
   # The following is a default setup (subject to change)
   rdb.impOpt = rocksdb_ingestexternalfileoptions_create()

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_put.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_put.nim
@@ -133,8 +133,10 @@ proc commit(
     if not csError.isNil:
       return err((RdbBeFinishSstWriter, $csError))
 
+    var sstPath = session.sstPath.cstring
     rdb.store.cPtr.rocksdb_ingest_external_file(
-      [session.sstPath].allocCStringArray, 1, rdb.impOpt, cast[cstringArray](csError.addr))
+      cast[cstringArray](sstPath.addr),
+      1, rdb.impOpt, cast[cstringArray](csError.addr))
     if not csError.isNil:
       return err((RdbBeIngestSstWriter, $csError))
 

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_put.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_put.nim
@@ -17,6 +17,7 @@ import
   std/[algorithm, os, sequtils, strutils, sets, tables],
   chronicles,
   eth/common,
+  rocksdb/lib/librocksdb,
   rocksdb,
   results,
   ../../kvt_desc,
@@ -27,7 +28,7 @@ logScope:
 
 type
   RdbPutSession = object
-    writer: rocksdb_sstfilewriter_t
+    writer: ptr rocksdb_sstfilewriter_t
     sstPath: string
     nRecords: int
 
@@ -74,7 +75,7 @@ proc begin(
   var csError: cstring
 
   var session = RdbPutSession(
-    writer: rocksdb_sstfilewriter_create(rdb.envOpt, rdb.store.options),
+    writer: rocksdb_sstfilewriter_create(rdb.envOpt, rdb.dbOpts.cPtr),
     sstPath: rdb.sstFilePath)
 
   if session.writer.isNil:
@@ -82,7 +83,7 @@ proc begin(
   session.sstPath.rmFileIgnExpt
 
   session.writer.rocksdb_sstfilewriter_open(
-    session.sstPath.cstring, addr csError)
+    session.sstPath.cstring, cast[cstringArray](csError.addr))
   if not csError.isNil:
     session.destroy()
     let info = $csError
@@ -109,7 +110,8 @@ proc add(
 
   session.writer.rocksdb_sstfilewriter_add(
     cast[cstring](unsafeAddr key[0]), csize_t(key.len),
-    cast[cstring](unsafeAddr val[0]), csize_t(val.len), addr csError)
+    cast[cstring](unsafeAddr val[0]), csize_t(val.len),
+    cast[cstringArray](csError.addr))
   if not csError.isNil:
     return err((RdbBeAddSstWriter, $csError))
 
@@ -127,12 +129,12 @@ proc commit(
   var csError: cstring
 
   if 0 < session.nRecords:
-    session.writer.rocksdb_sstfilewriter_finish(addr csError)
+    session.writer.rocksdb_sstfilewriter_finish(cast[cstringArray](csError.addr))
     if not csError.isNil:
       return err((RdbBeFinishSstWriter, $csError))
 
-    rdb.store.db.rocksdb_ingest_external_file(
-      [session.sstPath].allocCStringArray, 1, rdb.impOpt, addr csError)
+    rdb.store.cPtr.rocksdb_ingest_external_file(
+      [session.sstPath].allocCStringArray, 1, rdb.impOpt, cast[cstringArray](csError.addr))
     if not csError.isNil:
       return err((RdbBeIngestSstWriter, $csError))
 
@@ -170,7 +172,7 @@ proc put*(
       return -1
     if b.len < a.len:
       return 1
-  
+
   for key in tab.keys.toSeq.sorted cmpBlobs:
     let val = tab.getOrVoid key
     if val.isValid:
@@ -189,7 +191,7 @@ proc put*(
 
   # Delete vertices after successfully updating vertices with non-zero values.
   for key in delKey:
-    let rc = rdb.store.del key
+    let rc = rdb.store.delete key
     if rc.isErr:
       return err((RdbBeDriverDelError,rc.error))
 

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_put.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_put.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_walk.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_walk.nim
@@ -16,6 +16,7 @@
 import
   std/sequtils,
   eth/common,
+  rocksdb/lib/librocksdb,
   rocksdb,
   ./rdb_desc
 
@@ -26,8 +27,12 @@ import
 iterator walk*(rdb: RdbInst): tuple[key: Blob, data: Blob] =
   ## Walk over all key-value pairs of the database.
   ##
-  let rit = rdb.store.db.rocksdb_create_iterator(rdb.store.readOptions)
-  defer: rit.rocksdb_iter_destroy()
+  let
+    readOptions = rocksdb_readoptions_create()
+    rit = rdb.store.cPtr.rocksdb_create_iterator(readOptions)
+  defer:
+    rit.rocksdb_iter_destroy()
+    readOptions.rocksdb_readoptions_destroy()
 
   rit.rocksdb_iter_seek_to_first()
   while rit.rocksdb_iter_valid() != 0:

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_walk.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_walk.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/sync/snap/worker/db/rocky_bulk_load.nim
+++ b/nimbus/sync/snap/worker/db/rocky_bulk_load.nim
@@ -148,9 +148,10 @@ proc finish*(
   var csError: cstring
   rbl.writer.rocksdb_sstfilewriter_finish(cast[cstringArray](csError.addr))
 
+  var filePath = rbl.filePath.cstring
   if csError.isNil:
     rbl.db.store.cPtr.rocksdb_ingest_external_file(
-      [rbl.filePath].allocCStringArray, 1,
+      cast[cstringArray](filePath.addr), 1,
       rbl.importOption,
       cast[cstringArray](csError.addr))
 

--- a/tests/db/test_kvstore_rocksdb.nim
+++ b/tests/db/test_kvstore_rocksdb.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/tests/replay/undump_kvp.nim
+++ b/tests/replay/undump_kvp.nim
@@ -57,7 +57,7 @@ proc walkAllDb(
   ## Walk over all key-value pairs of the database (`RocksDB` only.)
   let
     rop = rocksdb_readoptions_create()
-    rit = rocky.store.cPtr.rocksdb_create_iterator(rop)
+    rit = rocky.readWriteDb.cPtr.rocksdb_create_iterator(rop)
 
   rit.rocksdb_iter_seek_to_first()
   while rit.rocksdb_iter_valid() != 0:

--- a/tests/replay/undump_kvp.nim
+++ b/tests/replay/undump_kvp.nim
@@ -12,6 +12,7 @@ import
   std/[os, sequtils, strformat, strutils],
   chronicles,
   eth/common,
+  rocksdb/lib/librocksdb,
   rocksdb,
   stew/byteutils,
   ../../nimbus/db/kvstore_rocksdb,
@@ -55,8 +56,8 @@ proc walkAllDb(
       ) =
   ## Walk over all key-value pairs of the database (`RocksDB` only.)
   let
-    rop = rocky.store.readOptions
-    rit = rocky.store.db.rocksdb_create_iterator(rop)
+    rop = rocksdb_readoptions_create()
+    rit = rocky.store.cPtr.rocksdb_create_iterator(rop)
 
   rit.rocksdb_iter_seek_to_first()
   while rit.rocksdb_iter_valid() != 0:
@@ -83,6 +84,7 @@ proc walkAllDb(
     # End while
 
   rit.rocksdb_iter_destroy()
+  rop.rocksdb_readoptions_destroy()
 
 proc dumpAllDbImpl(
     rocky: RocksStoreRef;           # Persistent database handle

--- a/tests/replay/undump_kvp.nim
+++ b/tests/replay/undump_kvp.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/tests/test_rocksdb_timing.nim
+++ b/tests/test_rocksdb_timing.nim
@@ -16,6 +16,7 @@ import
   eth/[common, p2p],
   rocksdb,
   unittest2,
+  ../nimbus/db/kvstore_rocksdb,
   ../nimbus/db/core_db/persistent,
   ../nimbus/core/chain,
   ../nimbus/sync/snap/range_desc,
@@ -119,7 +120,7 @@ proc flushDbs(db: TestDbs) =
     for n in 0 ..< nTestDbInstances:
       if db.cdb[n].isNil or db.cdb[n].dbType != LegacyDbPersistent:
          break
-      db.cdb[n].backend.toRocksStoreRef.store.close()
+      db.cdb[n].backend.toRocksStoreRef.close()
     db.baseDir.flushDbDir(db.subDir)
 
 proc testDbs(

--- a/tests/test_rocksdb_timing.nim
+++ b/tests/test_rocksdb_timing.nim
@@ -119,7 +119,7 @@ proc flushDbs(db: TestDbs) =
     for n in 0 ..< nTestDbInstances:
       if db.cdb[n].isNil or db.cdb[n].dbType != LegacyDbPersistent:
          break
-      db.cdb[n].backend.toRocksStoreRef.store.db.rocksdb_close
+      db.cdb[n].backend.toRocksStoreRef.store.close()
     db.baseDir.flushDbDir(db.subDir)
 
 proc testDbs(

--- a/tests/test_rocksdb_timing/test_db_timing.nim
+++ b/tests/test_rocksdb_timing/test_db_timing.nim
@@ -17,6 +17,7 @@ import
   rocksdb,
   unittest2,
   ../../nimbus/core/chain,
+  ../../nimbus/db/kvstore_rocksdb,
   ../../nimbus/db/core_db,
   ../../nimbus/db/core_db/persistent,
   ../../nimbus/sync/snap/range_desc,
@@ -136,7 +137,7 @@ proc test_dbTimingRockySetup*(
   let
     rdb = cdb.backend.toRocksStoreRef
     rop = rocksdb_readoptions_create()
-    rit = rdb.store.cPtr.rocksdb_create_iterator(rop)
+    rit = rdb.readWriteDb().cPtr.rocksdb_create_iterator(rop)
   check not rit.isNil
 
   var

--- a/tests/test_rocksdb_timing/test_db_timing.nim
+++ b/tests/test_rocksdb_timing/test_db_timing.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/tests/test_sync_snap.nim
+++ b/tests/test_sync_snap.nim
@@ -151,7 +151,7 @@ proc flushDbs(db: TestDbs) =
     for n in 0 ..< nTestDbInstances:
       if db.cdb[n].isNil or db.cdb[n].dbType != LegacyDbPersistent:
         break
-      db.cdb[n].backend.toRocksStoreRef.store.close()
+      db.cdb[n].backend.toRocksStoreRef.close()
     db.baseDir.flushDbDir(db.subDir)
 
 proc testDbs(

--- a/tests/test_sync_snap.nim
+++ b/tests/test_sync_snap.nim
@@ -151,7 +151,7 @@ proc flushDbs(db: TestDbs) =
     for n in 0 ..< nTestDbInstances:
       if db.cdb[n].isNil or db.cdb[n].dbType != LegacyDbPersistent:
         break
-      db.cdb[n].backend.toRocksStoreRef.store.db.rocksdb_close
+      db.cdb[n].backend.toRocksStoreRef.store.close()
     db.baseDir.flushDbDir(db.subDir)
 
 proc testDbs(

--- a/tests/test_sync_snap/test_pivot.nim
+++ b/tests/test_sync_snap/test_pivot.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
The new version of nim-rocksdb makes the following breaking changes:
- RocksDbInstance now named RocksDbReadWriteRef or RocksDbReadOnlyRef depending on readOnly mode.
- contains renamed to keyExists.
- del renamed to delete and no longer returns flag indicating if a record was deleted.
- Backup features moved to BackupEngineRef type.
- Low level c api moved to rocksdb/lib/librocksdb and is not exported by default.
- C API types are updated to be objects so ptr prefix is required. This was required in order to update the header file wrapper to the latest version.
- The RocksDbRef types no longer expose internal fields.

Due to these above changes a lot of files needed to be updated.