### PR TITLE
enable JWT auth tests

### DIFF
--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -12,12 +12,12 @@ import ./all_tests_macro
 cliBuilder:
   import  ./test_code_stream,
           #./test_accounts_cache,                  -- does not compile
-          #./test_jwt_auth,                        -- rpc is Aristo incompatible
+          ./test_jwt_auth,
           ./test_gas_meter,
           ./test_memory,
           ./test_stack,
           ./test_genesis,
-          /test_precompiles,
+          ./test_precompiles,
           ./test_generalstate_json,
           #./test_tracer_json,                     -- temporarily suspended
           #./test_persistblock_json,               -- fails
@@ -47,7 +47,7 @@ cliBuilder:
           #./test_merge,                           -- fails
           ./test_eip4844,
           ./test_beacon/test_skeleton,
-          /test_overflow,
+          ./test_overflow,
           #./test_getproof_json,                   -- fails
           #./test_rpc_experimental_json,           -- fails
           #./test_persistblock_witness_json        -- fails

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -261,7 +261,7 @@ proc importBlock(ctx: var TestCtx, com: CommonRef,
     chain = newChain(com, extraValidation = true, ctx.vmState)
     res = chain.persistBlocks([tb.header], [tb.body])
 
-  if res.isErr()
+  if res.isErr():
     raise newException(ValidationError, res.error())
   else:
     blockWitness(chain.vmState, com.db)

--- a/tests/test_graphql.nim
+++ b/tests/test_graphql.nim
@@ -98,7 +98,7 @@ proc graphqlMain*() =
     ethCtx  = newEthContext()
     ethNode = setupEthNode(conf, ethCtx, eth)
     com     = setupChain()
-    txPool  = TxPoolRef.new(com, conf.engineSigner)
+    txPool  = TxPoolRef.new(com)
 
   let ctx = setupGraphqlContext(com, ethNode, txPool)
   when isMainModule:

--- a/tests/test_jwt_auth.nim
+++ b/tests/test_jwt_auth.nim
@@ -60,7 +60,7 @@ proc findFilePath(file: string): Result[string,void] =
         return ok(path)
   err()
 
-proc say*(noisy = false; pfx = "***"; args: varargs[string, `$`]) =
+proc say(noisy = false; pfx = "***"; args: varargs[string, `$`]) =
   if noisy:
     if args.len == 0:
       echo "*** ", pfx
@@ -92,17 +92,17 @@ proc base64urlEncode(x: auto): string =
   ## from nimbus-eth2, engine_authentication.nim
   base64.encode(x, safe = true).replace("=", "")
 
-func getIatToken*(time: uint64): JsonNode =
+func getIatToken(time: uint64): JsonNode =
   ## from nimbus-eth2, engine_authentication.nim
   %* {"iat": time}
 
-proc getSignedToken*(key: openArray[byte], payload: string): string =
+proc getSignedToken(key: openArray[byte], payload: string): string =
   ## from nimbus-eth2, engine_authentication.nim
   # Using hard coded string for """{"typ": "JWT", "alg": "HS256"}"""
   let sData = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9." & base64urlEncode(payload)
   sData & "." & sha256.hmac(key, sData).data.base64urlEncode
 
-proc getSignedToken2*(key: openArray[byte], payload: string): string =
+proc getSignedToken2(key: openArray[byte], payload: string): string =
   ## Variant of `getSignedToken()`: different algorithm encoding
   let
     jNode = %* {"alg": "HS256", "typ": "JWT" }

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -12,8 +12,7 @@ import
   std/[algorithm, os, random, sequtils, strformat, strutils, tables, times],
   ../nimbus/core/chain, # must be early (compilation annoyance)
   ../nimbus/common/common,
-  ../nimbus/core/clique/clique_sealer,
-  ../nimbus/core/[clique, executor, casper, tx_pool, tx_pool/tx_item],
+  ../nimbus/core/[executor, casper, tx_pool, tx_pool/tx_item],
   ../nimbus/[config, vm_state, vm_types],
   ./test_txpool/[helpers, setup, sign_helper],
   chronos,

--- a/tests/test_txpool/setup.nim
+++ b/tests/test_txpool/setup.nim
@@ -66,7 +66,7 @@ proc toTxPool*(
     nTxs = 0
 
   doAssert not com.isNil
-  result[0] = TxPoolRef.new(com,testAddress)
+  result[0] = TxPoolRef.new(com)
   result[0].baseFee = baseFee
 
   for chain in file.undumpBlocksGz:
@@ -120,7 +120,7 @@ proc toTxPool*(
 
   doAssert not com.isNil
 
-  result = TxPoolRef.new(com,testAddress)
+  result = TxPoolRef.new(com)
   result.baseFee = baseFee
   result.maxRejects = itList.len
 
@@ -155,7 +155,7 @@ proc toTxPool*(
   doAssert not com.isNil
   doAssert 0 < itemsPC and itemsPC < 100
 
-  result = TxPoolRef.new(com,testAddress)
+  result = TxPoolRef.new(com)
   result.baseFee = baseFee
   result.maxRejects = itList.len
 

--- a/tests/test_txpool/sign_helper.nim
+++ b/tests/test_txpool/sign_helper.nim
@@ -12,7 +12,6 @@ import
   ../../nimbus/constants,
   ../../nimbus/utils/ec_recover,
   ../../nimbus/core/tx_pool/tx_item,
-  ../../nimbus/core/clique/clique_desc,
   eth/[common, common/transaction, keys],
   results,
   stint
@@ -91,7 +90,7 @@ proc testKeySign*(header: BlockHeader): BlockHeader =
   header.sign(prvTestKey)
 
 proc signerFunc*(signer: EthAddress, msg: openArray[byte]):
-                Result[RawSignature, cstring] {.gcsafe.} =
+                Result[array[RawSignatureSize, byte], cstring] {.gcsafe.} =
   doAssert(signer == testAddress)
   let
     data = keccakHash(msg)


### PR DESCRIPTION
Also,
- fix a few incorrect import paths (Nim 2.0 is stricter about some of the sillier ones, but Nim 1.6 is remarkably tolerant);
- fix some syntax errors in disabled tests;
- remove some imports on removed clique modules from disabled tests;
- update `TxPoolRef` initialization API usage to not pass an engine signer, which isn't a concept now that the tx pool doesn't support PoW/PoA