### PR TITLE
Replace some usage of std/options with results Opt

### DIFF
--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -160,8 +160,8 @@ proc init(com         : CommonRef,
   if genesis.isNil.not:
     com.hardForkTransition(ForkDeterminationInfo(
       blockNumber: 0.toBlockNumber,
-      td: some(0.u256),
-      time: some(genesis.timestamp)
+      td: Opt.some(0.u256),
+      time: Opt.some(genesis.timestamp)
     ))
 
     # Must not overwrite the global state on the single state DB
@@ -174,30 +174,30 @@ proc init(com         : CommonRef,
   else:
     com.hardForkTransition(ForkDeterminationInfo(
       blockNumber: 0.toBlockNumber,
-      td: some(0.u256),
-      time: some(TimeZero)
+      td: Opt.some(0.u256),
+      time: Opt.some(TimeZero)
     ))
 
   # By default, history begins at genesis.
   com.startOfHistory = GENESIS_PARENT_HASH
 
-proc getTd(com: CommonRef, blockHash: Hash256): Option[DifficultyInt] =
+proc getTd(com: CommonRef, blockHash: Hash256): Opt[DifficultyInt] =
   var td: DifficultyInt
   if not com.db.getTd(blockHash, td):
     # TODO: Is this really ok?
-    none[DifficultyInt]()
+    Opt.none(DifficultyInt)
   else:
-    some(td)
+    Opt.some(td)
 
 func needTdForHardForkDetermination(com: CommonRef): bool =
   let t = com.forkTransitionTable.mergeForkTransitionThreshold
   t.ttdPassed.isNone and t.blockNumber.isNone and t.ttd.isSome
 
-proc getTdIfNecessary(com: CommonRef, blockHash: Hash256): Option[DifficultyInt] =
+proc getTdIfNecessary(com: CommonRef, blockHash: Hash256): Opt[DifficultyInt] =
   if needTdForHardForkDetermination(com):
     getTd(com, blockHash)
   else:
-    none[DifficultyInt]()
+    Opt.none(DifficultyInt)
 
 # ------------------------------------------------------------------------------
 # Public constructors
@@ -285,8 +285,8 @@ func hardForkTransition(
 func hardForkTransition*(
     com: CommonRef,
     number: BlockNumber,
-    td: Option[DifficultyInt],
-    time: Option[EthTime]) =
+    td: Opt[DifficultyInt],
+    time: Opt[EthTime]) =
   com.hardForkTransition(ForkDeterminationInfo(
     blockNumber: number, time: time, td: td))
 
@@ -294,14 +294,14 @@ proc hardForkTransition*(
     com: CommonRef,
     parentHash: Hash256,
     number: BlockNumber,
-    time: Option[EthTime]) =
+    time: Opt[EthTime]) =
   com.hardForkTransition(number, getTdIfNecessary(com, parentHash), time)
 
 proc hardForkTransition*(
     com: CommonRef, header: BlockHeader)
     {.gcsafe, raises: [].} =
   com.hardForkTransition(
-    header.parentHash, header.blockNumber, some(header.timestamp))
+    header.parentHash, header.blockNumber, Opt.some(header.timestamp))
 
 func toEVMFork*(com: CommonRef, forkDeterminer: ForkDeterminationInfo): EVMFork =
   ## similar to toFork, but produce EVMFork

--- a/nimbus/common/hardforks.nim
+++ b/nimbus/common/hardforks.nim
@@ -10,6 +10,7 @@
 import
   std/[options, strutils],
   eth/common,
+  results,
   stew/endians2,
   json_serialization,
   ../utils/utils,
@@ -80,18 +81,20 @@ type
   # comment below on forkDeterminationInfo.
   ForkDeterminationInfo* = object
     blockNumber*: BlockNumber
-    time*: Option[EthTime]
-    td*: Option[DifficultyInt]
+    time*: Opt[EthTime]
+    td*: Opt[DifficultyInt]
 
 func forkDeterminationInfo*(n: BlockNumber): ForkDeterminationInfo =
   # FIXME: All callers of this function are suspect; I'm guess we should
   # always be using both block number and time. But we have a few places,
   # like various tests, where we only have block number and the tests are
   # meant for pre-Merge forks, so maybe those are okay.
-  ForkDeterminationInfo(blockNumber: n, time: none[EthTime](), td: none[DifficultyInt]())
+  ForkDeterminationInfo(
+    blockNumber: n, time: Opt.none(EthTime), td: Opt.none(DifficultyInt))
 
 func forkDeterminationInfo*(n: BlockNumber, t: EthTime): ForkDeterminationInfo =
-  ForkDeterminationInfo(blockNumber: n, time: some(t), td: none[DifficultyInt]())
+  ForkDeterminationInfo(
+    blockNumber: n, time: Opt.some(t), td: Opt.none(DifficultyInt))
 
 func forkDeterminationInfo*(header: BlockHeader): ForkDeterminationInfo =
   # FIXME-Adam-mightAlsoNeedTTD?

--- a/nimbus/core/pow.nim
+++ b/nimbus/core/pow.nim
@@ -121,14 +121,9 @@ func miningHash(header: BlockHeader): Hash256 =
 
 # ---------------
 
-proc init(tm: PowRef;
-          rng: Option[ref HmacDrbgContext];
-          light: Option[PowCacheRef]) =
+proc init(tm: PowRef; light: Option[PowCacheRef]) =
   ## Constructor
-  if rng.isSome:
-    tm.rng = rng.get
-  else:
-    tm.rng = newRng()
+  tm.rng = newRng()
 
   if light.isSome:
     tm.lightByEpoch = light.get
@@ -142,7 +137,7 @@ proc init(tm: PowRef;
 proc new*(T: type PowRef; cache: PowCacheRef): T =
   ## Constructor
   new result
-  result.init(none(ref HmacDrbgContext), some(cache))
+  result.init(some(cache))
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/nimbus/core/tx_pool/tx_chain.nim
+++ b/nimbus/core/tx_pool/tx_chain.nim
@@ -8,11 +8,14 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
+{.push raises: [].}
+
 ## Transaction Pool Block Chain Packer Environment
 ## ===============================================
 ##
 
 import
+  results,
   ../../common/common,
   ../../constants,
   ../../db/ledger,
@@ -29,8 +32,6 @@ import
 export
   TxChainGasLimits,
   TxChainGasLimitsPc
-
-{.push raises: [].}
 
 const
   TRG_THRESHOLD_PER_CENT = ##\
@@ -92,7 +93,8 @@ proc resetTxEnv(dh: TxChainRef; parent: BlockHeader; fee: Option[UInt256])
   # BaseVMState querying any hardfork/consensus from CommonRef
 
   let timestamp = dh.getTimestamp(parent)
-  dh.com.hardForkTransition(parent.blockHash, parent.blockNumber+1, some(timestamp))
+  dh.com.hardForkTransition(
+    parent.blockHash, parent.blockNumber+1, Opt.some(timestamp))
   dh.prepareHeader(parent, timestamp)
 
   # we don't consider PoS difficulty here

--- a/nimbus/db/aristo/aristo_init/memory_db.nim
+++ b/nimbus/db/aristo/aristo_init/memory_db.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023=-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -46,7 +46,7 @@ type
     sTab: Table[VertexID,Blob]       ## Structural vertex table making up a trie
     kMap: Table[VertexID,HashKey]    ## Merkle hash key mapping
     tUvi: Option[VertexID]           ## Top used vertex ID
-    lSst: Option[SavedState]         ## Last saved state
+    lSst: Opt[SavedState]            ## Last saved state
 
   MemBackendRef* = ref object of TypedBackendRef
     ## Inheriting table so access can be extended for debugging purposes
@@ -56,7 +56,7 @@ type
     sTab: Table[VertexID,Blob]
     kMap: Table[VertexID,HashKey]
     tUvi: Option[VertexID]
-    lSst: Option[SavedState]
+    lSst: Opt[SavedState]
 
 when extraTraceMessages:
   import chronicles
@@ -170,7 +170,7 @@ proc putLstFn(db: MemBackendRef): PutLstFn =
       if hdl.error.isNil:
         let rc = lst.blobify # test
         if rc.isOk:
-          hdl.lSst = some(lst)
+          hdl.lSst = Opt.some(lst)
         else:
           hdl.error = TypedPutHdlErrRef(
             pfx:  AdmPfx,

--- a/nimbus/evm/computation.nim
+++ b/nimbus/evm/computation.nim
@@ -291,12 +291,12 @@ func evmcStatus*(c: Computation): evmc_status_code =
   else:
     c.error.evmcStatus
 
-func errorOpt*(c: Computation): Option[string] =
+func errorOpt*(c: Computation): Opt[string] =
   if c.isSuccess:
-    return none(string)
+    return Opt.none(string)
   if c.error.evmcStatus == EVMC_REVERT:
-    return none(string)
-  some(c.error.info)
+    return Opt.none(string)
+  Opt.some(c.error.info)
 
 proc writeContract*(c: Computation) =
   template withExtra(tracer: untyped, args: varargs[untyped]) =

--- a/nimbus/evm/state.nim
+++ b/nimbus/evm/state.nim
@@ -313,7 +313,7 @@ proc captureStart*(vmState: BaseVMState, comp: Computation,
     vmState.tracer.captureStart(comp, sender, to, create, input, gasLimit, value)
 
 proc captureEnd*(vmState: BaseVMState, comp: Computation, output: openArray[byte],
-                 gasUsed: GasInt, error: Option[string]) =
+                 gasUsed: GasInt, error: Opt[string]) =
   if vmState.tracingEnabled:
     vmState.tracer.captureEnd(comp, output, gasUsed, error)
 
@@ -325,7 +325,7 @@ proc captureEnter*(vmState: BaseVMState, comp: Computation, op: Op,
     vmState.tracer.captureEnter(comp, op, sender, to, input, gasLimit, value)
 
 proc captureExit*(vmState: BaseVMState, comp: Computation, output: openArray[byte],
-                  gasUsed: GasInt, error: Option[string]) =
+                  gasUsed: GasInt, error: Opt[string]) =
   if vmState.tracingEnabled:
     vmState.tracer.captureExit(comp, output, gasUsed, error)
 
@@ -355,7 +355,7 @@ proc captureOpEnd*(vmState: BaseVMState, comp: Computation, pc: int,
 proc captureFault*(vmState: BaseVMState, comp: Computation, pc: int,
                    op: Op, gas: GasInt, refund: GasInt,
                    rData: openArray[byte],
-                   depth: int, error: Option[string]) =
+                   depth: int, error: Opt[string]) =
   if vmState.tracingEnabled:
     let fixed = vmState.gasCosts[op].kind == GckFixed
     vmState.tracer.captureFault(comp, fixed, pc, op, gas, refund, rData, depth, error)

--- a/nimbus/evm/tracer/json_tracer.nim
+++ b/nimbus/evm/tracer/json_tracer.nim
@@ -70,7 +70,7 @@ iterator storage(ctx: JsonTracer, compDepth: int): UInt256 =
 
 proc captureOpImpl(ctx: JsonTracer, c: Computation, pc: int,
                    op: Op, gas: GasInt, refund: GasInt,
-                   rData: openArray[byte], depth: int, error: Option[string]) {.gcsafe.} =
+                   rData: openArray[byte], depth: int, error: Opt[string]) {.gcsafe.} =
   let
     gasCost = ctx.gas - gas
 
@@ -142,7 +142,7 @@ method captureStart*(ctx: JsonTracer, comp: Computation,
   discard
 
 method captureEnd*(ctx: JsonTracer, comp: Computation, output: openArray[byte],
-                   gasUsed: GasInt, error: Option[string]) {.gcsafe.} =
+                   gasUsed: GasInt, error: Opt[string]) {.gcsafe.} =
   var res = %{
     "output": %(output),
     "gasUsed": encodeHex(gasUsed)
@@ -172,7 +172,7 @@ method captureOpStart*(ctx: JsonTracer, c: Computation,
       error "JsonTracer captureOpStart", msg=ex.msg
 
   try:
-    ctx.captureOpImpl(c, pc, op, 0, 0, [], depth, none(string))
+    ctx.captureOpImpl(c, pc, op, 0, 0, [], depth, Opt.none(string))
   except RlpError as ex:
     error "JsonTracer captureOpStart", msg=ex.msg
 
@@ -213,7 +213,7 @@ method captureOpEnd*(ctx: JsonTracer, comp: Computation,
 method captureFault*(ctx: JsonTracer, comp: Computation,
                      fixed: bool, pc: int, op: Op, gas: GasInt, refund: GasInt,
                      rData: openArray[byte],
-                     depth: int, error: Option[string]) {.gcsafe.} =
+                     depth: int, error: Opt[string]) {.gcsafe.} =
 
   if ctx.node.isNil.not:
     let res = ctx.node

--- a/nimbus/evm/tracer/legacy_tracer.nim
+++ b/nimbus/evm/tracer/legacy_tracer.nim
@@ -155,7 +155,7 @@ method captureOpEnd*(ctx: LegacyTracer, c: Computation,
 method captureFault*(ctx: LegacyTracer, comp: Computation,
                      fixed: bool, pc: int, op: Op, gas: GasInt, refund: GasInt,
                      rData: openArray[byte],
-                     depth: int, error: Option[string]) {.gcsafe.} =
+                     depth: int, error: Opt[string]) {.gcsafe.} =
   try:
     if ctx.trace["structLogs"].elems.len > 0:
       let j = ctx.trace["structLogs"].elems[^1]

--- a/nimbus/evm/types.nim
+++ b/nimbus/evm/types.nim
@@ -158,7 +158,7 @@ method captureStart*(ctx: TracerRef, comp: Computation,
   discard
 
 method captureEnd*(ctx: TracerRef, comp: Computation, output: openArray[byte],
-                   gasUsed: GasInt, error: Option[string]) {.base, gcsafe.} =
+                   gasUsed: GasInt, error: Opt[string]) {.base, gcsafe.} =
   discard
 
 # Rest of call frames
@@ -169,7 +169,7 @@ method captureEnter*(ctx: TracerRef, comp: Computation, op: Op,
   discard
 
 method captureExit*(ctx: TracerRef, comp: Computation, output: openArray[byte],
-                    gasUsed: GasInt, error: Option[string]) {.base, gcsafe.} =
+                    gasUsed: GasInt, error: Opt[string]) {.base, gcsafe.} =
   discard
 
 # Opcode level
@@ -192,7 +192,7 @@ method captureOpEnd*(ctx: TracerRef, comp: Computation,
 method captureFault*(ctx: TracerRef, comp: Computation,
                      fixed: bool, pc: int, op: Op, gas: GasInt, refund: GasInt,
                      rData: openArray[byte],
-                     depth: int, error: Option[string]) {.base, gcsafe.} =
+                     depth: int, error: Opt[string]) {.base, gcsafe.} =
   discard
 
 # Called at the start of EVM interpreter loop

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -133,8 +133,8 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf,
   # Early-initialise "--snap-sync" before starting any network connections.
   block:
     let
-      exCtrlFile = if conf.syncCtrlFile.isNone: none(string)
-                   else: some(conf.syncCtrlFile.get)
+      exCtrlFile = if conf.syncCtrlFile.isNone: Opt.none(string)
+                   else: Opt.some(conf.syncCtrlFile.get)
       tickerOK = conf.logLevel in {
         LogLevel.INFO, LogLevel.DEBUG, LogLevel.TRACE}
     case conf.syncMode:

--- a/nimbus/sync/beacon.nim
+++ b/nimbus/sync/beacon.nim
@@ -132,7 +132,7 @@ proc init*(
     maxPeers: int;
     id: int = 0): T =
   new result
-  result.initSync(ethNode, chain, maxPeers, none(string))
+  result.initSync(ethNode, chain, maxPeers, Opt.none(string))
   result.ctx.pool.rng = rng
   result.ctx.pool.id = id
 

--- a/nimbus/sync/full.nim
+++ b/nimbus/sync/full.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -112,7 +112,7 @@ proc init*(
     rng: ref HmacDrbgContext;
     maxPeers: int;
     enableTicker = false;
-    exCtrlFile = none(string);
+    exCtrlFile = Opt.none(string);
       ): T =
   new result
   result.initSync(ethNode, chain, maxPeers, exCtrlFile)

--- a/nimbus/sync/full/worker.nim
+++ b/nimbus/sync/full/worker.nim
@@ -313,7 +313,7 @@ proc runSingle*(buddy: FullBuddyRef) {.async.} =
       let rc = pv.pivotHeader(relaxedMode=true)
       if rc.isOK:
         # Update/activate `bestNumber` from the pivot header
-        bq.bestNumber = some(rc.value.blockNumber)
+        bq.bestNumber = Opt.some(rc.value.blockNumber)
         ctx.pool.pivotState = PivotRunMode
         buddy.ctrl.multiOk = true
         trace "Single pivot accepted", peer, pivot=('#' & $bq.bestNumber.get)
@@ -349,7 +349,7 @@ proc runSingle*(buddy: FullBuddyRef) {.async.} =
   # `case()` handler to process and `return`.
   if await pv.pivotNegotiate(buddy.only.bQueue.bestNumber):
     # Update/activate `bestNumber` from the pivot header
-    bq.bestNumber = some(pv.pivotHeader.value.blockNumber)
+    bq.bestNumber = Opt.some(pv.pivotHeader.value.blockNumber)
     ctx.pool.pivotState = PivotRunMode
     buddy.ctrl.multiOk = true
     trace "Pivot accepted", peer, pivot=('#' & $bq.bestNumber.get)

--- a/nimbus/sync/misc/best_pivot.nim
+++ b/nimbus/sync/misc/best_pivot.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at
 #     https://opensource.org/licenses/MIT).
@@ -321,7 +321,7 @@ proc pivotHeader*(
 
 proc pivotNegotiate*(
     bp: BestPivotWorkerRef;              ## Worker peer
-    minBlockNumber: Option[BlockNumber]; ## Minimum block number to expect
+    minBlockNumber: Opt[BlockNumber];    ## Minimum block number to expect
       ): Future[bool]
       {.async.} =
   ## Negotiate best header pivot. This function must be run in *single mode* at

--- a/nimbus/sync/misc/sync_ctrl.nim
+++ b/nimbus/sync/misc/sync_ctrl.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -38,7 +38,7 @@ proc getDataLine(
 # ------------------------------------------------------------------------------
 
 proc syncCtrlBlockNumberFromFile*(
-    fileName: Option[string];               # Optional file name
+    fileName: Opt[string];                  # Optional file name
     lineNum = 0;                            # Read line from file
       ): Result[BlockNumber,void] =
   ## Returns a block number from the file name argument `fileName`. The first
@@ -55,38 +55,6 @@ proc syncCtrlBlockNumberFromFile*(
         name {.used.} = $e.name
         msg {.used.} = e.msg
       debug "Exception while parsing block number", file, name, msg
-  err()
-
-proc syncCtrlHashOrBlockNumFromFile*(
-    fileName: Option[string];               # Optional file name
-    lineNum = 0;                            # Read line from file
-      ): Result[HashOrNum,void] =
-  ## Returns a block number or a hash from the file name argument `fileName`.
-  ## A block number is decimal encoded and a hash is expexted to be a 66 hex
-  ## digits string startnib wiyh `0x`.
-  if fileName.isSome:
-    let file = fileName.get
-
-    # Parse value dump and fetch a header from the peer (if any)
-    try:
-      let data = file.getDataLine(lineNum)
-      if 0 < data.len:
-        if 66 == data.len:
-          let hash = HashOrNum(
-            isHash: true,
-            hash:   Hash256(
-              data: UInt256.fromHex(data).toBytesBE))
-          return ok(hash)
-        else:
-          let num = HashOrNum(
-            isHash: false,
-            number: parse(data,UInt256))
-          return ok(num)
-    except CatchableError as e:
-      let
-        name {.used.} = $e.name
-        msg {.used.} = e.msg
-      debug "Exception while parsing hash or block number", file, name, msg
   err()
 
 # ------------------------------------------------------------------------------

--- a/nimbus/sync/misc/ticker.nim
+++ b/nimbus/sync/misc/ticker.nim
@@ -45,8 +45,8 @@ type
 
   TickerSnapStats* = object
     ## Snap sync state (see `TickerSnapStatsUpdater`)
-    beaconBlock*: Option[BlockNumber]
-    pivotBlock*: Option[BlockNumber]
+    beaconBlock*: Opt[BlockNumber]
+    pivotBlock*: Opt[BlockNumber]
     nAccounts*: (float,float)          ## Mean and standard deviation
     accountsFill*: (float,float,float) ## Mean, standard deviation, merged total
     nAccountStats*: int                ## #chunks
@@ -58,10 +58,10 @@ type
 
   TickerFullStats* = object
     ## Full sync state (see `TickerFullStatsUpdater`)
-    pivotBlock*: Option[BlockNumber]
+    pivotBlock*: Opt[BlockNumber]
     topPersistent*: BlockNumber
-    nextUnprocessed*: Option[BlockNumber]
-    nextStaged*: Option[BlockNumber]
+    nextUnprocessed*: Opt[BlockNumber]
+    nextStaged*: Opt[BlockNumber]
     nStagedQueue*: int
     suspended*: bool
     reOrg*: bool

--- a/nimbus/sync/misc/ticker.nim
+++ b/nimbus/sync/misc/ticker.nim
@@ -52,8 +52,8 @@ type
     nAccountStats*: int                ## #chunks
     nSlotLists*: (float,float)         ## Mean and standard deviation
     nContracts*: (float,float)         ## Mean and standard deviation
-    nStorageQueue*: Option[int]
-    nContractQueue*: Option[int]
+    nStorageQueue*: Opt[int]
+    nContractQueue*: Opt[int]
     nQueues*: int
 
   TickerFullStats* = object
@@ -96,7 +96,7 @@ proc pc99(val: float): string =
   elif 0.0 < val and val <= 0.01: "1%"
   else: val.toPC(0)
 
-proc toStr(a: Option[int]): string =
+proc toStr(a: Opt[int]): string =
   if a.isNone: "n/a"
   else: $a.unsafeGet
 

--- a/nimbus/sync/sync_desc.nim
+++ b/nimbus/sync/sync_desc.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -49,7 +49,7 @@ type
     chain*: ChainRef            ## Block chain database (no need for `Peer`)
     poolMode*: bool             ## Activate `runPool()` workers if set `true`
     daemon*: bool               ## Enable global background job
-    exCtrlFile*: Option[string] ## Extra instructions file (if any)
+    exCtrlFile*: Opt[string]    ## Extra instructions file (if any)
     pool*: S                    ## Shared context for all worker peers
 
 # ------------------------------------------------------------------------------

--- a/nimbus/sync/sync_sched.nim
+++ b/nimbus/sync/sync_sched.nim
@@ -385,7 +385,7 @@ proc initSync*[S,W](
     node: EthereumNode;
     chain: ChainRef,
     slots: int;
-    exCtrlFile = none(string);
+    exCtrlFile = Opt.none(string);
       ) =
   ## Constructor
   # Leave one extra slot so that it can holds a *zombie* even if all slots

--- a/nimbus/sync/types.nim
+++ b/nimbus/sync/types.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -13,6 +13,7 @@
 import
   std/[math, hashes],
   eth/common/eth_types_rlp,
+  results,
   stew/byteutils
 
 type
@@ -110,7 +111,7 @@ func toStr*(n: BlockNumber): string =
   ## Pretty print block number, explicitely format with a leading hash `#`
   if n == high(BlockNumber): "high" else:"#" & $n
 
-func toStr*(n: Option[BlockNumber]): string =
+func toStr*(n: Opt[BlockNumber]): string =
   if n.isNone: "n/a" else: n.get.toStr
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
`results` has better ergonomics than `std/options`, and for example allows safer approaches than `isSome`/`not isNone` followed by `foo.get`/`foo.unsafeGet`.

This is not complete, but a gradual change in a fairly mechanical way. It does not incorporate those improvements, deliberately, but just switches to the types which allow them, for easier review.