### PR TITLE
Added support for namespaces to RocksDb kvstore.

### DIFF
--- a/nimbus/db/aristo/aristo_desc/desc_error.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_error.nim
@@ -236,7 +236,6 @@ type
 
     # RocksDB backend
     RdbBeCantCreateDataDir
-    RdbBeCantCreateBackupDir
     RdbBeCantCreateTmpDir
     RdbBeDriverInitError
     RdbBeDriverGetError
@@ -268,7 +267,7 @@ type
     AccVtxUnsupported
     AccNodeUnsupported
     PayloadTypeUnsupported
-    
+
     # Miscelaneous handy helpers
     AccRootUnacceptable
     MptContextMissing

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -41,7 +41,6 @@ type
 const
   BaseFolder* = "nimbus"           # Same as for Legacy DB
   DataFolder* = "aristo"           # Legacy DB has "data"
-  BackupFolder* = "aristo-history" # Legacy DB has "backups"
   SstCache* = "bulkput"            # Rocks DB bulk load file name in temp folder
   TempFolder* = "tmp"              # No `tmp` directory used with legacy DB
 
@@ -54,9 +53,6 @@ func baseDir*(rdb: RdbInst): string =
 
 func dataDir*(rdb: RdbInst): string =
   rdb.baseDir / DataFolder
-
-func backupsDir*(rdb: RdbInst): string =
-  rdb.basePath / BaseFolder / BackupFolder
 
 func cacheDir*(rdb: RdbInst): string =
   rdb.dataDir / TempFolder

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
@@ -47,16 +47,11 @@ proc init*(
 
   let
     dataDir = rdb.dataDir
-    backupsDir = rdb.backupsDir
 
   try:
     dataDir.createDir
   except OSError, IOError:
     return err((RdbBeCantCreateDataDir, ""))
-  try:
-    backupsDir.createDir
-  except OSError, IOError:
-    return err((RdbBeCantCreateBackupDir, ""))
   try:
     rdb.cacheDir.createDir
   except OSError, IOError:
@@ -68,7 +63,7 @@ proc init*(
   let rc = openRocksDb(dataDir, dbOpts)
   if rc.isErr:
     let error = RdbBeDriverInitError
-    debug logTxt "driver failed", dataDir, backupsDir, openMax,
+    debug logTxt "driver failed", dataDir, openMax,
       error, info=rc.error
     return err((RdbBeDriverInitError, rc.error))
 

--- a/nimbus/db/kvt/kvt_desc/desc_error.nim
+++ b/nimbus/db/kvt/kvt_desc/desc_error.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/kvt/kvt_desc/desc_error.nim
+++ b/nimbus/db/kvt/kvt_desc/desc_error.nim
@@ -19,7 +19,6 @@ type
 
     # RocksDB backend
     RdbBeCantCreateDataDir
-    RdbBeCantCreateBackupDir
     RdbBeCantCreateTmpDir
     RdbBeDriverInitError
     RdbBeDriverGetError

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_desc.nim
@@ -31,7 +31,6 @@ type
 const
   BaseFolder* = "nimbus"         # Same as for Legacy DB
   DataFolder* = "kvt"            # Legacy DB has "data"
-  BackupFolder* = "kvt-history"  # Legacy DB has "backups"
   SstCache* = "bulkput"          # Rocks DB bulk load file name in temp folder
   TempFolder* = "tmp"            # No `tmp` directory used with legacy DB
 
@@ -44,9 +43,6 @@ func baseDir*(rdb: RdbInst): string =
 
 func dataDir*(rdb: RdbInst): string =
   rdb.baseDir / DataFolder
-
-func backupsDir*(rdb: RdbInst): string =
-  rdb.basePath / BaseFolder / BackupFolder
 
 func cacheDir*(rdb: RdbInst): string =
   rdb.dataDir / TempFolder

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_init.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_init.nim
@@ -47,16 +47,11 @@ proc init*(
 
   let
     dataDir = rdb.dataDir
-    backupsDir = rdb.backupsDir
 
   try:
     dataDir.createDir
   except OSError, IOError:
     return err((RdbBeCantCreateDataDir, ""))
-  try:
-    backupsDir.createDir
-  except OSError, IOError:
-    return err((RdbBeCantCreateBackupDir, ""))
   try:
     rdb.cacheDir.createDir
   except OSError, IOError:
@@ -68,7 +63,7 @@ proc init*(
   let rc = openRocksDb(dataDir, dbOpts)
   if rc.isErr:
     let error = RdbBeDriverInitError
-    debug logTxt "driver failed", dataDir, backupsDir, openMax,
+    debug logTxt "driver failed", dataDir, openMax,
       error, info=rc.error
     return err((RdbBeDriverInitError, rc.error))
 

--- a/nimbus/sync/snap/worker/db/rocky_bulk_load.nim
+++ b/nimbus/sync/snap/worker/db/rocky_bulk_load.nim
@@ -91,7 +91,7 @@ proc lastError*(rbl: RockyBulkLoadRef): string =
 
 proc store*(rbl: RockyBulkLoadRef): RocksDbReadWriteRef =
   ## Provide the diecriptor for backend functions as defined in `rocksdb`.
-  rbl.db.readWriteDb()
+  rbl.db.rocksDb()
 
 # ------------------------------------------------------------------------------
 # Public functions
@@ -154,7 +154,7 @@ proc finish*(
 
   var filePath = rbl.filePath.cstring
   if csError.isNil:
-    rbl.db.readWriteDb().cPtr.rocksdb_ingest_external_file(
+    rbl.db.rocksDb.cPtr.rocksdb_ingest_external_file(
       cast[cstringArray](filePath.addr), 1,
       rbl.importOption,
       cast[cstringArray](csError.addr))

--- a/tests/db/test_kvstore_rocksdb.nim
+++ b/tests/db/test_kvstore_rocksdb.nim
@@ -22,10 +22,6 @@ suite "KvStore RocksDb Tests":
   const
     NS_DEFAULT = "default"
     NS_OTHER = "other"
-    key = [0'u8, 1, 2, 3]
-    value = [3'u8, 2, 1, 0]
-    value2 = [5'u8, 2, 1, 0]
-    key2 = [255'u8, 255]
 
   test "RocksStoreRef KvStore interface":
     let tmp = getTempDir() / "nimbus-test-db"

--- a/tests/db/test_kvstore_rocksdb.nim
+++ b/tests/db/test_kvstore_rocksdb.nim
@@ -18,8 +18,16 @@ import
   ../../nimbus/db/kvstore_rocksdb,
   eth/../tests/db/test_kvstore
 
-suite "RocksStoreRef":
-  test "KvStore interface":
+suite "KvStore RocksDb Tests":
+  const
+    NS_DEFAULT = "default"
+    NS_OTHER = "other"
+    key = [0'u8, 1, 2, 3]
+    value = [3'u8, 2, 1, 0]
+    value2 = [5'u8, 2, 1, 0]
+    key2 = [255'u8, 255]
+
+  test "RocksStoreRef KvStore interface":
     let tmp = getTempDir() / "nimbus-test-db"
     removeDir(tmp)
 
@@ -28,3 +36,29 @@ suite "RocksStoreRef":
       db.close()
 
     testKvStore(kvStore db, false, false)
+
+  test "RocksNamespaceRef KvStore interface - default namespace":
+    let tmp = getTempDir() / "nimbus-test-db"
+    removeDir(tmp)
+
+    let db = RocksStoreRef.init(tmp, "test")[]
+    defer:
+      db.close()
+
+    let defaultNs = db.openNamespace(NS_DEFAULT)[]
+    testKvStore(kvStore defaultNs, false, false)
+
+  test "RocksNamespaceRef KvStore interface - multiple namespace":
+    let tmp = getTempDir() / "nimbus-test-db"
+    removeDir(tmp)
+
+    let db = RocksStoreRef.init(tmp, "test",
+        namespaces = @[NS_DEFAULT, NS_OTHER])[]
+    defer:
+      db.close()
+
+    let defaultNs = db.openNamespace(NS_DEFAULT)[]
+    testKvStore(kvStore defaultNs, false, false)
+
+    let otherNs = db.openNamespace(NS_OTHER)[]
+    testKvStore(kvStore otherNs, false, false)

--- a/tests/replay/undump_kvp.nim
+++ b/tests/replay/undump_kvp.nim
@@ -57,7 +57,7 @@ proc walkAllDb(
   ## Walk over all key-value pairs of the database (`RocksDB` only.)
   let
     rop = rocksdb_readoptions_create()
-    rit = rocky.db().cPtr.rocksdb_create_iterator(rop)
+    rit = rocky.rocksdb.cPtr.rocksdb_create_iterator(rop)
 
   rit.rocksdb_iter_seek_to_first()
   while rit.rocksdb_iter_valid() != 0:

--- a/tests/replay/undump_kvp.nim
+++ b/tests/replay/undump_kvp.nim
@@ -57,7 +57,7 @@ proc walkAllDb(
   ## Walk over all key-value pairs of the database (`RocksDB` only.)
   let
     rop = rocksdb_readoptions_create()
-    rit = rocky.readWriteDb.cPtr.rocksdb_create_iterator(rop)
+    rit = rocky.db().cPtr.rocksdb_create_iterator(rop)
 
   rit.rocksdb_iter_seek_to_first()
   while rit.rocksdb_iter_valid() != 0:

--- a/tests/test_rocksdb_timing/test_db_timing.nim
+++ b/tests/test_rocksdb_timing/test_db_timing.nim
@@ -137,7 +137,7 @@ proc test_dbTimingRockySetup*(
   let
     rdb = cdb.backend.toRocksStoreRef
     rop = rocksdb_readoptions_create()
-    rit = rdb.readWriteDb().cPtr.rocksdb_create_iterator(rop)
+    rit = rdb.db().cPtr.rocksdb_create_iterator(rop)
   check not rit.isNil
 
   var

--- a/tests/test_rocksdb_timing/test_db_timing.nim
+++ b/tests/test_rocksdb_timing/test_db_timing.nim
@@ -137,7 +137,7 @@ proc test_dbTimingRockySetup*(
   let
     rdb = cdb.backend.toRocksStoreRef
     rop = rocksdb_readoptions_create()
-    rit = rdb.db().cPtr.rocksdb_create_iterator(rop)
+    rit = rdb.rocksDb.cPtr.rocksdb_create_iterator(rop)
   check not rit.isNil
 
   var


### PR DESCRIPTION
This PR contains the first part of the namespaces/rockdb column family changes. 

**Changes in this PR:**
- Refactor/cleanup of the existing RocksStoreRef type.
- Added new RocksNamespaceRef type.
- Removed the unused and unneeded db backups feature from the RocksStoreRef and other locations.
- Removed the usage of the RocksDb readonly option from the RocksStoreRef as it complicates the API and was unused. Also the read only RocksDb instances have some issues to be aware of. Basically when starting a read only db connection the data read is from the point in time when the connection was opened but new updates won't be reflected in that connection. See here: https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances
- Bumped nim-rocksdb to the latest version which contains a recent fix to always open the default column family even if it is missing from the column families list.