### PR TITLE
import: read from era files

### DIFF
--- a/hive_integration/nodocker/engine/engine_env.nim
+++ b/hive_integration/nodocker/engine/engine_env.nim
@@ -219,4 +219,4 @@ func version*(env: EngineEnv, time: uint64): Version =
   env.version(time.EthTime)
 
 proc setBlock*(env: EngineEnv, header: common.BlockHeader, body: common.BlockBody): bool =
-  env.chain.setBlock(header, body) == ValidationResult.OK
+  env.chain.setBlock(header, body).isOk()

--- a/hive_integration/nodocker/engine/engine_env.nim
+++ b/hive_integration/nodocker/engine/engine_env.nim
@@ -219,4 +219,4 @@ func version*(env: EngineEnv, time: uint64): Version =
   env.version(time.EthTime)
 
 proc setBlock*(env: EngineEnv, header: common.BlockHeader, body: common.BlockBody): bool =
-  env.chain.setBlock(header, body).isOk()
+  env.chain.setBlock(header, body) == ValidationResult.OK

--- a/hive_integration/nodocker/engine/node.nim
+++ b/hive_integration/nodocker/engine/node.nim
@@ -86,8 +86,7 @@ proc processBlock(
   ValidationResult.OK
 
 proc getVmState(c: ChainRef, header: BlockHeader):
-                 Result[BaseVMState, void]
-                  {.gcsafe, raises: [CatchableError].} =
+                 Result[BaseVMState, void] =
   if c.vmState.isNil.not:
     return ok(c.vmState)
 
@@ -96,6 +95,7 @@ proc getVmState(c: ChainRef, header: BlockHeader):
     debug "Cannot initialise VmState",
       number = header.blockNumber
     return err()
+
   return ok(vmState)
 
 # A stripped down version of persistBlocks without validation

--- a/nimbus/beacon/api_handler/api_newpayload.nim
+++ b/nimbus/beacon/api_handler/api_newpayload.nim
@@ -191,10 +191,10 @@ proc newPayload*(ben: BeaconEngineRef,
     hash = blockHash, number = header.blockNumber
   let body = blockBody(payload)
   let vres = ben.chain.insertBlockWithoutSetHead(header, body)
-  if vres != ValidationResult.OK:
+  if vres.isErr:
     ben.setInvalidAncestor(header, blockHash)
     let blockHash = latestValidHash(db, parent, ttd)
-    return invalidStatus(blockHash, "Failed to insert block")
+    return invalidStatus(blockHash, vres.error())
 
   # We've accepted a valid payload from the beacon client. Mark the local
   # chain transitions to notify other subsystems (e.g. downloader) of the

--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -374,7 +374,7 @@ proc initializeEmptyDb*(com: CommonRef)
     {.gcsafe, raises: [CatchableError].} =
   let kvt = com.db.kvt()
   if canonicalHeadHashKey().toOpenArray notin kvt:
-    trace "Writing genesis to DB"
+    info "Writing genesis to DB"
     doAssert(com.genesisHeader.blockNumber.isZero,
       "can't commit genesis block with number > 0")
     discard com.db.persistHeaderToDb(com.genesisHeader,

--- a/nimbus/core/chain/chain_desc.nim
+++ b/nimbus/core/chain/chain_desc.nim
@@ -41,16 +41,12 @@ type
       ## First block to when `extraValidation` will be applied (only
       ## effective if `extraValidation` is true.)
 
-    vmState: BaseVMState
-      ## If it's not nil, block validation will use this
-      ## If it's nil, a new vmState state will be created.
-
 # ------------------------------------------------------------------------------
 # Public constructors
 # ------------------------------------------------------------------------------
 
 proc newChain*(com: CommonRef,
-               extraValidation: bool, vmState = BaseVMState(nil)): ChainRef =
+               extraValidation: bool): ChainRef =
   ## Constructor for the `Chain` descriptor object.
   ## The argument `extraValidation` enables extra block
   ## chain validation if set `true`.
@@ -58,7 +54,6 @@ proc newChain*(com: CommonRef,
     com: com,
     validateBlock: true,
     extraValidation: extraValidation,
-    vmState: vmState,
   )
 
 func newChain*(com: CommonRef): ChainRef =

--- a/nimbus/nim.cfg
+++ b/nimbus/nim.cfg
@@ -1,5 +1,10 @@
--d:chronicles_line_numbers
+-d:"chronicles_runtime_filtering=on"
+-d:"chronicles_disable_thread_id"
+
+@if release:
+  -d:"chronicles_line_numbers:0"
+@end
+
 -d:"chronicles_sinks=textlines[file]"
 -d:"chronicles_runtime_filtering=on"
 -d:nimDebugDlOpen
-

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -22,8 +22,8 @@ import
   ./version,
   ./constants,
   ./nimbus_desc,
+  ./nimbus_import,
   ./core/eip4844,
-  ./core/block_import,
   ./db/core_db/persistent,
   ./sync/protocol,
   ./sync/handlers
@@ -35,14 +35,6 @@ when defined(evmc_enabled):
 ## * No IPv6 support
 ## * No multiple bind addresses support
 ## * No database support
-
-proc importBlocks(conf: NimbusConf, com: CommonRef) =
-  if string(conf.blocksFile).len > 0:
-    # success or not, we quit after importing blocks
-    if not importRlpBlock(string conf.blocksFile, com):
-      quit(QuitFailure)
-    else:
-      quit(QuitSuccess)
 
 proc basicServices(nimbus: NimbusNode,
                    conf: NimbusConf,
@@ -218,7 +210,7 @@ proc localServices(nimbus: NimbusNode, conf: NimbusConf,
     nimbus.metricsServer = res.get
     waitFor nimbus.metricsServer.start()
 
-proc start(nimbus: NimbusNode, conf: NimbusConf) =
+proc run(nimbus: NimbusNode, conf: NimbusConf) =
   ## logging
   setLogLevel(conf.logLevel)
   if conf.logFile.isSome:
@@ -241,26 +233,29 @@ proc start(nimbus: NimbusNode, conf: NimbusConf) =
     networkId = conf.networkId,
     params = conf.networkParams)
 
+  defer:
+    com.db.finish()
+
   com.initializeEmptyDb()
-
-  let protocols = conf.getProtocolFlags()
-
-  if conf.cmd != NimbusCmd.`import` and conf.trustedSetupFile.isSome:
-    let fileName = conf.trustedSetupFile.get()
-    let res = Kzg.loadTrustedSetup(fileName)
-    if res.isErr:
-      fatal "Cannot load Kzg trusted setup from file", msg=res.error
-      quit(QuitFailure)
-  else:
-    let res = loadKzgTrustedSetup()
-    if res.isErr:
-      fatal "Cannot load baked in Kzg trusted setup", msg=res.error
-      quit(QuitFailure)
 
   case conf.cmd
   of NimbusCmd.`import`:
     importBlocks(conf, com)
   else:
+    if conf.trustedSetupFile.isSome:
+      let fileName = conf.trustedSetupFile.get()
+      let res = Kzg.loadTrustedSetup(fileName)
+      if res.isErr:
+        fatal "Cannot load Kzg trusted setup from file", msg=res.error
+        quit(QuitFailure)
+    else:
+      let res = loadKzgTrustedSetup()
+      if res.isErr:
+        fatal "Cannot load baked in Kzg trusted setup", msg=res.error
+        quit(QuitFailure)
+
+    let protocols = conf.getProtocolFlags()
+
     basicServices(nimbus, conf, com)
     manageAccounts(nimbus, conf)
     setupP2P(nimbus, conf, com, protocols)
@@ -282,17 +277,16 @@ proc start(nimbus: NimbusNode, conf: NimbusConf) =
       # it might have been set to "Stopping" with Ctrl+C
       nimbus.state = NimbusState.Running
 
-proc process*(nimbus: NimbusNode, conf: NimbusConf) =
-  # Main event loop
-  while nimbus.state == NimbusState.Running:
-    try:
-      poll()
-    except CatchableError as e:
-      debug "Exception in poll()", exc = e.name, err = e.msg
-      discard e # silence warning when chronicles not activated
+    # Main event loop
+    while nimbus.state == NimbusState.Running:
+      try:
+        poll()
+      except CatchableError as e:
+        debug "Exception in poll()", exc = e.name, err = e.msg
+        discard e # silence warning when chronicles not activated
 
-  # Stop loop
-  waitFor nimbus.stop(conf)
+    # Stop loop
+    waitFor nimbus.stop(conf)
 
 when isMainModule:
   var nimbus = NimbusNode(state: NimbusState.Starting, ctx: newEthContext())
@@ -312,5 +306,4 @@ when isMainModule:
   ## Processing command line arguments
   let conf = makeConfig()
 
-  nimbus.start(conf)
-  nimbus.process(conf)
+  nimbus.run(conf)

--- a/nimbus/nimbus_import.nim
+++ b/nimbus/nimbus_import.nim
@@ -1,0 +1,117 @@
+# Nimbus
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  chronicles,
+  std/[monotimes, strformat, times],
+  stew/io2,
+  ./config,
+  ./common/common,
+  ./core/[block_import, chain],
+  ./db/era1_db,
+  beacon_chain/era_db
+
+var running {.volatile.} = true
+
+proc importBlocks*(conf: NimbusConf, com: CommonRef) =
+  # ## Ctrl+C handling
+  proc controlCHandler() {.noconv.} =
+    when defined(windows):
+      # workaround for https://github.com/nim-lang/Nim/issues/4057
+      setupForeignThreadGc()
+    running = false
+
+  setControlCHook(controlCHandler)
+
+  let
+    start = com.db.getLatestJournalBlockNumber().truncate(uint64) + 1
+    chain = com.newChain()
+
+  var
+    imported = 0'u64
+    gas = 0.u256
+    txs = 0
+    time0 = getMonoTime()
+  template blockNumber(): uint64 =
+    start + imported
+
+  if isDir(conf.era1Dir.string):
+    doAssert conf.networkId == MainNet, "Only mainnet era1 current supported"
+
+    const
+      # TODO the merge block number could be fetched from the era1 file instead,
+      #      specially if the accumulator is added to the chain metadata
+      lastEra1Block = 15537393
+
+    if start <= lastEra1Block:
+      notice "Importing era1 archive",
+        start, dataDir = conf.dataDir.string, era1Dir = conf.era1Dir.string
+      var
+        headers: seq[BlockHeader]
+        bodies: seq[BlockBody]
+
+      func f(value: float): string =
+        &"{value:4.3f}"
+
+      template process() =
+        let
+          time1 = getMonoTime()
+          statsRes = chain.persistBlocks(headers, bodies)
+        if statsRes.isErr():
+          error "Failed to persist blocks", error = statsRes.error
+          quit(QuitFailure)
+
+        txs += statsRes[].txs
+        gas += uint64 statsRes[].gas
+        let
+          time2 = getMonoTime()
+          diff1 = (time2 - time1).inNanoseconds().float / 1000000000
+          diff0 = (time2 - time0).inNanoseconds().float / 1000000000
+
+        # TODO generate csv with import statistics
+        info "Imported blocks",
+          blockNumber,
+          gas,
+          bps = f(headers.len.float / diff1),
+          tps = f(statsRes[].txs.float / diff1),
+          gps = f(statsRes[].gas.float / diff1),
+          avgBps = f(imported.float / diff0),
+          avgGps = f(txs.float / diff0),
+          avgGps = f(gas.truncate(uint64).float / diff0) # TODO fix truncate
+        headers.setLen(0)
+        bodies.setLen(0)
+
+      let db =
+        Era1DbRef.init(conf.era1Dir.string, "mainnet").expect("Era files present")
+      defer:
+        db.dispose()
+
+      while running and imported < conf.maxBlocks and blockNumber <= lastEra1Block:
+        var blk = db.getBlockTuple(blockNumber).valueOr:
+          error "Could not load block from era1", blockNumber, error
+          break
+
+        imported += 1
+
+        headers.add move(blk.header)
+        bodies.add move(blk.body)
+
+        if headers.lenu64 mod conf.chunkSize == 0:
+          process()
+
+      if headers.len > 0:
+        process() # last chunk, if any
+
+  for blocksFile in conf.blocksFile:
+    if isFile(string blocksFile):
+      # success or not, we quit after importing blocks
+      if not importRlpBlock(string blocksFile, com):
+        quit(QuitFailure)
+      else:
+        quit(QuitSuccess)

--- a/nimbus/sync/beacon/skeleton_db.nim
+++ b/nimbus/sync/beacon/skeleton_db.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at
 #     https://opensource.org/licenses/MIT).

--- a/nimbus/sync/beacon/skeleton_db.nim
+++ b/nimbus/sync/beacon/skeleton_db.nim
@@ -197,13 +197,8 @@ proc insertBlocks*(sk: SkeletonRef,
                    headers: openArray[BlockHeader],
                    body: openArray[BlockBody],
                    fromEngine: bool): Result[uint64, string] =
-  try:
-    let res = sk.chain.persistBlocks(headers, body)
-    if res != ValidationResult.OK:
-      return err("insertBlocks validation error")
-    ok(headers.len.uint64)
-  except CatchableError as ex:
-    err(ex.msg)
+  discard ? sk.chain.persistBlocks(headers, body)
+  ok(headers.len.uint64)
 
 proc insertBlock*(sk: SkeletonRef,
                   header: BlockHeader,

--- a/nimbus/sync/full/worker.nim
+++ b/nimbus/sync/full/worker.nim
@@ -122,7 +122,7 @@ proc processStaged(buddy: FullBuddyRef): bool =
 
   # Store in persistent database
   try:
-    if chain.persistBlocks(wi.headers, wi.bodies) == ValidationResult.OK:
+    if chain.persistBlocks(wi.headers, wi.bodies).isOk():
       bq.blockQueueAccept(wi)
       return true
   except CatchableError as e:

--- a/premix/persist.nim
+++ b/premix/persist.nim
@@ -104,8 +104,8 @@ proc main() {.used.} =
 
     if numBlocks == numBlocksToCommit:
       persistToDb(com.db):
-        if chain.persistBlocks(headers, bodies) != ValidationResult.OK:
-          raise newException(ValidationError, "Error when validating blocks")
+        if chain.persistBlocks(headers, bodies).isErrOr:
+          raise newException(ValidationError, "Error when validating blocks: " & error)
       numBlocks = 0
       headers.setLen(0)
       bodies.setLen(0)
@@ -116,8 +116,8 @@ proc main() {.used.} =
 
   if numBlocks > 0:
     persistToDb(com.db):
-      if chain.persistBlocks(headers, bodies) != ValidationResult.OK:
-        raise newException(ValidationError, "Error when validating blocks")
+      if chain.persistBlocks(headers, bodies).isErrOr:
+        raise newException(ValidationError, "Error when validating blocks: " & error)
 
 when isMainModule:
   var message: string

--- a/premix/persist.nim
+++ b/premix/persist.nim
@@ -82,7 +82,6 @@ proc main() {.used.} =
   var retryCount = 0
 
   while true:
-
     var thisBlock: Block
     try:
       thisBlock = requestBlock(blockNumber, { DownloadAndValidate })
@@ -104,8 +103,9 @@ proc main() {.used.} =
 
     if numBlocks == numBlocksToCommit:
       persistToDb(com.db):
-        if chain.persistBlocks(headers, bodies).isErrOr:
-          raise newException(ValidationError, "Error when validating blocks: " & error)
+        let res = chain.persistBlocks(headers, bodies)
+        res.isOkOr:
+          raise newException(ValidationError, "Error when validating blocks: " & res.error)
       numBlocks = 0
       headers.setLen(0)
       bodies.setLen(0)
@@ -116,8 +116,9 @@ proc main() {.used.} =
 
   if numBlocks > 0:
     persistToDb(com.db):
-      if chain.persistBlocks(headers, bodies).isErrOr:
-        raise newException(ValidationError, "Error when validating blocks: " & error)
+      let res = chain.persistBlocks(headers, bodies)
+      res.isOkOr:
+        raise newException(ValidationError, "Error when validating blocks: " & res.error)
 
 when isMainModule:
   var message: string

--- a/scripts/check_copyright_year.sh
+++ b/scripts/check_copyright_year.sh
@@ -8,7 +8,7 @@
 # according to those terms.
 
 excluded_files="config.yaml|.gitmodules"
-excluded_extensions="json|md|png|txt|toml|gz|key|rlp|era1"
+excluded_extensions="json|md|png|txt|toml|gz|key|rlp|era1|cfg"
 
 current_year=$(date +"%Y")
 outdated_files=()

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -9,7 +9,9 @@
 # according to those terms.
 
 -d:chronicles_line_numbers
--d:"chronicles_sinks=textblocks"
+-d:"chronicles_sinks=textlines"
 # comment this out, to run the tests in a serial manner:
 #-d:nimtestParallel
 
+-d:"chronicles_disable_thread_id"
+-d:"chronicles_runtime_filtering=on"

--- a/tests/test_accounts_cache.nim
+++ b/tests/test_accounts_cache.nim
@@ -86,7 +86,7 @@ when false:
     discard
     when defined(chronicles_runtime_filtering) and loggingEnabled:
       setLogLevel(LogLevel.TRACE)
-  
+
   proc setErrorLevel =
     discard
     when defined(chronicles_runtime_filtering) and loggingEnabled:
@@ -104,7 +104,7 @@ proc blockChainForTesting*(network: NetworkId): CommonRef =
   initializeEmptyDb(result)
 
 proc importBlocks(com: CommonRef; h: seq[BlockHeader]; b: seq[BlockBody]) =
-  if com.newChain.persistBlocks(h,b) != ValidationResult.OK:
+  if com.newChain.persistBlocks(h,b).isErr:
     raiseAssert "persistBlocks() failed at block #" & $h[0].blockNumber
 
 proc getVmState(com: CommonRef; number: BlockNumber): BaseVMState =

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -261,8 +261,8 @@ proc importBlock(ctx: var TestCtx, com: CommonRef,
     chain = newChain(com, extraValidation = true, ctx.vmState)
     res = chain.persistBlocks([tb.header], [tb.body])
 
-  if res == ValidationResult.Error:
-    raise newException(ValidationError, "persistBlocks validation")
+  if res.isErr()
+    raise newException(ValidationError, res.error())
   else:
     blockWitness(chain.vmState, com.db)
     testGetBlockWitness(chain, chain.vmState.parent, tb.header)

--- a/tests/test_configuration.nim
+++ b/tests/test_configuration.nim
@@ -52,7 +52,7 @@ proc configurationMain*() =
 
       let bb = makeConfig(@["import", genesisFile])
       check bb.cmd == NimbusCmd.`import`
-      check bb.blocksFile.string == genesisFile
+      check bb.blocksFile[0].string == genesisFile
 
     test "custom-network loading config file with no genesis data":
       # no genesis will fallback to geth compatibility mode

--- a/tests/test_coredb/test_chainsync.nim
+++ b/tests/test_coredb/test_chainsync.nim
@@ -234,7 +234,7 @@ proc test_chainSync*(
 
       noisy.stopLoggingAfter():
         let runPersistBlocksRc = chain.persistBlocks(w[0], w[1])
-        xCheck runPersistBlocksRc == ValidationResult.OK:
+        xCheck runPersistBlocksRc.isOk():
           if noisy:
             noisy.whisper "***", "Re-run with logging enabled...\n"
             setTraceLevel()
@@ -269,7 +269,7 @@ proc test_chainSync*(
         noisy.whisper "***",
            &"processing {dotsOrSpace}[#{fromBlock:>8},#{(lastBlock-1):>8}]"
       let runPersistBlocks1Rc = chain.persistBlocks(headers1, bodies1)
-      xCheck runPersistBlocks1Rc == ValidationResult.OK
+      xCheck runPersistBlocks1Rc.isOk()
       dotsOrSpace = "   "
 
     noisy.startLogging(headers9[0].blockNumber)
@@ -286,7 +286,7 @@ proc test_chainSync*(
           &"processing {dotsOrSpace}[#{lastBlock:>8},#{lastBlock:>8}]"
       noisy.stopLoggingAfter():
         let runPersistBlocks0Rc = chain.persistBlocks(headers0, bodies0)
-        xCheck runPersistBlocks0Rc == ValidationResult.OK
+        xCheck runPersistBlocks0Rc.isOk()
     else:
       if oldLogAlign:
         noisy.whisper "***",
@@ -297,7 +297,7 @@ proc test_chainSync*(
           &"processing {dotsOrSpace}[#{lastBlock:>8},#{toBlock:>8}]"
       noisy.stopLoggingAfter():
         let runPersistBlocks9Rc = chain.persistBlocks(headers9, bodies9)
-        xCheck runPersistBlocks9Rc == ValidationResult.OK
+        xCheck runPersistBlocks9Rc.isOk()
     break
   if not oldLogAlign:
     sayPerf

--- a/tests/test_graphql.nim
+++ b/tests/test_graphql.nim
@@ -88,7 +88,7 @@ proc setupChain(): CommonRef =
 
   let chain = newChain(com)
   let res = chain.persistBlocks(headers, bodies)
-  assert(res == ValidationResult.OK)
+  assert res.isOk(), res.error()
 
   com
 

--- a/tests/test_persistblock_json.nim
+++ b/tests/test_persistblock_json.nim
@@ -40,7 +40,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus) =
   # it's ok if setHead fails here because of missing ancestors
   discard com.db.setHead(parent, true)
   let validationResult = chain.persistBlocks(headers, bodies)
-  check validationResult == ValidationResult.OK
+  check validationResult.isOk()
 
 proc persistBlockJsonMain*() =
   suite "persist block json tests":

--- a/tests/test_persistblock_witness_json.nim
+++ b/tests/test_persistblock_witness_json.nim
@@ -43,7 +43,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus) =
   # it's ok if setHead fails here because of missing ancestors
   discard com.db.setHead(parent, true)
   let validationResult = chain.persistBlocks(headers, bodies)
-  check validationResult == ValidationResult.OK
+  check validationResult.isOk()
 
   let
     blockHash = memoryDB.getBlockHash(blockNumber)

--- a/tests/test_rocksdb_timing/test_db_timing.nim
+++ b/tests/test_rocksdb_timing/test_db_timing.nim
@@ -123,7 +123,7 @@ proc test_dbTimingUndumpBlocks*(
     # Message if [fromBlock,toBlock] contains a multiple of 700
     if fromBlock + (toBlock mod 900) <= toBlock:
       loadNoise.say "***", &"processing ...[#{fromBlock},#{toBlock}]..."
-    check chain.persistBlocks(w[0], w[1]) == ValidationResult.OK
+    check chain.persistBlocks(w[0], w[1]).isOk()
     if numBlocks.toBlockNumber <= w[0][^1].blockNumber:
       break
 

--- a/tests/test_rpc_experimental_json.nim
+++ b/tests/test_rpc_experimental_json.nim
@@ -52,7 +52,7 @@ proc importBlockData(node: JsonNode): (CommonRef, Hash256, Hash256, UInt256) {. 
   # it's ok if setHead fails here because of missing ancestors
   discard com.db.setHead(parent, true)
   let validationResult = chain.persistBlocks(headers, bodies)
-  doAssert validationResult == ValidationResult.OK
+  doAssert validationResult.isOk()
 
   return (com, parent.stateRoot, header.stateRoot, blockNumber)
 

--- a/tests/test_txpool/setup.nim
+++ b/tests/test_txpool/setup.nim
@@ -31,7 +31,7 @@ proc setStatus(xp: TxPoolRef; item: TxItemRef; status: TxItemStatus)
     discard xp.txDB.reassign(item, status)
 
 proc importBlocks(c: ChainRef; h: seq[BlockHeader]; b: seq[BlockBody]): int =
-  if c.persistBlocks(h,b) != ValidationResult.OK:
+  if c.persistBlocks(h,b).isErr():
     raiseAssert "persistBlocks() failed at block #" & $h[0].blockNumber
   for body in b:
     result += body.transactions.len

--- a/tests/test_txpool2.nim
+++ b/tests/test_txpool2.nim
@@ -171,7 +171,7 @@ proc runTxPoolPosTest() =
 
     test "PoS persistBlocks":
       let rr = chain.persistBlocks([blk.header], [body])
-      check rr == ValidationResult.OK
+      check rr.isOk()
 
     test "validate TxPool prevRandao setter":
       var sdb = LedgerRef.init(com.db, blk.header.stateRoot)
@@ -234,7 +234,7 @@ proc runTxPoolBlobhashTest() =
 
     test "Blobhash persistBlocks":
       let rr = chain.persistBlocks([blk.header], [body])
-      check rr == ValidationResult.OK
+      check rr.isOk()
 
     test "validate TxPool prevRandao setter":
       var sdb = LedgerRef.init(com.db, blk.header.stateRoot)


### PR DESCRIPTION
This PR extends the `nimbus import` command to also allow reading from era files - this command allows creating or topping up an existing database with data coming from era files instead of network sync.

* add `--era1-dir` and `--max-blocks` options to command line
* make `persistBlocks` report basic stats like transactions and gas
* improve error reporting in several API
* allow importing multiple RLP files in one go
* clean up logging options to match nimbus-eth2
* make sure database is closed properly on shutdown