### PR TITLE
Add post Bellatrix beacon block proof exports

### DIFF
--- a/fluffy/eth_data/yaml_eth_types.nim
+++ b/fluffy/eth_data/yaml_eth_types.nim
@@ -1,0 +1,43 @@
+# fluffy
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import ssz_serialization/types
+
+type
+  YamlTestProofBellatrix* = object
+    execution_block_header*: string # Not part of the actual proof
+    beacon_block_body_proof*: array[8, string]
+    beacon_block_body_root*: string
+    beacon_block_header_proof*: array[3, string]
+    beacon_block_header_root*: string
+    historical_roots_proof*: array[14, string]
+    slot*: uint64
+
+  YamlTestProof* = object
+    execution_block_header*: string # Not part of the actual proof
+    beacon_block_body_proof*: array[8, string]
+    beacon_block_body_root*: string
+    beacon_block_header_proof*: array[3, string]
+    beacon_block_header_root*: string
+    historical_summaries_proof*: array[13, string]
+    slot*: uint64
+
+proc fromHex*[n](T: type array[n, Digest], a: array[n, string]): T =
+  var res: T
+  for i in 0 ..< a.len:
+    res[i] = Digest.fromHex(a[i])
+
+  res
+
+proc toHex*[n](a: array[n, Digest], T: type array[n, string]): T =
+  var res: T
+  for i in 0 ..< a.len:
+    res[i] = toHex(a[i].data)
+
+  res

--- a/fluffy/eth_data/yaml_utils.nim
+++ b/fluffy/eth_data/yaml_utils.nim
@@ -39,3 +39,20 @@ proc loadFromYaml*(T: type, file: string): Result[T, string] =
   except IOError as e:
     return err(e.msg)
   ok(res)
+
+proc dumpToYaml*[T](value: T, file: string): Result[void, string] =
+  let s = newFileStream(file, fmWrite)
+  defer:
+    try:
+      close(s)
+    except Exception as e:
+      raiseAssert(e.msg)
+  try:
+    dump(value, s)
+  except YamlPresenterJsonError as e:
+    return err(e.msg)
+  except YamlSerializationError as e:
+    return err(e.msg)
+  except YamlPresenterOutputError as e:
+    return err(e.msg)
+  ok()

--- a/fluffy/network/history/beacon_chain_block_proof_common.nim
+++ b/fluffy/network/history/beacon_chain_block_proof_common.nim
@@ -1,0 +1,50 @@
+# Fluffy
+# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import results, beacon_chain/spec/presets, beacon_chain/spec/forks
+
+type
+  BeaconBlockBodyProof* = array[8, Digest]
+  BeaconBlockHeaderProof* = array[3, Digest]
+
+func getBlockRootsIndex*(slot: Slot): uint64 =
+  slot mod SLOTS_PER_HISTORICAL_ROOT
+
+func getBlockRootsIndex*(blockHeader: BeaconBlockHeader): uint64 =
+  getBlockRootsIndex(blockHeader.slot)
+
+# Builds proof to be able to verify that the EL block hash is part of
+# BeaconBlockBody for given root.
+func buildProof*(
+    blockBody: ForkyTrustedBeaconBlockBody | ForkyBeaconBlockBody
+): Result[BeaconBlockBodyProof, string] =
+  # 16 as there are 10 fields
+  # 9 as index (pos) of field = 9
+  let gIndexTopLevel = (1 * 1 * 16 + 9)
+  # 16 as there are 14 fields
+  # 12 as pos of field = 12
+  let gIndex = GeneralizedIndex(gIndexTopLevel * 1 * 16 + 12)
+
+  var proof: BeaconBlockBodyProof
+  ?blockBody.build_proof(gIndex, proof)
+
+  ok(proof)
+
+# Builds proof to be able to verify that the CL BlockBody root is part of
+# BeaconBlockHeader for given root.
+func buildProof*(
+    blockHeader: BeaconBlockHeader
+): Result[BeaconBlockHeaderProof, string] =
+  # 5th field of container with 5 fields -> 7 + 5
+  let gIndex = GeneralizedIndex(12)
+
+  var proof: BeaconBlockHeaderProof
+  ?blockHeader.build_proof(gIndex, proof)
+
+  ok(proof)

--- a/fluffy/tests/beacon_network_tests/test_beacon_content.nim
+++ b/fluffy/tests/beacon_network_tests/test_beacon_content.nim
@@ -1,4 +1,4 @@
-# Nimbus - Portal Network
+# Fluffy
 # Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
@@ -16,7 +16,7 @@ import
   beacon_chain/spec/forks,
   beacon_chain/spec/datatypes/altair,
   ../../network/beacon/beacon_content,
-  ../test_yaml_utils,
+  ../../eth_data/yaml_utils,
   "."/light_client_test_data
 
 suite "Beacon Content Encodings - Mainnet":

--- a/fluffy/tests/portal_spec_tests/mainnet/test_history_block_proof_bellatrix.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_history_block_proof_bellatrix.nim
@@ -17,23 +17,7 @@ import
   ../../../common/common_types,
   ../../../network_metadata,
   ../../../network/history/beacon_chain_block_proof_bellatrix,
-  ../../test_yaml_utils
-
-type YamlTestProof = object
-  execution_block_header: string # Not part of the actual proof
-  beacon_block_body_proof: array[8, string]
-  beacon_block_body_root: string
-  beacon_block_header_proof: array[3, string]
-  beacon_block_header_root: string
-  historical_roots_proof: array[14, string]
-  slot: uint64
-
-proc fromHex[n](T: type array[n, Digest], a: array[n, string]): T =
-  var res: T
-  for i in 0 ..< a.len:
-    res[i] = Digest.fromHex(a[i])
-
-  res
+  ../../../eth_data/[yaml_utils, yaml_eth_types]
 
 suite "History Block Proofs - Bellatrix":
   test "BeaconChainBlockProof for Execution BlockHeader":
@@ -45,7 +29,7 @@ suite "History Block Proofs - Bellatrix":
     for kind, path in walkDir(testsPath):
       if kind == pcFile and path.splitFile.ext == ".yaml":
         let
-          testProof = YamlTestProof.loadFromYaml(path).valueOr:
+          testProof = YamlTestProofBellatrix.loadFromYaml(path).valueOr:
             raiseAssert "Cannot read test vector: " & error
 
           blockHash = BlockHash.fromHex(testProof.execution_block_header)

--- a/fluffy/tests/portal_spec_tests/mainnet/test_history_content.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_history_content.nim
@@ -17,7 +17,7 @@ import
   ../../../eth_data/[history_data_json_store, history_data_ssz_e2s],
   ../../../network/history/[history_content, history_network, accumulator],
   ../../test_history_util,
-  ../../test_yaml_utils
+  ../../../eth_data/yaml_utils
 
 suite "History Content Encodings":
   test "HeaderWithProof Building and Encoding":

--- a/fluffy/tests/state_network_tests/test_state_content_keys.nim
+++ b/fluffy/tests/state_network_tests/test_state_content_keys.nim
@@ -5,7 +5,11 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import unittest2, stew/byteutils, ../../network/state/state_content, ../test_yaml_utils
+import
+  unittest2,
+  stew/byteutils,
+  ../../network/state/state_content,
+  ../../eth_data/yaml_utils
 
 const testVectorDir = "./vendor/portal-spec-tests/tests/mainnet/state/serialization/"
 

--- a/fluffy/tests/state_network_tests/test_state_content_values.nim
+++ b/fluffy/tests/state_network_tests/test_state_content_values.nim
@@ -10,7 +10,7 @@ import
   unittest2,
   stew/byteutils,
   ../../network/state/state_content,
-  ../test_yaml_utils
+  ../../eth_data/yaml_utils
 
 const testVectorDir = "./vendor/portal-spec-tests/tests/mainnet/state/serialization/"
 

--- a/fluffy/tests/state_network_tests/test_state_network_gossip.nim
+++ b/fluffy/tests/state_network_tests/test_state_network_gossip.nim
@@ -15,7 +15,7 @@ import
   ../../network/state/[state_content, state_network],
   ../../database/content_db,
   .././test_helpers,
-  ../test_yaml_utils
+  ../../eth_data/yaml_utils
 
 const testVectorDir = "./vendor/portal-spec-tests/tests/mainnet/state/validation/"
 

--- a/fluffy/tests/test_beacon_chain_block_proof_capella.nim
+++ b/fluffy/tests/test_beacon_chain_block_proof_capella.nim
@@ -168,7 +168,7 @@ suite "Beacon Chain Block Proofs - Capella":
             # the blockHash from the execution payload.
             blockHash = beaconBlockBody.execution_payload.block_hash
 
-          let proofRes = buildProof(blockRoots, beaconBlockHeader, beaconBlockBody, cfg)
+          let proofRes = buildProof(blockRoots, beaconBlockHeader, beaconBlockBody)
           check proofRes.isOk()
           let proof = proofRes.get()
 

--- a/fluffy/tools/eth_data_exporter.nim
+++ b/fluffy/tools/eth_data_exporter.nim
@@ -692,7 +692,7 @@ when isMainModule:
       waitFor exportHistoricalRoots(
         config.restUrl, string config.dataDir, cfg, forkDigests
       )
-    of BeaconCmd.exportBlockProofBellatrix:
-      cmdExportBlockProofBellatrix(
+    of BeaconCmd.exportBeaconBlockProof:
+      exportBeaconBlockProof(
         string config.dataDir, string config.eraDir, config.slotNumber
       )

--- a/fluffy/tools/eth_data_exporter/exporter_conf.nim
+++ b/fluffy/tools/eth_data_exporter/exporter_conf.nim
@@ -70,7 +70,8 @@ type
     exportLCFinalityUpdate = "Export Light Client Finality Update"
     exportLCOptimisticUpdate = "Export Light Client Optimistic Update"
     exportHistoricalRoots = "Export historical roots from the beacon state (SSZ format)"
-    exportBlockProofBellatrix = "Export Bellatrix EL block proof from era files"
+    exportBeaconBlockProof =
+      "Export EL beacon block proof from era files (Bellatrix and later)"
 
   ExporterConf* = object
     logLevel* {.
@@ -211,9 +212,9 @@ type
         discard
       of exportHistoricalRoots:
         discard
-      of exportBlockProofBellatrix:
+      of exportBeaconBlockProof:
         slotNumber* {.
-          desc: "The slot for which to export the block proof", name: "slot"
+          desc: "The slot for which to export the beacon block proof", name: "slot"
         .}: uint64
         eraDir* {.desc: "Directory containing era files", name: "era-dir".}: InputDir
 


### PR DESCRIPTION
- Add post Bellatrix Beacon block proof exporting to eth_data_exporter
- Rework the Bellatrix Beacon block proof exports to us yaml format
- Move some common code of the two different beacon block proofs to beacon_chain_block_proof_common module
- Move + add to yaml utils to be usable not just for the tests but also for eth data exporter