### PR TITLE
Static link rocksdb with Nimbus.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ VERIF_PROXY_OUT_PATH ?= build/libverifproxy/
 	libnimbus.so \
 	libnimbus.a \
 	libbacktrace \
+	rocksdb \
 	dist-amd64 \
 	dist-arm64 \
 	dist-arm \
@@ -180,6 +181,8 @@ ifneq ($(USE_LIBBACKTRACE), 0)
 deps: | libbacktrace
 endif
 
+deps: | rocksdb
+
 ifneq ($(USE_MIRACL), 0)
   NIM_PARAMS += -d:BLS_FORCE_BACKEND=miracl
 endif
@@ -232,6 +235,10 @@ nimbus.nims:
 # nim-libbacktrace
 libbacktrace:
 	+ $(MAKE) -C vendor/nim-libbacktrace --no-print-directory BUILD_CXX_LIB=0
+
+# nim-rocksdb
+rocksdb:
+	+ vendor/nim-rocksdb/scripts/build_static_deps.sh
 
 # builds and runs the nimbus test suite
 test: | build deps

--- a/Makefile
+++ b/Makefile
@@ -181,8 +181,6 @@ ifneq ($(USE_LIBBACKTRACE), 0)
 deps: | libbacktrace
 endif
 
-deps: | rocksdb
-
 ifneq ($(USE_MIRACL), 0)
   NIM_PARAMS += -d:BLS_FORCE_BACKEND=miracl
 endif
@@ -228,6 +226,11 @@ nimbus: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim c $(NIM_PARAMS) -d:chronicles_log_level=TRACE -o:build/$@ "nimbus/$@.nim"
 
+nimbus_rocksdb_static: | build deps rocksdb_static_deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim c $(NIM_PARAMS) -d:enable_rocksdb_static_linking -d:chronicles_log_level=TRACE \
+		-o:build/$@ "nimbus/nimbus.nim"
+
 # symlink
 nimbus.nims:
 	ln -s nimbus.nimble $@
@@ -236,8 +239,8 @@ nimbus.nims:
 libbacktrace:
 	+ $(MAKE) -C vendor/nim-libbacktrace --no-print-directory BUILD_CXX_LIB=0
 
-# nim-rocksdb
-rocksdb:
+# nim-rocksdb static dependencies
+rocksdb_static_deps:
 	+ vendor/nim-rocksdb/scripts/build_static_deps.sh
 
 # builds and runs the nimbus test suite

--- a/config.nims
+++ b/config.nims
@@ -160,9 +160,12 @@ if defined(windows) and defined(i386):
 # disable nim-kzg's blst
 switch("define", "kzgExternalBlst")
 
-# RocksDB static linking is enabled by default
-# but can be disabled by setting this flag
-when not defined(disable_rocksdb_static_linking):
+# RocksDB static linking is disabled by default
+when defined(enable_rocksdb_static_linking):
+
+  when defined(windows):
+    {.fatal: "RocksDB static linking is not supported on Windows".}
+
   switch("define", "rocksdb_static_linking")
 
   # use the C++ linker profile because it's a C++ library

--- a/config.nims
+++ b/config.nims
@@ -166,8 +166,15 @@ import std/os
 const libsDir = currentSourcePath.parentDir() & "/vendor/nim-rocksdb/build/lib"
 switch("define", "rocksdb_static_linking")
 switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
-switch("dynlibOverride", "libz.a")
 switch("dynlibOverride", "librocksdb.a")
+switch("dynlibOverride", "libz.a")
+switch("dynlibOverride", "libbz2.a")
+switch("dynlibOverride", "liblz4.a")
+switch("dynlibOverride", "libzstd.a")
+
 switch("l", libsDir & "/librocksdb.a")
 switch("l", libsDir & "/libz.a")
+switch("l", libsDir & "/libbz2.a")
+switch("l", libsDir & "/liblz4.a")
+switch("l", libsDir & "/libzstd.a")
 #switch("passL", "-s") # to reduce the binary size if needed

--- a/config.nims
+++ b/config.nims
@@ -159,3 +159,15 @@ if defined(windows) and defined(i386):
 # nim-kzg shipping their own blst, nimbus-eth1 too.
 # disable nim-kzg's blst
 switch("define", "kzgExternalBlst")
+
+# nim-rocksdb static linking
+import std/os
+
+const libsDir = currentSourcePath.parentDir() & "/vendor/nim-rocksdb/build/lib"
+switch("define", "rocksdb_static_linking")
+switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
+switch("dynlibOverride", "libz.a")
+switch("dynlibOverride", "librocksdb.a")
+switch("l", libsDir & "/librocksdb.a")
+switch("l", libsDir & "/libz.a")
+#switch("passL", "-s") # to reduce the binary size if needed

--- a/config.nims
+++ b/config.nims
@@ -160,15 +160,17 @@ if defined(windows) and defined(i386):
 # disable nim-kzg's blst
 switch("define", "kzgExternalBlst")
 
-# nim-rocksdb static linking
-switch("define", "rocksdb_static_linking")
+# RocksDB static linking is enabled by default
+# but can be disabled by setting this flag
+when not defined(disable_rocksdb_static_linking):
+  switch("define", "rocksdb_static_linking")
 
-# use the C++ linker profile because it's a C++ library
-when defined(macosx):
-  switch("clang.linkerexe", "clang++")
-else:
-  switch("gcc.linkerexe", "g++")
+  # use the C++ linker profile because it's a C++ library
+  when defined(macosx):
+    switch("clang.linkerexe", "clang++")
+  else:
+    switch("gcc.linkerexe", "g++")
 
-switch("dynlibOverride", "librocksdb.a")
-switch("dynlibOverride", "liblz4.a")
-switch("dynlibOverride", "libzstd.a")
+  switch("dynlibOverride", "rocksdb")
+  switch("dynlibOverride", "lz4")
+  switch("dynlibOverride", "zstd")

--- a/config.nims
+++ b/config.nims
@@ -161,20 +161,14 @@ if defined(windows) and defined(i386):
 switch("define", "kzgExternalBlst")
 
 # nim-rocksdb static linking
-import std/os
-
-const libsDir = currentSourcePath.parentDir() & "/vendor/nim-rocksdb/build/lib"
 switch("define", "rocksdb_static_linking")
-switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
+
+# use the C++ linker profile because it's a C++ library
+when defined(macosx):
+  switch("clang.linkerexe", "clang++")
+else:
+  switch("gcc.linkerexe", "g++")
+
 switch("dynlibOverride", "librocksdb.a")
-switch("dynlibOverride", "libz.a")
-switch("dynlibOverride", "libbz2.a")
 switch("dynlibOverride", "liblz4.a")
 switch("dynlibOverride", "libzstd.a")
-
-switch("l", libsDir & "/librocksdb.a")
-switch("l", libsDir & "/libz.a")
-switch("l", libsDir & "/libbz2.a")
-switch("l", libsDir & "/liblz4.a")
-switch("l", libsDir & "/libzstd.a")
-#switch("passL", "-s") # to reduce the binary size if needed


### PR DESCRIPTION
This PR include the following changes:
- Update nim-rocksdb to the latest version which includes support for building RocksDb libs from source and static linking.
- Make file is updated to support triggering building the RocksDb static library dependencies.
- New make target nimbus_rocksdb_static will build nimbus using static linking.
- Static linking is disabled by default so the regular make nimbus will continue to use the dynamic library.
- Static linking is not supported on windows because RocksDb doesn't support building with Mingw.