### PR TITLE
Implementation of Fluffy state network gossip.

### DIFF
--- a/fluffy/network/state/content/content_keys.nim
+++ b/fluffy/network/state/content/content_keys.nim
@@ -73,24 +73,14 @@ func init*(
 func init*(T: type ContractCodeKey, address: Address, codeHash: CodeHash): T =
   ContractCodeKey(address: address, codeHash: codeHash)
 
-func initAccountTrieNodeKey*(path: Nibbles, nodeHash: NodeHash): ContentKey =
-  ContentKey(
-    contentType: accountTrieNode,
-    accountTrieNodeKey: AccountTrieNodeKey.init(path, nodeHash),
-  )
+func toContentKey*(key: AccountTrieNodeKey): ContentKey =
+  ContentKey(contentType: accountTrieNode, accountTrieNodeKey: key)
 
-func initContractTrieNodeKey*(
-    address: Address, path: Nibbles, nodeHash: NodeHash
-): ContentKey =
-  ContentKey(
-    contentType: contractTrieNode,
-    contractTrieNodeKey: ContractTrieNodeKey.init(address, path, nodeHash),
-  )
+func toContentKey*(key: ContractTrieNodeKey): ContentKey =
+  ContentKey(contentType: contractTrieNode, contractTrieNodeKey: key)
 
-func initContractCodeKey*(address: Address, codeHash: CodeHash): ContentKey =
-  ContentKey(
-    contentType: contractCode, contractCodeKey: ContractCodeKey.init(address, codeHash)
-  )
+func toContentKey*(key: ContractCodeKey): ContentKey =
+  ContentKey(contentType: contractCode, contractCodeKey: key)
 
 proc readSszBytes*(data: openArray[byte], val: var ContentKey) {.raises: [SszError].} =
   mixin readSszValue

--- a/fluffy/network/state/content/content_values.nim
+++ b/fluffy/network/state/content/content_values.nim
@@ -47,9 +47,10 @@ type
   ContractCodeRetrieval* = object
     code*: Bytecode
 
-  ContentValue* =
-    AccountTrieNodeOffer | ContractTrieNodeOffer | ContractCodeOffer |
+  ContentOfferType* = AccountTrieNodeOffer | ContractTrieNodeOffer | ContractCodeOffer
+  ContentRetrievalType* =
     AccountTrieNodeRetrieval | ContractTrieNodeRetrieval | ContractCodeRetrieval
+  ContentValueType* = ContentOfferType | ContentRetrievalType
 
 func init*(T: type AccountTrieNodeOffer, proof: TrieProof, blockHash: BlockHash): T =
   AccountTrieNodeOffer(proof: proof, blockHash: blockHash)
@@ -90,8 +91,8 @@ func toRetrievalValue*(offer: ContractTrieNodeOffer): ContractTrieNodeRetrieval 
 func toRetrievalValue*(offer: ContractCodeOffer): ContractCodeRetrieval =
   ContractCodeRetrieval.init(offer.code)
 
-func encode*(value: ContentValue): seq[byte] =
+func encode*(value: ContentValueType): seq[byte] =
   SSZ.encode(value)
 
-func decode*(T: type ContentValue, bytes: openArray[byte]): Result[T, string] =
+func decode*(T: type ContentValueType, bytes: openArray[byte]): Result[T, string] =
   decodeSsz(bytes, T)

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -196,19 +196,19 @@ proc processContentLoop(n: StateNetwork) {.async.} =
             error "Received content with unused content type"
             continue
           of accountTrieNode:
-            await processOffer(
-              n, srcNodeId, contentKeyBytes, contentValueBytes,
+            await n.processOffer(
+              srcNodeId, contentKeyBytes, contentValueBytes,
               contentKey.accountTrieNodeKey, AccountTrieNodeOffer,
             )
           of contractTrieNode:
-            await processOffer(
-              n, srcNodeId, contentKeyBytes, contentValueBytes,
+            await n.processOffer(
+              srcNodeId, contentKeyBytes, contentValueBytes,
               contentKey.contractTrieNodeKey, ContractTrieNodeOffer,
             )
           of contractCode:
-            await processOffer(
-              n, srcNodeId, contentKeyBytes, contentValueBytes,
-              contentKey.contractCodeKey, ContractCodeOffer,
+            await n.processOffer(
+              srcNodeId, contentKeyBytes, contentValueBytes, contentKey.contractCodeKey,
+              ContractCodeOffer,
             )
         if offerRes.isOk():
           info "Offered content processed successfully", contentKeyBytes

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -69,67 +69,63 @@ proc new*(
     historyNetwork: historyNetwork,
   )
 
-# TODO: implement content lookups for each type
-proc getContent*(
-    n: StateNetwork, contentKey: ContentKey
-): Future[Opt[seq[byte]]] {.async.} =
+proc getContent(
+    n: StateNetwork,
+    key: AccountTrieNodeKey | ContractTrieNodeKey | ContractCodeKey,
+    V: type ContentRetrievalType,
+): Future[Opt[V]] {.async.} =
   let
-    contentKeyBytes = contentKey.encode()
+    contentKeyBytes = key.toContentKey().encode()
     contentId = contentKeyBytes.toContentId()
-    contentInRange = n.portalProtocol.inRange(contentId)
 
-  # When the content id is in the radius range, try to look it up in the db.
-  if contentInRange:
+  if n.portalProtocol.inRange(contentId):
     let contentFromDB = n.contentDB.get(contentId)
     if contentFromDB.isSome():
-      return contentFromDB
+      let contentValue = V.decode(contentFromDB.get()).valueOr:
+        error "Unable to decode account trie node content value from database"
+        return Opt.none(V)
+
+      info "Fetched account trie node from database"
+      return Opt.some(contentValue)
 
   let
     contentLookupResult = (
       await n.portalProtocol.contentLookup(contentKeyBytes, contentId)
     ).valueOr:
-      return Opt.none(seq[byte])
+      return Opt.none(V)
     contentValueBytes = contentLookupResult.content
 
-  case contentKey.contentType
-  of unused:
-    error "Received content with unused content type"
-    return Opt.none(seq[byte])
-  of accountTrieNode:
-    let contentValue = AccountTrieNodeRetrieval.decode(contentValueBytes).valueOr:
-      error "Unable to decode AccountTrieNodeRetrieval content value"
-      return Opt.none(seq[byte])
+  let contentValue = V.decode(contentValueBytes).valueOr:
+    error "Unable to decode account trie node content value from content lookup"
+    return Opt.none(V)
 
-    validateRetrieval(contentKey.accountTrieNodeKey, contentValue).isOkOr:
-      error "Validation of retrieval content failed: ", error
-      return Opt.none(seq[byte])
-  of contractTrieNode:
-    let contentValue = ContractTrieNodeRetrieval.decode(contentValueBytes).valueOr:
-      error "Unable to decode ContractTrieNodeRetrieval content value"
-      return Opt.none(seq[byte])
+  validateRetrieval(key, contentValue).isOkOr:
+    error "Validation of retrieved content failed"
+    return Opt.none(V)
 
-    validateRetrieval(contentKey.contractTrieNodeKey, contentValue).isOkOr:
-      error "Validation of retrieval content failed: ", error
-      return Opt.none(seq[byte])
-  of contractCode:
-    let contentValue = ContractCodeRetrieval.decode(contentValueBytes).valueOr:
-      error "Unable to decode ContractCodeRetrieval content value"
-      return Opt.none(seq[byte])
+  n.portalProtocol.storeContent(contentKeyBytes, contentId, contentValueBytes)
 
-    validateRetrieval(contentKey.contractCodeKey, contentValue).isOkOr:
-      error "Validation of retrieval content failed: ", error
-      return Opt.none(seq[byte])
+  return Opt.some(contentValue)
 
-  # When content is in the radius range, store it.
-  if contentInRange:
-    # TODO Add poke when working on state network
-    # TODO When working on state network, make it possible to pass different
-    # distance functions to store content
-    n.portalProtocol.storeContent(contentKeyBytes, contentId, contentValueBytes)
+proc getAccountTrieNode*(
+    n: StateNetwork, key: AccountTrieNodeKey
+): Future[Opt[AccountTrieNodeRetrieval]] {.inline.} =
+  n.getContent(key, AccountTrieNodeRetrieval)
 
-  # TODO: for now returning bytes, ultimately it would be nice to return proper
-  # domain types.
-  return Opt.some(contentValueBytes)
+proc getContractTrieNode*(
+    n: StateNetwork, key: ContractTrieNodeKey
+): Future[Opt[ContractTrieNodeRetrieval]] {.inline.} =
+  n.getContent(key, ContractTrieNodeRetrieval)
+
+proc getContractCode*(
+    n: StateNetwork, key: ContractCodeKey
+): Future[Opt[ContractCodeRetrieval]] {.inline.} =
+  n.getContent(key, ContractCodeRetrieval)
+
+# High level endpoints
+# eth_getBalance
+# eth_getStorageAt
+# eth_getCode
 
 func decodeKey(contentKey: ByteList): Opt[ContentKey] =
   let key = ContentKey.decode(contentKey).valueOr:
@@ -150,14 +146,16 @@ proc getStateRootByBlockHash(
 
   Opt.some(header.stateRoot)
 
-proc processOffer[K, V](
+proc processOffer(
     n: StateNetwork,
     maybeSrcNodeId: Opt[NodeId],
     contentKeyBytes: ByteList,
-    contentKey: K,
-    contentValue: V,
+    contentValueBytes: seq[byte],
+    contentKey: AccountTrieNodeKey | ContractTrieNodeKey | ContractCodeKey,
+    V: type ContentOfferType,
 ): Future[Result[void, string]] {.async.} =
-  mixin blockHash, validateOffer, toRetrievalValue, gossipOffer
+  let contentValue = V.decode(contentValueBytes).valueOr:
+    return err("Unable to decode offered content value")
 
   let stateRoot = (await n.getStateRootByBlockHash(contentValue.blockHash)).valueOr:
     return err("Failed to get state root by block hash")
@@ -193,31 +191,19 @@ proc processContentLoop(n: StateNetwork) {.async.} =
             error "Received content with unused content type"
             continue
           of accountTrieNode:
-            let contentValue = AccountTrieNodeOffer.decode(contentValueBytes).valueOr:
-              error "Unable to decode offered AccountTrieNodeOffer content value"
-              continue
-
             await processOffer(
-              n, maybeSrcNodeId, contentKeyBytes, contentKey.accountTrieNodeKey,
-              contentValue,
+              n, maybeSrcNodeId, contentKeyBytes, contentValueBytes,
+              contentKey.accountTrieNodeKey, AccountTrieNodeOffer,
             )
           of contractTrieNode:
-            let contentValue = ContractTrieNodeOffer.decode(contentValueBytes).valueOr:
-              error "Unable to decode offered ContractTrieNodeOffer content value"
-              continue
-
             await processOffer(
-              n, maybeSrcNodeId, contentKeyBytes, contentKey.contractTrieNodeKey,
-              contentValue,
+              n, maybeSrcNodeId, contentKeyBytes, contentValueBytes,
+              contentKey.contractTrieNodeKey, ContractTrieNodeOffer,
             )
           of contractCode:
-            let contentValue = ContractCodeOffer.decode(contentValueBytes).valueOr:
-              error "Unable to decode offered ContractCodeOffer content value"
-              continue
-
             await processOffer(
-              n, maybeSrcNodeId, contentKeyBytes, contentKey.contractCodeKey,
-              contentValue,
+              n, maybeSrcNodeId, contentKeyBytes, contentValueBytes,
+              contentKey.contractCodeKey, ContractCodeOffer,
             )
         if offerRes.isOk():
           info "Offered content processed successfully", contentKeyBytes

--- a/fluffy/network/state/state_utils.nim
+++ b/fluffy/network/state/state_utils.nim
@@ -9,7 +9,7 @@ import results, eth/common, ./state_content
 
 export results, common
 
-proc decodePrefix*(nodePrefixRlp: Rlp): (byte, bool, Nibbles) =
+func decodePrefix*(nodePrefixRlp: Rlp): (byte, bool, Nibbles) =
   doAssert(not nodePrefixRlp.isEmpty())
 
   let
@@ -22,7 +22,7 @@ proc decodePrefix*(nodePrefixRlp: Rlp): (byte, bool, Nibbles) =
 
   (firstNibble.byte, isLeaf, nibbles)
 
-proc rlpDecodeAccountTrieNode*(accountNode: TrieNode): Result[Account, string] =
+func rlpDecodeAccountTrieNode*(accountNode: TrieNode): Result[Account, string] =
   let accNodeRlp = rlpFromBytes(accountNode.asSeq())
   if accNodeRlp.isEmpty() or accNodeRlp.listLen() != 2:
     return err("invalid account trie node - malformed")

--- a/fluffy/network/state/state_utils.nim
+++ b/fluffy/network/state/state_utils.nim
@@ -1,0 +1,38 @@
+# Fluffy
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import results, eth/common, ./state_content
+
+export results, common
+
+proc decodePrefix*(nodePrefixRlp: Rlp): (byte, bool, Nibbles) =
+  doAssert(not nodePrefixRlp.isEmpty())
+
+  let
+    rlpBytes = nodePrefixRlp.toBytes()
+    firstNibble = (rlpBytes[0] and 0xF0) shr 4
+    isLeaf = firstNibble == 2 or firstNibble == 3
+    isEven = firstNibble == 0 or firstNibble == 2
+    startIdx = if isEven: 1 else: 0
+    nibbles = Nibbles.init(rlpBytes[startIdx .. ^1], isEven)
+
+  (firstNibble.byte, isLeaf, nibbles)
+
+proc rlpDecodeAccountTrieNode*(accountNode: TrieNode): Result[Account, string] =
+  let accNodeRlp = rlpFromBytes(accountNode.asSeq())
+  if accNodeRlp.isEmpty() or accNodeRlp.listLen() != 2:
+    return err("invalid account trie node - malformed")
+
+  let accNodePrefixRlp = accNodeRlp.listElem(0)
+  if accNodePrefixRlp.isEmpty():
+    return err("invalid account trie node - empty prefix")
+
+  let (_, isLeaf, _) = decodePrefix(accNodePrefixRlp)
+  if not isLeaf:
+    return err("invalid account trie node - leaf prefix expected")
+
+  decodeRlp(accNodeRlp.listElem(1).toBytes(), Account)

--- a/fluffy/network/state/state_validation.nim
+++ b/fluffy/network/state/state_validation.nim
@@ -30,7 +30,10 @@ proc isValidNextNode(thisNodeRlp: Rlp, rlpIdx: int, nextNode: TrieNode): bool =
   nextNode.hashEquals(nextHash)
 
 proc validateTrieProof*(
-    expectedRootHash: KeccakHash, path: Nibbles, proof: TrieProof
+    expectedRootHash: KeccakHash,
+    path: Nibbles,
+    proof: TrieProof,
+    allowKeyEndInPathForLeafs = false,
 ): Result[void, string] =
   if proof.len() == 0:
     return err("proof is empty")
@@ -68,7 +71,7 @@ proc validateTrieProof*(
       if prefix >= 4:
         return err("invalid prefix in node")
 
-      if not isLastNode or isLeaf:
+      if not isLastNode or (isLeaf and allowKeyEndInPathForLeafs):
         let unpackedPrefix = prefixNibbles.unpackNibbles()
         if remainingNibbles < unpackedPrefix.len():
           return err("not enough nibbles to validate node prefix")
@@ -142,7 +145,10 @@ proc validateOffer*(
 ): Result[void, string] =
   let addressHash = keccakHash(key.address).data
   ?validateTrieProof(
-    trustedStateRoot, Nibbles.init(addressHash, true), offer.accountProof
+    trustedStateRoot,
+    Nibbles.init(addressHash, true),
+    offer.accountProof,
+    allowKeyEndInPathForLeafs = true,
   )
 
   let account = ?rlpDecodeAccountTrieNode(offer.accountProof[^1])
@@ -159,7 +165,10 @@ proc validateOffer*(
 ): Result[void, string] =
   let addressHash = keccakHash(key.address).data
   ?validateTrieProof(
-    trustedStateRoot, Nibbles.init(addressHash, true), offer.accountProof
+    trustedStateRoot,
+    Nibbles.init(addressHash, true),
+    offer.accountProof,
+    allowKeyEndInPathForLeafs = true,
   )
 
   let account = ?rlpDecodeAccountTrieNode(offer.accountProof[^1])

--- a/fluffy/tests/state_network_tests/test_state_content_keys.nim
+++ b/fluffy/tests/state_network_tests/test_state_content_keys.nim
@@ -29,7 +29,7 @@ suite "State Content Keys":
 
       packedNibbles = packNibbles(testCase.path)
       nodeHash = NodeHash.fromHex(testCase.node_hash)
-      contentKey = initAccountTrieNodeKey(packedNibbles, nodeHash)
+      contentKey = AccountTrieNodeKey.init(packedNibbles, nodeHash).toContentKey()
       encoded = contentKey.encode()
 
     check:
@@ -60,7 +60,8 @@ suite "State Content Keys":
       packedNibbles = packNibbles(testCase.path)
       address = Address.fromHex(testCase.address)
       nodeHash = NodeHash.fromHex(testCase.node_hash)
-      contentKey = initContractTrieNodeKey(address, packedNibbles, nodeHash)
+      contentKey =
+        ContractTrieNodeKey.init(address, packedNibbles, nodeHash).toContentKey()
       encoded = contentKey.encode()
 
     check:
@@ -89,7 +90,7 @@ suite "State Content Keys":
 
       address = Address.fromHex(testCase.address)
       codeHash = CodeHash.fromHex(testCase.code_hash)
-      contentKey = initContractCodeKey(address, codeHash)
+      contentKey = ContractCodeKey.init(address, codeHash).toContentKey()
       encoded = contentKey.encode()
 
     check:

--- a/fluffy/tests/state_network_tests/test_state_content_nibbles.nim
+++ b/fluffy/tests/state_network_tests/test_state_content_nibbles.nim
@@ -15,7 +15,7 @@ suite "State Content Nibbles":
       packedNibbles = packNibbles(nibbles)
       unpackedNibbles = unpackNibbles(packedNibbles)
 
-    let encoded = SSZ.encode(packedNibbles)
+    let encoded = packedNibbles.encode()
 
     check:
       encoded.toHex() == expected
@@ -28,7 +28,7 @@ suite "State Content Nibbles":
       packedNibbles = packNibbles(nibbles)
       unpackedNibbles = unpackNibbles(packedNibbles)
 
-    let encoded = SSZ.encode(packedNibbles)
+    let encoded = packedNibbles.encode()
 
     check:
       encoded.toHex() == expected
@@ -41,7 +41,7 @@ suite "State Content Nibbles":
       packedNibbles = packNibbles(nibbles)
       unpackedNibbles = unpackNibbles(packedNibbles)
 
-    let encoded = SSZ.encode(packedNibbles)
+    let encoded = packedNibbles.encode()
 
     check:
       encoded.toHex() == expected
@@ -54,7 +54,7 @@ suite "State Content Nibbles":
       packedNibbles = packNibbles(nibbles)
       unpackedNibbles = unpackNibbles(packedNibbles)
 
-    let encoded = SSZ.encode(packedNibbles)
+    let encoded = packedNibbles.encode()
 
     check:
       encoded.toHex() == expected
@@ -67,7 +67,7 @@ suite "State Content Nibbles":
       packedNibbles = packNibbles(nibbles)
       unpackedNibbles = unpackNibbles(packedNibbles)
 
-    let encoded = SSZ.encode(packedNibbles)
+    let encoded = packedNibbles.encode()
 
     check:
       encoded.toHex() == expected
@@ -86,7 +86,7 @@ suite "State Content Nibbles":
       packedNibbles = packNibbles(nibbles)
       unpackedNibbles = unpackNibbles(packedNibbles)
 
-    let encoded = SSZ.encode(packedNibbles)
+    let encoded = packedNibbles.encode()
 
     check:
       encoded.toHex() == expected

--- a/fluffy/tests/state_network_tests/test_state_network.nim
+++ b/fluffy/tests/state_network_tests/test_state_network.nim
@@ -73,11 +73,8 @@ procSuite "State Network":
 
       # Note: GetContent and thus the lookup here is not really needed, as we
       # only have to request data to one node.
-      let foundContent = await proto2.getContent(contentKey)
-      check foundContent.isSome()
-
-      let accTrieNode = decodeSsz(foundContent.get(), AccountTrieNodeRetrieval)
-      check accTrieNode.isOk()
+      let accTrieNode = await proto2.getAccountTrieNode(accountTrieNodeKey)
+      check accTrieNode.isSome()
 
       let hash = keccakHash(accTrieNode.get().node.asSeq())
       check hash.data == key
@@ -148,11 +145,8 @@ procSuite "State Network":
       contentKey =
         ContentKey(contentType: accountTrieNode, accountTrieNodeKey: accountTrieNodeKey)
 
-    let foundContent = await proto1.getContent(contentKey)
-    check foundContent.isSome()
-
-    let accTrieNode = decodeSsz(foundContent.get(), AccountTrieNodeRetrieval)
-    check accTrieNode.isOk()
+    let accTrieNode = await proto1.getAccountTrieNode(accountTrieNodeKey)
+    check accTrieNode.isSome()
 
     let hash = keccakHash(accTrieNode.get().node.asSeq())
     check hash.data == firstKey

--- a/fluffy/tests/state_network_tests/test_state_network_gossip.nim
+++ b/fluffy/tests/state_network_tests/test_state_network_gossip.nim
@@ -100,7 +100,7 @@ procSuite "State Network Gossip":
         decodedValue = AccountTrieNodeOffer.decode(value).get()
         nextValue = recursiveGossipSteps[1].content_value.hexToSeqByte()
         nextDecodedValue = AccountTrieNodeOffer.decode(nextValue).get()
-        nextRetrievalValue = nextDecodedValue.toRetrievalValue().encode()
+        nextRetrievalValue = nextDecodedValue.toRetrievalValue()
 
       if i == 0:
         await currentNode.portalProtocol.gossipOffer(
@@ -109,7 +109,8 @@ procSuite "State Network Gossip":
 
       await sleepAsync(100.milliseconds) #TODO figure out how to get rid of this sleep
 
-      check (await nextNode.getContent(decodedNextKey)) == Opt.some(nextRetrievalValue)
+      check (await nextNode.getAccountTrieNode(decodedNextKey.accountTrieNodeKey)) ==
+        Opt.some(nextRetrievalValue)
 
     for i in 0 .. numOfClients:
       await clients[i].portalProtocol.baseProtocol.closeWait()

--- a/fluffy/tests/state_network_tests/test_state_network_gossip.nim
+++ b/fluffy/tests/state_network_tests/test_state_network_gossip.nim
@@ -13,7 +13,7 @@ import
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   ../../network/wire/[portal_protocol, portal_stream],
   ../../network/history/[history_content, history_network],
-  ../../network/state/[state_content, state_network, state_gossip],
+  ../../network/state/[state_network, state_gossip],
   ../../database/content_db,
   .././test_helpers,
   ../../eth_data/yaml_utils
@@ -104,7 +104,7 @@ procSuite "State Network Gossip":
 
       if i == 0:
         await currentNode.portalProtocol.gossipOffer(
-          Opt.none(NodeId), decodedKey.accountTrieNodeKey, decodedValue
+          Opt.none(NodeId), key, value, decodedKey.accountTrieNodeKey, decodedValue
         )
 
       await sleepAsync(100.milliseconds) #TODO figure out how to get rid of this sleep

--- a/fluffy/tests/state_network_tests/test_state_validation.nim
+++ b/fluffy/tests/state_network_tests/test_state_validation.nim
@@ -87,8 +87,7 @@ suite "State Validation":
       let res = validateRetrieval(contentKey.accountTrieNodeKey, contentValueRetrieval)
       check:
         res.isErr()
-        res.error() ==
-          "hash of fetched account trie node doesn't match the expected node hash"
+        res.error() == "hash of account trie node doesn't match the expected node hash"
 
   test "Validate valid ContractTrieNodeRetrieval nodes":
     const file = testVectorDir / "contract_storage_trie_node.yaml"
@@ -124,8 +123,7 @@ suite "State Validation":
       let res = validateRetrieval(contentKey.contractTrieNodeKey, contentValueRetrieval)
       check:
         res.isErr()
-        res.error() ==
-          "hash of fetched contract trie node doesn't match the expected node hash"
+        res.error() == "hash of contract trie node doesn't match the expected node hash"
 
   test "Validate valid ContractCodeRetrieval nodes":
     const file = testVectorDir / "contract_bytecode.yaml"
@@ -161,7 +159,7 @@ suite "State Validation":
       let res = validateRetrieval(contentKey.contractCodeKey, contentValueRetrieval)
       check:
         res.isErr()
-        res.error() == "hash of fetched bytecode doesn't match the expected code hash"
+        res.error() == "hash of bytecode doesn't match the expected code hash"
 
   # Account offer validation tests
 
@@ -489,7 +487,8 @@ suite "State Validation":
           validateOffer(stateRoot, contentKey.contractCodeKey, contentValueOffer)
         check:
           res.isErr()
-          res.error() == "hash of offered bytecode doesn't match the expected code hash"
+          res.error() ==
+            "hash of bytecode doesn't match the code hash in the account proof"
 
       block:
         let contentKey =
@@ -514,7 +513,8 @@ suite "State Validation":
           validateOffer(stateRoot, contentKey.contractCodeKey, contentValueOffer)
         check:
           res.isErr()
-          res.error() == "hash of offered bytecode doesn't match the expected code hash"
+          res.error() ==
+            "hash of bytecode doesn't match the code hash in the account proof"
 
   # Recursive gossip offer validation tests
 

--- a/fluffy/tests/state_network_tests/test_state_validation_trieproof.nim
+++ b/fluffy/tests/state_network_tests/test_state_validation_trieproof.nim
@@ -38,7 +38,7 @@ suite "MPT trie proof verification":
       let
         kv = getKeyBytes(i)
         proof = trie.getTrieProof(kv)
-        res = validateTrieProof(rootHash, kv.asNibbles(), proof)
+        res = validateTrieProof(rootHash, kv.asNibbles(), proof, true)
 
       check:
         res.isOk()
@@ -55,7 +55,7 @@ suite "MPT trie proof verification":
       rootHash = trie.rootHash()
       key = getKeyBytes(numValues + 1)
       proof = trie.getTrieProof(key)
-      res = validateTrieProof(rootHash, key.asNibbles(), proof)
+      res = validateTrieProof(rootHash, key.asNibbles(), proof, true)
 
     check:
       res.isErr()
@@ -68,7 +68,7 @@ suite "MPT trie proof verification":
       rootHash = trie.rootHash()
       key = "not-exist".toBytes
       proof = trie.getTrieProof(key)
-      res = validateTrieProof(rootHash, key.asNibbles(), proof)
+      res = validateTrieProof(rootHash, key.asNibbles(), proof, true)
 
     check:
       res.isErr()
@@ -83,7 +83,7 @@ suite "MPT trie proof verification":
     let
       rootHash = trie.rootHash
       proof = trie.getTrieProof(key)
-      res = validateTrieProof(rootHash, key.asNibbles(), proof)
+      res = validateTrieProof(rootHash, key.asNibbles(), proof, true)
 
     check:
       res.isOk()
@@ -101,25 +101,25 @@ suite "MPT trie proof verification":
       let
         key = "doe".toBytes
         proof = trie.getTrieProof(key)
-      check validateTrieProof(rootHash, key.asNibbles(), proof).isOk()
+      check validateTrieProof(rootHash, key.asNibbles(), proof, true).isOk()
 
     block:
       let
         key = "dog".toBytes
         proof = trie.getTrieProof(key)
-      check validateTrieProof(rootHash, key.asNibbles(), proof).isOk()
+      check validateTrieProof(rootHash, key.asNibbles(), proof, true).isOk()
 
     block:
       let
         key = "dogglesworth".toBytes
         proof = trie.getTrieProof(key)
-      check validateTrieProof(rootHash, key.asNibbles(), proof).isOk()
+      check validateTrieProof(rootHash, key.asNibbles(), proof, true).isOk()
 
     block:
       let
         key = "dogg".toBytes
         proof = trie.getTrieProof(key)
-        res = validateTrieProof(rootHash, key.asNibbles(), proof)
+        res = validateTrieProof(rootHash, key.asNibbles(), proof, true)
       check:
         res.isErr()
         res.error() == "not enough nibbles to validate node prefix"
@@ -128,7 +128,7 @@ suite "MPT trie proof verification":
       let
         key = "dogz".toBytes
         proof = trie.getTrieProof(key)
-        res = validateTrieProof(rootHash, key.asNibbles(), proof)
+        res = validateTrieProof(rootHash, key.asNibbles(), proof, true)
       check:
         res.isErr()
         res.error() == "path contains more nibbles than expected for proof"
@@ -137,7 +137,7 @@ suite "MPT trie proof verification":
       let
         key = "doe".toBytes
         proof = newSeq[seq[byte]]().asTrieProof()
-        res = validateTrieProof(rootHash, key.asNibbles(), proof)
+        res = validateTrieProof(rootHash, key.asNibbles(), proof, true)
       check:
         res.isErr()
         res.error() == "proof is empty"
@@ -146,7 +146,7 @@ suite "MPT trie proof verification":
       let
         key = "doe".toBytes
         proof = @["aaa".toBytes, "ccc".toBytes].asTrieProof()
-        res = validateTrieProof(rootHash, key.asNibbles(), proof)
+        res = validateTrieProof(rootHash, key.asNibbles(), proof, true)
       check:
         res.isErr()
         res.error() == "hash of proof root node doesn't match the expected root hash"
@@ -157,9 +157,9 @@ suite "MPT trie proof verification":
     let
       # leaf nodes
       kv1 = "0xa7113550".hexToSeqByte()
-      kv2 = "0xa77d3370".hexToSeqByte()
+      kv2 = "0xa77d33".hexToSeqByte() # without key end
       kv3 = "0xa7f93650".hexToSeqByte()
-      kv4 = "0xa77d3970".hexToSeqByte()
+      kv4 = "0xa77d39".hexToSeqByte() # without key end
 
       kv5 = "".hexToSeqByte() # root/first extension node
       kv6 = "0xa7".hexToSeqByte() # first branch node
@@ -174,6 +174,8 @@ suite "MPT trie proof verification":
       kv11 = "0xa71135".hexToSeqByte()
       kv12 = "0xa711355000".hexToSeqByte()
       kv13 = "0xa711".hexToSeqByte()
+      kv14 = "0xa77d3370".hexToSeqByte()
+      kv15 = "0xa77d3970".hexToSeqByte()
 
     trie.put(kv1, kv1)
     trie.put(kv2, kv2)
@@ -183,10 +185,10 @@ suite "MPT trie proof verification":
     let rootHash = trie.rootHash
 
     check:
-      validateTrieProof(rootHash, kv1.asNibbles(), trie.getTrieProof(kv1)).isOk()
-      validateTrieProof(rootHash, kv2.asNibbles(), trie.getTrieProof(kv2)).isOk()
-      validateTrieProof(rootHash, kv3.asNibbles(), trie.getTrieProof(kv3)).isOk()
-      validateTrieProof(rootHash, kv4.asNibbles(), trie.getTrieProof(kv4)).isOk()
+      validateTrieProof(rootHash, kv1.asNibbles(), trie.getTrieProof(kv1), true).isOk()
+      validateTrieProof(rootHash, kv2.asNibbles(), trie.getTrieProof(kv2), false).isOk()
+      validateTrieProof(rootHash, kv3.asNibbles(), trie.getTrieProof(kv3), true).isOk()
+      validateTrieProof(rootHash, kv4.asNibbles(), trie.getTrieProof(kv4), false).isOk()
       validateTrieProof(rootHash, kv5.asNibbles(), trie.getTrieProof(kv5)).isOk()
       validateTrieProof(rootHash, kv6.asNibbles(), trie.getTrieProof(kv6)).isOk()
       validateTrieProof(rootHash, kv7.asNibbles(), trie.getTrieProof(kv7)).isOk()
@@ -197,3 +199,7 @@ suite "MPT trie proof verification":
       validateTrieProof(rootHash, kv11.asNibbles(), trie.getTrieProof(kv11)).isErr()
       validateTrieProof(rootHash, kv12.asNibbles(), trie.getTrieProof(kv12)).isErr()
       validateTrieProof(rootHash, kv13.asNibbles(), trie.getTrieProof(kv13)).isErr()
+      validateTrieProof(rootHash, kv14.asNibbles(), trie.getTrieProof(kv14), false)
+      .isErr()
+      validateTrieProof(rootHash, kv15.asNibbles(), trie.getTrieProof(kv15), false)
+      .isErr()

--- a/fluffy/tests/state_network_tests/test_state_validation_trieproof.nim
+++ b/fluffy/tests/state_network_tests/test_state_validation_trieproof.nim
@@ -199,7 +199,9 @@ suite "MPT trie proof verification":
       validateTrieProof(rootHash, kv11.asNibbles(), trie.getTrieProof(kv11)).isErr()
       validateTrieProof(rootHash, kv12.asNibbles(), trie.getTrieProof(kv12)).isErr()
       validateTrieProof(rootHash, kv13.asNibbles(), trie.getTrieProof(kv13)).isErr()
+
       validateTrieProof(rootHash, kv14.asNibbles(), trie.getTrieProof(kv14), false)
       .isErr()
+
       validateTrieProof(rootHash, kv15.asNibbles(), trie.getTrieProof(kv15), false)
       .isErr()


### PR DESCRIPTION
Summary of changes:
- Implemented `getParent` helper functions to calculate the parent path and proof for recursive gossip.
- We now handle cases where multiple nibbles should be removed when calculating the parent path for recursive gossip.
- Fixed/re-implemented recursive gossip for account trie proof offers. 
- Implemented recursive gossip for contract trie proof offers.
- Now always gossip the received offer after validation.
- Some other minor refactors/cleanups.
- Moved some helper functions to state_utils.nim
- Implemented typed lookups for getting state network content: `getAccountTrieNode`, `getContractTrieNode` and `getContractCode`

Tests still in progress.