### PR TITLE
Use --styleCheck:error for Fluffy + fixes

### DIFF
--- a/fluffy/network/beacon/beacon_light_client.nim
+++ b/fluffy/network/beacon/beacon_light_client.nim
@@ -36,7 +36,7 @@ type
     onFinalizedHeader*, onOptimisticHeader*: LightClientHeaderCallback
     trustedBlockRoot*: Option[Eth2Digest]
 
-func finalizedHeader*(lightClient: LightClient): ForkedLightClientHeader =
+func getFinalizedHeader*(lightClient: LightClient): ForkedLightClientHeader =
   withForkyStore(lightClient.store[]):
     when lcDataFork > LightClientDataFork.None:
       var header = ForkedLightClientHeader(kind: lcDataFork)
@@ -45,7 +45,7 @@ func finalizedHeader*(lightClient: LightClient): ForkedLightClientHeader =
     else:
       default(ForkedLightClientHeader)
 
-func optimisticHeader*(lightClient: LightClient): ForkedLightClientHeader =
+func getOptimisticHeader*(lightClient: LightClient): ForkedLightClientHeader =
   withForkyStore(lightClient.store[]):
     when lcDataFork > LightClientDataFork.None:
       var header = ForkedLightClientHeader(kind: lcDataFork)
@@ -82,11 +82,11 @@ proc new*(
 
   proc onFinalizedHeader() =
     if lightClient.onFinalizedHeader != nil:
-      lightClient.onFinalizedHeader(lightClient, lightClient.finalizedHeader)
+      lightClient.onFinalizedHeader(lightClient, lightClient.getFinalizedHeader)
 
   proc onOptimisticHeader() =
     if lightClient.onOptimisticHeader != nil:
-      lightClient.onOptimisticHeader(lightClient, lightClient.optimisticHeader)
+      lightClient.onOptimisticHeader(lightClient, lightClient.getOptimisticHeader)
 
   lightClient.processor = LightClientProcessor.new(
     dumpEnabled, dumpDirInvalid, dumpDirIncoming, cfg, genesis_validators_root,

--- a/fluffy/nim.cfg
+++ b/fluffy/nim.cfg
@@ -15,6 +15,6 @@
 -d:PREFER_BLST_SHA256=false
 
 --styleCheck:usages
---styleCheck:hint
+--styleCheck:error
 --hint[ConvFromXtoItselfNotNeeded]:off
 --hint[Processing]:off

--- a/fluffy/scripts/test_portal_testnet.nim
+++ b/fluffy/scripts/test_portal_testnet.nim
@@ -172,13 +172,14 @@ procSuite "Portal testnet tests":
     let clients = await connectToRpcServers(config)
 
     var nodeInfos: seq[NodeInfo]
+
     for client in clients:
-      let nodeInfo = await client.portal_state_nodeInfo()
+      let nodeInfo = await client.portal_stateNodeInfo()
       await client.close()
       nodeInfos.add(nodeInfo)
 
     for client in clients:
-      discard await client.portal_state_addEnrs(
+      discard await client.portal_stateAddEnrs(
         nodeInfos.map(
           proc(x: NodeInfo): Record =
             x.enr
@@ -187,7 +188,7 @@ procSuite "Portal testnet tests":
       await client.close()
 
     for client in clients:
-      let routingTableInfo = await client.portal_state_routingTableInfo()
+      let routingTableInfo = await client.portal_stateRoutingTableInfo()
       await client.close()
       var start: seq[NodeId]
       let nodes = foldl(routingTableInfo.buckets, a & b, start)
@@ -198,7 +199,7 @@ procSuite "Portal testnet tests":
     for client in clients:
       var enr: Record
       try:
-        enr = await client.portal_state_lookupEnr(randomNodeInfo.nodeId)
+        enr = await client.portal_stateLookupEnr(randomNodeInfo.nodeId)
       except CatchableError as e:
         echo e.msg
       # TODO: For state network this occasionally fails. It might be because the
@@ -214,12 +215,12 @@ procSuite "Portal testnet tests":
 
     var nodeInfos: seq[NodeInfo]
     for client in clients:
-      let nodeInfo = await client.portal_history_nodeInfo()
+      let nodeInfo = await client.portal_historyNodeInfo()
       await client.close()
       nodeInfos.add(nodeInfo)
 
     for client in clients:
-      discard await client.portal_history_addEnrs(
+      discard await client.portal_historyAddEnrs(
         nodeInfos.map(
           proc(x: NodeInfo): Record =
             x.enr
@@ -228,7 +229,7 @@ procSuite "Portal testnet tests":
       await client.close()
 
     for client in clients:
-      let routingTableInfo = await client.portal_history_routingTableInfo()
+      let routingTableInfo = await client.portal_historyRoutingTableInfo()
       await client.close()
       var start: seq[NodeId]
       let nodes = foldl(routingTableInfo.buckets, a & b, start)
@@ -238,7 +239,7 @@ procSuite "Portal testnet tests":
     let randomNodeInfo = sample(rng[], nodeInfos)
     for client in clients:
       var enr: Record
-      enr = await client.portal_history_lookupEnr(randomNodeInfo.nodeId)
+      enr = await client.portal_historyLookupEnr(randomNodeInfo.nodeId)
       await client.close()
       check enr == randomNodeInfo.enr
 
@@ -266,7 +267,7 @@ procSuite "Portal testnet tests":
     # require them for validation.
     for (content, contentKey) in blockHeadersWithProof:
       discard
-        (await clients[0].portal_history_gossip(content.toHex(), contentKey.toHex()))
+        (await clients[0].portal_historyGossip(content.toHex(), contentKey.toHex()))
 
     # This will fill the first node its db with blocks from the data file. Next,
     # this node wil offer all these blocks their headers one by one.

--- a/fluffy/tools/utp_testing/utp_test.nim
+++ b/fluffy/tools/utp_testing/utp_test.nim
@@ -62,14 +62,14 @@ procSuite "uTP network simulator tests":
 
   proc findServerConnection(
       connections: openArray[SKey], clientId: NodeId, clientConnectionId: uint16
-  ): Option[Skey] =
+  ): Option[SKey] =
     let conns: seq[SKey] = connections.filter(
-      (key: Skey) => key.id == (clientConnectionId + 1) and key.nodeId == clientId
+      (key: SKey) => key.id == (clientConnectionId + 1) and key.nodeId == clientId
     )
     if len(conns) == 0:
-      none[Skey]()
+      none[SKey]()
     else:
-      some[Skey](conns[0])
+      some[SKey](conns[0])
 
   proc setupTest(): Future[(RpcHttpClient, NodeInfo, RpcHttpClient, NodeInfo)] {.async.} =
     let client = newRpcHttpClient()

--- a/fluffy/tools/utp_testing/utp_test_app.nim
+++ b/fluffy/tools/utp_testing/utp_test_app.nim
@@ -63,8 +63,8 @@ proc installUtpHandlers(
       let nodeAddress = NodeAddress.init(node).unsafeGet()
       discard d.addNode(node)
       let connResult = await s.connectTo(nodeAddress)
-      if (connresult.isOk()):
-        let socket = connresult.get()
+      if (connResult.isOk()):
+        let socket = connResult.get()
         let sKey = socket.socketKey.toSKey()
         t[sKey] = socket
         return sKey


### PR DESCRIPTION
There seems to be a clash between the names of an object field and a proc here. As workaround names of the procs are changed.