### PR TITLE
Engine API: forkChoiceUpdated V2 And V3 should return invalidPayloadA…

### DIFF
--- a/hive_integration/nodocker/engine/cancun_tests.nim
+++ b/hive_integration/nodocker/engine/cancun_tests.nim
@@ -485,7 +485,7 @@ let cancunTestList* = [
       - Payload Attributes uses Shanghai timestamp
       - Payload Attributes' Beacon Root is nil
 
-      Verify that client returns INVALID_PARAMS_ERROR.
+      Verify that client returns INVALID_PAYLOAD_ATTRIBUTES.
       """,
     run: specExecute,
     spec: CancunSpec(
@@ -494,11 +494,11 @@ let cancunTestList* = [
       testSequence: @[
         NewPayloads(
           fcUOnPayloadRequest: UpgradeForkchoiceUpdatedVersion(
-            expectedError: engineApiInvalidParams,
+            expectedError: engineApiInvalidPayloadAttributes,
           ),
           expectationDescription: """
-          ForkchoiceUpdatedV3 before Cancun with any nil field must return INVALID_PARAMS_ERROR (code $1)
-          """ % [$engineApiInvalidParams],
+          ForkchoiceUpdatedV3 before Cancun with any nil field must return INVALID_PAYLOAD_ATTRIBUTES (code $1)
+          """ % [$engineApiInvalidPayloadAttributes],
         ).TestStep,
       ]
     ),
@@ -539,7 +539,7 @@ let cancunTestList* = [
       - Payload Attributes uses Shanghai timestamp
       - Payload Attributes' Beacon Root zero
 
-      Verify that client returns INVALID_PARAMS_ERROR.
+      Verify that client returns INVALID_PAYLOAD_ATTRIBUTES.
       """,
     run: specExecute,
     spec: CancunSpec(
@@ -549,11 +549,11 @@ let cancunTestList* = [
         NewPayloads(
           fcUOnPayloadRequest: DowngradeForkchoiceUpdatedVersion(
             beaconRoot: some(common.Hash256()),
-            expectedError: engineApiInvalidParams,
+            expectedError: engineApiInvalidPayloadAttributes,
           ),
           expectationDescription: """
-          ForkchoiceUpdatedV2 before Cancun with beacon root field must return INVALID_PARAMS_ERROR (code $1)
-          """ % [$engineApiInvalidParams],
+          ForkchoiceUpdatedV2 before Cancun with beacon root field must return INVALID_PAYLOAD_ATTRIBUTES (code $1)
+          """ % [$engineApiInvalidPayloadAttributes],
         ).TestStep,
       ]
     ),
@@ -567,7 +567,7 @@ let cancunTestList* = [
       - Payload Attributes uses Cancun timestamp
       - Payload Attributes' Beacon Root zero
 
-      Verify that client returns INVALID_PARAMS_ERROR.
+      Verify that client returns INVALID_PAYLOAD_ATTRIBUTES.
       """,
     run: specExecute,
     spec: CancunSpec(
@@ -577,11 +577,11 @@ let cancunTestList* = [
         NewPayloads(
           fcUOnPayloadRequest: DowngradeForkchoiceUpdatedVersion(
             beaconRoot: some(common.Hash256()),
-            expectedError: engineApiInvalidParams,
+            expectedError: engineApiInvalidPayloadAttributes,
           ),
           expectationDescription: """
-          ForkchoiceUpdatedV2 after Cancun with beacon root field must return INVALID_PARAMS_ERROR (code $1)
-          """ % [$engineApiInvalidParams],
+          ForkchoiceUpdatedV2 after Cancun with beacon root field must return INVALID_PAYLOAD_ATTRIBUTES (code $1)
+          """ % [$engineApiInvalidPayloadAttributes],
         ).TestStep,
       ]
     ),

--- a/nimbus/beacon/api_handler/api_forkchoice.nim
+++ b/nimbus/beacon/api_handler/api_forkchoice.nim
@@ -28,7 +28,7 @@ template validateVersion(attrsOpt, com, apiVersion) =
 
     if apiVersion == Version.V3:
       if version != apiVersion:
-        raise invalidParams("forkChoiceUpdatedV3 expect PayloadAttributesV3" &
+        raise invalidAttr("forkChoiceUpdatedV3 expect PayloadAttributesV3" &
         " but got PayloadAttributes" & $version)
       if not com.isCancunOrLater(timestamp):
         raise unsupportedFork(
@@ -39,11 +39,11 @@ template validateVersion(attrsOpt, com, apiVersion) =
           raise unsupportedFork("forkChoiceUpdated" & $apiVersion &
             " doesn't support payloadAttributes with Cancun timestamp")
         if version >= Version.V3:
-          raise invalidParams("forkChoiceUpdated" & $apiVersion &
+          raise invalidAttr("forkChoiceUpdated" & $apiVersion &
             " doesn't support PayloadAttributes" & $version)
       elif com.isShanghaiOrLater(timestamp):
         if version != Version.V2:
-          raise invalidParams("if timestamp is Shanghai or later," &
+          raise invalidAttr("if timestamp is Shanghai or later," &
             " payloadAttributes must be PayloadAttributesV2")
       else:
         if version != Version.V1:


### PR DESCRIPTION
…ttributes error instead of invalidParams error upon receiving erroneous payload attributes