### PR TITLE
Introduce wrapper type for EIP-4844 transactions

### DIFF
--- a/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
+++ b/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
@@ -154,7 +154,7 @@ proc asPortalBlockData*(
   (hash, headerWithProof, body)
 
 proc asPortalBlockData*(
-    payload: ExecutionPayloadV2 | ExecutionPayloadV3
+    payload: ExecutionPayloadV2 | ExecutionPayloadV3 | ExecutionPayloadV4
 ): (common_types.BlockHash, BlockHeaderWithProof, PortalBlockBodyShanghai) =
   let
     txRoot = calculateTransactionData(payload.transactions)

--- a/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge_conf.nim
+++ b/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge_conf.nim
@@ -99,10 +99,9 @@ type BeaconBridgeConf* = object # Config
 
   listenAddress* {.
     desc: "Listening address for the Ethereum LibP2P and Discovery v5 traffic",
-    defaultValue: defaultListenAddress,
-    defaultValueDesc: $defaultListenAddressDesc,
+    defaultValueDesc: "*",
     name: "listen-address"
-  .}: IpAddress
+  .}: Option[IpAddress]
 
   tcpPort* {.
     desc: "Listening TCP port for Ethereum LibP2P traffic",

--- a/hive_integration/nodocker/engine/cancun/customizer.nim
+++ b/hive_integration/nodocker/engine/cancun/customizer.nim
@@ -336,7 +336,7 @@ func getTimestamp*(cust: CustomPayloadData, basePayload: ExecutionPayload): uint
 # Construct a customized payload by taking an existing payload as base and mixing it CustomPayloadData
 # blockHash is calculated automatically.
 proc customizePayload*(cust: CustomPayloadData, data: ExecutableData): ExecutableData {.gcsafe.} =
-  var customHeader = blockHeader(data.basePayload, removeBlobs = false, beaconRoot = data.beaconRoot)
+  var customHeader = blockHeader(data.basePayload, beaconRoot = data.beaconRoot)
   if cust.transactions.isSome:
     customHeader.txRoot = calcTxRoot(cust.transactions.get)
 

--- a/hive_integration/nodocker/engine/cancun/step_devp2p_pooledtx.nim
+++ b/hive_integration/nodocker/engine/cancun/step_devp2p_pooledtx.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -40,7 +40,7 @@ method execute*(step: DevP2PRequestPooledTransactionHash, ctx: CancunTestContext
 
   var
     txHashes = newSeq[common.Hash256](step.transactionIndexes.len)
-    txs      = newSeq[Transaction](step.transactionIndexes.len)
+    txs      = newSeq[PooledTransaction](step.transactionIndexes.len)
 
   for i, txIndex in step.transactionIndexes:
     if not ctx.txPool.hashesByIndex.hasKey(txIndex):

--- a/hive_integration/nodocker/engine/cancun/step_sendblobtx.nim
+++ b/hive_integration/nodocker/engine/cancun/step_sendblobtx.nim
@@ -80,7 +80,7 @@ method execute*(step: SendBlobTransactions, ctx: CancunTestContext): bool =
 
     let blobTx = res.get
     if not step.skipVerificationFromNode:
-      let r = verifyTransactionFromNode(engine.client, blobTx)
+      let r = verifyTransactionFromNode(engine.client, blobTx.tx)
       if r.isErr:
         error "verify tx from node", msg=r.error
         return false

--- a/hive_integration/nodocker/engine/clmock.nim
+++ b/hive_integration/nodocker/engine/clmock.nim
@@ -333,7 +333,7 @@ proc getNextPayload(cl: CLMocker): bool =
   cl.latestShouldOverrideBuilder = x.shouldOverrideBuilder
 
   let beaconRoot = ethHash cl.latestPayloadAttributes.parentBeaconblockRoot
-  let header = blockHeader(cl.latestPayloadBuilt, removeBlobs = true, beaconRoot = beaconRoot)
+  let header = blockHeader(cl.latestPayloadBuilt, beaconRoot = beaconRoot)
   let blockHash = w3Hash header.blockHash
   if blockHash != cl.latestPayloadBuilt.blockHash:
     error "CLMocker: getNextPayload blockHash mismatch",

--- a/hive_integration/nodocker/engine/engine/invalid_ancestor.nim
+++ b/hive_integration/nodocker/engine/engine/invalid_ancestor.nim
@@ -192,7 +192,7 @@ method getName(cs: InvalidMissingAncestorReOrgSyncTest): string =
     $cs.invalidField, $cs.emptyTransactions, $cs.reOrgFromCanonical, $cs.invalidIndex]
 
 proc executableDataToBlock(ex: ExecutableData): EthBlock =
-  ethBlock(ex.basePayload, removeBlobs = true, beaconRoot = ex.beaconRoot)
+  ethBlock(ex.basePayload, beaconRoot = ex.beaconRoot)
 
 method execute(cs: InvalidMissingAncestorReOrgSyncTest, env: TestEnv): bool =
   var sec = env.addEngine(true, cs.reOrgFromCanonical)

--- a/hive_integration/nodocker/engine/engine/invalid_payload.nim
+++ b/hive_integration/nodocker/engine/engine/invalid_payload.nim
@@ -380,7 +380,7 @@ method execute(cs: PayloadBuildAfterInvalidPayloadTest, env: TestEnv): bool =
 type
   InvalidTxChainIDTest* = ref object of EngineSpec
   InvalidTxChainIDShadow = ref object
-    invalidTx: Transaction
+    invalidTx: PooledTransaction
 
 method withMainFork(cs: InvalidTxChainIDTest, fork: EngineFork): BaseSpec =
   var res = cs.clone()
@@ -430,7 +430,9 @@ method execute(cs: InvalidTxChainIDTest, env: TestEnv): bool =
         chainID: some((chainId.uint64 + 1'u64).ChainId)
       )
 
-      shadow.invalidTx = env.customizeTransaction(sender, tx, txCustomizerData)
+      shadow.invalidTx = tx
+      shadow.invalidTx.tx = env.customizeTransaction(
+        sender, shadow.invalidTx.tx, txCustomizerData)
       testCond env.sendTx(shadow.invalidTx):
         info "Error on sending transaction with incorrect chain ID"
 

--- a/hive_integration/nodocker/engine/engine/prev_randao.nim
+++ b/hive_integration/nodocker/engine/engine/prev_randao.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -23,7 +23,7 @@ type
     startBlockNumber: uint64
     blockCount: int
     currentTxIndex: int
-    txs: seq[Transaction]
+    txs: seq[PooledTransaction]
 
 method withMainFork(cs: PrevRandaoTransactionTest, fork: EngineFork): BaseSpec =
   var res = cs.clone()

--- a/hive_integration/nodocker/engine/engine/reorg.nim
+++ b/hive_integration/nodocker/engine/engine/reorg.nim
@@ -119,9 +119,9 @@ type
 
   ShadowTx = ref object
     payload: ExecutionPayload
-    nextTx: Transaction
-    tx: Option[Transaction]
-    sendTransaction: proc(i: int): Transaction {.gcsafe.}
+    nextTx: PooledTransaction
+    tx: Option[PooledTransaction]
+    sendTransaction: proc(i: int): PooledTransaction {.gcsafe.}
 
 method withMainFork(cs: TransactionReOrgTest, fork: EngineFork): BaseSpec =
   var res = cs.clone()
@@ -153,7 +153,7 @@ method execute(cs: TransactionReOrgTest, env: TestEnv): bool =
   var shadow = ShadowTx()
 
   # Send a transaction on each payload of the canonical chain
-  shadow.sendTransaction = proc(i: int): Transaction {.gcsafe.} =
+  shadow.sendTransaction = proc(i: int): PooledTransaction {.gcsafe.} =
     let sstoreContractAddr = hexToByteArray[20]("0000000000000000000000000000000000000317")
     var data: array[32, byte]
     data[^1] = i.byte
@@ -332,7 +332,7 @@ method execute(cs: TransactionReOrgTest, env: TestEnv): bool =
           txt.expectBlockHash(ethHash env.clMock.latestForkchoice.headBlockHash)
 
           if cs.scenario != TransactionReOrgScenarioReOrgBackIn:
-            shadow.tx = none(Transaction)
+            shadow.tx = none(PooledTransaction)
 
         if cs.scenario == TransactionReOrgScenarioReOrgBackIn and i > 0:
           # Reasoning: Most of the clients do not re-add blob transactions to the pool

--- a/hive_integration/nodocker/engine/engine_client.nim
+++ b/hive_integration/nodocker/engine/engine_client.nim
@@ -512,7 +512,8 @@ proc namedHeader*(client: RpcClient, name: string): Result[common.BlockHeader, s
       return err("failed to get named blockHeader")
     return ok(res.toBlockHeader)
 
-proc sendTransaction*(client: RpcClient, tx: common.Transaction): Result[void, string] =
+proc sendTransaction*(
+    client: RpcClient, tx: common.PooledTransaction): Result[void, string] =
   wrapTry:
     let encodedTx = rlp.encode(tx)
     let res = waitFor client.eth_sendRawTransaction(encodedTx)
@@ -603,7 +604,10 @@ TraceOpts.useDefaultSerializationIn JrpcConv
 createRpcSigsFromNim(RpcClient):
   proc debug_traceTransaction(hash: TxHash, opts: TraceOpts): JsonNode
 
-proc debugPrevRandaoTransaction*(client: RpcClient, tx: Transaction, expectedPrevRandao: Hash256): Result[void, string] =
+proc debugPrevRandaoTransaction*(
+    client: RpcClient,
+    tx: PooledTransaction,
+    expectedPrevRandao: Hash256): Result[void, string] =
   wrapTry:
     let hash = w3Hash tx.rlpHash
     # we only interested in stack, disable all other elems

--- a/hive_integration/nodocker/engine/test_env.nim
+++ b/hive_integration/nodocker/engine/test_env.nim
@@ -116,18 +116,20 @@ func numEngines*(env: TestEnv): int =
 func accounts*(env: TestEnv, idx: int): TestAccount =
   env.sender.getAccount(idx)
 
-proc makeTx*(env: TestEnv, tc: BaseTx, nonce: AccountNonce): Transaction =
+proc makeTx*(
+    env: TestEnv, tc: BaseTx, nonce: AccountNonce): PooledTransaction =
   env.sender.makeTx(tc, nonce)
 
-proc makeTx*(env: TestEnv, tc: BigInitcodeTx, nonce: AccountNonce): Transaction =
+proc makeTx*(
+    env: TestEnv, tc: BigInitcodeTx, nonce: AccountNonce): PooledTransaction =
   env.sender.makeTx(tc, nonce)
 
-proc makeTxs*(env: TestEnv, tc: BaseTx, num: int): seq[Transaction] =
-  result = newSeqOfCap[Transaction](num)
+proc makeTxs*(env: TestEnv, tc: BaseTx, num: int): seq[PooledTransaction] =
+  result = newSeqOfCap[PooledTransaction](num)
   for _ in 0..<num:
     result.add env.sender.makeNextTx(tc)
 
-proc makeNextTx*(env: TestEnv, tc: BaseTx): Transaction =
+proc makeNextTx*(env: TestEnv, tc: BaseTx): PooledTransaction =
   env.sender.makeNextTx(tc)
 
 proc sendNextTx*(env: TestEnv, eng: EngineEnv, tc: BaseTx): bool =
@@ -145,7 +147,8 @@ proc sendTx*(env: TestEnv, eng: EngineEnv, tc: BaseTx, nonce: AccountNonce): boo
 proc sendTx*(env: TestEnv, eng: EngineEnv, tc: BigInitcodeTx, nonce: AccountNonce): bool =
   env.sender.sendTx(eng.client, tc, nonce)
 
-proc sendTxs*(env: TestEnv, eng: EngineEnv, txs: openArray[Transaction]): bool =
+proc sendTxs*(
+    env: TestEnv, eng: EngineEnv, txs: openArray[PooledTransaction]): bool =
   for tx in txs:
     if not sendTx(eng.client, tx):
       return false
@@ -163,17 +166,29 @@ proc sendTx*(env: TestEnv, tc: BigInitcodeTx, nonce: AccountNonce): bool =
   let client = env.engine.client
   env.sender.sendTx(client, tc, nonce)
 
-proc sendTx*(env: TestEnv, tx: Transaction): bool =
+proc sendTx*(env: TestEnv, tx: PooledTransaction): bool =
   let client = env.engine.client
   sendTx(client, tx)
 
-proc sendTx*(env: TestEnv, sender: TestAccount, eng: EngineEnv, tc: BlobTx): Result[Transaction, void] =
+proc sendTx*(
+    env: TestEnv,
+    sender: TestAccount,
+    eng: EngineEnv,
+    tc: BlobTx): Result[PooledTransaction, void] =
   env.sender.sendTx(sender, eng.client, tc)
 
-proc replaceTx*(env: TestEnv, sender: TestAccount, eng: EngineEnv, tc: BlobTx): Result[Transaction, void] =
+proc replaceTx*(
+    env: TestEnv,
+    sender: TestAccount,
+    eng: EngineEnv,
+    tc: BlobTx): Result[PooledTransaction, void] =
   env.sender.replaceTx(sender, eng.client, tc)
 
-proc makeTx*(env: TestEnv, tc: BaseTx, sender: TestAccount, nonce: AccountNonce): Transaction =
+proc makeTx*(
+    env: TestEnv,
+    tc: BaseTx,
+    sender: TestAccount,
+    nonce: AccountNonce): PooledTransaction =
   env.sender.makeTx(tc, sender, nonce)
 
 proc customizeTransaction*(env: TestEnv,

--- a/hive_integration/nodocker/engine/withdrawals/wd_max_init_code_spec.nim
+++ b/hive_integration/nodocker/engine/withdrawals/wd_max_init_code_spec.nim
@@ -112,7 +112,7 @@ proc execute*(ws: MaxInitcodeSizeSpec, env: TestEnv): bool =
       # Customize the payload to include a tx with an invalid initcode
       let customizer = CustomPayloadData(
         parentBeaconRoot: ethHash env.clMock.latestPayloadAttributes.parentBeaconBlockRoot,
-        transactions: some( @[invalidTx] ),
+        transactions: some( @[invalidTx.tx] ),
       )
 
       let customPayload = customizer.customizePayload(env.clMock.latestExecutableData).basePayload

--- a/hive_integration/nodocker/rpc/client.nim
+++ b/hive_integration/nodocker/rpc/client.nim
@@ -18,7 +18,8 @@ import
 
 export eth_api
 
-proc sendTransaction*(client: RpcClient, tx: Transaction): Future[bool] {.async.} =
+proc sendTransaction*(
+    client: RpcClient, tx: PooledTransaction): Future[bool] {.async.} =
   let data   = rlp.encode(tx)
   let txHash = keccakHash(data)
   let hex    = await client.eth_sendRawTransaction(data)

--- a/hive_integration/nodocker/rpc/rpc_tests.nim
+++ b/hive_integration/nodocker/rpc/rpc_tests.nim
@@ -90,7 +90,7 @@ proc balanceAndNonceAtTest(t: TestEnv): Future[TestStatus] {.async.} =
 
   let txHash = rlpHash(tx)
   echo "BalanceAt: send $1 wei from 0x$2 to 0x$3 in 0x$4" % [
-    $tx.value, sourceAddr.toHex, targetAddr.toHex, txHash.data.toHex]
+    $tx.tx.value, sourceAddr.toHex, targetAddr.toHex, txHash.data.toHex]
 
   let ok = await client.sendTransaction(tx)
   if not ok:
@@ -117,14 +117,16 @@ proc balanceAndNonceAtTest(t: TestEnv): Future[TestStatus] {.async.} =
   let balanceTargetAccountAfter = await client.balanceAt(targetAddr)
 
   # expected balance is previous balance - tx amount - tx fee (gasUsed * gasPrice)
-  let exp = sourceAddressBalanceBefore - amount - (gasUsed * tx.gasPrice).u256
+  let exp =
+    sourceAddressBalanceBefore - amount - (gasUsed * tx.tx.gasPrice).u256
 
   if exp != accountBalanceAfter:
     echo "Expected sender account to have a balance of $1, got $2" % [$exp, $accountBalanceAfter]
     return TestStatus.Failed
 
   if balanceTargetAccountAfter != amount:
-    echo "Expected new account to have a balance of $1, got $2" % [$tx.value, $balanceTargetAccountAfter]
+    echo "Expected new account to have a balance of $1, got $2" % [
+      $tx.tx.value, $balanceTargetAccountAfter]
     return TestStatus.Failed
 
   # ensure nonce is incremented by 1

--- a/hive_integration/nodocker/rpc/vault.nim
+++ b/hive_integration/nodocker/rpc/vault.nim
@@ -79,7 +79,8 @@ proc sendSome(address: EthAddress, amount: UInt256): seq[byte] =
   result.add amount.toBytesBE
   doAssert(result.len == 68) # 4 + 32 + 32
 
-proc makeFundingTx*(v: Vault, recipient: EthAddress, amount: UInt256): Transaction =
+proc makeFundingTx*(
+    v: Vault, recipient: EthAddress, amount: UInt256): PooledTransaction =
   let
     unsignedTx = Transaction(
       txType  : TxLegacy,
@@ -92,7 +93,8 @@ proc makeFundingTx*(v: Vault, recipient: EthAddress, amount: UInt256): Transacti
       payload : sendSome(recipient, amount)
     )
 
-  signTransaction(unsignedTx, v.vaultKey, v.chainId, eip155 = true)
+  PooledTransaction(
+    tx: signTransaction(unsignedTx, v.vaultKey, v.chainId, eip155 = true))
 
 proc signTx*(v: Vault,
              sender: EthAddress,
@@ -100,7 +102,7 @@ proc signTx*(v: Vault,
              recipient: EthAddress,
              amount: UInt256,
              gasLimit, gasPrice: GasInt,
-             payload: seq[byte] = @[]): Transaction =
+             payload: seq[byte] = @[]): PooledTransaction =
 
   let
     unsignedTx = Transaction(
@@ -115,7 +117,8 @@ proc signTx*(v: Vault,
     )
 
   let key = v.accounts[sender]
-  signTransaction(unsignedTx, key, v.chainId, eip155 = true)
+  PooledTransaction(
+    tx: signTransaction(unsignedTx, key, v.chainId, eip155 = true))
 
 # createAccount creates a new account that is funded from the vault contract.
 # It will panic when the account could not be created and funded.

--- a/nimbus/beacon/api_handler/api_forkchoice.nim
+++ b/nimbus/beacon/api_handler/api_forkchoice.nim
@@ -188,17 +188,17 @@ proc forkchoiceUpdated*(ben: BeaconEngineRef,
     let attrs = attrsOpt.get()
     validateVersion(attrs, com, apiVersion)
 
-    let payload = ben.generatePayload(attrs).valueOr:
+    let bundle = ben.generatePayload(attrs).valueOr:
       error "Failed to create sealing payload", err = error
       raise invalidAttr(error)
 
     let id = computePayloadId(blockHash, attrs)
-    ben.put(id, ben.blockValue, payload)
+    ben.put(id, ben.blockValue, bundle.executionPayload, bundle.blobsBundle)
 
     info "Created payload for sealing",
       id = id.toHex,
-      hash = payload.blockHash.short,
-      number = payload.blockNumber
+      hash = bundle.executionPayload.blockHash.short,
+      number = bundle.executionPayload.blockNumber
 
     return validFCU(some(id), blockHash)
 

--- a/nimbus/beacon/api_handler/api_newpayload.nim
+++ b/nimbus/beacon/api_handler/api_newpayload.nim
@@ -118,20 +118,20 @@ proc newPayload*(ben: BeaconEngineRef,
 
   validatePayload(apiVersion, version, payload)
   validateVersion(com, timestamp, version, apiVersion)
-  
-  var header = blockHeader(payload, removeBlobs = true, beaconRoot = ethHash beaconRoot)
-  
+
+  var header = blockHeader(payload, beaconRoot = ethHash beaconRoot)
+
   if apiVersion >= Version.V3:
     if versionedHashes.isNone:
       raise invalidParams("newPayload" & $apiVersion &
         " expect blobVersionedHashes but got none")
     if not validateVersionedHashed(payload, versionedHashes.get):
       return invalidStatus(header.parentHash, "invalid blob versionedHashes")
-    
+
   let blockHash = ethHash payload.blockHash
   header.validateBlockHash(blockHash, version).isOkOr:
     return error
-        
+
   # If we already have the block locally, ignore the entire execution and just
   # return a fake success.
   if db.getBlockHeader(blockHash, header):
@@ -195,7 +195,7 @@ proc newPayload*(ben: BeaconEngineRef,
 
   trace "Inserting block without sethead",
     hash = blockHash, number = header.blockNumber
-  let body = blockBody(payload, removeBlobs = true)
+  let body = blockBody(payload)
   let vres = ben.chain.insertBlockWithoutSetHead(header, body)
   if vres != ValidationResult.OK:
     let blockHash = latestValidHash(db, parent, ttd)

--- a/nimbus/beacon/payload_queue.nim
+++ b/nimbus/beacon/payload_queue.nim
@@ -82,7 +82,7 @@ proc put*(api: var PayloadQueue, id: PayloadID,
           blobsBundle: Option[BlobsBundleV1]) =
   doAssert blobsBundle.isNone == (payload is
     ExecutionPayloadV1 | ExecutionPayloadV2)
-  api.put(id, blockValue, payload.executionPayload, blobsBundle: blobsBundle)
+  api.put(id, blockValue, payload.executionPayload, blobsBundle = blobsBundle)
 
 proc put*(api: var PayloadQueue, id: PayloadID,
           blockValue: UInt256,

--- a/nimbus/beacon/payload_queue.nim
+++ b/nimbus/beacon/payload_queue.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -35,6 +35,7 @@ type
     id: PayloadID
     payload: ExecutionPayload
     blockValue: UInt256
+    blobsBundle: Option[BlobsBundleV1]
 
   HeaderItem = object
     hash: common.Hash256
@@ -71,13 +72,22 @@ proc put*(api: var PayloadQueue,
   api.headerQueue.put(HeaderItem(hash: hash, header: header))
 
 proc put*(api: var PayloadQueue, id: PayloadID,
-          blockValue: UInt256, payload: ExecutionPayload) =
+          blockValue: UInt256, payload: ExecutionPayload,
+          blobsBundle: Option[BlobsBundleV1]) =
   api.payloadQueue.put(PayloadItem(id: id,
-    payload: payload, blockValue: blockValue))
+    payload: payload, blockValue: blockValue, blobsBundle: blobsBundle))
 
 proc put*(api: var PayloadQueue, id: PayloadID,
-          blockValue: UInt256, payload: SomeExecutionPayload) =
-  api.put(id, blockValue, payload.executionPayload)
+          blockValue: UInt256, payload: SomeExecutionPayload,
+          blobsBundle: Option[BlobsBundleV1]) =
+  doAssert blobsBundle.isNone == (payload is
+    ExecutionPayloadV1 | ExecutionPayloadV2)
+  api.put(id, blockValue, payload.executionPayload, blobsBundle: blobsBundle)
+
+proc put*(api: var PayloadQueue, id: PayloadID,
+          blockValue: UInt256,
+          payload: ExecutionPayloadV1 | ExecutionPayloadV2) =
+  api.put(id, blockValue, payload, blobsBundle = options.none(BlobsBundleV1))
 
 # ------------------------------------------------------------------------------
 # Public functions, getters
@@ -93,46 +103,66 @@ proc get*(api: PayloadQueue, hash: common.Hash256,
 
 proc get*(api: PayloadQueue, id: PayloadID,
           blockValue: var UInt256,
-          payload: var ExecutionPayload): bool =
+          payload: var ExecutionPayload,
+          blobsBundle: var Option[BlobsBundleV1]): bool =
   for x in api.payloadQueue:
     if x.id == id:
       payload = x.payload
       blockValue = x.blockValue
+      blobsBundle = x.blobsBundle
       return true
   false
 
 proc get*(api: PayloadQueue, id: PayloadID,
           blockValue: var UInt256,
           payload: var ExecutionPayloadV1): bool =
-  var p: ExecutionPayload
-  let found = api.get(id, blockValue, p)
-  doAssert(p.version == Version.V1)
-  payload = p.V1
+  var
+    p: ExecutionPayload
+    blobsBundleOpt: Option[BlobsBundleV1]
+  let found = api.get(id, blockValue, p, blobsBundleOpt)
+  if found:
+    doAssert(p.version == Version.V1)
+    payload = p.V1
+    doAssert(blobsBundleOpt.isNone)
   return found
 
 proc get*(api: PayloadQueue, id: PayloadID,
           blockValue: var UInt256,
           payload: var ExecutionPayloadV2): bool =
-  var p: ExecutionPayload
-  let found = api.get(id, blockValue, p)
-  doAssert(p.version == Version.V2)
-  payload = p.V2
+  var
+    p: ExecutionPayload
+    blobsBundleOpt: Option[BlobsBundleV1]
+  let found = api.get(id, blockValue, p, blobsBundleOpt)
+  if found:
+    doAssert(p.version == Version.V2)
+    payload = p.V2
+    doAssert(blobsBundleOpt.isNone)
   return found
 
 proc get*(api: PayloadQueue, id: PayloadID,
           blockValue: var UInt256,
-          payload: var ExecutionPayloadV3): bool =
-  var p: ExecutionPayload
-  let found = api.get(id, blockValue, p)
-  doAssert(p.version == Version.V3)
-  payload = p.V3
+          payload: var ExecutionPayloadV3,
+          blobsBundle: var BlobsBundleV1): bool =
+  var
+    p: ExecutionPayload
+    blobsBundleOpt: Option[BlobsBundleV1]
+  let found = api.get(id, blockValue, p, blobsBundleOpt)
+  if found:
+    doAssert(p.version == Version.V3)
+    payload = p.V3
+    doAssert(blobsBundleOpt.isSome)
+    blobsBundle = blobsBundleOpt.unsafeGet
   return found
 
 proc get*(api: PayloadQueue, id: PayloadID,
           blockValue: var UInt256,
           payload: var ExecutionPayloadV1OrV2): bool =
-  var p: ExecutionPayload
-  let found = api.get(id, blockValue, p)
-  doAssert(p.version in {Version.V1, Version.V2})
-  payload = p.V1V2
+  var
+    p: ExecutionPayload
+    blobsBundleOpt: Option[BlobsBundleV1]
+  let found = api.get(id, blockValue, p, blobsBundleOpt)
+  if found:
+    doAssert(p.version in {Version.V1, Version.V2})
+    payload = p.V1V2
+    doAssert(blobsBundleOpt.isNone)
   return found

--- a/nimbus/beacon/web3_eth_conv.nim
+++ b/nimbus/beacon/web3_eth_conv.nim
@@ -151,15 +151,11 @@ func ethWithdrawals*(x: Option[seq[WithdrawalV1]]):
 func ethTx*(x: Web3Tx): common.Transaction {.gcsafe, raises:[RlpError].} =
   result = rlp.decode(distinctBase x, common.Transaction)
 
-func ethTxs*(list: openArray[Web3Tx], removeBlobs = false):
+func ethTxs*(list: openArray[Web3Tx]):
                seq[common.Transaction] {.gcsafe, raises:[RlpError].} =
   result = newSeqOfCap[common.Transaction](list.len)
-  if removeBlobs:
-    for x in list:
-      result.add ethTx(x).removeNetworkPayload
-  else:
-    for x in list:
-      result.add ethTx(x)
+  for x in list:
+    result.add ethTx(x)
 
 func storageKeys(list: seq[FixedBytes[32]]): seq[StorageKey] =
   for x in list:

--- a/nimbus/core/sealer.nim
+++ b/nimbus/core/sealer.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -61,8 +61,9 @@ proc validateSealer*(conf: NimbusConf, ctx: EthContext, chain: ChainRef): Result
 proc generateBlock(engine: SealingEngineRef,
                    outBlock: var EthBlock): Result[void, string] =
 
-  outBlock = engine.txPool.assembleBlock().valueOr:
+  let bundle = engine.txPool.assembleBlock().valueOr:
     return err(error)
+  outBlock = bundle.blk
 
   if engine.chain.com.consensus == ConsensusType.POS:
     # Stop the block generator if we reach TTD

--- a/nimbus/core/tx_pool.nim
+++ b/nimbus/core/tx_pool.nim
@@ -423,7 +423,7 @@
 ##
 
 import
-  std/[sequtils, tables],
+  std/[options, sequtils, tables],
   ./tx_pool/[tx_chain, tx_desc, tx_info, tx_item],
   ./tx_pool/tx_tabs,
   ./tx_pool/tx_tasks/[
@@ -517,7 +517,7 @@ proc new*(T: type TxPoolRef; com: CommonRef; miner: EthAddress): T
 
 # core/tx_pool.go(848): func (pool *TxPool) AddLocals(txs []..
 # core/tx_pool.go(864): func (pool *TxPool) AddRemotes(txs []..
-proc add*(xp: TxPoolRef; txs: openArray[Transaction]; info = "")
+proc add*(xp: TxPoolRef; txs: openArray[PooledTransaction]; info = "")
     {.gcsafe,raises: [CatchableError].} =
   ## Add a list of transactions to be processed and added to the buckets
   ## database. It is OK pass an empty list in which case some maintenance
@@ -533,7 +533,7 @@ proc add*(xp: TxPoolRef; txs: openArray[Transaction]; info = "")
 
 # core/tx_pool.go(854): func (pool *TxPool) AddLocals(txs []..
 # core/tx_pool.go(883): func (pool *TxPool) AddRemotes(txs []..
-proc add*(xp: TxPoolRef; tx: Transaction; info = "")
+proc add*(xp: TxPoolRef; tx: PooledTransaction; info = "")
     {.gcsafe,raises: [CatchableError].} =
   ## Variant of `add()` for a single transaction.
   xp.add(@[tx], info)
@@ -607,8 +607,14 @@ proc dirtyBuckets*(xp: TxPoolRef): bool =
   ## flag is also set.
   xp.pDirtyBuckets
 
-proc assembleBlock*(xp: TxPoolRef, someBaseFee: bool = false): Result[EthBlock, string]
-    {.gcsafe,raises: [CatchableError].} =
+type EthBlockAndBlobsBundle* = object
+  blk*: EthBlock
+  blobsBundle*: Option[BlobsBundle]
+
+proc assembleBlock*(
+    xp: TxPoolRef,
+    someBaseFee: bool = false
+): Result[EthBlockAndBlobsBundle, string] {.gcsafe,raises: [CatchableError].} =
   ## Getter, retrieves a packed block ready for mining and signing depending
   ## on the internally cached block chain head, the txs in the pool and some
   ## tuning parameters. The following block header fields are left
@@ -627,19 +633,41 @@ proc assembleBlock*(xp: TxPoolRef, someBaseFee: bool = false): Result[EthBlock, 
   var blk = EthBlock(
     header: xp.chain.getHeader               # uses updated vmState
   )
+  var blobsBundle: BlobsBundle
 
-  for (_,nonceList) in xp.txDB.packingOrderAccounts(txItemPacked):
-    blk.txs.add toSeq(nonceList.incNonce).mapIt(it.tx)
+  for _, nonceList in xp.txDB.packingOrderAccounts(txItemPacked):
+    for item in nonceList.incNonce:
+      let tx = item.pooledTx
+      blk.txs.add tx.tx
+      if tx.networkPayload != nil:
+        for k in tx.networkPayload.commitments:
+          blobsBundle.commitments.add k
+        for p in tx.networkPayload.proofs:
+          blobsBundle.proofs.add p
+        for blob in tx.networkPayload.blobs:
+          blobsBundle.blobs.add blob
 
   let com = xp.chain.com
   if com.forkGTE(Shanghai):
     blk.withdrawals = some(com.pos.withdrawals)
 
+  if not com.forkGTE(Cancun) and blobsBundle.commitments.len > 0:
+    return err("PooledTransaction contains blobs prior to Cancun")
+  let blobsBundleOpt =
+    if com.forkGTE(Cancun):
+      doAssert blobsBundle.commitments.len == blobsBundle.blobs.len
+      doAssert blobsBundle.proofs.len == blobsBundle.blobs.len
+      options.some blobsBundle
+    else:
+      options.none BlobsBundle
+
   if someBaseFee:
     # make sure baseFee always has something
     blk.header.fee = some(blk.header.fee.get(0.u256))
 
-  ok(blk)
+  ok EthBlockAndBlobsBundle(
+    blk: blk,
+    blobsBundle: blobsBundleOpt)
 
 proc gasCumulative*(xp: TxPoolRef): GasInt =
   ## Getter, retrieves the gas that will be burned in the block after
@@ -856,7 +884,7 @@ proc accountRanks*(xp: TxPoolRef): TxTabsLocality =
   xp.txDB.locality
 
 proc addRemote*(xp: TxPoolRef;
-                tx: Transaction; force = false): Result[void,TxInfo]
+                tx: PooledTransaction; force = false): Result[void,TxInfo]
     {.gcsafe,raises: [CatchableError].} =
   ## Adds the argument transaction `tx` to the buckets database.
   ##
@@ -890,7 +918,7 @@ proc addRemote*(xp: TxPoolRef;
   ok()
 
 proc addLocal*(xp: TxPoolRef;
-               tx: Transaction; force = false): Result[void,TxInfo]
+               tx: PooledTransaction; force = false): Result[void,TxInfo]
     {.gcsafe,raises: [CatchableError].} =
   ## Adds the argument transaction `tx` to the buckets database.
   ##

--- a/nimbus/core/tx_pool/tx_tabs.nim
+++ b/nimbus/core/tx_pool/tx_tabs.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -138,7 +138,7 @@ proc new*(T: type TxTabsRef): T {.gcsafe,raises: [].} =
 
 proc insert*(
     xp: TxTabsRef;
-    tx: var Transaction;
+    tx: var PooledTransaction;
     status = txItemPending;
     info = ""): Result[void,TxInfo]
     {.gcsafe,raises: [CatchableError].} =
@@ -221,7 +221,7 @@ proc dispose*(xp: TxTabsRef; item: TxItemRef; reason: TxInfo): bool
     xp.byRejects[item.itemID] = item
     return true
 
-proc reject*(xp: TxTabsRef; tx: var Transaction;
+proc reject*(xp: TxTabsRef; tx: var PooledTransaction;
              reason: TxInfo; status = txItemPending; info = "") =
   ## Similar to dispose but for a tx without the item wrapper, the function
   ## imports the tx into the waste basket (e.g. after it could not
@@ -239,7 +239,7 @@ proc reject*(xp: TxTabsRef; item: TxItemRef; reason: TxInfo) =
   item.reject = reason
   xp.byRejects[item.itemID] = item
 
-proc reject*(xp: TxTabsRef; tx: Transaction;
+proc reject*(xp: TxTabsRef; tx: PooledTransaction;
              reason: TxInfo; status = txItemPending; info = "") =
   ## Variant of `reject()`
   var ty = tx

--- a/nimbus/core/tx_pool/tx_tasks/tx_add.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_add.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -160,7 +160,7 @@ proc addTx*(xp: TxPoolRef; item: TxItemRef): bool
 # core/tx_pool.go(883): func (pool *TxPool) AddRemotes(txs []..
 # core/tx_pool.go(889): func (pool *TxPool) addTxs(txs []*types.Transaction, ..
 proc addTxs*(xp: TxPoolRef;
-             txs: openArray[Transaction]; info = ""): TxAddStats
+             txs: openArray[PooledTransaction]; info = ""): TxAddStats
     {.discardable,gcsafe,raises: [CatchableError].} =
   ## Add a list of transactions. The list is sorted after nonces and txs are
   ## tested and stored into either of the `pending` or `staged` buckets, or
@@ -181,7 +181,7 @@ proc addTxs*(xp: TxPoolRef;
   for tx in txs.items:
     var reason: TxInfo
 
-    if tx.txType == TxEip4844:
+    if tx.tx.txType == TxEip4844:
       let res = tx.validateBlobTransactionWrapper()
       if res.isErr:
         # move item to waste basket

--- a/nimbus/core/tx_pool/tx_tasks/tx_classify.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_classify.nim
@@ -38,7 +38,7 @@ logScope:
 
 proc checkTxBasic(xp: TxPoolRef; item: TxItemRef): bool =
   let res = validateTxBasic(
-    item.tx.removeNetworkPayload,
+    item.tx,
     xp.chain.nextFork,
     # A new transaction of the next fork may be
     # coming before the fork activated
@@ -234,7 +234,8 @@ proc classifyValidatePacked*(xp: TxPoolRef;
     tx = item.tx.eip1559TxNormalization(xp.chain.baseFee.GasInt)
     excessBlobGas = calcExcessBlobGas(vmState.parent)
 
-  roDB.validateTransaction(tx.removeNetworkPayload, item.sender, gasLimit, baseFee, excessBlobGas, fork).isOk
+  roDB.validateTransaction(
+    tx, item.sender, gasLimit, baseFee, excessBlobGas, fork).isOk
 
 proc classifyPacked*(xp: TxPoolRef; gasBurned, moreBurned: GasInt): bool =
   ## Classifier for *packing* (i.e. adding up `gasUsed` values after executing

--- a/nimbus/core/tx_pool/tx_tasks/tx_head.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_head.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -31,7 +31,7 @@ type
     ## Diff data, txs changes that apply after changing the head\
     ## insertion point of the block chain
 
-    addTxs*: KeyedQueue[Hash256,Transaction] ##\
+    addTxs*: KeyedQueue[Hash256, PooledTransaction] ##\
       ## txs to add; using a queue makes it more intuive to delete
       ## items while travesing the queue in a loop.
 
@@ -50,7 +50,13 @@ proc insert(xp: TxPoolRef; kq: TxHeadDiffRef; blockHash: Hash256)
     {.gcsafe,raises: [CatchableError].} =
   let db = xp.chain.com.db
   for tx in db.getBlockBody(blockHash).transactions:
-    kq.addTxs[tx.itemID] = tx
+    if tx.versionedHashes.len > 0:
+      # EIP-4844 blobs are not persisted and cannot be re-broadcasted.
+      # Note that it is also not possible to crete a cache in all cases,
+      # as we may have never seen the actual blob sidecar while syncing.
+      # Only the consensus layer persists the blob sidecar.
+      continue
+    kq.addTxs[tx.itemID] = PooledTransaction(tx: tx)
 
 proc remove(xp: TxPoolRef; kq: TxHeadDiffRef; blockHash: Hash256)
     {.gcsafe,raises: [CatchableError].} =

--- a/nimbus/core/tx_pool/tx_tasks/tx_packer.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_packer.nim
@@ -141,7 +141,7 @@ proc runTxCommit(pst: TxPackerStateRef; item: TxItemRef; gasBurned: GasInt)
     pst.blobGasUsed += item.tx.getTotalBlobGas
 
   # Update txRoot
-  pst.tr.put(rlp.encode(inx), rlp.encode(item.tx.removeNetworkPayload))
+  pst.tr.put(rlp.encode(inx), rlp.encode(item.tx))
 
   # Add the item to the `packed` bucket. This implicitely increases the
   # receipts index `inx` at the next visit of this function.

--- a/nimbus/core/tx_pool/tx_tasks/tx_recover.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_recover.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -35,7 +35,7 @@ let
 # Public functions
 # ------------------------------------------------------------------------------
 
-proc recoverItem*(xp: TxPoolRef; tx: Transaction; status = txItemPending;
+proc recoverItem*(xp: TxPoolRef; tx: PooledTransaction; status = txItemPending;
                   info = ""; acceptExisting = false): Result[TxItemRef,TxInfo] =
   ## Recover item from waste basket or create new. It is an error if the item
   ## is in the buckets database, already.

--- a/nimbus/core/validate.nim
+++ b/nimbus/core/validate.nim
@@ -267,9 +267,6 @@ proc validateTxBasic*(
             "index=$1, len=$2" % [$i, $acl.storageKeys.len])
 
     if tx.txType >= TxEip4844:
-      if tx.networkPayload.isNil.not:
-        return err("invalid tx: network payload should not appear in block validation")
-
       if tx.to.isNone:
         return err("invalid tx: destination must be not empty")
 

--- a/nimbus/db/core_db/core_apps_newapi.nim
+++ b/nimbus/db/core_db/core_apps_newapi.nim
@@ -558,8 +558,8 @@ proc persistTransactions*(
   for idx, tx in transactions:
     let
       encodedKey = rlp.encode(idx)
-      encodedTx = rlp.encode(tx.removeNetworkPayload)
-      txHash = rlpHash(tx) # beware EIP-4844
+      encodedTx = rlp.encode(tx)
+      txHash = rlpHash(tx)
       blockKey = transactionHashToBlockKey(txHash)
       txKey: TransactionKey = (blockNumber, idx)
     mpt.merge(encodedKey, encodedTx).isOkOr:

--- a/nimbus/graphql/ethapi.nim
+++ b/nimbus/graphql/ethapi.nim
@@ -1364,8 +1364,8 @@ proc sendRawTransaction(ud: RootRef, params: Args, parent: Node): RespResult {.a
   let ctx = GraphqlContextRef(ud)
   try:
     let data   = hexToSeqByte(params[0].val.stringVal)
-    let tx     = decodeTx(data) # we want to know if it is a valid tx blob
-    let txHash = rlpHash(tx) # beware EIP-4844
+    let tx     = decodePooledTx(data) # we want to know if it is a valid tx blob
+    let txHash = rlpHash(tx)
 
     ctx.txPool.add(tx)
 

--- a/nimbus/sync/protocol/eth/eth_types.nim
+++ b/nimbus/sync/protocol/eth/eth_types.nim
@@ -65,7 +65,7 @@ method getReceipts*(ctx: EthWireBase,
 
 method getPooledTxs*(ctx: EthWireBase,
                      hashes: openArray[Hash256]):
-                       Result[seq[Transaction], string]
+                       Result[seq[PooledTransaction], string]
     {.base, gcsafe.} =
   notImplemented("getPooledTxs")
 

--- a/nimbus/sync/protocol/eth66.nim
+++ b/nimbus/sync/protocol/eth66.nim
@@ -266,7 +266,8 @@ p2pProtocol eth66(version = ethVersion,
       await response.send(txs.get)
 
     # User message 0x0a: PooledTransactions.
-    proc pooledTransactions(peer: Peer, transactions: openArray[Transaction])
+    proc pooledTransactions(
+        peer: Peer, transactions: openArray[PooledTransaction])
 
   nextId 0x0d
 

--- a/nimbus/sync/protocol/eth67.nim
+++ b/nimbus/sync/protocol/eth67.nim
@@ -267,7 +267,8 @@ p2pProtocol eth67(version = ethVersion,
       await response.send(txs.get)
 
     # User message 0x0a: PooledTransactions.
-    proc pooledTransactions(peer: Peer, transactions: openArray[Transaction])
+    proc pooledTransactions(
+        peer: Peer, transactions: openArray[PooledTransaction])
 
   # User message 0x0d: GetNodeData -- removed, was so 66ish
   # User message 0x0e: NodeData -- removed, was so 66ish

--- a/nimbus/sync/protocol/eth68.nim
+++ b/nimbus/sync/protocol/eth68.nim
@@ -270,7 +270,8 @@ p2pProtocol eth68(version = ethVersion,
       await response.send(txs.get)
 
     # User message 0x0a: PooledTransactions.
-    proc pooledTransactions(peer: Peer, transactions: openArray[Transaction])
+    proc pooledTransactions(
+        peer: Peer, transactions: openArray[PooledTransaction])
 
   # User message 0x0d: GetNodeData -- removed, was so 66ish
   # User message 0x0e: NodeData -- removed, was so 66ish

--- a/nimbus/transaction.nim
+++ b/nimbus/transaction.nim
@@ -233,3 +233,9 @@ proc decodeTx*(bytes: openArray[byte]): Transaction =
   result = rlp.read(Transaction)
   if rlp.hasData:
     raise newException(RlpError, "rlp: input contains more than one value")
+
+proc decodePooledTx*(bytes: openArray[byte]): PooledTransaction =
+  var rlp = rlpFromBytes(bytes)
+  result = rlp.read(PooledTransaction)
+  if rlp.hasData:
+    raise newException(RlpError, "rlp: input contains more than one value")

--- a/nimbus/utils/debug.nim
+++ b/nimbus/utils/debug.nim
@@ -134,7 +134,12 @@ proc debug*(tx: Transaction): string =
   result.add "accessList    : " & $tx.accessList     & "\n"
   result.add "maxFeePerBlobGas: " & $tx.maxFeePerBlobGas & "\n"
   result.add "versionedHashes.len: " & $tx.versionedHashes.len & "\n"
+  result.add "V             : " & $tx.V              & "\n"
+  result.add "R             : " & $tx.R              & "\n"
+  result.add "S             : " & $tx.S              & "\n"
 
+proc debug*(tx: PooledTransaction): string =
+  result.add debug(tx.tx)
   if tx.networkPayload.isNil:
     result.add "networkPaylod : nil\n"
   else:
@@ -142,10 +147,6 @@ proc debug*(tx: Transaction): string =
     result.add " - blobs       : " & $tx.networkPayload.blobs.len & "\n"
     result.add " - commitments : " & $tx.networkPayload.commitments.len & "\n"
     result.add " - proofs      : " & $tx.networkPayload.proofs.len & "\n"
-
-  result.add "V             : " & $tx.V              & "\n"
-  result.add "R             : " & $tx.R              & "\n"
-  result.add "S             : " & $tx.S              & "\n"
 
 proc debugSum*(h: BlockHeader): string =
   result.add "txRoot         : " & $h.txRoot      & "\n"

--- a/nimbus_verified_proxy/libverifproxy/verifproxy.nim
+++ b/nimbus_verified_proxy/libverifproxy/verifproxy.nim
@@ -28,6 +28,7 @@ proc initLib() =
     nimGC_setStackBottom(locals)
 
 proc runContext(ctx: ptr Context) {.thread.} =
+  const defaultListenAddress = (static parseIpAddress("0.0.0.0"))
   let str = $ctx.configJson
   try:
     let jsonNode = parseJson(str)
@@ -35,7 +36,7 @@ proc runContext(ctx: ptr Context) {.thread.} =
     let rpcAddr = jsonNode["RpcAddress"].getStr()
     let myConfig = VerifiedProxyConf(
       rpcAddress: parseIpAddress(rpcAddr),
-      listenAddress: defaultListenAddress,
+      listenAddress: some(defaultListenAddress),
       eth2Network: some(jsonNode["Eth2Network"].getStr()),
       trustedBlockRoot: Eth2Digest.fromHex(jsonNode["TrustedBlockRoot"].getStr()),
       web3Url: parseCmdArg(Web3Url, jsonNode["Web3Url"].getStr()),

--- a/nimbus_verified_proxy/nimbus_verified_proxy_conf.nim
+++ b/nimbus_verified_proxy/nimbus_verified_proxy_conf.nim
@@ -108,10 +108,8 @@ type VerifiedProxyConf* = object # Config
 
   listenAddress* {.
     desc: "Listening address for the Ethereum LibP2P and Discovery v5 traffic",
-    defaultValue: defaultListenAddress,
-    defaultValueDesc: $defaultListenAddressDesc,
     name: "listen-address"
-  .}: IpAddress
+  .}: Option[IpAddress]
 
   tcpPort* {.
     desc: "Listening TCP port for Ethereum LibP2P traffic",

--- a/nimbus_verified_proxy/rpc/rpc_utils.nim
+++ b/nimbus_verified_proxy/rpc/rpc_utils.nim
@@ -35,7 +35,7 @@ type ExecutionData* = object
   withdrawals*: seq[WithdrawalV1]
 
 proc asExecutionData*(
-    payload: ExecutionPayloadV1 | ExecutionPayloadV2 | ExecutionPayloadV3
+    payload: SomeExecutionPayload
 ): ExecutionData =
   when payload is ExecutionPayloadV1:
     return ExecutionData(

--- a/nimbus_verified_proxy/rpc/rpc_utils.nim
+++ b/nimbus_verified_proxy/rpc/rpc_utils.nim
@@ -34,9 +34,7 @@ type ExecutionData* = object
   transactions*: seq[TypedTransaction]
   withdrawals*: seq[WithdrawalV1]
 
-proc asExecutionData*(
-    payload: SomeExecutionPayload
-): ExecutionData =
+proc asExecutionData*(payload: SomeExecutionPayload): ExecutionData =
   when payload is ExecutionPayloadV1:
     return ExecutionData(
       parentHash: payload.parentHash,

--- a/tests/replay/pp.nim
+++ b/tests/replay/pp.nim
@@ -100,7 +100,6 @@ func pp*(t: Transaction; sep = " "): string =
     &"accessList=[#{t.accessList.len}]{sep}" &
     &"maxFeePerBlobGas={t.maxFeePerBlobGas}{sep}" &
     &"versionedHashes=[#{t.versionedHashes.len}]{sep}" &
-    &"networkPayload={t.networkPayload.pp}{sep}" &
     &"V={t.V}{sep}" &
     &"R={t.R}{sep}" &
     &"S={t.S}{sep}"

--- a/tests/test_eip4844.nim
+++ b/tests/test_eip4844.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -16,11 +16,9 @@ import
 
 const
   recipient = hexToByteArray[20]("095e7baea6a6c7c4c2dfeb977efac326af552d87")
-  zeroG1    = hexToByteArray[48]("0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
   source    = hexToByteArray[20]("0x0000000000000000000000000000000000000001")
   storageKey= default(StorageKey)
   accesses  = @[AccessPair(address: source, storageKeys: @[storageKey])]
-  blob      = default(NetworkBlob)
   abcdef    = hexToSeqByte("abcdef")
   hexKey    = "af1a9be9f1a54421cac82943820a0fe0f601bb5f4f6d0bccc81c613f0ce6ae22"
   senderTop = hexToByteArray[20]("73cf19657412508833f618a15e8251306b3e6ee5")
@@ -98,12 +96,7 @@ proc tx6(i: int): Transaction =
     maxPriorityFee:      42.GasInt,
     maxFee:              10.GasInt,
     accessList:          accesses,
-    versionedHashes:     @[digest],
-    networkPayload: NetworkPayload(
-        commitments: @[zeroG1],
-        blobs: @[blob],
-        proofs: @[zeroG1],
-    )
+    versionedHashes:     @[digest]
   )
 
 proc tx7(i: int): Transaction =

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -287,7 +287,7 @@ proc runTxPoolTests(noisy = true) =
 
         # insert some txs
         for triple in testTxs:
-          xq.add(triple[1], triple[0].info)
+          xq.add(PooledTransaction(tx: triple[1]), triple[0].info)
 
         check xq.nItems.total == testTxs.len
         check xq.nItems.disposed == 0
@@ -296,7 +296,7 @@ proc runTxPoolTests(noisy = true) =
 
         # re-insert modified transactions
         for triple in testTxs:
-          xq.add(triple[2], "alt " & triple[0].info)
+          xq.add(PooledTransaction(tx: triple[2]), "alt " & triple[0].info)
 
         check xq.nItems.total == testTxs.len
         check xq.nItems.disposed == testTxs.len
@@ -505,7 +505,7 @@ proc runTxPoolTests(noisy = true) =
         check txList.len == xq.nItems.total + xq.nItems.disposed
 
         # re-add item
-        xq.add(thisItem.tx)
+        xq.add(thisItem.pooledTx)
 
         # verify that the pivot item was moved out from the waste basket
         check not xq.txDB.byRejects.hasKey(thisItem.itemID)
@@ -793,7 +793,7 @@ proc runTxPackerTests(noisy = true) =
           check false
           return
 
-        let blk = r.get
+        let blk = r.get.blk
         # Make sure that there are at least two txs on the packed block so
         # this test does not degenerate.
         check 1 < xq.chain.receipts.len

--- a/tests/test_txpool/setup.nim
+++ b/tests/test_txpool/setup.nim
@@ -103,7 +103,7 @@ proc toTxPool*(
           status = statusInfo[getStatus()]
           info = &"{txCount} #{num}({chainNo}) {n}/{txs.len} {status}"
         noisy.showElapsed(&"insert: {info}"):
-          result[0].add(txs[n], info)
+          result[0].add(PooledTransaction(tx: txs[n]), info)
 
       if loadTxs <= txCount:
         break
@@ -132,11 +132,11 @@ proc toTxPool*(
   noisy.showElapsed(&"Loading {itList.len} transactions"):
     for item in itList:
       if noLocals:
-        result.add(item.tx, item.info)
+        result.add(item.pooledTx, item.info)
       elif localAddr.hasKey(item.sender):
-        doAssert result.addLocal(item.tx, true).isOk
+        doAssert result.addLocal(item.pooledTx, true).isOk
       else:
-        doAssert result.addRemote(item.tx, true).isOk
+        doAssert result.addRemote(item.pooledTx, true).isOk
   doAssert result.nItems.total == itList.len
 
 
@@ -174,11 +174,11 @@ proc toTxPool*(
     for n in 0 ..< itList.len:
       let item = itList[n]
       if noLocals:
-        result.add(item.tx, item.info)
+        result.add(item.pooledTx, item.info)
       elif localAddr.hasKey(item.sender):
-        doAssert result.addLocal(item.tx, true).isOk
+        doAssert result.addLocal(item.pooledTx, true).isOk
       else:
-        doAssert result.addRemote(item.tx, true).isOk
+        doAssert result.addRemote(item.pooledTx, true).isOk
       if n < 3 or delayAt-3 <= n and n <= delayAt+3 or itList.len-4 < n:
         let t = result.getItem(item.itemID).value.timeStamp.format(tFmt, utc())
         noisy.say &"added item {n} time={t}"

--- a/tests/test_txpool2.nim
+++ b/tests/test_txpool2.nim
@@ -156,7 +156,7 @@ proc runTxPoolCliqueTest*() =
 
   suite "Test TxPool with Clique sealer":
     test "TxPool addLocal":
-      let res = xp.addLocal(tx, force = true)
+      let res = xp.addLocal(PooledTransaction(tx: tx), force = true)
       check res.isOk
       if res.isErr:
         debugEcho res.error
@@ -172,7 +172,7 @@ proc runTxPoolCliqueTest*() =
         check false
         return
 
-      blk = res.get
+      blk = res.get.blk
       body = BlockBody(
         transactions: blk.txs,
         uncles: blk.uncles
@@ -201,7 +201,7 @@ proc runTxPoolCliqueTest*() =
       check xp.smartHead(blk.header)
 
       let tx = env.makeTx(recipient, amount)
-      let res = xp.addLocal(tx, force = true)
+      let res = xp.addLocal(PooledTransaction(tx: tx), force = true)
       check res.isOk
       if res.isErr:
         debugEcho res.error
@@ -214,7 +214,7 @@ proc runTxPoolCliqueTest*() =
         check false
         return
 
-      blk = r.get
+      blk = r.get.blk
       body = BlockBody(
         transactions: blk.txs,
         uncles: blk.uncles
@@ -249,7 +249,7 @@ proc runTxPoolPosTest*() =
 
   suite "Test TxPool with PoS block":
     test "TxPool addLocal":
-      let res = xp.addLocal(tx, force = true)
+      let res = xp.addLocal(PooledTransaction(tx: tx), force = true)
       check res.isOk
       if res.isErr:
         debugEcho res.error
@@ -269,7 +269,7 @@ proc runTxPoolPosTest*() =
         check false
         return
 
-      blk = r.get
+      blk = r.get.blk
       check com.isBlockAfterTtd(blk.header)
 
       body = BlockBody(
@@ -310,12 +310,12 @@ proc runTxPoolBlobhashTest*() =
 
   suite "Test TxPool with blobhash block":
     test "TxPool addLocal":
-      let res = xp.addLocal(tx1, force = true)
+      let res = xp.addLocal(PooledTransaction(tx: tx1), force = true)
       check res.isOk
       if res.isErr:
         debugEcho res.error
         return
-      let res2 = xp.addLocal(tx2, force = true)
+      let res2 = xp.addLocal(PooledTransaction(tx: tx2), force = true)
       check res2.isOk
 
     test "TxPool jobCommit":
@@ -332,7 +332,7 @@ proc runTxPoolBlobhashTest*() =
         check false
         return
 
-      blk = r.get
+      blk = r.get.blk
       check com.isBlockAfterTtd(blk.header)
 
       body = BlockBody(
@@ -366,7 +366,7 @@ proc runTxPoolBlobhashTest*() =
         xp = env.xp
 
       check xp.smartHead(blk.header)
-      let res = xp.addLocal(tx4, force = true)
+      let res = xp.addLocal(PooledTransaction(tx: tx4), force = true)
       check res.isOk
       if res.isErr:
         debugEcho res.error
@@ -400,7 +400,7 @@ proc runTxHeadDelta*(noisy = true) =
             let tx = env.makeTx(recipient, amount)
             # Instead of `add()`, the functions `addRemote()` or `addLocal()`
             # also would do.
-            xp.add(tx)
+            xp.add(PooledTransaction(tx: tx))
 
           noisy.say "***", "txDB",
             &" n={n}",
@@ -418,7 +418,7 @@ proc runTxHeadDelta*(noisy = true) =
             check false
             return
 
-          let blk = r.get
+          let blk = r.get.blk
           check com.isBlockAfterTtd(blk.header)
 
           let body = BlockBody(


### PR DESCRIPTION
EIP-4844 blob sidecars are a concept that only exists in the mempool. After inclusion of a transaction into an execution block, only the versioned hash within the transaction remains. To improve type safety, replace the `Transaction.networkPayload` member with a wrapper type `PooledTransaction` that is used in contexts where blob sidecars exist.