### PR TITLE
Add kvstore for contract code

### DIFF
--- a/nimbus/db/ledger/backend/accounts_cache.nim
+++ b/nimbus/db/ledger/backend/accounts_cache.nim
@@ -14,7 +14,7 @@ import
   eth/common,
   ../../../../stateless/multi_keys,
   "../.."/[core_db, distinct_tries],
-  ../accounts_cache as impl,
+  ../verkle_accounts_cache as impl,
   ".."/[base, base/base_desc],
   ./accounts_cache_desc as wrp
 
@@ -51,7 +51,7 @@ proc ledgerMethods(lc: impl.AccountsCache): LedgerFns =
       lc.addLogEntry(log),
 
     beginSavepointFn: proc(): LedgerSpRef =
-      wrp.SavePoint(sp: lc.beginSavepoint()),
+      wrp.SavePoint(sp: lc.beginSavePoint()),
 
     clearStorageFn: proc(eAddr: EthAddress) =
       lc.clearStorage(eAddr),
@@ -184,7 +184,7 @@ proc ledgerMethods(lc: impl.AccountsCache): LedgerFns =
 proc ledgerExtras(lc: impl.AccountsCache): LedgerExtras =
   LedgerExtras(
     getMptFn: proc(): CoreDbMptRef =
-      lc.rawTrie.mpt,
+      lc.rawTrie.mpt,                                                 # -----------> needs to be fixed, MPT doesn't exist anymore
 
     rawRootHashFn: proc(): Hash256 =
       lc.rawTrie.rootHash())
@@ -195,7 +195,7 @@ proc newLegacyAccountsCache(
     root: Hash256;
     pruneTrie: bool): LedgerRef =
   ## Constructor
-  let lc = impl.AccountsCache.init(db, root, pruneTrie)
+  let lc = impl.AccountsCache.init()
   wrp.AccountsCache(
     ldgType:   LegacyAccountsCache,
     ac:        lc,
@@ -231,7 +231,7 @@ iterator storageIt*(
       ): (UInt256,UInt256)
       {.gcsafe, raises: [CoreDbApiError].} =
   noRlpException "storage()":
-    for w in lc.ac.storage(eAddr):
+    for w in lc.ac.storage(eAddr):                                         # -----------> needs to be fixed, storage() doesn't exist yet 
       yield w
 
 # ------------------------------------------------------------------------------

--- a/nimbus/db/ledger/backend/accounts_cache_desc.nim
+++ b/nimbus/db/ledger/backend/accounts_cache_desc.nim
@@ -9,7 +9,7 @@
 # according to those terms.
 
 import
-  ../accounts_cache as impl,
+  ../verkle_accounts_cache as impl,
   ../base/base_desc
 
 type

--- a/nimbus/db/verkle/verkle_accounts.nim
+++ b/nimbus/db/verkle/verkle_accounts.nim
@@ -19,13 +19,14 @@ import
   ],
   "../../../vendor/nim-eth-verkle/constantine/constantine"/[
     serialization/codecs_banderwagon
-  ]
+  ],
+  ".."/core_db
 
 type
   ChunkedCode* = seq[byte]
   VerkleTrieRef* = ref object
     root: BranchesNode
-  # db: <something>
+    db:   CoreDxKvtRef
   # persistcheck: <some-flag>
 
 const

--- a/nimbus/db/verkle/verkle_accounts.nim
+++ b/nimbus/db/verkle/verkle_accounts.nim
@@ -26,7 +26,7 @@ type
   ChunkedCode* = seq[byte]
   VerkleTrieRef* = ref object
     root: BranchesNode
-    db:   CoreDxKvtRef
+    db:   CoreDbKvtRef
   # persistcheck: <some-flag>
 
 const

--- a/nimbus/db/verkle/verkle_accounts.nim
+++ b/nimbus/db/verkle/verkle_accounts.nim
@@ -53,6 +53,10 @@ var MainStorageOffsetLshVerkleNodeWidth*: UInt256 = one shl twofourty
 #
 # ################################################################
 
+# Returns the kv-store ref
+proc db*(trie: VerkleTrieRef): CoreDbKvtRef =
+  return trie.db
+
 # Check if the account loaded is empty or not
 proc isEmptyVerkleAccount*(acc: Account): bool =
   var zero: array[32, byte]
@@ -243,7 +247,10 @@ proc getTreeKeyStorageSlotWithEvaluatedAddress*(addressPoint: Point, storageKey:
   return getTreeKeyWithEvaluatedAddress(addressPoint, treeIndex, subIndex)
 
 proc newVerkleTrie*(): VerkleTrieRef =
-  result = VerkleTrieRef(root: newTree())
+  result = VerkleTrieRef(
+    root: newTree(),
+    db: LegacyDbMemory.newCoreDbRef().newKvt().CoreDbKvtRef
+  )
 
 # ################################################################
 #


### PR DESCRIPTION
Fetching of ContractCode from the Verkle Trie is very slow, due to chunk key caulculation requires pedersen commitment. And number of chunks is generally around 300 to 500

The only solution that seems to work would be to add the kvstore along with the `VerkleTrieRef`, 
I am planning to use the `CoreDxKvtRef`/`CoreDbKvtRef`

Since our `VerkleTrie` is already distinct `VerkleTrieRef`, using the `CoreDxKvtRef` shouldn't be a problem, we would be adding the contract code to the kv-store whenever we update contract-code, and later we can easily fetch is from the in-memory kvstore