### PR TITLE
Disable t8n log output

### DIFF
--- a/tools/t8n/config.nims
+++ b/tools/t8n/config.nims
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -12,5 +12,8 @@ if defined(evmc_enabled):
   # evmcLoadVMShowDetail log output will intefere with t8n ouput
   switch("define", "chronicles_enabled=off")
 else:
-  switch("define", "chronicles_default_output_device=stderr")
-  switch("define", "chronicles_runtime_filtering=on")
+  switch("define", "chronicles_enabled=off")
+  # TODO: redirect the logs to a custom stream?
+  # They are interfering with t8n_test
+  #switch("define", "chronicles_default_output_device=stderr")
+  #switch("define", "chronicles_runtime_filtering=on")


### PR DESCRIPTION
It's a relief nothing serious with t8n regression. The EVM is still in a good condition after migration to new database.
Hopefully other regressions although looks scary, probably just superficial too.
