### PR TITLE
change an Aristo function name to avoid Nim stdlib ambiguity

### DIFF
--- a/nimbus/db/aristo/aristo_journal/journal_scheduler.nim
+++ b/nimbus/db/aristo/aristo_journal/journal_scheduler.nim
@@ -242,7 +242,7 @@ func fifoDel(
         # Delete all available
         return (@[(QueueID(1), fifo[1]), (fifo[0], wrap)], ZeroQidPair)
 
-func capacity(
+func volumeSize(
     ctx: openArray[tuple[size, width: int]];       # Schedule layout
       ): tuple[maxQueue: int, minCovered: int, maxCovered: int] =
   ## Number of maximally stored and covered queued entries for the argument
@@ -262,20 +262,20 @@ func capacity(
 # Public functions
 # ------------------------------------------------------------------------------
 
-func capacity*(
+func volumeSize*(
     ctx: openArray[tuple[size, width, wrap: int]]; # Schedule layout
       ): tuple[maxQueue: int, minCovered: int, maxCovered: int] =
-  ## Variant of `capacity()`.
-  ctx.toSeq.mapIt((it[0],it[1])).capacity
+  ## Variant of `volumeSize()`.
+  ctx.toSeq.mapIt((it[0],it[1])).volumeSize
 
-func capacity*(
+func volumeSize*(
     journal: QidSchedRef;                          # Cascaded fifos descriptor
       ): tuple[maxQueue: int, minCovered: int, maxCovered: int] =
   ## Number of maximally stored and covered queued entries for the layout of
   ## argument `journal`. The resulting value of `maxQueue` entry is the maximal
   ## number of database slots needed, the `minCovered` and `maxCovered` entry
   ## indicate the rancge of the backlog foa a fully populated database.
-  journal.ctx.q.toSeq.mapIt((it[0].int,it[1].int)).capacity()
+  journal.ctx.q.toSeq.mapIt((it[0].int,it[1].int)).volumeSize()
 
 
 func addItem*(

--- a/tests/test_aristo/test_helpers.nim
+++ b/tests/test_aristo/test_helpers.nim
@@ -36,7 +36,7 @@ const
     [(2,0,high int),(1,1,high int),(1,1,high int),(1,1,high int)],
   ]
 
-  LyoSamples* = samples.mapIt((it, (3 * it.capacity.minCovered) div 2))
+  LyoSamples* = samples.mapIt((it, (3 * it.volumeSize.minCovered) div 2))
 
 # ------------------------------------------------------------------------------
 # Private helpers

--- a/tests/test_aristo/test_misc.nim
+++ b/tests/test_aristo/test_misc.nim
@@ -390,7 +390,7 @@ proc testQidScheduler*(
 
   if debug:
     noisy.say "***", "sampleSize=", sampleSize,
-      " ctx=", ctx, " stats=", scd.capacity()
+      " ctx=", ctx, " stats=", scd.volumeSize()
 
   for n in 1 .. sampleSize:
     let w = scd.addItem()


### PR DESCRIPTION
Minimal example:
```nim
func capacity(ctx: openArray[int]): float = discard
func a(): float = capacity(@[0])
```

This compiles in Nim 1.6 but not 2.0. The change here also avoids a Nim 2.0 porting issue.