### PR TITLE
fix import path; force refc memory management even with Nim 2.0+

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -107,6 +107,7 @@ if not defined(windows):
 --define:nimTypeNames
 --styleCheck:usages
 --styleCheck:hint
+--mm:refc
 
 switch("define", "withoutPCRE")
 

--- a/nimbus/db/era1_db/db_desc.nim
+++ b/nimbus/db/era1_db/db_desc.nim
@@ -15,7 +15,7 @@ import
   std/[os, parseutils, strutils, tables],
   results,
   eth/common/eth_types,
-  ../../fluffy/eth_data/era1
+  ../../../fluffy/eth_data/era1
 
 export results, eth_types
 

--- a/tests/test_pow.nim
+++ b/tests/test_pow.nim
@@ -13,7 +13,6 @@ import
   ./replay/[pp, gunzip],
   ../nimbus/core/[pow, pow/pow_cache],
   eth/common,
-  stew/endians2,
   unittest2
 
 const


### PR DESCRIPTION
This enables `make LOG_LEVEL=TRACE && make LOG_LEVEL=TRACE test` to run cleanly on the Nim `version-2-0` branch, in addition to 1.6.