### PR TITLE
Add test vector to evmstate

### DIFF
--- a/tools/evmstate/testdata/00094809-mixed-5.json
+++ b/tools/evmstate/testdata/00094809-mixed-5.json
@@ -1,0 +1,60 @@
+{
+  "00094809-mixed-5": {
+    "env": {
+      "currentCoinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "currentDifficulty": "0x200000",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000200000",
+      "currentGasLimit": "0x26e1f476fe1e22",
+      "currentNumber": "0x1",
+      "currentTimestamp": "0x3e8",
+      "previousHash": "0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
+      "currentBaseFee": "0x10"
+    },
+    "pre": {
+      "0x00000000000000000000000000000000000000f1": {
+        "code": "0x7c076295866ff4036c9b107f60026000556001545060016002556003545060095450600260025560006000556000527f60016000557f7f60",
+        "storage": {
+          "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000008"
+        },
+        "balance": "0x0",
+        "nonce": "0x0"
+      },
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "code": "0x",
+        "storage": {},
+        "balance": "0xffffffffff",
+        "nonce": "0x0"
+      }
+    },
+    "transaction": {
+      "gasPrice": "0x10",
+      "nonce": "0x0",
+      "to": "0x00000000000000000000000000000000000000f1",
+      "data": [
+        "0x1cf2af2f3707a3c842e804ffbb6a636a14c75a3b3af7a2ed0d0f8eafbefa3b1dd847338705e2ff4b6f7d1210dbc54c8cd372d4239de86e40838977e6a3ce2eb989a8e5631803b2db3a4d"
+      ],
+      "gasLimit": [
+        "0x14886"
+      ],
+      "value": [
+        "0x"
+      ],
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+    },
+    "out": "0x",
+    "post": {
+      "Merge": [
+        {
+          "hash": "0xa9829e736e05cf41decddb295e03817b43fc066f50efc363e424d5c7fd599789",
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The bug already fixed by #2251.

This PR only add a new test vector to evmstate.
Fix #2228