### PR TITLE
Add tests for beacon block proofs Capella and onwards

### DIFF
--- a/fluffy/tests/portal_spec_tests/mainnet/all_fluffy_portal_spec_tests.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/all_fluffy_portal_spec_tests.nim
@@ -1,4 +1,4 @@
-# Nimbus
+# Fluffy
 # Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
@@ -13,5 +13,6 @@ import
   ./test_history_content,
   ./test_history_content_validation,
   ./test_history_block_proof_bellatrix,
+  ./test_history_block_proof_capella,
   ./test_header_content,
   ./test_accumulator_root

--- a/fluffy/tests/portal_spec_tests/mainnet/test_history_block_proof_capella.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_history_block_proof_capella.nim
@@ -1,0 +1,79 @@
+# Fluffy
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+{.push raises: [].}
+
+import
+  std/os,
+  stew/io2,
+  unittest2,
+  yaml,
+  ssz_serialization,
+  beacon_chain/spec/datatypes/capella,
+  ../../../common/common_types,
+  ../../../network/history/experimental/beacon_chain_block_proof_capella,
+  ../../../network/beacon/beacon_init_loader,
+  ../../../eth_data/[yaml_utils, yaml_eth_types]
+
+proc toString(v: IoErrorCode): string =
+  try:
+    ioErrorMsg(v)
+  except Exception as e:
+    raiseAssert e.msg
+
+# Testing only proc as in the real network the historical_summaries are
+# retrieved from the network.
+proc readHistoricalSummaries(
+    file: string
+): Result[HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT], string] =
+  let encodedHistoricalSummaries = ?readAllFile(file).mapErr(toString)
+
+  try:
+    ok(
+      SSZ.decode(
+        encodedHistoricalSummaries,
+        HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT],
+      )
+    )
+  except SerializationError as err:
+    err("Failed decoding historical_summaries: " & err.msg)
+
+suite "History Block Proofs - Capella":
+  test "BeaconChainBlockProof for Execution BlockHeader":
+    let
+      testsPath =
+        "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/block_proofs_capella/"
+      historicalSummaries_path =
+        "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/block_proofs_capella/historical_summaries_at_slot_8953856.ssz"
+      networkData = loadNetworkData("mainnet")
+      historicalSummaries = readHistoricalSummaries(historicalSummaries_path).valueOr:
+        raiseAssert "Cannot read historical summaries: " & error
+
+    for kind, path in walkDir(testsPath):
+      if kind == pcFile and path.splitFile.ext == ".yaml":
+        let
+          testProof = YamlTestProof.loadFromYaml(path).valueOr:
+            raiseAssert "Cannot read test vector: " & error
+
+          blockHash = BlockHash.fromHex(testProof.execution_block_header)
+          blockProof = BeaconChainBlockProof(
+            beaconBlockBodyProof:
+              array[8, Digest].fromHex(testProof.beacon_block_body_proof),
+            beaconBlockBodyRoot: Digest.fromHex(testProof.beacon_block_body_root),
+            beaconBlockHeaderProof:
+              array[3, Digest].fromHex(testProof.beacon_block_header_proof),
+            beaconBlockHeaderRoot: Digest.fromHex(testProof.beacon_block_header_root),
+            historicalSummariesProof:
+              array[13, Digest].fromHex(testProof.historical_summaries_proof),
+            slot: Slot(testProof.slot),
+          )
+
+        check verifyProof(
+          historicalSummaries, blockProof, blockHash, networkData.metadata.cfg
+        )


### PR DESCRIPTION
Draft as it requires an update of vendor/portal-spec-tests when test vectors get merged: https://github.com/ethereum/portal-spec-tests/pull/12