### PR TITLE
Rename the Portal testnet0 to mainnet

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -58,7 +58,8 @@ type
 
   PortalNetwork* = enum
     none
-    testnet0
+    mainnet
+    testnet
 
   # The networks alias Portal sub-protocols
   Network* = enum
@@ -97,7 +98,7 @@ type
       desc:
         "Select which Portal network to join. This will set the " &
         "Portal network specific bootstrap nodes automatically",
-      defaultValue: PortalNetwork.testnet0,
+      defaultValue: PortalNetwork.mainnet,
       name: "portal-network"
     .}: PortalNetwork
 
@@ -107,7 +108,7 @@ type
         "DEPRECATED: The --network flag will be removed in the future, please use the drop in replacement --portal-network flag instead",
       defaultValue: none(PortalNetwork),
       name: "network"
-    .}: Option[PortalNetwork.testnet0]
+    .}: Option[PortalNetwork.mainnet]
 
     networks* {.
       desc: "Select which networks (Portal sub-protocols) to enable",

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -108,11 +108,14 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
     portalNetwork = config.portalNetwork
 
   case portalNetwork
-  of testnet0:
-    for enrURI in testnet0BootstrapNodes:
+  of mainnet:
+    for enrURI in mainnetBootstrapNodes:
       var record: Record
       if fromURI(record, enrURI):
         bootstrapRecords.add(record)
+  of testnet:
+    # TODO: add testnet repo with bootstrap file.
+    discard
   else:
     discard
 

--- a/fluffy/network_metadata.nim
+++ b/fluffy/network_metadata.nim
@@ -33,16 +33,16 @@ const
     currentSourcePath.parentDir.parentDir.replace('\\', '/') / "vendor" /
     "portal-mainnet" / "config"
   # Note:
-  # For now it gets called testnet0 but this Portal network serves Eth1 mainnet
-  # data. Giving the actual Portal (test)networks different names might not be
-  # that useful as there is no way to distinguish the networks currently.
+  # These are the bootstrap nodes for the Portal mainnet.
+  # TODO: For the Portal testnet, additional bootstrap nodes need to be read
+  # still and Protocol Ids need to be adjusted.
   #
   # When more config data is required per Portal network, a metadata object can
   # be created, but right now only bootstrap nodes can be different.
   # TODO: It would be nice to be able to use `loadBootstrapFile` here, but that
   # doesn't work at compile time. The main issue seems to be the usage of
   # rlp.rawData() in the enr code.
-  testnet0BootstrapNodes* =
+  mainnetBootstrapNodes* =
     loadCompileTimeBootstrapNodes(portalConfigDir / "bootstrap_nodes.txt")
 
   finishedAccumulatorSSZ* = slurp(portalConfigDir / "finished_accumulator.ssz")


### PR DESCRIPTION
Also adds the new testnet as option, but this needs to be still implemented by adding testnet bootstrap nodes and protocol ids.