### PR TITLE
Add beacon state historical_roots to fluffy

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -215,10 +215,7 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
         )
       else:
         # Get it from binary file containing SSZ encoded accumulator
-        try:
-          SSZ.decode(finishedAccumulator, FinishedAccumulator)
-        except SszError as err:
-          raiseAssert "Invalid baked-in accumulator: " & err.msg
+        loadAccumulator()
 
     historyNetwork =
       if Network.history in config.networks:

--- a/fluffy/tests/portal_spec_tests/mainnet/test_history_content.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_history_content.nim
@@ -35,11 +35,7 @@ suite "History Content Encodings":
         raiseAssert "Invalid epoch accumulator file: " & accumulatorFile
       blockHeadersWithProof = buildHeadersWithProof(blockHeaders, epochAccumulator).valueOr:
         raiseAssert "Could not build headers with proof"
-      accumulator =
-        try:
-          SSZ.decode(finishedAccumulator, FinishedAccumulator)
-        except SszError as err:
-          raiseAssert "Invalid baked-in accumulator: " & err.msg
+      accumulator = loadAccumulator()
 
     let res = readJsonType(headersWithProofFile, JsonPortalContentTable)
     check res.isOk()
@@ -85,11 +81,7 @@ suite "History Content Encodings":
     const dataFile =
       "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/14764013.json"
 
-    let accumulator =
-      try:
-        SSZ.decode(finishedAccumulator, FinishedAccumulator)
-      except SszError as err:
-        raiseAssert "Invalid baked-in accumulator: " & err.msg
+    let accumulator = loadAccumulator()
 
     let res = readJsonType(dataFile, JsonPortalContentTable)
     check res.isOk()

--- a/fluffy/tools/content_verifier.nim
+++ b/fluffy/tools/content_verifier.nim
@@ -38,12 +38,7 @@ type ContentVerifierConf* = object
   .}: uint16
 
 proc checkAccumulators(client: RpcClient) {.async.} =
-  let accumulator =
-    # Get it from binary file containing SSZ encoded accumulator
-    try:
-      SSZ.decode(finishedAccumulator, FinishedAccumulator)
-    except SszError as err:
-      raiseAssert "Invalid baked-in accumulator: " & err.msg
+  let accumulator = loadAccumulator()
 
   for i, hash in accumulator.historicalEpochs:
     let root = Digest(data: hash)

--- a/fluffy/tools/eth_data_exporter.nim
+++ b/fluffy/tools/eth_data_exporter.nim
@@ -688,3 +688,7 @@ when isMainModule:
       waitFor exportLCOptimisticUpdate(
         config.restUrl, string config.dataDir, cfg, forkDigests
       )
+    of BeaconCmd.exportHistoricalRoots:
+      waitFor exportHistoricalRoots(
+        config.restUrl, string config.dataDir, cfg, forkDigests
+      )

--- a/fluffy/tools/eth_data_exporter/exporter_conf.nim
+++ b/fluffy/tools/eth_data_exporter/exporter_conf.nim
@@ -69,6 +69,7 @@ type
     exportLCUpdates = "Export Light Client Updates"
     exportLCFinalityUpdate = "Export Light Client Finality Update"
     exportLCOptimisticUpdate = "Export Light Client Optimistic Update"
+    exportHistoricalRoots = "Export historical roots from the beacon state (SSZ format)"
 
   ExporterConf* = object
     logLevel* {.
@@ -206,6 +207,8 @@ type
       of exportLCFinalityUpdate:
         discard
       of exportLCOptimisticUpdate:
+        discard
+      of exportHistoricalRoots:
         discard
 
 proc parseCmdArg*(T: type Web3Url, p: string): T {.raises: [ValueError].} =

--- a/fluffy/tools/portal_bridge/portal_bridge_history.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_history.nim
@@ -346,12 +346,7 @@ proc runBackfillLoop(
 ) {.async: (raises: [CancelledError]).} =
   let
     rng = newRng()
-    accumulator =
-      try:
-        SSZ.decode(finishedAccumulator, FinishedAccumulator)
-      except SerializationError as err:
-        raiseAssert "Invalid baked-in accumulator: " & err.msg
-
+    accumulator = loadAccumulator()
   while true:
     let
       # Grab a random era1 to backfill


### PR DESCRIPTION
- Add historical_roots in the binary for proof verification pre-capella
- Add command to export historical_roots to file in eth_data_exporter tool