### PR TITLE
Remove usages of CoreDb in Fluffy.

### DIFF
--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -11,7 +11,7 @@ import
   stew/results,
   chronos,
   chronicles,
-  eth/[common/eth_types_rlp, rlp],
+  eth/[common/eth_types_rlp, rlp, trie, trie/db],
   eth/p2p/discoveryv5/[protocol, enr],
   ../../common/common_types,
   ../../database/content_db,
@@ -190,7 +190,7 @@ func encode*(receipts: seq[Receipt]): seq[byte] =
 # for if/when peer scoring/banning is added.
 
 proc calcRootHash(items: Transactions | PortalReceipts | Withdrawals): Hash256 =
-  var tr = newCoreDbRef(LegacyDbMemory).mptPrune
+  var tr = initHexaryTrie(newMemoryDB(), isPruning = false)
   for i, item in items:
     try:
       tr.put(rlp.encode(i), item.asSeq())

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -16,7 +16,7 @@ import
   ../../common/common_types,
   ../../database/content_db,
   ../../network_metadata,
-  ../../../nimbus/[constants, db/core_db],
+  ../../../nimbus/constants,
   ../wire/[portal_protocol, portal_stream, portal_protocol_config],
   "."/[history_content, accumulator, beacon_chain_historical_roots]
 

--- a/fluffy/tests/test_discovery_rpc.nim
+++ b/fluffy/tests/test_discovery_rpc.nim
@@ -39,7 +39,9 @@ proc setupTest(rng: ref HmacDrbgContext): Future[TestCase] {.async.} =
   rpcHttpServerWithProxy.installDiscoveryApiHandlers(localDiscoveryNode)
 
   await rpcHttpServerWithProxy.start()
-  await client.connect(localSrvAddress, rpcHttpServerWithProxy.localAddress[0].port, false)
+  await client.connect(
+    localSrvAddress, rpcHttpServerWithProxy.localAddress[0].port, false
+  )
   return TestCase(
     localDiscovery: localDiscoveryNode, server: rpcHttpServerWithProxy, client: client
   )

--- a/fluffy/tests/test_discovery_rpc.nim
+++ b/fluffy/tests/test_discovery_rpc.nim
@@ -27,7 +27,7 @@ type TestCase = ref object
 proc setupTest(rng: ref HmacDrbgContext): Future[TestCase] {.async.} =
   let
     localSrvAddress = "127.0.0.1"
-    localSrvPort = 8545
+    localSrvPort = 0 # let the OS choose a port
     ta = initTAddress(localSrvAddress, localSrvPort)
     localDiscoveryNode =
       initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(20302))
@@ -39,7 +39,7 @@ proc setupTest(rng: ref HmacDrbgContext): Future[TestCase] {.async.} =
   rpcHttpServerWithProxy.installDiscoveryApiHandlers(localDiscoveryNode)
 
   await rpcHttpServerWithProxy.start()
-  await client.connect(localSrvAddress, Port(localSrvPort), false)
+  await client.connect(localSrvAddress, rpcHttpServerWithProxy.localAddress[0].port, false)
   return TestCase(
     localDiscovery: localDiscoveryNode, server: rpcHttpServerWithProxy, client: client
   )

--- a/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
+++ b/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
@@ -81,7 +81,7 @@ template unsafeQuantityToInt64(q: Quantity): int64 =
 proc calculateTransactionData(
     items: openArray[TypedTransaction]
 ): Hash256 {.raises: [].} =
-  var tr = newCoreDbRef(LegacyDbMemory).mptPrune
+  var tr = initHexaryTrie(newMemoryDB(), isPruning = false)
   for i, t in items:
     try:
       let tx = distinctBase(t)
@@ -95,7 +95,7 @@ proc calculateTransactionData(
 # TODO: Since Capella we can also access ExecutionPayloadHeader and thus
 # could get the Roots through there instead.
 proc calculateWithdrawalsRoot(items: openArray[WithdrawalV1]): Hash256 {.raises: [].} =
-  var tr = newCoreDbRef(LegacyDbMemory).mptPrune
+  var tr = initHexaryTrie(newMemoryDB(), isPruning = false)
   for i, w in items:
     try:
       let withdrawal = etypes.Withdrawal(

--- a/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
+++ b/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
@@ -59,7 +59,6 @@ import
   ../../network/history/[history_content, history_network],
   ../../network/beacon/beacon_content,
   ../../common/common_types,
-  ../../nimbus/db/core_db,
   ./beacon_lc_bridge_conf
 
 from stew/objects import checkedEnumAssign

--- a/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
+++ b/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
@@ -41,7 +41,7 @@ import
   chronicles,
   chronos,
   confutils,
-  eth/[keys, rlp],
+  eth/[keys, rlp, trie, trie/db],
   # Need to rename this because of web3 ethtypes and ambigious indentifier mess
   # for `BlockHeader`.
   eth/common/eth_types as etypes,


### PR DESCRIPTION
Considering that we don't need the complexity of CoreDb and will likely never need the CoreDb aristo implemention in Fluffy, lets keep it simple and use the HexaryTrie implementation when doing in memory merkle root calculations.