### PR TITLE
disable vid reuse compaction

### DIFF
--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -300,7 +300,7 @@ proc delSubTreeImpl(
     db.layersPutVtx(VertexID(1), wp.vid, leaf)
     db.layersResKey(VertexID(1), wp.vid)
 
-  # Squeze list of recycled vertex IDs
+  # Squeeze list of recycled vertex IDs
   # TODO this causes a reallocation of vGen which slows down subsequent
   #      additions to the list because the sequence must grow which entails a
   #      full copy in addition to this reorg itself - around block 2.5M this
@@ -397,7 +397,7 @@ proc deleteImpl(
     db.layersPutVtx(VertexID(1), wp.vid, leaf)
     db.layersResKey(VertexID(1), wp.vid)
 
-  # Squeze list of recycled vertex IDs
+  # Squeeze list of recycled vertex IDs
   # TODO this causes a reallocation of vGen which slows down subsequent
   #      additions to the list because the sequence must grow which entails a
   #      full copy in addition to this reorg itself - around block 2.5M this

--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -301,7 +301,11 @@ proc delSubTreeImpl(
     db.layersResKey(VertexID(1), wp.vid)
 
   # Squeze list of recycled vertex IDs
-  db.top.final.vGen = db.vGen.vidReorg()
+  # TODO this causes a reallocation of vGen which slows down subsequent
+  #      additions to the list because the sequence must grow which entails a
+  #      full copy in addition to this reorg itself - around block 2.5M this
+  #      causes significant slowdown as the vid list is >1M entries long
+  # db.top.final.vGen = db.vGen.vidReorg()
   ok()
 
 
@@ -394,7 +398,11 @@ proc deleteImpl(
     db.layersResKey(VertexID(1), wp.vid)
 
   # Squeze list of recycled vertex IDs
-  db.top.final.vGen = db.vGen.vidReorg()
+  # TODO this causes a reallocation of vGen which slows down subsequent
+  #      additions to the list because the sequence must grow which entails a
+  #      full copy in addition to this reorg itself - around block 2.5M this
+  #      causes significant slowdown as the vid list is >1M entries long
+  # db.top.final.vGen = db.vGen.vidReorg()
   ok(emptySubTreeOk)
 
 # ------------------------------------------------------------------------------

--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -305,6 +305,7 @@ proc delSubTreeImpl(
   #      additions to the list because the sequence must grow which entails a
   #      full copy in addition to this reorg itself - around block 2.5M this
   #      causes significant slowdown as the vid list is >1M entries long
+  #      See also EIP-161 which is why there are so many deletions
   # db.top.final.vGen = db.vGen.vidReorg()
   ok()
 
@@ -402,6 +403,7 @@ proc deleteImpl(
   #      additions to the list because the sequence must grow which entails a
   #      full copy in addition to this reorg itself - around block 2.5M this
   #      causes significant slowdown as the vid list is >1M entries long
+  #      See also EIP-161 which is why there are so many deletions```
   # db.top.final.vGen = db.vGen.vidReorg()
   ok(emptySubTreeOk)
 


### PR DESCRIPTION
The current implementation cannot be used practically since it causes several full reallocations of the whole free list per deletion - it needs to be reimplemented, or the chain cannot practically progress beyond ~2.5M blocks where a lot of removals happen.
