### PR TITLE
import: add csv debug option

### DIFF
--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -520,6 +520,11 @@ type
         defaultValue: 8192
         name: "chunk-size" .}: uint64
 
+      csvStats* {.
+        hidden
+        desc: "Save performance statistics to CSV"
+        name: "debug-csv-stats".}: Option[string]
+
 func parseCmdArg(T: type NetworkId, p: string): T
     {.gcsafe, raises: [ValueError].} =
   parseInt(p).T


### PR DESCRIPTION
This new option saves a CSV to disk while performing `import` such that the performance of one import can be compared with the other.

This early version is likely to change in the future, hence it's also hidden behind a debug flag.

Here's a sample output:

```
block_number,blocks,txs,gas,time
8193,8192,0,0,964623666
16385,8192,0,0,1052502040
24577,8192,0,0,1033609541
32769,8192,0,0,1053529132
40961,8192,0,0,1129258484
49153,8192,1514,0,1497880436
57345,8192,3916,0,2453669141
```

This can be used to generate a bps/tps graph like so (, where the initial ~100k blocks have been cut out since they're mostly empty:
![image](https://github.com/status-im/nimbus-eth1/assets/1382986/e53ca167-83ae-4e86-b448-c8f3a793445a)

This is generated with `gnuplot`:

```
set datafile separator ","
plot 'xx.csv' using 1:(1/(($5/1000000000)/$2)) with lines title 'bps', '' using 1:(1/(($5/1000000000)/$3)) with lines title 'tps'
```
