### PR TITLE
Speed up account ledger a little

### DIFF
--- a/hive_integration/nodocker/engine/node.nim
+++ b/hive_integration/nodocker/engine/node.nim
@@ -74,7 +74,7 @@ proc processBlock(
 
   vmState.mutateStateDB:
     let clearEmptyAccount = vmState.determineFork >= FkSpurious
-    db.persist(clearEmptyAccount, ClearCache in vmState.flags)
+    db.persist(clearEmptyAccount)
 
   # `applyDeletes = false`
   # If the trie pruning activated, each of the block will have its own state

--- a/nimbus/core/executor/process_block.nim
+++ b/nimbus/core/executor/process_block.nim
@@ -117,8 +117,8 @@ proc procBlkEpilogue(vmState: BaseVMState;
   vmState.mutateStateDB:
     if vmState.generateWitness:
       db.collectWitnessData()
-    let clearEmptyAccount = vmState.determineFork >= FkSpurious
-    db.persist(clearEmptyAccount, ClearCache in vmState.flags)
+
+    db.persist(clearEmptyAccount = vmState.determineFork >= FkSpurious)
 
   let stateDb = vmState.stateDB
   if header.stateRoot != stateDb.rootHash:

--- a/nimbus/core/executor/process_transaction.nim
+++ b/nimbus/core/executor/process_transaction.nim
@@ -118,9 +118,7 @@ proc processTransactionImpl(
 
   if vmState.generateWitness:
     vmState.stateDB.collectWitnessData()
-  vmState.stateDB.persist(
-    clearEmptyAccount = fork >= FkSpurious,
-    clearCache = false)
+  vmState.stateDB.persist(clearEmptyAccount = fork >= FkSpurious)
 
   return res
 
@@ -157,7 +155,7 @@ proc processBeaconBlockRoot*(vmState: BaseVMState, beaconRoot: Hash256):
   if res.isError:
     return err("processBeaconBlockRoot: " & res.error)
 
-  statedb.persist(clearEmptyAccount = true, clearCache = false)
+  statedb.persist(clearEmptyAccount = true)
   ok()
 
 proc processTransaction*(

--- a/nimbus/core/tx_pool/tx_tasks/tx_packer.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_packer.nim
@@ -71,9 +71,7 @@ proc persist(pst: TxPackerStateRef)
   ## Smart wrapper
   if not pst.cleanState:
     let fork = pst.xp.chain.nextFork
-    pst.xp.chain.vmState.stateDB.persist(
-      clearEmptyAccount = fork >= FkSpurious,
-      clearCache = false)
+    pst.xp.chain.vmState.stateDB.persist(clearEmptyAccount = fork >= FkSpurious)
     pst.cleanState = true
 
 # ------------------------------------------------------------------------------
@@ -227,9 +225,7 @@ proc vmExecGrabItem(pst: TxPackerStateRef; item: TxItemRef): Result[bool,void]
   # Commit account state DB
   vmState.stateDB.commit(accTx)
 
-  vmState.stateDB.persist(
-    clearEmptyAccount = xp.chain.nextFork >= FkSpurious,
-    clearCache = false)
+  vmState.stateDB.persist(clearEmptyAccount = xp.chain.nextFork >= FkSpurious)
   # let midRoot = vmState.stateDB.rootHash -- notused
 
   # Finish book-keeping and move item to `packed` bucket
@@ -254,9 +250,7 @@ proc vmExecCommit(pst: TxPackerStateRef)
     if vmState.generateWitness:
       db.collectWitnessData()
     # Finish up, then vmState.stateDB.rootHash may be accessed
-    db.persist(
-      clearEmptyAccount = xp.chain.nextFork >= FkSpurious,
-      clearCache = ClearCache in vmState.flags)
+    db.persist(clearEmptyAccount = xp.chain.nextFork >= FkSpurious)
 
   # Update flexi-array, set proper length
   let nItems = xp.txDB.byStatus.eq(txItemPacked).nItems

--- a/nimbus/core/validate.nim
+++ b/nimbus/core/validate.nim
@@ -354,7 +354,7 @@ proc validateTransaction*(
     # `eth_call` and `eth_estimateGas`
     # EOA = Externally Owned Account
     let codeHash = roDB.getCodeHash(sender)
-    if codeHash != EMPTY_SHA3:
+    if codeHash != EMPTY_CODE_HASH:
       return err("invalid tx: sender is not an EOA. sender=$1, codeHash=$2" % [
         sender.toHex, codeHash.data.toHex])
 

--- a/nimbus/db/ledger/base.nim
+++ b/nimbus/db/ledger/base.nim
@@ -268,10 +268,10 @@ proc makeMultiKeys*(ldg: LedgerRef): MultiKeysRef =
   result = ldg.ac.makeMultiKeys()
   ldg.ifTrackApi: debug apiTxt, api, elapsed
 
-proc persist*(ldg: LedgerRef, clearEmptyAccount = false, clearCache = true) =
+proc persist*(ldg: LedgerRef, clearEmptyAccount = false) =
   ldg.beginTrackApi LdgPersistFn
-  ldg.ac.persist(clearEmptyAccount, clearCache)
-  ldg.ifTrackApi: debug apiTxt, api, elapsed, clearEmptyAccount, clearCache
+  ldg.ac.persist(clearEmptyAccount)
+  ldg.ifTrackApi: debug apiTxt, api, elapsed, clearEmptyAccount
 
 proc ripemdSpecial*(ldg: LedgerRef) =
   ldg.beginTrackApi LdgRipemdSpecialFn

--- a/nimbus/db/state_db/base.nim
+++ b/nimbus/db/state_db/base.nim
@@ -223,7 +223,7 @@ proc getCode*(db: AccountStateDB, address: EthAddress): seq[byte] =
 
 proc contractCollision*(db: AccountStateDB, address: EthAddress): bool {.inline.} =
   db.getNonce(address) != 0 or
-    db.getCodeHash(address) != EMPTY_SHA3 or
+    db.getCodeHash(address) != EMPTY_CODE_HASH or
       db.getStorageRoot(address) != EMPTY_ROOT_HASH
 
 proc dumpAccount*(db: AccountStateDB, addressS: string): string =
@@ -238,19 +238,19 @@ proc isEmptyAccount*(db: AccountStateDB, address: EthAddress): bool =
   assert(recordFound.len > 0)
 
   let account = rlp.decode(recordFound, Account)
-  result = account.codeHash == EMPTY_SHA3 and
+  account.nonce == 0 and
     account.balance.isZero and
-    account.nonce == 0
+    account.codeHash == EMPTY_CODE_HASH
 
 proc isDeadAccount*(db: AccountStateDB, address: EthAddress): bool =
   let recordFound = db.trie.getAccountBytes(address)
   if recordFound.len > 0:
     let account = rlp.decode(recordFound, Account)
-    result = account.codeHash == EMPTY_SHA3 and
+    account.nonce == 0 and
       account.balance.isZero and
-      account.nonce == 0
+      account.codeHash == EMPTY_CODE_HASH
   else:
-    result = true
+    true
 
 proc removeEmptyRlpNode(branch: var seq[MptNodeRlpBytes]) =
   if branch.len() == 1 and branch[0] == emptyRlp:

--- a/nimbus/evm/types.nim
+++ b/nimbus/evm/types.nim
@@ -39,7 +39,6 @@ type
   VMFlag* = enum
     ExecutionOK
     GenerateWitness
-    ClearCache
 
   BlockContext* = object
     timestamp*        : EthTime

--- a/nimbus/sync/protocol/snap/snap_types.nim
+++ b/nimbus/sync/protocol/snap/snap_types.nim
@@ -99,12 +99,12 @@ proc snapRead*(
   if rlp.blobLen != 0 or not rlp.isBlob:
     result.codeHash = rlp.read(typeof(result.codeHash))
     when strict:
-      if result.codeHash == EMPTY_SHA3:
+      if result.codeHash == EMPTY_CODE_HASH:
         raise newException(RlpTypeMismatch,
           "EMPTY_SHA3 not encoded as empty string in Snap protocol")
   else:
     rlp.skipElem()
-    result.codeHash = EMPTY_SHA3
+    result.codeHash = EMPTY_CODE_HASH
 
 proc snapAppend*(
     writer: var RlpWriter;
@@ -121,7 +121,7 @@ proc snapAppend*(
     writer.append("")
   else:
     writer.append(account.storageRoot)
-  if account.codeHash == EMPTY_SHA3:
+  if account.codeHash == EMPTY_CODE_HASH:
     writer.append("")
   else:
     writer.append(account.codeHash)

--- a/tests/test_accounts_cache.nim
+++ b/tests/test_accounts_cache.nim
@@ -135,7 +135,7 @@ proc runTrial2ok(vmState: BaseVMState; inx: int) =
     vmState.stateDB.modBalance(eAddr)
     vmState.stateDB.commit(accTx)
 
-  vmState.stateDB.persist(clearCache = false)
+  vmState.stateDB.persist()
 
 
 proc runTrial3(vmState: BaseVMState; inx: int; rollback: bool) =
@@ -146,7 +146,7 @@ proc runTrial3(vmState: BaseVMState; inx: int; rollback: bool) =
     let accTx = vmState.stateDB.beginSavepoint
     vmState.stateDB.modBalance(eAddr)
     vmState.stateDB.commit(accTx)
-    vmState.stateDB.persist(clearCache = false)
+    vmState.stateDB.persist()
 
   block:
     let accTx = vmState.stateDB.beginSavepoint
@@ -157,13 +157,13 @@ proc runTrial3(vmState: BaseVMState; inx: int; rollback: bool) =
       break
 
     vmState.stateDB.commit(accTx)
-    vmState.stateDB.persist(clearCache = false)
+    vmState.stateDB.persist()
 
   block:
     let accTx = vmState.stateDB.beginSavepoint
     vmState.stateDB.modBalance(eAddr)
     vmState.stateDB.commit(accTx)
-    vmState.stateDB.persist(clearCache = false)
+    vmState.stateDB.persist()
 
 
 proc runTrial3crash(vmState: BaseVMState; inx: int; noisy = false) =
@@ -177,7 +177,7 @@ proc runTrial3crash(vmState: BaseVMState; inx: int; noisy = false) =
       let accTx = vmState.stateDB.beginSavepoint
       vmState.stateDB.modBalance(eAddr)
       vmState.stateDB.commit(accTx)
-      vmState.stateDB.persist(clearCache = false)
+      vmState.stateDB.persist()
 
     block:
       let accTx = vmState.stateDB.beginSavepoint
@@ -216,7 +216,7 @@ proc runTrial3crash(vmState: BaseVMState; inx: int; noisy = false) =
       vmState.stateDB.commit(accTx)
 
       try:
-        vmState.stateDB.persist(clearCache = false)
+        vmState.stateDB.persist()
       except AssertionDefect as e:
         if noisy:
           let msg = e.msg.rsplit($DirSep,1)[^1]
@@ -224,7 +224,7 @@ proc runTrial3crash(vmState: BaseVMState; inx: int; noisy = false) =
         dbTx.dispose()
         raise e
 
-      vmState.stateDB.persist(clearCache = false)
+      vmState.stateDB.persist()
 
     dbTx.commit()
 
@@ -240,13 +240,13 @@ proc runTrial4(vmState: BaseVMState; inx: int; rollback: bool) =
       let accTx = vmState.stateDB.beginSavepoint
       vmState.stateDB.modBalance(eAddr)
       vmState.stateDB.commit(accTx)
-      vmState.stateDB.persist(clearCache = false)
+      vmState.stateDB.persist()
 
     block:
       let accTx = vmState.stateDB.beginSavepoint
       vmState.stateDB.modBalance(eAddr)
       vmState.stateDB.commit(accTx)
-      vmState.stateDB.persist(clearCache = false)
+      vmState.stateDB.persist()
 
     block:
       let accTx = vmState.stateDB.beginSavepoint
@@ -257,7 +257,7 @@ proc runTrial4(vmState: BaseVMState; inx: int; rollback: bool) =
         break
 
       vmState.stateDB.commit(accTx)
-      vmState.stateDB.persist(clearCache = false)
+      vmState.stateDB.persist()
 
     # There must be no dbTx.rollback() here unless `vmState.stateDB` is
     # discarded and/or re-initialised.
@@ -270,7 +270,7 @@ proc runTrial4(vmState: BaseVMState; inx: int; rollback: bool) =
       let accTx = vmState.stateDB.beginSavepoint
       vmState.stateDB.modBalance(eAddr)
       vmState.stateDB.commit(accTx)
-      vmState.stateDB.persist(clearCache = false)
+      vmState.stateDB.persist()
 
     dbTx.commit()
 

--- a/tests/test_rpc_experimental_json.nim
+++ b/tests/test_rpc_experimental_json.nim
@@ -116,9 +116,9 @@ proc checkAndValidateWitnessAgainstProofs(
     check stateDB.getBalance(address) == balance
     check stateDB.getNonce(address) == nonce
 
-    if codeHash == ZERO_HASH256 or codeHash == EMPTY_SHA3:
+    if codeHash == ZERO_HASH256 or codeHash == EMPTY_CODE_HASH:
       check stateDB.getCode(address).len() == 0
-      check stateDB.getCodeHash(address) == EMPTY_SHA3
+      check stateDB.getCodeHash(address) == EMPTY_CODE_HASH
     else:
       check stateDB.getCodeHash(address) == codeHash
 

--- a/tests/test_rpc_getproofs_track_state_changes.nim
+++ b/tests/test_rpc_getproofs_track_state_changes.nim
@@ -103,11 +103,11 @@ proc updateStateUsingProofsAndCheckStateRoot(
       stateDB.setCode(address, @[])
       stateDB.clearStorage(address)
       stateDB.deleteAccount(address)
-    elif (balance == 0 and nonce == 0 and codeHash == EMPTY_SHA3 and storageHash == EMPTY_ROOT_HASH):
+    elif (balance == 0 and nonce == 0 and codeHash == EMPTY_CODE_HASH and storageHash == EMPTY_ROOT_HASH):
       # Account exists but is empty:
       # The account was deleted due to a self destruct or the storage was cleared/set to zero
       # and the bytecode is empty.
-      # The RPC API correctly returns codeHash == EMPTY_SHA3 and storageHash == EMPTY_ROOT_HASH
+      # The RPC API correctly returns codeHash == EMPTY_CODE_HASH and storageHash == EMPTY_ROOT_HASH
       # in this scenario which is the same behavior implemented by geth.
       stateDB.setCode(address, @[])
       stateDB.clearStorage(address)
@@ -123,9 +123,9 @@ proc updateStateUsingProofsAndCheckStateRoot(
     check stateDB.getBalance(address) == balance
     check stateDB.getNonce(address) == nonce
 
-    if codeHash == ZERO_HASH256 or codeHash == EMPTY_SHA3:
+    if codeHash == ZERO_HASH256 or codeHash == EMPTY_CODE_HASH:
       check stateDB.getCode(address).len() == 0
-      check stateDB.getCodeHash(address) == EMPTY_SHA3
+      check stateDB.getCodeHash(address) == EMPTY_CODE_HASH
     else:
       check stateDB.getCodeHash(address) == codeHash
 

--- a/tools/common/state_clearing.nim
+++ b/tools/common/state_clearing.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/tools/common/state_clearing.nim
+++ b/tools/common/state_clearing.nim
@@ -38,6 +38,4 @@ proc coinbaseStateClearing*(vmState: BaseVMState,
 
     # do not clear cache, we need the cache when constructing
     # post state
-    db.persist(
-      clearEmptyAccount = fork >= FkSpurious,
-      clearCache = false)
+    db.persist(clearEmptyAccount = fork >= FkSpurious)

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -157,7 +157,7 @@ proc runExecution(ctx: var StateContext, conf: StateConf, pre: JsonNode): StateR
 
   vmState.mutateStateDB:
     setupStateDB(pre, db)
-    db.persist(clearEmptyAccount = false, clearCache = false) # settle accounts storage
+    db.persist(clearEmptyAccount = false) # settle accounts storage
 
   defer:
     ctx.verifyResult(vmState)

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -481,7 +481,7 @@ proc transitionAction*(ctx: var TransContext, conf: T8NConf) =
 
     vmState.mutateStateDB:
       db.setupAlloc(ctx.alloc)
-      db.persist(clearEmptyAccount = false, clearCache = false)
+      db.persist(clearEmptyAccount = false)
 
     let res = exec(ctx, vmState, conf.stateReward, header, conf)
 


### PR DESCRIPTION
`persist` is a hotspot when processing blocks because it is run at least once per transaction and loops over the entire account cache every time.

Here, we introduce an extra `dirty` map that keeps track of all accounts that need checking during `persist` which fixes the immediate inefficiency, though probably this could benefit from a more thorough review - we also get rid of the unused clearCache flag - we start with a fresh cache on every fresh vmState.

* avoid unnecessary code hash comparisons
* avoid unnecessary copies when iterating
* use EMPTY_CODE_HASH throughout for code hash comparison