### PR TITLE
Add exportBlockProofBellatrix command to eth_data_exporter

### DIFF
--- a/fluffy/network/history/experimental/beacon_chain_block_proof.nim
+++ b/fluffy/network/history/experimental/beacon_chain_block_proof.nim
@@ -87,12 +87,12 @@ type
 
   BeaconChainBlockProof* = object
     # Total size (8 + 1 + 3 + 1 + 14) * 32 bytes + 4 bytes = 868 bytes
-    beaconBlockBodyProof: BeaconBlockBodyProof
-    beaconBlockBodyRoot: Digest
-    beaconBlockHeaderProof: BeaconBlockHeaderProof
-    beaconBlockHeaderRoot: Digest
-    historicalRootsProof: HistoricalRootsProof
-    slot: Slot
+    beaconBlockBodyProof*: BeaconBlockBodyProof
+    beaconBlockBodyRoot*: Digest
+    beaconBlockHeaderProof*: BeaconBlockHeaderProof
+    beaconBlockHeaderRoot*: Digest
+    historicalRootsProof*: HistoricalRootsProof
+    slot*: Slot
 
 func getHistoricalRootsIndex*(slot: Slot): uint64 =
   slot div SLOTS_PER_HISTORICAL_ROOT
@@ -109,7 +109,7 @@ func getBlockRootsIndex*(blockHeader: BeaconBlockHeader): uint64 =
 # Builds proof to be able to verify that the EL block hash is part of
 # BeaconBlockBody for given root.
 func buildProof*(
-    blockBody: bellatrix.BeaconBlockBody
+    blockBody: bellatrix.TrustedBeaconBlockBody | bellatrix.BeaconBlockBody
 ): Result[BeaconBlockBodyProof, string] =
   # 16 as there are 10 fields
   # 9 as index (pos) of field = 9
@@ -152,7 +152,7 @@ func buildProof*(
 func buildProof*(
     batch: HistoricalBatch,
     blockHeader: BeaconBlockHeader,
-    blockBody: bellatrix.BeaconBlockBody,
+    blockBody: bellatrix.TrustedBeaconBlockBody | bellatrix.BeaconBlockBody,
 ): Result[BeaconChainBlockProof, string] =
   let
     blockRootIndex = getBlockRootsIndex(blockHeader)

--- a/fluffy/tools/eth_data_exporter.nim
+++ b/fluffy/tools/eth_data_exporter.nim
@@ -692,3 +692,7 @@ when isMainModule:
       waitFor exportHistoricalRoots(
         config.restUrl, string config.dataDir, cfg, forkDigests
       )
+    of BeaconCmd.exportBlockProofBellatrix:
+      cmdExportBlockProofBellatrix(
+        string config.dataDir, string config.eraDir, config.slotNumber
+      )

--- a/fluffy/tools/eth_data_exporter/exporter_conf.nim
+++ b/fluffy/tools/eth_data_exporter/exporter_conf.nim
@@ -70,6 +70,7 @@ type
     exportLCFinalityUpdate = "Export Light Client Finality Update"
     exportLCOptimisticUpdate = "Export Light Client Optimistic Update"
     exportHistoricalRoots = "Export historical roots from the beacon state (SSZ format)"
+    exportBlockProofBellatrix = "Export Bellatrix EL block proof from era files"
 
   ExporterConf* = object
     logLevel* {.
@@ -210,6 +211,11 @@ type
         discard
       of exportHistoricalRoots:
         discard
+      of exportBlockProofBellatrix:
+        slotNumber* {.
+          desc: "The slot for which to export the block proof", name: "slot"
+        .}: uint64
+        eraDir* {.desc: "Directory containing era files", name: "era-dir".}: InputDir
 
 proc parseCmdArg*(T: type Web3Url, p: string): T {.raises: [ValueError].} =
   let


### PR DESCRIPTION
Add functionality to  export bellatrix block proofs from era files to the eth_data_exporter tool.