### PR TITLE
Introduce --networks and --portal-network cli options

### DIFF
--- a/fluffy/docs/the_fluffy_book/docs/connect-to-portal.md
+++ b/fluffy/docs/the_fluffy_book/docs/connect-to-portal.md
@@ -13,7 +13,7 @@ which contains nodes of the different clients.
     Default the Fluffy node will connect to the
     [bootstrap nodes](https://github.com/ethereum/portal-network-specs/blob/master/testnet.md#bootnodes) of the public testnet.
 
-    When testing locally the `--network:none` option can be provided to avoid
+    When testing locally the `--portal-network:none` option can be provided to avoid
     connecting to any of the testnet bootstrap nodes.
 
 The `--rpc` option will also enable the different JSON-RPC interfaces through

--- a/fluffy/docs/the_fluffy_book/docs/run-local-testnet.md
+++ b/fluffy/docs/the_fluffy_book/docs/run-local-testnet.md
@@ -27,5 +27,5 @@ any of the running nodes their ENR.
 E.g. to manually add a Fluffy node to the local testnet run:
 
 ```bash
-./build/fluffy --rpc --network:none --udp-port:9010 --nat:extip:127.0.0.1 --bootstrap-node:`cat ./local_testnet_data/node0/fluffy_node.enr`
+./build/fluffy --rpc --portal-network:none --udp-port:9010 --nat:extip:127.0.0.1 --bootstrap-node:`cat ./local_testnet_data/node0/fluffy_node.enr`
 ```

--- a/fluffy/scripts/launch_local_testnet.sh
+++ b/fluffy/scripts/launch_local_testnet.sh
@@ -304,7 +304,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --log-level="${LOG_LEVEL}" \
     --udp-port=$(( BASE_PORT + NUM_NODE )) \
     --data-dir="${NODE_DATA_DIR}" \
-    --network="none" \
+    --portal-network="none" \
     ${BOOTSTRAP_ARG} \
     --rpc \
     --rpc-address="127.0.0.1" \
@@ -315,7 +315,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --table-ip-limit=1024 \
     --bucket-ip-limit=24 \
     --bits-per-hop=1 \
-    --state=1 \
+    --networks:beacon,history,state \
     ${TRUSTED_BLOCK_ROOT_ARG} \
     ${RADIUS_ARG} \
     ${EXTRA_ARGS} \


### PR DESCRIPTION
The --networks option is to select the networks alias the Portal sub-protocols.
The --network option is deprecated and replaced with the --portal-network option to avoid confusion with --networks option.

This commit also remove the --state flag which was a temporary quick-fix.