### PR TITLE
Workaround for disallowed transaction superseding

### DIFF
--- a/nimbus/core/tx_pool/tx_tasks/tx_add.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_add.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/core/tx_pool/tx_tasks/tx_add.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_add.nim
@@ -77,10 +77,16 @@ proc supersede(xp: TxPoolRef; item: TxItemRef): Result[void,TxInfo]
       return err(txInfoErrUnspecified)
     current = rc.value.data
 
-  # verify whether replacing is allowed, at all
-  let bumpPrice = (current.tx.gasPrice * xp.priceBump.GasInt + 99) div 100
-  if item.tx.gasPrice < current.tx.gasPrice + bumpPrice:
-    return err(txInfoErrReplaceUnderpriced)
+  # TODO: To unblock `kurtosis-tech/ethereum-package` based testing,
+  # we have to accept superseding transactions temporarily until `rpc_utils.nim`
+  # supports the 'pending' tag by incorporating pending transactions from the
+  # mempool when returning the current account nonce. Until that is fixed,
+  # we keep telling the transaction spammer that their nonce has not changed,
+  # and it keeps spamming transactions with the same nonce repeatedly.
+  if false:
+    let bumpPrice = (current.tx.gasPrice * xp.priceBump.GasInt + 99) div 100
+    if item.tx.gasPrice < current.tx.gasPrice + bumpPrice:
+      return err(txInfoErrReplaceUnderpriced)
 
   # make space, delete item
   if not xp.txDB.dispose(current, txInfoSenderNonceSuperseded):

--- a/nimbus/core/tx_pool/tx_tasks/tx_add.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_add.nim
@@ -83,6 +83,8 @@ proc supersede(xp: TxPoolRef; item: TxItemRef): Result[void,TxInfo]
   # mempool when returning the current account nonce. Until that is fixed,
   # we keep telling the transaction spammer that their nonce has not changed,
   # and it keeps spamming transactions with the same nonce repeatedly.
+  # Note: When this is fixed, update `tests/test_txpool.nim` and
+  # re-enable the "Superseding txs with sender and nonce variants" test case.
   if false:
     let bumpPrice = (current.tx.gasPrice * xp.priceBump.GasInt + 99) div 100
     if item.tx.gasPrice < current.tx.gasPrice + bumpPrice:

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -301,11 +301,12 @@ proc runTxPoolTests(noisy = true) =
         check xq.nItems.total == testTxs.len
         check xq.nItems.disposed == testTxs.len
 
-        # last update item was underpriced, so it must not have been
-        # replaced
-        var altLst = testTxs.toSeq.mapIt("alt " & it[0].info)
-        altLst[^1] = testTxs[^1][0].info
-        check altLst.sorted == xq.toItems.toSeq.mapIt(it.info).sorted
+        if false:  # Temporarily disabled, see `supersede` in `tx_add.nim`
+          # last update item was underpriced, so it must not have been
+          # replaced
+          var altLst = testTxs.toSeq.mapIt("alt " & it[0].info)
+          altLst[^1] = testTxs[^1][0].info
+          check altLst.sorted == xq.toItems.toSeq.mapIt(it.info).sorted
 
       test &"Deleting tx => also delete higher nonces":
 


### PR DESCRIPTION
The transaction spammer from Kurtosis keeps spamming transactions with the same nonce because report 'pending' account nocne based on 'latest' rather than actually considering the mempool. To avoid errors from rejecting those, disable the required gas price bump when replacing a transaction with a new nonce.