### PR TITLE
CoreDb+Aristo: Update tracer

### DIFF
--- a/tests/test_coredb.nim
+++ b/tests/test_coredb.nim
@@ -280,12 +280,8 @@ when isMainModule:
     noisy.profileSection("@sample #" & $n, state):
       noisy.chainSyncRunner(
         capture = capture,
-        #dbType = ..,
-        ldgType=LedgerCache,
         #profilingOk = true,
         #finalDiskCleanUpOk = false,
-        #enaLoggingOk = ..,
-        #lastOneExtraOk = ..,
       )
 
   noisy.say "***", "total: ", state[0].pp, " sections: ", state[1]


### PR DESCRIPTION
why:
  When deleting accounts while restoring the previous state, storage tries
  must be deleted first. Otherwise a `DelDanglingStoTrie` error will occur
  when trying to delete an account which refers to an active storage trie.