### PR TITLE
append instead of reallocate in blobify

### DIFF
--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_walk.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_walk.nim
@@ -88,7 +88,7 @@ iterator walk*(
 
         let val = rit.value()
         if val.len != 0:
-          yield (uint64.fromBytesBE key[1..^1], val)
+          yield (uint64.fromBytesBE key.toOpenArray(1, key.high()), val)
 
       # Update Iterator
       rit.next()


### PR DESCRIPTION
...otherwise, we get lots and lots of temporary allocations of seq's