### PR TITLE
Adjust color scheme for fluffy.guide

### DIFF
--- a/fluffy/docs/the_fluffy_book/docs/stylesheets/extra.css
+++ b/fluffy/docs/the_fluffy_book/docs/stylesheets/extra.css
@@ -1,0 +1,6 @@
+[data-md-color-scheme="slate"] {
+  --md-hue: 180;
+  --md-default-bg-color: hsla(var(--md-hue), 0%, 0%, 1);
+  --md-footer-bg-color: hsla(var(--md-hue), 0%, 0%, 1);
+  --md-footer-bg-color--dark: hsla(var(--md-hue), 0%, 0%, 1);
+}

--- a/fluffy/docs/the_fluffy_book/mkdocs.yml
+++ b/fluffy/docs/the_fluffy_book/mkdocs.yml
@@ -14,9 +14,22 @@ theme:
     - navigation.top
     - content.tabs.link
   palette:
-    scheme: default
-    primary: orange
-    accent: amber
+    - scheme: slate
+      primary: black
+      accent: light blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - scheme: default
+      primary: white
+      accent: light blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+
+extra_css:
+  - stylesheets/extra.css
 
 # Support urls previously used by mdbook
 use_directory_urls: false
@@ -26,7 +39,6 @@ docs_dir: docs
 
 markdown_extensions:
   - admonition
-  - meta
   - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true


### PR DESCRIPTION
Use the same scheme as for the nimbus.guide.
Two differences however:
- Set the dark scheme as default, considering the new nimbus.team website also has dark as default.
- Remove the orange/amber for the light scheme, considering the light version of nimbus.team has no more orange.