### PR TITLE
Db namespaces changes.

### DIFF
--- a/nimbus/beacon/merge_tracker.nim
+++ b/nimbus/beacon/merge_tracker.nim
@@ -37,10 +37,12 @@ type
 # ------------------------------------------------------------------------------
 
 proc writeStatus(db: CoreDbRef, status: TransitionStatus) =
-  db.kvt.put(transitionStatusKey().toOpenArray(), rlp.encode(status))
+  let key = transitionStatusKey()
+  db.kvt(key.namespace).put(key.toOpenArray(), rlp.encode(status))
 
 proc readStatus(db: CoreDbRef): TransitionStatus =
-  var bytes = db.kvt.get(transitionStatusKey().toOpenArray())
+  let key = transitionStatusKey()
+  var bytes = db.kvt(key.namespace).get(key.toOpenArray())
   if bytes.len > 0:
     try:
       result = rlp.decode(bytes, typeof result)

--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -408,7 +408,7 @@ proc initializeEmptyDb*(com: CommonRef)
     {.gcsafe, raises: [CatchableError].} =
   let
     key = canonicalHeadHashKey()
-    kvt = com.db.kvt(key.toNamespace())
+    kvt = com.db.kvt(key.namespace)
   if key.toOpenArray notin kvt:
     trace "Writing genesis to DB"
     doAssert(com.genesisHeader.blockNumber.isZero,

--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -406,14 +406,16 @@ proc consensus*(com: CommonRef, header: BlockHeader): ConsensusType
 
 proc initializeEmptyDb*(com: CommonRef)
     {.gcsafe, raises: [CatchableError].} =
-  let kvt = com.db.kvt()
-  if canonicalHeadHashKey().toOpenArray notin kvt:
+  let
+    key = canonicalHeadHashKey()
+    kvt = com.db.kvt(key.toNamespace())
+  if key.toOpenArray notin kvt:
     trace "Writing genesis to DB"
     doAssert(com.genesisHeader.blockNumber.isZero,
       "can't commit genesis block with number > 0")
     discard com.db.persistHeaderToDb(com.genesisHeader,
       com.consensusType == ConsensusType.POS)
-    doAssert(canonicalHeadHashKey().toOpenArray in kvt)
+    doAssert(key.toOpenArray in kvt)
 
 proc syncReqNewHead*(com: CommonRef; header: BlockHeader)
     {.gcsafe, raises: [].} =

--- a/nimbus/db/aristo/aristo_desc/desc_error.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_error.nim
@@ -236,7 +236,6 @@ type
 
     # RocksDB backend
     RdbBeCantCreateDataDir
-    RdbBeCantCreateBackupDir
     RdbBeCantCreateTmpDir
     RdbBeDriverInitError
     RdbBeDriverGetError
@@ -268,7 +267,7 @@ type
     AccVtxUnsupported
     AccNodeUnsupported
     PayloadTypeUnsupported
-    
+
     # Miscelaneous handy helpers
     AccRootUnacceptable
     MptContextMissing

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -41,7 +41,6 @@ type
 const
   BaseFolder* = "nimbus"           # Same as for Legacy DB
   DataFolder* = "aristo"           # Legacy DB has "data"
-  BackupFolder* = "aristo-history" # Legacy DB has "backups"
   SstCache* = "bulkput"            # Rocks DB bulk load file name in temp folder
   TempFolder* = "tmp"              # No `tmp` directory used with legacy DB
 
@@ -54,9 +53,6 @@ func baseDir*(rdb: RdbInst): string =
 
 func dataDir*(rdb: RdbInst): string =
   rdb.baseDir / DataFolder
-
-func backupsDir*(rdb: RdbInst): string =
-  rdb.basePath / BaseFolder / BackupFolder
 
 func cacheDir*(rdb: RdbInst): string =
   rdb.dataDir / TempFolder

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
@@ -47,16 +47,11 @@ proc init*(
 
   let
     dataDir = rdb.dataDir
-    backupsDir = rdb.backupsDir
 
   try:
     dataDir.createDir
   except OSError, IOError:
     return err((RdbBeCantCreateDataDir, ""))
-  try:
-    backupsDir.createDir
-  except OSError, IOError:
-    return err((RdbBeCantCreateBackupDir, ""))
   try:
     rdb.cacheDir.createDir
   except OSError, IOError:
@@ -68,7 +63,7 @@ proc init*(
   let rc = openRocksDb(dataDir, dbOpts)
   if rc.isErr:
     let error = RdbBeDriverInitError
-    debug logTxt "driver failed", dataDir, backupsDir, openMax,
+    debug logTxt "driver failed", dataDir, openMax,
       error, info=rc.error
     return err((RdbBeDriverInitError, rc.error))
 

--- a/nimbus/db/core_db/backend/aristo_db.nim
+++ b/nimbus/db/core_db/backend/aristo_db.nim
@@ -20,7 +20,9 @@ import
   ../../kvt,
   ../../kvt/[kvt_desc, kvt_init, kvt_tx, kvt_walk],
   ".."/[base, base/base_desc],
-  ./aristo_db/[common_desc, handlers_aristo, handlers_kvt]
+  ./aristo_db/[common_desc, handlers_aristo, handlers_kvt],
+  ../../storage_types
+
 
 import
   ../../aristo/aristo_init/memory_only as aristo_memory_only
@@ -135,7 +137,8 @@ proc baseMethods(
           ): CoreDbRc[CoreDbTrieRef] =
       db.adbBase.getTrie(kind, root, address, "getTrieFn()"),
 
-    newKvtFn: proc(saveMode: CoreDbSaveFlags): CoreDbRc[CoreDxKvtRef] =
+    newKvtFn: proc(namespace: DbNamespace, saveMode: CoreDbSaveFlags): CoreDbRc[CoreDxKvtRef] =
+      # TODO: use namespace
       db.kdbBase.gc()
       db.kdbBase.newKvtHandler(saveMode, "newKvtFn()"),
 

--- a/nimbus/db/core_db/base.nim
+++ b/nimbus/db/core_db/base.nim
@@ -555,6 +555,10 @@ proc forget*(dsc: CoreDxKvtRef): CoreDbRc[void] {.discardable.} =
   result = dsc.methods.forgetFn()
   dsc.ifTrackNewApi: debug newApiTxt, ctx, elapsed, result
 
+proc namespace*(dsc: CoreDxKvtRef, namespace: string): CoreDxKvtRef =
+  ## TODO:
+  dsc.methods.namespaceFn(namespace)
+
 # ------------------------------------------------------------------------------
 # Public Merkle Patricia Tree, hexary trie constructors
 # ------------------------------------------------------------------------------
@@ -1029,10 +1033,16 @@ when ProvideLegacyAPI:
 
   # ----------------
 
-  proc kvt*(db: CoreDbRef): CoreDbKvtRef =
+  proc kvt*(db: CoreDbRef, namespace = ""): CoreDbKvtRef =
     ## Legacy pseudo constructor, see `toKvt()` for production constructor
     db.setTrackLegaApi LegaNewKvtFn
-    result = db.newKvt().CoreDbKvtRef
+    db.ifTrackLegaApi: debug legaApiTxt, ctx, elapsed, result
+
+    if namespace.len() > 0:
+      result = db.newKvt().namespace(namespace).CoreDbKvtRef
+    else:
+      result = db.newKvt().CoreDbKvtRef
+
     db.ifTrackLegaApi: debug legaApiTxt, ctx, elapsed, result
 
   proc get*(kvt: CoreDbKvtRef; key: openArray[byte]): Blob =

--- a/nimbus/db/core_db/base/base_desc.nim
+++ b/nimbus/db/core_db/base/base_desc.nim
@@ -144,13 +144,14 @@ type
   # Sub-descriptor: KVT methods
   # --------------------------------------------------
   CoreDbKvtBackendFn* = proc(): CoreDbKvtBackendRef {.noRaise.}
-  CoreDbKvtGetFn* = proc(k: openArray[byte]): CoreDbRc[Blob] {.noRaise.} 
+  CoreDbKvtGetFn* = proc(k: openArray[byte]): CoreDbRc[Blob] {.noRaise.}
   CoreDbKvtDelFn* = proc(k: openArray[byte]): CoreDbRc[void] {.noRaise.}
   CoreDbKvtPutFn* =
     proc(k: openArray[byte]; v: openArray[byte]): CoreDbRc[void] {.noRaise.}
   CoreDbKvtPersistentFn* = proc(): CoreDbRc[void] {.noRaise.}
   CoreDbKvtForgetFn* = proc(): CoreDbRc[void] {.noRaise.}
   CoreDbKvtHasKeyFn* = proc(k: openArray[byte]): CoreDbRc[bool] {.noRaise.}
+  CoreDbKvtNamespaceFn* = proc(ns: string): CoreDxKvtRef {.noRaise.}
 
   CoreDbKvtFns* = object
     ## Methods for key-value table
@@ -161,6 +162,7 @@ type
     hasKeyFn*:     CoreDbKvtHasKeyFn
     persistentFn*: CoreDbKvtPersistentFn
     forgetFn*:     CoreDbKvtForgetFn
+    namespaceFn*:  CoreDbKvtNamespaceFn
 
 
   # --------------------------------------------------

--- a/nimbus/db/core_db/base/base_desc.nim
+++ b/nimbus/db/core_db/base/base_desc.nim
@@ -13,6 +13,7 @@
 import
   eth/common,
   results,
+  ../../storage_types,
   ../../aristo/aristo_profile
 
 # Annotation helpers
@@ -101,7 +102,7 @@ type
     ): CoreDbRc[CoreDbTrieRef] {.noRaise.}
   CoreDbBaseLevelFn* = proc(): int {.noRaise.}
   CoreDbBaseKvtFn* = proc(
-    saveMode: CoreDbSaveFlags): CoreDbRc[CoreDxKvtRef] {.noRaise.}
+    namespace: DbNamespace, saveMode: CoreDbSaveFlags): CoreDbRc[CoreDxKvtRef] {.noRaise.}
   CoreDbBaseMptFn* = proc(
     root: CoreDbTrieRef; prune: bool; saveMode: CoreDbSaveFlags;
     ): CoreDbRc[CoreDxMptRef] {.noRaise.}
@@ -151,7 +152,7 @@ type
   CoreDbKvtPersistentFn* = proc(): CoreDbRc[void] {.noRaise.}
   CoreDbKvtForgetFn* = proc(): CoreDbRc[void] {.noRaise.}
   CoreDbKvtHasKeyFn* = proc(k: openArray[byte]): CoreDbRc[bool] {.noRaise.}
-  CoreDbKvtNamespaceFn* = proc(ns: string): CoreDxKvtRef {.noRaise.}
+  CoreDbKvtNamespaceFn* = proc(ns: DbNamespace): CoreDxKvtRef {.noRaise.}
 
   CoreDbKvtFns* = object
     ## Methods for key-value table

--- a/nimbus/db/distinct_tries.nim
+++ b/nimbus/db/distinct_tries.nim
@@ -52,14 +52,15 @@ proc toSvp*(sl: StorageTrie): seq[(UInt256,UInt256)] =
     save = db.trackLegaApi
   db.trackLegaApi = false
   defer: db.trackLegaApi = save
-  let kvt = db.kvt
+
   var kvp: Table[UInt256,UInt256]
   try:
     for (slotHash,val) in sl.toBase.toMpt.pairs:
       if slotHash.len == 0:
         kvp[high UInt256] = high UInt256
       else:
-        let slotRlp = kvt.get(slotHashToSlotKey(slotHash).toOpenArray)
+        let key = slotHashToSlotKey(slotHash)
+        let slotRlp = db.kvt(key.namespace).get(key.toOpenArray)
         if slotRlp.len == 0:
           kvp[high UInt256] = high UInt256
         else:

--- a/nimbus/db/incomplete_db.nim
+++ b/nimbus/db/incomplete_db.nim
@@ -41,13 +41,13 @@ proc populateDbWithNodes*(db: CoreDbRef, nodes: seq[seq[byte]]) =
   for nodeBytes in nodes:
     let nodeHash = keccakHash(nodeBytes)
     info("AARDVARK: populateDbWithNodes about to add node", nodeHash, nodeBytes)
-    db.kvt.put(nodeHash.data, nodeBytes)
+    db.defaultKvt.put(nodeHash.data, nodeBytes)
 
 # AARDVARK: just make the callers call populateDbWithNodes directly?
 proc populateDbWithBranch*(db: CoreDbRef, branch: seq[seq[byte]]) =
   for nodeBytes in branch:
     let nodeHash = keccakHash(nodeBytes)
-    db.kvt.put(nodeHash.data, nodeBytes)
+    db.defaultKvt.put(nodeHash.data, nodeBytes)
 
 # Returns a none if there are missing nodes; if the account itself simply
 # doesn't exist yet, that's fine and it returns some(newAccount()).
@@ -57,14 +57,15 @@ proc ifNodesExistGetAccount*(trie: AccountsTrie, address: EthAddress): Option[Ac
 proc maybeGetCode*(db: CoreDbRef, codeHash: Hash256): Option[seq[byte]] =
   when defined(geth):
     if db.isLegacy:
-      db.kvt.backend.toLegacy.maybeGet(codeHash.data)
+      db.defaultKvt.backend.toLegacy.maybeGet(codeHash.data)
     else:
-      db.kvt.get(codeHash.data)
+      db.defaultKvt.get(codeHash.data)
   else:
+    let key = contractHashKey(codeHash)
     if db.isLegacy:
-      db.kvt.backend.toLegacy.maybeGet(contractHashKey(codeHash).toOpenArray)
+      db.kvt(key.namespace).backend.toLegacy.maybeGet(key.toOpenArray)
     else:
-      some(db.kvt.get(contractHashKey(codeHash).toOpenArray))
+      some(db.kvt(key.namespace).get(key.toOpenArray))
 
 proc maybeGetCode*(trie: AccountsTrie, address: EthAddress): Option[seq[byte]] =
   let maybeAcc = trie.ifNodesExistGetAccount(address)

--- a/nimbus/db/kvt/kvt_desc/desc_error.nim
+++ b/nimbus/db/kvt/kvt_desc/desc_error.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/kvt/kvt_desc/desc_error.nim
+++ b/nimbus/db/kvt/kvt_desc/desc_error.nim
@@ -19,7 +19,6 @@ type
 
     # RocksDB backend
     RdbBeCantCreateDataDir
-    RdbBeCantCreateBackupDir
     RdbBeCantCreateTmpDir
     RdbBeDriverInitError
     RdbBeDriverGetError

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_desc.nim
@@ -31,7 +31,6 @@ type
 const
   BaseFolder* = "nimbus"         # Same as for Legacy DB
   DataFolder* = "kvt"            # Legacy DB has "data"
-  BackupFolder* = "kvt-history"  # Legacy DB has "backups"
   SstCache* = "bulkput"          # Rocks DB bulk load file name in temp folder
   TempFolder* = "tmp"            # No `tmp` directory used with legacy DB
 
@@ -44,9 +43,6 @@ func baseDir*(rdb: RdbInst): string =
 
 func dataDir*(rdb: RdbInst): string =
   rdb.baseDir / DataFolder
-
-func backupsDir*(rdb: RdbInst): string =
-  rdb.basePath / BaseFolder / BackupFolder
 
 func cacheDir*(rdb: RdbInst): string =
   rdb.dataDir / TempFolder

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_init.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_init.nim
@@ -47,16 +47,11 @@ proc init*(
 
   let
     dataDir = rdb.dataDir
-    backupsDir = rdb.backupsDir
 
   try:
     dataDir.createDir
   except OSError, IOError:
     return err((RdbBeCantCreateDataDir, ""))
-  try:
-    backupsDir.createDir
-  except OSError, IOError:
-    return err((RdbBeCantCreateBackupDir, ""))
   try:
     rdb.cacheDir.createDir
   except OSError, IOError:
@@ -68,7 +63,7 @@ proc init*(
   let rc = openRocksDb(dataDir, dbOpts)
   if rc.isErr:
     let error = RdbBeDriverInitError
-    debug logTxt "driver failed", dataDir, backupsDir, openMax,
+    debug logTxt "driver failed", dataDir, openMax,
       error, info=rc.error
     return err((RdbBeDriverInitError, rc.error))
 

--- a/nimbus/db/ledger/distinct_ledgers.nim
+++ b/nimbus/db/ledger/distinct_ledgers.nim
@@ -47,11 +47,12 @@ proc toSvp*(sl: StorageLedger): seq[(UInt256,UInt256)] =
     save = db.trackNewApi
   db.trackNewApi = false
   defer: db.trackNewApi = save
-  let kvt = db.newKvt
+
   var kvp: Table[UInt256,UInt256]
   try:
     for (slotHash,val) in sl.distinctBase.toMpt.pairs:
-      let rc = kvt.get(slotHashToSlotKey(slotHash).toOpenArray)
+      let key = slotHashToSlotKey(slotHash)
+      let rc = db.newKvt(key.namespace).get(key.toOpenArray)
       if rc.isErr:
         warn "StorageLedger.dump()", slotHash, error=($$rc.error)
       else:

--- a/nimbus/db/storage_types.nim
+++ b/nimbus/db/storage_types.nim
@@ -13,7 +13,10 @@ import
 
 type
   DbNamespace* = enum
-    default
+    # Start at -1 because the existing code and tests require this.
+    # Don't change the order or ord values of the below enums or the
+    # tests will break.
+    default = -1
     genericHash
     blockNumberToHash
     blockHashToScore

--- a/nimbus/db/storage_types.nim
+++ b/nimbus/db/storage_types.nim
@@ -34,103 +34,129 @@ type
     blockHashToBlockWitness
 
   DbKey* = object
+    kind*: DBKeyKind
     # The first byte stores the key type. The rest are key-specific values
     data*: array[33, byte]
     dataEndPos*: uint8 # the last populated position in the data
 
+proc toNamespace*(kind: DBKeyKind): string =
+  $ord(kind)
+
+proc toNamespace*(key: DbKey): string =
+  $ord(key.kind)
+
 proc genericHashKey*(h: Hash256): DbKey {.inline.} =
+  result.kind = genericHash
   result.data[0] = byte ord(genericHash)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc blockHashToScoreKey*(h: Hash256): DbKey {.inline.} =
+  result.kind = blockHashToScore
   result.data[0] = byte ord(blockHashToScore)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc transactionHashToBlockKey*(h: Hash256): DbKey {.inline.} =
+  result.kind = transactionHashToBlock
   result.data[0] = byte ord(transactionHashToBlock)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc blockNumberToHashKey*(u: BlockNumber): DbKey {.inline.} =
+  result.kind = blockNumberToHash
   result.data[0] = byte ord(blockNumberToHash)
   doAssert sizeof(u) <= 32
   copyMem(addr result.data[1], unsafeAddr u, sizeof(u))
   result.dataEndPos = uint8 sizeof(u)
 
 proc canonicalHeadHashKey*(): DbKey {.inline.} =
+  result.kind = canonicalHeadHash
   result.data[0] = byte ord(canonicalHeadHash)
   result.dataEndPos = 1
 
 proc slotHashToSlotKey*(h: openArray[byte]): DbKey {.inline.} =
   doAssert(h.len == 32)
+  result.kind = slotHashToSlot
   result.data[0] = byte ord(slotHashToSlot)
   result.data[1 .. 32] = h
   result.dataEndPos = uint8 32
 
 proc contractHashKey*(h: Hash256): DbKey {.inline.} =
+  result.kind = contractHash
   result.data[0] = byte ord(contractHash)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc cliqueSnapshotKey*(h: Hash256): DbKey {.inline.} =
+  result.kind = cliqueSnapshot
   result.data[0] = byte ord(cliqueSnapshot)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc transitionStatusKey*(): DbKey =
+  result.kind = transitionStatus
   # ETH-2 Transition Status
   result.data[0] = byte ord(transitionStatus)
   result.dataEndPos = uint8 1
 
 proc safeHashKey*(): DbKey {.inline.} =
+  result.kind = safeHash
   result.data[0] = byte ord(safeHash)
   result.dataEndPos = uint8 1
 
 proc finalizedHashKey*(): DbKey {.inline.} =
+  result.kind = finalizedHash
   result.data[0] = byte ord(finalizedHash)
   result.dataEndPos = uint8 1
 
 proc skeletonProgressKey*(): DbKey {.inline.} =
+  result.kind = skeletonProgress
   result.data[0] = byte ord(skeletonProgress)
   result.dataEndPos = 1
 
 proc skeletonBlockHashToNumberKey*(h: Hash256): DbKey {.inline.} =
+  result.kind = skeletonBlockHashToNumber
   result.data[0] = byte ord(skeletonBlockHashToNumber)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc skeletonHeaderKey*(u: BlockNumber): DbKey {.inline.} =
-  result.data[0] = byte ord(skeletonHeader)
   doAssert sizeof(u) <= 32
+  result.kind = skeletonHeader
+  result.data[0] = byte ord(skeletonHeader)
   copyMem(addr result.data[1], unsafeAddr u, sizeof(u))
   result.dataEndPos = uint8 sizeof(u)
 
 proc skeletonBodyKey*(h: Hash256): DbKey {.inline.} =
+  result.kind = skeletonBody
   result.data[0] = byte ord(skeletonBody)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc snapSyncAccountKey*(h: openArray[byte]): DbKey {.inline.} =
   doAssert(h.len == 32)
+  result.kind = snapSyncAccount
   result.data[0] = byte ord(snapSyncAccount)
   result.data[1 .. 32] = h
   result.dataEndPos = uint8 sizeof(h)
 
 proc snapSyncStorageSlotKey*(h: openArray[byte]): DbKey {.inline.} =
   doAssert(h.len == 32)
+  result.kind = snapSyncStorageSlot
   result.data[0] = byte ord(snapSyncStorageSlot)
   result.data[1 .. 32] = h
   result.dataEndPos = uint8 sizeof(h)
 
 proc snapSyncStateRootKey*(h: openArray[byte]): DbKey {.inline.} =
   doAssert(h.len == 32)
+  result.kind = snapSyncStateRoot
   result.data[0] = byte ord(snapSyncStateRoot)
   result.data[1 .. 32] = h
   result.dataEndPos = uint8 sizeof(h)
 
 proc blockHashToBlockWitnessKey*(h: Hash256): DbKey {.inline.} =
+  result.kind = blockHashToBlockWitness
   result.data[0] = byte ord(blockHashToBlockWitness)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
@@ -140,4 +166,3 @@ template toOpenArray*(k: DbKey): openArray[byte] =
 
 proc `==`*(a, b: DbKey): bool {.inline.} =
   a.toOpenArray == b.toOpenArray
-

--- a/nimbus/db/storage_types.nim
+++ b/nimbus/db/storage_types.nim
@@ -12,7 +12,8 @@ import
   eth/common
 
 type
-  DBKeyKind* = enum
+  DbNamespace* = enum
+    default
     genericHash
     blockNumberToHash
     blockHashToScore
@@ -34,129 +35,126 @@ type
     blockHashToBlockWitness
 
   DbKey* = object
-    kind*: DBKeyKind
+    namespace: DbNamespace
     # The first byte stores the key type. The rest are key-specific values
     data*: array[33, byte]
     dataEndPos*: uint8 # the last populated position in the data
 
-proc toNamespace*(kind: DBKeyKind): string =
-  $ord(kind)
-
-proc toNamespace*(key: DbKey): string =
-  $ord(key.kind)
+proc namespace*(key: DbKey): DbNamespace =
+  key.namespace
 
 proc genericHashKey*(h: Hash256): DbKey {.inline.} =
-  result.kind = genericHash
+  result.namespace = genericHash
   result.data[0] = byte ord(genericHash)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc blockHashToScoreKey*(h: Hash256): DbKey {.inline.} =
-  result.kind = blockHashToScore
+  result.namespace = blockHashToScore
   result.data[0] = byte ord(blockHashToScore)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc transactionHashToBlockKey*(h: Hash256): DbKey {.inline.} =
-  result.kind = transactionHashToBlock
+  result.namespace = transactionHashToBlock
   result.data[0] = byte ord(transactionHashToBlock)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc blockNumberToHashKey*(u: BlockNumber): DbKey {.inline.} =
-  result.kind = blockNumberToHash
+  result.namespace = blockNumberToHash
   result.data[0] = byte ord(blockNumberToHash)
   doAssert sizeof(u) <= 32
   copyMem(addr result.data[1], unsafeAddr u, sizeof(u))
   result.dataEndPos = uint8 sizeof(u)
 
 proc canonicalHeadHashKey*(): DbKey {.inline.} =
-  result.kind = canonicalHeadHash
+  result.namespace = canonicalHeadHash
   result.data[0] = byte ord(canonicalHeadHash)
   result.dataEndPos = 1
 
 proc slotHashToSlotKey*(h: openArray[byte]): DbKey {.inline.} =
   doAssert(h.len == 32)
-  result.kind = slotHashToSlot
+  result.namespace = slotHashToSlot
   result.data[0] = byte ord(slotHashToSlot)
   result.data[1 .. 32] = h
   result.dataEndPos = uint8 32
 
 proc contractHashKey*(h: Hash256): DbKey {.inline.} =
-  result.kind = contractHash
+  result.namespace = contractHash
   result.data[0] = byte ord(contractHash)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc cliqueSnapshotKey*(h: Hash256): DbKey {.inline.} =
-  result.kind = cliqueSnapshot
+  result.namespace = cliqueSnapshot
   result.data[0] = byte ord(cliqueSnapshot)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc transitionStatusKey*(): DbKey =
-  result.kind = transitionStatus
+  result.namespace = transitionStatus
   # ETH-2 Transition Status
   result.data[0] = byte ord(transitionStatus)
   result.dataEndPos = uint8 1
 
 proc safeHashKey*(): DbKey {.inline.} =
-  result.kind = safeHash
+  result.namespace = safeHash
   result.data[0] = byte ord(safeHash)
   result.dataEndPos = uint8 1
 
 proc finalizedHashKey*(): DbKey {.inline.} =
-  result.kind = finalizedHash
+  result.namespace = finalizedHash
   result.data[0] = byte ord(finalizedHash)
   result.dataEndPos = uint8 1
 
 proc skeletonProgressKey*(): DbKey {.inline.} =
-  result.kind = skeletonProgress
+  result.namespace = skeletonProgress
   result.data[0] = byte ord(skeletonProgress)
   result.dataEndPos = 1
 
 proc skeletonBlockHashToNumberKey*(h: Hash256): DbKey {.inline.} =
-  result.kind = skeletonBlockHashToNumber
+  result.namespace = skeletonBlockHashToNumber
   result.data[0] = byte ord(skeletonBlockHashToNumber)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc skeletonHeaderKey*(u: BlockNumber): DbKey {.inline.} =
   doAssert sizeof(u) <= 32
-  result.kind = skeletonHeader
+  result.namespace = skeletonHeader
   result.data[0] = byte ord(skeletonHeader)
   copyMem(addr result.data[1], unsafeAddr u, sizeof(u))
   result.dataEndPos = uint8 sizeof(u)
 
 proc skeletonBodyKey*(h: Hash256): DbKey {.inline.} =
-  result.kind = skeletonBody
+  result.namespace = skeletonBody
   result.data[0] = byte ord(skeletonBody)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
 proc snapSyncAccountKey*(h: openArray[byte]): DbKey {.inline.} =
   doAssert(h.len == 32)
-  result.kind = snapSyncAccount
+  result.namespace = snapSyncAccount
   result.data[0] = byte ord(snapSyncAccount)
   result.data[1 .. 32] = h
   result.dataEndPos = uint8 sizeof(h)
 
 proc snapSyncStorageSlotKey*(h: openArray[byte]): DbKey {.inline.} =
   doAssert(h.len == 32)
-  result.kind = snapSyncStorageSlot
+  result.namespace = snapSyncStorageSlot
   result.data[0] = byte ord(snapSyncStorageSlot)
   result.data[1 .. 32] = h
   result.dataEndPos = uint8 sizeof(h)
 
 proc snapSyncStateRootKey*(h: openArray[byte]): DbKey {.inline.} =
   doAssert(h.len == 32)
-  result.kind = snapSyncStateRoot
+  result.namespace = snapSyncStateRoot
   result.data[0] = byte ord(snapSyncStateRoot)
   result.data[1 .. 32] = h
   result.dataEndPos = uint8 sizeof(h)
 
 proc blockHashToBlockWitnessKey*(h: Hash256): DbKey {.inline.} =
-  result.kind = blockHashToBlockWitness
+  result.namespace = blockHashToBlockWitness
   result.data[0] = byte ord(blockHashToBlockWitness)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32

--- a/nimbus/db/trie_get_branch.nim
+++ b/nimbus/db/trie_get_branch.nim
@@ -41,7 +41,7 @@ proc getLocalBytes(x: TrieNodeKey): seq[byte] =
 
 proc dbGet(db: CoreDbRef, data: openArray[byte]): seq[byte]
   {.gcsafe, raises: [].} =
-  db.kvt.get(data)
+  db.defaultKvt.get(data)
 
 template keyToLocalBytes(db: CoreDbRef, k: TrieNodeKey): seq[byte] =
   if k.len < 32: k.getLocalBytes

--- a/nimbus/sync/beacon/skeleton_db.nim
+++ b/nimbus/sync/beacon/skeleton_db.nim
@@ -29,14 +29,14 @@ logScope:
 # Private helpers
 # ------------------------------------------------------------------------------
 
-template get(sk: SkeletonRef, key: untyped): untyped =
-  get(sk.db.kvt, key.toOpenArray)
+template get(sk: SkeletonRef, key: DbKey): untyped =
+  get(sk.db.kvt(key.namespace), key.toOpenArray)
 
-template put(sk: SkeletonRef, key, val: untyped): untyped =
-  put(sk.db.kvt, key.toOpenArray, val)
+template put(sk: SkeletonRef, key: DbKey, val: untyped): untyped =
+  put(sk.db.kvt(key.namespace), key.toOpenArray, val)
 
-template del(sk: SkeletonRef, key: untyped): untyped =
-  del(sk.db.kvt, key.toOpenArray)
+template del(sk: SkeletonRef, key: DbKey): untyped =
+  del(sk.db.kvt(key.namespace), key.toOpenArray)
 
 proc append(w: var RlpWriter, s: Segment) =
   w.startList(3)

--- a/nimbus/sync/handlers/eth.nim
+++ b/nimbus/sync/handlers/eth.nim
@@ -619,7 +619,7 @@ when defined(legacy_eth66_enabled):
   method getStorageNodes*(ctx: EthWireRef,
                           hashes: openArray[Hash256]):
                             Result[seq[Blob], string] {.gcsafe.} =
-    let db = ctx.db.kvt
+    let db = ctx.db.defaultKvt()
     var list: seq[Blob]
     for hash in hashes:
       list.add db.get(hash.data)

--- a/nimbus/sync/handlers/snap.nim
+++ b/nimbus/sync/handlers/snap.nim
@@ -80,7 +80,7 @@ proc getAccountFn(
   let db = ctx.chain.com.db
   return proc(key: openArray[byte]): Blob =
     if db.isLegacy:
-      return db.kvt.backend.toLegacy.get(key)
+      return db.defaultKvt.backend.toLegacy.get(key)
 
 proc getStoSlotFn(
     ctx: SnapWireRef;
@@ -93,7 +93,7 @@ proc getStoSlotFn(
   let db = ctx.chain.com.db
   return proc(key: openArray[byte]): Blob =
     if db.isLegacy:
-      return db.kvt.backend.toLegacy.get(key)
+      return db.defaultKvt.backend.toLegacy.get(key)
 
 proc getCodeFn(
     ctx: SnapWireRef;

--- a/nimbus/sync/snap/worker/db/rocky_bulk_load.nim
+++ b/nimbus/sync/snap/worker/db/rocky_bulk_load.nim
@@ -91,7 +91,7 @@ proc lastError*(rbl: RockyBulkLoadRef): string =
 
 proc store*(rbl: RockyBulkLoadRef): RocksDbReadWriteRef =
   ## Provide the diecriptor for backend functions as defined in `rocksdb`.
-  rbl.db.readWriteDb()
+  rbl.db.db()
 
 # ------------------------------------------------------------------------------
 # Public functions
@@ -154,7 +154,7 @@ proc finish*(
 
   var filePath = rbl.filePath.cstring
   if csError.isNil:
-    rbl.db.readWriteDb().cPtr.rocksdb_ingest_external_file(
+    rbl.db.db().cPtr.rocksdb_ingest_external_file(
       cast[cstringArray](filePath.addr), 1,
       rbl.importOption,
       cast[cstringArray](csError.addr))

--- a/nimbus/sync/snap/worker/db/snapdb_desc.nim
+++ b/nimbus/sync/snap/worker/db/snapdb_desc.nim
@@ -130,7 +130,7 @@ proc init*(
 proc copyWithoutRoot*(a, b: SnapDbBaseRef) =
   a.xDb = b.xDb
   a.base = b.base
-    
+
 # ------------------------------------------------------------------------------
 # Public getters
 # ------------------------------------------------------------------------------
@@ -159,23 +159,23 @@ proc kvDb*(pv: SnapDbRef): CoreDbRef =
 # Public functions, select sub-tables for persistent storage
 # ------------------------------------------------------------------------------
 
-proc toBlockHeaderKey*(a: Hash256): ByteArray33 =
-  a.genericHashKey.data
+proc toBlockHeaderKey*(a: Hash256): DbKey =
+  a.genericHashKey
 
-proc toBlockNumberKey*(a: BlockNumber): ByteArray33 =
+proc toBlockNumberKey*(a: BlockNumber): DbKey =
   static:
     doAssert 32 == sizeof BlockNumber # needed in `blockNumberToHashKey()`
-  a.blockNumberToHashKey.data
+  a.blockNumberToHashKey
 
-proc toContractHashKey*(a: NodeKey): ByteArray33 =
-  a.to(Hash256).contractHashKey.data
+proc toContractHashKey*(a: NodeKey): DbKey =
+  a.to(Hash256).contractHashKey
 
 when false:
-  proc toAccountsKey*(a: NodeKey): ByteArray33 =
-    a.ByteArray32.snapSyncAccountKey.data
+  proc toAccountsKey*(a: NodeKey): DbKey =
+    a.ByteArray32.snapSyncAccountKey
 
-  proc toStorageSlotsKey*(a: NodeKey): ByteArray33 =
-    a.ByteArray32.snapSyncStorageSlotKey.data
+  proc toStorageSlotsKey*(a: NodeKey): DbKey =
+    a.ByteArray32.snapSyncStorageSlotKey
 else:
   proc toAccountsKey*(a: NodeKey): ByteArray32 =
     a.ByteArray32
@@ -183,8 +183,8 @@ else:
   proc toStorageSlotsKey*(a: NodeKey): ByteArray32 =
     a.ByteArray32
 
-proc toStateRootKey*(a: NodeKey): ByteArray33 =
-  a.ByteArray32.snapSyncStateRootKey.data
+proc toStateRootKey*(a: NodeKey): DbKey =
+  a.ByteArray32.snapSyncStateRootKey
 
 template toOpenArray*(k: ByteArray32): openArray[byte] =
   k.toOpenArray(0, 31)

--- a/nimbus/tracer.nim
+++ b/nimbus/tracer.nim
@@ -82,7 +82,7 @@ proc captureAccount(n: JsonNode, db: LedgerRef, address: EthAddress, name: strin
 
 proc dumpMemoryDB*(node: JsonNode, db: CoreDbRef) =
   var n = newJObject()
-  for k, v in db.kvt:
+  for k, v in db.defaultKvt():
     n[k.toHex(false)] = %v
   node["state"] = n
 

--- a/premix/debug.nim
+++ b/premix/debug.nim
@@ -1,3 +1,13 @@
+# Nimbus
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
 import
   std/[json, os],
   stew/byteutils,

--- a/premix/debug.nim
+++ b/premix/debug.nim
@@ -14,7 +14,7 @@ proc prepareBlockEnv(node: JsonNode, memoryDB: CoreDbRef) =
   for k, v in state:
     let key = hexToSeqByte(k)
     let value = hexToSeqByte(v.getStr())
-    memoryDB.kvt.put(key, value)
+    memoryDB.defaultKvt.put(key, value)
 
 proc executeBlock(blockEnv: JsonNode, memoryDB: CoreDbRef, blockNumber: UInt256) =
   let

--- a/premix/hunter.nim
+++ b/premix/hunter.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Copyright (c) 2020-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/premix/hunter.nim
+++ b/premix/hunter.nim
@@ -27,7 +27,7 @@ proc store(memoryDB: CoreDbRef, branch: JsonNode) =
   for p in branch:
     let rlp = hexToSeqByte(p.getStr)
     let hash = keccakHash(rlp)
-    memoryDB.kvt.put(hash.data, rlp)
+    memoryDB.defaultKvt.put(hash.data, rlp)
 
 proc parseAddress(address: string): EthAddress =
   hexToByteArray(address, result)

--- a/premix/persist.nim
+++ b/premix/persist.nim
@@ -62,11 +62,13 @@ proc main() {.used.} =
     var parentBlock = requestBlock(conf.head, { DownloadAndValidate })
     discard com.db.setHead(parentBlock.header)
 
-  if canonicalHeadHashKey().toOpenArray notin com.db.kvt:
+  let key = canonicalHeadHashKey()
+  let kvt = com.db.kvt(key.toNamespace())
+  if key.toOpenArray notin kvt:
     persistToDb(com.db):
       com.initializeEmptyDb()
       com.db.compensateLegacySetup()
-    doAssert(canonicalHeadHashKey().toOpenArray in com.db.kvt)
+    doAssert(key.toOpenArray in kvt)
 
   var head = com.db.getCanonicalHead()
   var blockNumber = head.blockNumber + 1

--- a/premix/persist.nim
+++ b/premix/persist.nim
@@ -63,7 +63,7 @@ proc main() {.used.} =
     discard com.db.setHead(parentBlock.header)
 
   let key = canonicalHeadHashKey()
-  let kvt = com.db.kvt(key.toNamespace())
+  let kvt = com.db.kvt(key.namespace)
   if key.toOpenArray notin kvt:
     persistToDb(com.db):
       com.initializeEmptyDb()

--- a/premix/prestate.nim
+++ b/premix/prestate.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Copyright (c) 2020-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/premix/prestate.nim
+++ b/premix/prestate.nim
@@ -26,13 +26,13 @@ proc generatePrestate*(nimbus, geth: JsonNode, blockNumber: UInt256, parent, hea
   discard chainDB.persistUncles(body.uncles)
 
   let key = genericHashKey(headerHash)
-  chainDB.kvt(key.toNamespace()).put(key.toOpenArray, rlp.encode(header))
+  chainDB.kvt(key.namespace).put(key.toOpenArray, rlp.encode(header))
   chainDB.addBlockNumberToHashLookup(header)
 
   for k, v in state:
     let key = hexToSeqByte(k)
     let value = hexToSeqByte(v.getStr())
-    chainDB.kvt.put(key, value)
+    chainDB.defaultKvt.put(key, value)
 
   var metaData = %{
     "blockNumber": %blockNumber.toHex,

--- a/premix/prestate.nim
+++ b/premix/prestate.nim
@@ -25,7 +25,8 @@ proc generatePrestate*(nimbus, geth: JsonNode, blockNumber: UInt256, parent, hea
   discard chainDB.persistTransactions(blockNumber, body.transactions)
   discard chainDB.persistUncles(body.uncles)
 
-  chainDB.kvt.put(genericHashKey(headerHash).toOpenArray, rlp.encode(header))
+  let key = genericHashKey(headerHash)
+  chainDB.kvt(key.toNamespace()).put(key.toOpenArray, rlp.encode(header))
   chainDB.addBlockNumberToHashLookup(header)
 
   for k, v in state:

--- a/stateless/test_witness_keys.nim
+++ b/stateless/test_witness_keys.nim
@@ -43,7 +43,8 @@ proc randCode(db: DB): Hash256 =
     let codeLen = rand(1..150)
     let code = randList(byte, rng(0, 255), codeLen, unique = false)
     result = keccakHash(code)
-    db.kvt.put(contractHashKey(result).toOpenArray, code)
+    let key = contractHashKey(result)
+    db.kvt(key.namespace).put(contractHashKey(result).toOpenArray, code)
 
 proc randStorage(db: DB): StorageKeys =
   if rand(0..1) == 0:

--- a/stateless/tree_from_witness.nim
+++ b/stateless/tree_from_witness.nim
@@ -178,7 +178,7 @@ proc toNodeKey(t: var TreeBuilder, z: openArray[byte]): NodeKey =
   else:
     result.data = keccakHash(z).data
     result.usedBytes = 32
-    t.db.kvt.put(result.data, z)
+    t.db.defaultKvt.put(result.data, z)
 
 proc toNodeKey(z: openArray[byte]): NodeKey =
   if z.len >= 32:
@@ -188,13 +188,13 @@ proc toNodeKey(z: openArray[byte]): NodeKey =
 
 proc forceSmallNodeKeyToHash(t: var TreeBuilder, r: NodeKey): NodeKey =
   let hash = keccakHash(r.data.toOpenArray(0, r.usedBytes-1))
-  t.db.kvt.put(hash.data, r.data.toOpenArray(0, r.usedBytes-1))
+  t.db.defaultKvt.put(hash.data, r.data.toOpenArray(0, r.usedBytes-1))
   result.data = hash.data
   result.usedBytes = 32
 
 proc writeCode(t: var TreeBuilder, code: openArray[byte]): Hash256 =
   result = keccakHash(code)
-  put(t.db.kvt, result.data, code)
+  put(t.db.defaultKvt, result.data, code)
 
 proc branchNode(t: var TreeBuilder, depth: int, storageMode: bool): NodeKey {.gcsafe.}
 proc extensionNode(t: var TreeBuilder, depth: int, storageMode: bool): NodeKey {.gcsafe.}

--- a/stateless/witness_verification.nim
+++ b/stateless/witness_verification.nim
@@ -34,7 +34,7 @@ proc buildAccountsTableFromKeys(
   for key in keys:
     let account = db.getAccount(key.address)
     let code = if key.codeLen > 0:
-        db.getTrie().parent().kvt().get(account.codeHash.data)
+        db.getTrie().parent().defaultKvt().get(account.codeHash.data)
       else: @[]
     var storage = initTable[UInt256, UInt256]()
 

--- a/tests/db/test_kvstore_rocksdb.nim
+++ b/tests/db/test_kvstore_rocksdb.nim
@@ -18,8 +18,16 @@ import
   ../../nimbus/db/kvstore_rocksdb,
   eth/../tests/db/test_kvstore
 
-suite "RocksStoreRef":
-  test "KvStore interface":
+suite "KvStore RocksDb Tests":
+  const
+    NS_DEFAULT = "default"
+    NS_OTHER = "other"
+    key = [0'u8, 1, 2, 3]
+    value = [3'u8, 2, 1, 0]
+    value2 = [5'u8, 2, 1, 0]
+    key2 = [255'u8, 255]
+
+  test "RocksStoreRef KvStore interface":
     let tmp = getTempDir() / "nimbus-test-db"
     removeDir(tmp)
 
@@ -28,3 +36,76 @@ suite "RocksStoreRef":
       db.close()
 
     testKvStore(kvStore db, false, false)
+
+  test "RocksNamespaceRef KvStore interface - default namespace":
+    let tmp = getTempDir() / "nimbus-test-db"
+    removeDir(tmp)
+
+    let db = RocksStoreRef.init(tmp, "test")[]
+    defer:
+      db.close()
+
+    let defaultNs = db.openNamespace(NS_DEFAULT)[]
+    testKvStore(kvStore defaultNs, false, false)
+
+  test "RocksNamespaceRef KvStore interface - multiple namespace":
+    let tmp = getTempDir() / "nimbus-test-db"
+    removeDir(tmp)
+
+    let db = RocksStoreRef.init(tmp, "test",
+        readOnly = false,
+        namespaces = @[NS_DEFAULT, NS_OTHER])[]
+    defer:
+      db.close()
+
+    let defaultNs = db.openNamespace(NS_DEFAULT)[]
+    testKvStore(kvStore defaultNs, false, false)
+
+    let otherNs = db.openNamespace(NS_OTHER)[]
+    testKvStore(kvStore otherNs, false, false)
+
+  test "RocksStoreRef - read-only":
+    let tmp = getTempDir() / "nimbus-test-db"
+    removeDir(tmp)
+
+    let db = RocksStoreRef.init(tmp, "test")[]
+    check db.put(key, value).isOk()
+
+    # We need to open the db in read-only mode after writing to the database
+    # otherwise we won't see the updates.
+    let readOnlyDb = RocksStoreRef.init(tmp, "test", readOnly = true)[]
+    defer:
+      readOnlyDb.close()
+      db.close()
+
+    check:
+      readOnlyDb.contains(key)[] == true
+      readOnlyDb.contains(key2)[] == false
+
+  test "RocksNamespaceRef - read-only":
+    let tmp = getTempDir() / "nimbus-test-db"
+    removeDir(tmp)
+
+    let db = RocksStoreRef.init(tmp, "test",
+        namespaces = @[NS_DEFAULT, NS_OTHER])[]
+    let ns = db.openNamespace(NS_OTHER)[]
+    check ns.put(key, value).isOk()
+
+    # We need to open the db in read-only mode after writing to the database
+    # otherwise we won't see the updates.
+    let readOnlyDb = RocksStoreRef.init(tmp, "test",
+        readOnly = true,
+        namespaces = @[NS_DEFAULT, NS_OTHER])[]
+    defer:
+      readOnlyDb.close()
+      db.close()
+
+    let defaultNs = db.openNamespace(NS_DEFAULT)[]
+    check:
+      defaultNs.contains(key)[] == false
+      defaultNs.contains(key2)[] == false
+
+    let otherNs = db.openNamespace(NS_OTHER)[]
+    check:
+      otherNs.contains(key)[] == true
+      otherNs.contains(key2)[] == false

--- a/tests/db/test_kvstore_rocksdb.nim
+++ b/tests/db/test_kvstore_rocksdb.nim
@@ -53,7 +53,6 @@ suite "KvStore RocksDb Tests":
     removeDir(tmp)
 
     let db = RocksStoreRef.init(tmp, "test",
-        readOnly = false,
         namespaces = @[NS_DEFAULT, NS_OTHER])[]
     defer:
       db.close()
@@ -63,49 +62,3 @@ suite "KvStore RocksDb Tests":
 
     let otherNs = db.openNamespace(NS_OTHER)[]
     testKvStore(kvStore otherNs, false, false)
-
-  test "RocksStoreRef - read-only":
-    let tmp = getTempDir() / "nimbus-test-db"
-    removeDir(tmp)
-
-    let db = RocksStoreRef.init(tmp, "test")[]
-    check db.put(key, value).isOk()
-
-    # We need to open the db in read-only mode after writing to the database
-    # otherwise we won't see the updates.
-    let readOnlyDb = RocksStoreRef.init(tmp, "test", readOnly = true)[]
-    defer:
-      readOnlyDb.close()
-      db.close()
-
-    check:
-      readOnlyDb.contains(key)[] == true
-      readOnlyDb.contains(key2)[] == false
-
-  test "RocksNamespaceRef - read-only":
-    let tmp = getTempDir() / "nimbus-test-db"
-    removeDir(tmp)
-
-    let db = RocksStoreRef.init(tmp, "test",
-        namespaces = @[NS_DEFAULT, NS_OTHER])[]
-    let ns = db.openNamespace(NS_OTHER)[]
-    check ns.put(key, value).isOk()
-
-    # We need to open the db in read-only mode after writing to the database
-    # otherwise we won't see the updates.
-    let readOnlyDb = RocksStoreRef.init(tmp, "test",
-        readOnly = true,
-        namespaces = @[NS_DEFAULT, NS_OTHER])[]
-    defer:
-      readOnlyDb.close()
-      db.close()
-
-    let defaultNs = db.openNamespace(NS_DEFAULT)[]
-    check:
-      defaultNs.contains(key)[] == false
-      defaultNs.contains(key2)[] == false
-
-    let otherNs = db.openNamespace(NS_OTHER)[]
-    check:
-      otherNs.contains(key)[] == true
-      otherNs.contains(key2)[] == false

--- a/tests/replay/undump_kvp.nim
+++ b/tests/replay/undump_kvp.nim
@@ -57,7 +57,7 @@ proc walkAllDb(
   ## Walk over all key-value pairs of the database (`RocksDB` only.)
   let
     rop = rocksdb_readoptions_create()
-    rit = rocky.readWriteDb.cPtr.rocksdb_create_iterator(rop)
+    rit = rocky.db().cPtr.rocksdb_create_iterator(rop)
 
   rit.rocksdb_iter_seek_to_first()
   while rit.rocksdb_iter_valid() != 0:

--- a/tests/test_persistblock_json.nim
+++ b/tests/test_persistblock_json.nim
@@ -25,7 +25,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus) =
   for k, v in state:
     let key = hexToSeqByte(k)
     let value = hexToSeqByte(v.getStr())
-    memoryDB.kvt.put(key, value)
+    memoryDB.defaultKvt.put(key, value)
 
   let
     parentNumber = blockNumber - 1

--- a/tests/test_persistblock_witness_json.nim
+++ b/tests/test_persistblock_witness_json.nim
@@ -26,7 +26,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus) =
   for k, v in state:
     let key = hexToSeqByte(k)
     let value = hexToSeqByte(v.getStr())
-    memoryDB.kvt.put(key, value)
+    memoryDB.defaultKvt.put(key, value)
 
   let
     parentNumber = blockNumber - 1

--- a/tests/test_rocksdb_timing/test_db_timing.nim
+++ b/tests/test_rocksdb_timing/test_db_timing.nim
@@ -187,7 +187,7 @@ proc test_dbTimingStoreDirect32*(
      ) =
   ## Direct db, key length 32, no transaction
   var ela: Duration
-  let tdb = cdb.kvt
+  let tdb = cdb.defaultKvt
 
   if noisy: echo ""
   noisy.showElapsed("Standard db loader(keyLen 32)", ela):
@@ -209,7 +209,7 @@ proc test_dbTimingStoreDirectly32as33*(
      ) =
   ## Direct db, key length 32 as 33, no transaction
   var ela = initDuration()
-  let tdb = cdb.kvt
+  let tdb = cdb.defaultKvt
 
   if noisy: echo ""
   noisy.showElapsed("Standard db loader(keyLen 32 as 33)", ela):
@@ -231,7 +231,7 @@ proc test_dbTimingStoreTx32*(
      ) =
   ## Direct db, key length 32, transaction based
   var ela: Duration
-  let tdb = cdb.kvt
+  let tdb = cdb.defaultKvt
 
   if noisy: echo ""
   noisy.showElapsed("Standard db loader(tx,keyLen 32)", ela):
@@ -256,7 +256,7 @@ proc test_dbTimingStoreTx32as33*(
      ) =
   ## Direct db, key length 32 as 33, transaction based
   var ela: Duration
-  let tdb = cdb.kvt
+  let tdb = cdb.defaultKvt
 
   if noisy: echo ""
   noisy.showElapsed("Standard db loader(tx,keyLen 32 as 33)", ela):
@@ -281,7 +281,7 @@ proc test_dbTimingDirect33*(
      ) =
   ## Direct db, key length 33, no transaction
   var ela: Duration
-  let tdb = cdb.kvt
+  let tdb = cdb.defaultKvt
 
   if noisy: echo ""
   noisy.showElapsed("Standard db loader(keyLen 33)", ela):
@@ -303,7 +303,7 @@ proc test_dbTimingTx33*(
      ) =
   ## Direct db, key length 33, transaction based
   var ela: Duration
-  let tdb = cdb.kvt
+  let tdb = cdb.defaultKvt
 
   if noisy: echo ""
   noisy.showElapsed("Standard db loader(tx,keyLen 33)", ela):

--- a/tests/test_rocksdb_timing/test_db_timing.nim
+++ b/tests/test_rocksdb_timing/test_db_timing.nim
@@ -137,7 +137,7 @@ proc test_dbTimingRockySetup*(
   let
     rdb = cdb.backend.toRocksStoreRef
     rop = rocksdb_readoptions_create()
-    rit = rdb.readWriteDb().cPtr.rocksdb_create_iterator(rop)
+    rit = rdb.db().cPtr.rocksdb_create_iterator(rop)
   check not rit.isNil
 
   var

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -85,7 +85,8 @@ proc verifySlotProof(trustedStorageRoot: Web3Hash, slot: StorageProof): MptProof
 proc persistFixtureBlock(chainDB: CoreDbRef) =
   let header = getBlockHeader4514995()
   # Manually inserting header to avoid any parent checks
-  chainDB.kvt.put(genericHashKey(header.blockHash).toOpenArray, rlp.encode(header))
+  let key = genericHashKey(header.blockHash)
+  chainDB.kvt(key.namespace).put(key.toOpenArray, rlp.encode(header))
   chainDB.addBlockNumberToHashLookup(header)
   discard chainDB.persistTransactions(header.blockNumber, getBlockBody4514995().transactions)
   discard chainDB.persistReceipts(getReceipts4514995())

--- a/tests/test_rpc_experimental_json.nim
+++ b/tests/test_rpc_experimental_json.nim
@@ -37,7 +37,7 @@ proc importBlockData(node: JsonNode): (CommonRef, Hash256, Hash256, UInt256) {. 
   for k, v in state:
     let key = hexToSeqByte(k)
     let value = hexToSeqByte(v.getStr())
-    memoryDB.kvt.put(key, value)
+    memoryDB.defaultKvt.put(key, value)
 
   let
     parentNumber = blockNumber - 1

--- a/tests/test_state_db.nim
+++ b/tests/test_state_db.nim
@@ -151,7 +151,7 @@ proc stateDBMain*() =
       ac.persist()
       check ac.getCode(addr2) == code
       let key = contractHashKey(keccakHash(code))
-      check acDB.kvt.get(key.toOpenArray) == code
+      check acDB.kvt(key.namespace).get(key.toOpenArray) == code
 
     test "accessList operations":
       proc verifyAddrs(ac: AccountsCache, addrs: varargs[int]): bool =

--- a/tests/test_tracer_json.nim
+++ b/tests/test_tracer_json.nim
@@ -34,7 +34,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus) =
   for k, v in state:
     let key = hexToSeqByte(k)
     let value = hexToSeqByte(v.getStr())
-    memoryDB.kvt.put(key, value)
+    memoryDB.defaultKvt.put(key, value)
 
   var header = com.db.getBlockHeader(blockNumber)
   var headerHash = header.blockHash


### PR DESCRIPTION
**Changes in this PR:**
- Removed the unused and unneeded db backups feature from the RocksStoreRef and other locations.
- Removed the usage of the RocksDb readonly option from the RocksStoreRef as it complicates the API and was unused. Also the read only RocksDb instances have some issues to be aware of. Basically when starting a read only db connection the data read is from the point in time when the connection was opened but new updates won't be reflected in that connection. See here: https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances
- Refactored and created KvStore types for both creating a RocksDb connection and for connecting to a specific RocksDb column family (namespace).
- New KvStore types have been added into the LegacyPersistantDb backend so that default operations go to the default column family and operations that select a namespace will go to that specific column family.

I'm using the DbNamespace enum as the type which is passed around to decide which namespace to use. The kvt and newKvt procs now have an additional required namespace parameter. I opted to do it this way so that the compiler would help me apply the correct changes in all effected locations in the code. Unfortunately this change touches a lot of places and I couldn't think of a better way to go about it. 

The new namespace change currently only affects the legacy persistent mode which is using RocksDB.

Note, that due to the legacy namespace hack/kludge which uses a special prefix byte to virtually separate the various types of data, there will be some difficultly in in removing this tech dept. Many of the tests are based on dumps of the database which are dependent on the data containing these exact prefix bytes so trying to move away from using these prefix bytes will break the tests and would potentially require significant updates to test data.

Also, only the persistent mode has been updated to use the column families to separate the data. This means that most of the tests which use the in memory db modes won't be covering or testing that this column families change will work in production. For this reason I'm wondering if I should also implement some form of separation for the in memory db as well. Alternatively we could opt to only implement column families for the Aristo persistant and Aristo in memory backends and simply leave the legacy dbs as they are because we are planning to switch to Aristo.