### PR TITLE
trivial memory-based speedups

### DIFF
--- a/nimbus/db/aristo/aristo_desc.nim
+++ b/nimbus/db/aristo/aristo_desc.nim
@@ -98,7 +98,7 @@ func getOrVoid*[W](tab: Table[W,HashSet[VertexID]]; w: W): HashSet[VertexID] =
 # --------
 
 func isValid*(vtx: VertexRef): bool =
-  vtx != VertexRef(nil) 
+  vtx != VertexRef(nil)
 
 func isValid*(nd: NodeRef): bool =
   nd != NodeRef(nil)
@@ -259,6 +259,11 @@ proc forgetOthers*(db: AristoDbRef): Result[void,AristoError] =
 
     db.dudes = DudesRef(nil)
   ok()
+
+iterator rstack*(db: AristoDbRef): LayerRef =
+  # Stack in reverse order
+  for i in 0..<db.stack.len:
+    yield db.stack[db.stack.len - i - 1]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_walk.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_walk.nim
@@ -54,7 +54,7 @@ iterator walk*(
           break walkBody
         let
           pfx = StorageType(key[0])
-          id = uint64.fromBytesBE key[1..^1]
+          id = uint64.fromBytesBE key.toOpenArray(1, key.len - 1)
         yield (pfx, id, val)
 
 

--- a/nimbus/db/aristo/aristo_layers.nim
+++ b/nimbus/db/aristo/aristo_layers.nim
@@ -69,7 +69,7 @@ proc layersGetVtx*(db: AristoDbRef; vid: VertexID): Result[VertexRef,void] =
   if db.top.delta.sTab.hasKey vid:
     return ok(db.top.delta.sTab.getOrVoid vid)
 
-  for w in db.stack.reversed:
+  for w in db.rstack:
     if w.delta.sTab.hasKey vid:
       return ok(w.delta.sTab.getOrVoid vid)
 
@@ -89,7 +89,7 @@ proc layersGetKey*(db: AristoDbRef; vid: VertexID): Result[HashKey,void] =
     # dirty, there is an empty `kMap[]` entry on this layer.
     return ok(db.top.delta.kMap.getOrVoid vid)
 
-  for w in db.stack.reversed:
+  for w in db.rstack:
     if w.delta.kMap.hasKey vid:
       # Same reasoning as above regarding the `dirty` flag.
       return ok(w.delta.kMap.getOrVoid vid)
@@ -233,7 +233,7 @@ iterator layersWalkVtx*(
     yield (vid,vtx)
     seen.incl vid
 
-  for w in db.stack.reversed:
+  for w in db.rstack:
     for (vid,vtx) in w.delta.sTab.pairs:
       if vid notin seen:
         yield (vid,vtx)
@@ -258,7 +258,7 @@ iterator layersWalkKey*(
     yield (vid,key)
     seen.incl vid
 
-  for w in db.stack.reversed:
+  for w in db.rstack:
     for (vid,key) in w.delta.kMap.pairs:
       if vid notin seen:
         yield (vid,key)

--- a/nimbus/db/aristo/aristo_path.nim
+++ b/nimbus/db/aristo/aristo_path.nim
@@ -45,9 +45,9 @@ func pathAsBlob*(tag: PathID): Blob =
   ## used to index database leaf values can be represented as `Blob`, i.e.
   ## `PathID` type paths with an even number of nibbles.
   if 0 < tag.length:
-    let key = @(tag.pfx.toBytesBE)
+    let key = tag.pfx.toBytesBE
     if 64 <= tag.length:
-      return key
+      return @key
     else:
       return key[0 .. (tag.length - 1) div 2]
 

--- a/nimbus/db/aristo/aristo_serialise.nim
+++ b/nimbus/db/aristo/aristo_serialise.nim
@@ -133,9 +133,9 @@ proc append*(writer: var RlpWriter; node: NodeRef) =
   ## list.
   func addHashKey(w: var RlpWriter; key: HashKey) =
     if 1 < key.len and key.len < 32:
-      w.appendRawBytes @key
+      w.appendRawBytes key.data
     else:
-      w.append @key
+      w.append key.data
 
   if node.error != AristoError(0):
     writer.startList(0)

--- a/nimbus/db/aristo/aristo_serialise.nim
+++ b/nimbus/db/aristo/aristo_serialise.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/kvt/kvt_desc.nim
+++ b/nimbus/db/kvt/kvt_desc.nim
@@ -191,6 +191,11 @@ proc forgetOthers*(db: KvtDbRef): Result[void,KvtError] =
     db.dudes = DudesRef(nil)
   ok()
 
+iterator rstack*(db: KvtDbRef): LayerRef =
+  # Stack in reverse order
+  for i in 0..<db.stack.len:
+    yield db.stack[db.stack.len - i - 1]
+
 # ------------------------------------------------------------------------------
 # End
 # ------------------------------------------------------------------------------

--- a/nimbus/db/kvt/kvt_layers.nim
+++ b/nimbus/db/kvt/kvt_layers.nim
@@ -37,7 +37,7 @@ proc layersHasKey*(db: KvtDbRef; key: openArray[byte]): bool =
   if db.top.delta.sTab.hasKey @key:
     return true
 
-  for w in db.stack.reversed:
+  for w in db.rstack:
     if w.delta.sTab.hasKey @key:
       return true
 
@@ -49,7 +49,7 @@ proc layersGet*(db: KvtDbRef; key: openArray[byte]): Result[Blob,void] =
   if db.top.delta.sTab.hasKey @key:
     return ok(db.top.delta.sTab.getOrVoid @key)
 
-  for w in db.stack.reversed:
+  for w in db.rstack:
     if w.delta.sTab.hasKey @key:
       return ok(w.delta.sTab.getOrVoid @key)
 
@@ -101,7 +101,7 @@ iterator layersWalk*(
     yield (key,val)
     seen.incl key
 
-  for w in db.stack.reversed:
+  for w in db.rstack:
     for (key,val) in w.delta.sTab.pairs:
       if key notin seen:
         yield (key,val)

--- a/tests/test_coredb/test_helpers.nim
+++ b/tests/test_coredb/test_helpers.nim
@@ -53,6 +53,16 @@ proc say*(noisy = false; pfx = "***"; args: varargs[string, `$`]) =
     else:
       echo pfx, args.toSeq.join
 
+proc whisper*(noisy = false; pfx = "***"; args: varargs[string, `$`]) =
+  if noisy:
+    if args.len == 0:
+      stdout.write("*** ", pfx)
+    elif 0 < pfx.len and pfx[^1] != ' ':
+      stdout.write(pfx, " ", args.toSeq.join)
+    else:
+      stdout.write(pfx, args.toSeq.join)
+    stdout.flushFile()
+
 proc toPfx*(indent: int): string =
   "\n" & " ".repeat(indent)
 


### PR DESCRIPTION
* HashKey becomes non-ref
* use openArray instead of seq in lots of places
* avoid sequtils.reversed when unnecessary
* add basic perf stats to test_coredb