### PR TITLE
fix Dencun fcU being always rejected as invalid; rm newPayload fork validation hack

### DIFF
--- a/nimbus/beacon/api_handler/api_forkchoice.nim
+++ b/nimbus/beacon/api_handler/api_forkchoice.nim
@@ -36,7 +36,7 @@ template validateVersion(attr, com, apiVersion) =
       if version < Version.V3:
         raise unsupportedFork("forkChoiceUpdated" & $apiVersion &
           " doesn't support payloadAttributes" & $version)
-      if version >= Version.V3:
+      if version > Version.V3:
         raise invalidAttr("forkChoiceUpdated" & $apiVersion &
           " doesn't support PayloadAttributes" & $version)
     elif com.isShanghaiOrLater(timestamp):

--- a/nimbus/beacon/api_handler/api_newpayload.nim
+++ b/nimbus/beacon/api_handler/api_newpayload.nim
@@ -59,12 +59,8 @@ template validateVersion(com, timestamp, version, apiVersion) =
         "payload must be ExecutionPayloadV2, got ExecutionPayload" & $version)
 
   elif version != Version.V1:
-    if com.syncReqRelaxV2:
-      trace "Relaxed mode, treating payload as V1"
-      discard
-    else:
-      raise invalidParams("if timestamp is earlier than Shanghai, " &
-        "payload must be ExecutionPayloadV1, got ExecutionPayload" & $version)
+    raise invalidParams("if timestamp is earlier than Shanghai, " &
+      "payload must be ExecutionPayloadV1, got ExecutionPayload" & $version)
 
   if apiVersion >= Version.V3:
     if version != apiVersion:

--- a/nimbus/sync/beacon.nim
+++ b/nimbus/sync/beacon.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -105,7 +105,7 @@ proc runMulti(buddy: BeaconBuddyRef) {.async.} =
 # Private helpers
 # ------------------------------------------------------------------------------
 
-proc updateBeaconHeaderCB(ctx: BeaconSyncRef): SyncReqNewHeadCB =
+func updateBeaconHeaderCB(ctx: BeaconSyncRef): SyncReqNewHeadCB =
   ## Update beacon header. This function is intended as a call back function
   ## for the RPC module.
   result = proc(h: BlockHeader) {.gcsafe, raises: [].} =
@@ -119,8 +119,6 @@ proc enableRpcMagic(ctx: BeaconSyncRef) =
   ## Helper for `setup()`: Enable external pivot update via RPC
   let com = ctx.ctx.chain.com
   com.syncReqNewHead = ctx.updateBeaconHeaderCB
-  # We need engine_newPayload to be strict
-  com.syncReqRelaxV2 = false
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/tests/test_txpool2.nim
+++ b/tests/test_txpool2.nim
@@ -9,7 +9,7 @@
 # according to those terms.
 
 import
-  std/[tables,  os],
+  std/tables,
   eth/[keys],
   stew/byteutils, results, unittest2,
   ../nimbus/db/ledger,
@@ -17,10 +17,9 @@ import
   ../nimbus/[config, transaction, constants],
   ../nimbus/core/tx_pool,
   ../nimbus/core/casper,
-  ../nimbus/core/executor,
   ../nimbus/common/common,
   ../nimbus/utils/utils,
-  ../nimbus/[vm_state, vm_types],
+  ../nimbus/vm_types,
   ./test_txpool/helpers,
   ./macro_assembler
 
@@ -58,7 +57,9 @@ proc privKey(keyHex: string): PrivateKey =
 
   kRes.get()
 
-proc makeTx(t: var TestEnv, recipient: EthAddress, amount: UInt256, payload: openArray[byte] = []): Transaction =
+func makeTx(
+    t: var TestEnv, recipient: EthAddress, amount: UInt256,
+    payload: openArray[byte] = []): Transaction =
   const
     gasLimit = 75000.GasInt
     gasPrice = 30.gwei
@@ -77,7 +78,8 @@ proc makeTx(t: var TestEnv, recipient: EthAddress, amount: UInt256, payload: ope
   inc t.nonce
   signTransaction(tx, t.vaultKey, t.chainId, eip155 = true)
 
-proc signTxWithNonce(t: TestEnv, tx: Transaction, nonce: AccountNonce): Transaction =
+func signTxWithNonce(
+    t: TestEnv, tx: Transaction, nonce: AccountNonce): Transaction =
   var tx = tx
   tx.nonce = nonce
   signTransaction(tx, t.vaultKey, t.chainId, eip155 = true)


### PR DESCRIPTION
This "relaxed mode" is incorrect, should not be necessary, and is only specified for V2 APIs anyway, so is outdated.

fcU was checking if either `version < Version.V3` or `version >= Version.V3` and erroring on either.

I don't totally understand why that code isn't just using `!=`, but this at least fixes the effectively off-by-one in the comparison.

The `test_txpool2` refactoring resulted in some unused imports producing compilation warnings, now fixed.