### PR TITLE
Consolidate block type for block processing

### DIFF
--- a/fluffy/database/era1_db.nim
+++ b/fluffy/database/era1_db.nim
@@ -50,6 +50,11 @@ proc new*(
 ): Era1DB =
   Era1DB(path: path, network: network, accumulator: accumulator)
 
+proc getEthBlock*(db: Era1DB, blockNumber: uint64): Result[EthBlock, string] =
+  let f = ?db.getEra1File(blockNumber.era)
+
+  f.getEthBlock(blockNumber)
+
 proc getBlockTuple*(db: Era1DB, blockNumber: uint64): Result[BlockTuple, string] =
   let f = ?db.getEra1File(blockNumber.era)
 

--- a/fluffy/eth_data/era1.nim
+++ b/fluffy/eth_data/era1.nim
@@ -338,6 +338,30 @@ proc getTotalDifficulty(f: Era1File): Result[UInt256, string] =
 
   ok(UInt256.fromBytesLE(bytes))
 
+proc getNextEthBlock*(f: Era1File): Result[EthBlock, string] =
+  doAssert not isNil(f) and f[].handle.isSome
+
+  var
+    header = ?getBlockHeader(f)
+    body = ?getBlockBody(f)
+  ?skipRecord(f) # receipts
+  ?skipRecord(f) # totalDifficulty
+
+  ok(EthBlock.init(move(header), move(body)))
+
+proc getEthBlock*(f: Era1File, blockNumber: uint64): Result[EthBlock, string] =
+  doAssert not isNil(f) and f[].handle.isSome
+  doAssert(
+    blockNumber >= f[].blockIdx.startNumber and blockNumber <= f[].blockIdx.endNumber,
+    "Wrong era1 file for selected block number",
+  )
+
+  let pos = f[].blockIdx.offsets[blockNumber - f[].blockIdx.startNumber]
+
+  ?f[].handle.get().setFilePos(pos, SeekPosition.SeekBegin).mapErr(ioErrorMsg)
+
+  getNextEthBlock(f)
+
 proc getNextBlockTuple*(f: Era1File): Result[BlockTuple, string] =
   doAssert not isNil(f) and f[].handle.isSome
 

--- a/fluffy/tools/portal_bridge/portal_bridge_history.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_history.nim
@@ -37,7 +37,7 @@ func asEthBlock(blockObject: BlockObject): EthBlock =
     transactions = toTransactions(blockObject.transactions)
     withdrawals = toWithdrawals(blockObject.withdrawals)
 
-  EthBlock(header: header, txs: transactions, withdrawals: withdrawals)
+  EthBlock(header: header, transactions: transactions, withdrawals: withdrawals)
 
 func asPortalBlock(
     ethBlock: EthBlock

--- a/hive_integration/nodocker/engine/cancun/customizer.nim
+++ b/hive_integration/nodocker/engine/cancun/customizer.nim
@@ -400,12 +400,12 @@ proc customizePayload*(cust: CustomPayloadData, data: ExecutableData): Executabl
 
   var blk = EthBlock(
     header: customHeader,
+    transactions:
+      if cust.transactions.isSome:
+        cust.transactions.get
+      else:
+        ethTxs data.basePayload.transactions
   )
-
-  if cust.transactions.isSome:
-    blk.txs = cust.transactions.get
-  else:
-    blk.txs = ethTxs data.basePayload.transactions
 
   if cust.removeWithdrawals:
     blk.withdrawals = none(seq[Withdrawal])

--- a/hive_integration/nodocker/engine/engine/invalid_ancestor.nim
+++ b/hive_integration/nodocker/engine/engine/invalid_ancestor.nim
@@ -323,7 +323,7 @@ method execute(cs: InvalidMissingAncestorReOrgSyncTest, env: TestEnv): bool =
             invalidHeader = blockHeader(shadow.payloads[i])
             invalidBody = blockBody(shadow.payloads[i])
 
-          testCond sec.setBlock(invalidHeader, invalidBody):
+          testCond sec.setBlock(EthBlock.init(invalidHeader, invalidBody)):
               fatal "TEST ISSUE - Failed to set invalid block"
           info "Invalid block successfully set",
             idx=i,

--- a/hive_integration/nodocker/engine/engine_client.nim
+++ b/hive_integration/nodocker/engine/engine_client.nim
@@ -236,7 +236,7 @@ proc newPayload*(client: RpcClient,
   case version
   of Version.V1: return client.newPayloadV1(payload)
   of Version.V2: return client.newPayloadV2(payload)
-  of Version.V3:    
+  of Version.V3:
     let versionedHashes = collectBlobHashes(payload.transactions)
     return client.newPayloadV3(payload,
       some(versionedHashes),
@@ -246,7 +246,7 @@ proc newPayload*(client: RpcClient,
     return client.newPayloadV4(payload,
       some(versionedHashes),
       w3Hash beaconRoot)
-      
+
 proc newPayload*(client: RpcClient,
                  version: Version,
                  payload: ExecutableData): Result[PayloadStatusV1, string] =
@@ -518,7 +518,7 @@ proc latestBlock*(client: RpcClient): Result[common.EthBlock, string] =
       return err("failed to get latest blockHeader")
     let output = EthBlock(
       header: toBlockHeader(res),
-      txs: toTransactions(res.transactions),
+      transactions: toTransactions(res.transactions),
       withdrawals: toWithdrawals(res.withdrawals),
     )
     return ok(output)

--- a/hive_integration/nodocker/engine/engine_env.nim
+++ b/hive_integration/nodocker/engine/engine_env.nim
@@ -218,5 +218,5 @@ func version*(env: EngineEnv, time: Web3Quantity): Version =
 func version*(env: EngineEnv, time: uint64): Version =
   env.version(time.EthTime)
 
-proc setBlock*(env: EngineEnv, header: common.BlockHeader, body: common.BlockBody): bool =
-  env.chain.setBlock(header, body) == ValidationResult.OK
+proc setBlock*(env: EngineEnv, blk: common.EthBlock): bool =
+  env.chain.setBlock(blk) == ValidationResult.OK

--- a/hive_integration/nodocker/engine/node.nim
+++ b/hive_integration/nodocker/engine/node.nim
@@ -32,8 +32,8 @@ import
 
 proc processBlock(
     vmState: BaseVMState;  ## Parent environment of header/body block
-    header:  BlockHeader;  ## Header/body block to add to the blockchain
-    body:    BlockBody): ValidationResult
+    blk:     EthBlock;  ## Header/body block to add to the blockchain
+    ): ValidationResult
     {.gcsafe, raises: [CatchableError].} =
   ## Generalised function to processes `(header,body)` pair for any network,
   ## regardless of PoA or not.
@@ -43,7 +43,7 @@ proc processBlock(
   ## the `poa` descriptor is currently unused and only provided for later
   ## implementations (but can be savely removed, as well.)
   ## variant of `processBlock()` where the `header` argument is explicitely set.
-
+  template header: BlockHeader = blk.header
   var dbTx = vmState.com.db.newTransaction()
   defer: dbTx.dispose()
 
@@ -57,20 +57,20 @@ proc processBlock(
     if r.isErr:
       error("error in processing beaconRoot", err=r.error)
 
-  let r = processTransactions(vmState, header, body.transactions)
+  let r = processTransactions(vmState, header, blk.transactions)
   if r.isErr:
     error("error in processing transactions", err=r.error)
 
   if vmState.determineFork >= FkShanghai:
-    for withdrawal in body.withdrawals.get:
+    for withdrawal in blk.withdrawals.get:
       vmState.stateDB.addBalance(withdrawal.address, withdrawal.weiAmount)
 
   if header.ommersHash != EMPTY_UNCLE_HASH:
-    discard vmState.com.db.persistUncles(body.uncles)
+    discard vmState.com.db.persistUncles(blk.uncles)
 
   # EIP-3675: no reward for miner in POA/POS
   if vmState.com.consensus == ConsensusType.POW:
-    vmState.calculateReward(header, body)
+    vmState.calculateReward(header, blk.uncles)
 
   vmState.mutateStateDB:
     let clearEmptyAccount = vmState.determineFork >= FkSpurious
@@ -95,9 +95,9 @@ proc getVmState(c: ChainRef, header: BlockHeader):
 
 # A stripped down version of persistBlocks without validation
 # intended to accepts invalid block
-proc setBlock*(c: ChainRef; header: BlockHeader;
-                  body: BlockBody): ValidationResult
+proc setBlock*(c: ChainRef; blk: EthBlock): ValidationResult
                           {.inline, raises: [CatchableError].} =
+  template header: BlockHeader = blk.header
   let dbTx = c.db.newTransaction()
   defer: dbTx.dispose()
 
@@ -108,18 +108,18 @@ proc setBlock*(c: ChainRef; header: BlockHeader;
     vmState = c.getVmState(header).valueOr:
       return ValidationResult.Error
     stateRootChpt = vmState.parent.stateRoot # Check point
-    validationResult = vmState.processBlock(header, body)
+    validationResult = vmState.processBlock(blk)
 
   if validationResult != ValidationResult.OK:
     return validationResult
 
-  discard c.db.persistHeaderToDb(
+  c.db.persistHeaderToDb(
     header, c.com.consensus == ConsensusType.POS, c.com.startOfHistory)
-  discard c.db.persistTransactions(header.blockNumber, body.transactions)
+  discard c.db.persistTransactions(header.blockNumber, blk.transactions)
   discard c.db.persistReceipts(vmState.receipts)
 
-  if body.withdrawals.isSome:
-    discard c.db.persistWithdrawals(body.withdrawals.get)
+  if blk.withdrawals.isSome:
+    discard c.db.persistWithdrawals(blk.withdrawals.get)
 
   # update currentBlock *after* we persist it
   # so the rpc return consistent result

--- a/hive_integration/nodocker/pyspec/test_env.nim
+++ b/hive_integration/nodocker/pyspec/test_env.nim
@@ -61,7 +61,7 @@ proc setupELClient*(t: TestEnv, conf: ChainConfig, node: JsonNode) =
 
   doAssert stateDB.rootHash == genesisHeader.stateRoot
 
-  discard t.com.db.persistHeaderToDb(genesisHeader,
+  t.com.db.persistHeaderToDb(genesisHeader,
     t.com.consensus == ConsensusType.POS)
   doAssert(t.com.db.getCanonicalHead().blockHash == genesisHeader.blockHash)
 

--- a/nimbus/beacon/api_handler/api_newpayload.nim
+++ b/nimbus/beacon/api_handler/api_newpayload.nim
@@ -115,7 +115,8 @@ proc newPayload*(ben: BeaconEngineRef,
   validatePayload(apiVersion, version, payload)
   validateVersion(com, timestamp, version, apiVersion)
 
-  var header = blockHeader(payload, beaconRoot = ethHash beaconRoot)
+  var blk = ethBlock(payload, beaconRoot = ethHash beaconRoot)
+  template header: BlockHeader = blk.header
 
   if apiVersion >= Version.V3:
     if versionedHashes.isNone:
@@ -185,8 +186,7 @@ proc newPayload*(ben: BeaconEngineRef,
 
   trace "Inserting block without sethead",
     hash = blockHash, number = header.blockNumber
-  let body = blockBody(payload)
-  let vres = ben.chain.insertBlockWithoutSetHead(header, body)
+  let vres = ben.chain.insertBlockWithoutSetHead(blk)
   if vres.isErr:
     ben.setInvalidAncestor(header, blockHash)
     let blockHash = latestValidHash(db, parent, ttd)

--- a/nimbus/beacon/payload_conv.nim
+++ b/nimbus/beacon/payload_conv.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [].}
+
 import
   ./web3_eth_conv,
   web3/execution_types,
@@ -81,7 +83,7 @@ func executionPayloadV1V2*(blk: EthBlock): ExecutionPayloadV1OrV2 =
 
 func blockHeader*(p: ExecutionPayload,
                   beaconRoot: Option[common.Hash256]):
-                    common.BlockHeader {.gcsafe, raises:[CatchableError].} =
+                    common.BlockHeader {.gcsafe, raises:[RlpError].} =
   common.BlockHeader(
     parentHash     : ethHash p.parentHash,
     ommersHash     : EMPTY_UNCLE_HASH,
@@ -115,10 +117,10 @@ func blockBody*(p: ExecutionPayload):
 
 func ethBlock*(p: ExecutionPayload,
                beaconRoot: Option[common.Hash256]):
-                 common.EthBlock {.gcsafe, raises:[CatchableError].} =
+                 common.EthBlock {.gcsafe, raises:[RlpError].} =
   common.EthBlock(
-    header     : blockHeader(p, beaconRoot),
-    uncles     : @[],
-    txs        : ethTxs p.transactions,
+    header      : blockHeader(p, beaconRoot),
+    uncles      : @[],
+    transactions: ethTxs p.transactions,
     withdrawals: ethWithdrawals p.withdrawals,
   )

--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -374,7 +374,7 @@ proc initializeEmptyDb*(com: CommonRef)
     info "Writing genesis to DB"
     doAssert(com.genesisHeader.blockNumber.isZero,
       "can't commit genesis block with number > 0")
-    discard com.db.persistHeaderToDb(com.genesisHeader,
+    com.db.persistHeaderToDb(com.genesisHeader,
       com.consensusType == ConsensusType.POS)
     doAssert(canonicalHeadHashKey().toOpenArray in kvt)
 

--- a/nimbus/core/executor/calculate_reward.nim
+++ b/nimbus/core/executor/calculate_reward.nim
@@ -35,7 +35,7 @@ proc calculateReward*(vmState: BaseVMState; account: EthAddress;
 
 
 proc calculateReward*(vmState: BaseVMState;
-                      header: BlockHeader; body: BlockBody) =
-  vmState.calculateReward(header.coinbase, header.blockNumber, body.uncles)
+                      header: BlockHeader; uncles: openArray[BlockHeader]) =
+  vmState.calculateReward(header.coinbase, header.blockNumber, uncles)
 
 # End

--- a/nimbus/core/executor/calculate_reward.nim
+++ b/nimbus/core/executor/calculate_reward.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/core/withdrawals.nim
+++ b/nimbus/core/withdrawals.nim
@@ -8,35 +8,29 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import
-  results,
-  ../common/common
-
 {.push raises: [].}
+
+import results, ../common/common
 
 # https://eips.ethereum.org/EIPS/eip-4895
 proc validateWithdrawals*(
-    com: CommonRef,
-    header: BlockHeader,
-    body: BlockBody
-      ): Result[void, string]
-      {.gcsafe, raises: [].} =
-
+    com: CommonRef, header: BlockHeader, withdrawals: Option[seq[Withdrawal]]
+): Result[void, string] =
   if com.forkGTE(Shanghai):
     if header.withdrawalsRoot.isNone:
       return err("Post-Shanghai block header must have withdrawalsRoot")
-    elif body.withdrawals.isNone:
+    elif withdrawals.isNone:
       return err("Post-Shanghai block body must have withdrawals")
     else:
       try:
-        if body.withdrawals.get.calcWithdrawalsRoot != header.withdrawalsRoot.get:
+        if withdrawals.get.calcWithdrawalsRoot != header.withdrawalsRoot.get:
           return err("Mismatched withdrawalsRoot blockNumber =" & $header.blockNumber)
       except RlpError as ex:
         return err(ex.msg)
   else:
     if header.withdrawalsRoot.isSome:
       return err("Pre-Shanghai block header must not have withdrawalsRoot")
-    elif body.withdrawals.isSome:
+    elif withdrawals.isSome:
       return err("Pre-Shanghai block body must not have withdrawals")
 
   return ok()

--- a/nimbus/db/core_db/core_apps_newapi.nim
+++ b/nimbus/db/core_db/core_apps_newapi.nim
@@ -248,8 +248,7 @@ proc removeTransactionFromCanonicalChain(
 proc setAsCanonicalChainHead(
     db: CoreDbRef;
     headerHash: Hash256;
-      ): seq[BlockHeader]
-      {.gcsafe, raises: [RlpError,BlockNotFound].} =
+      ) {.gcsafe, raises: [RlpError,BlockNotFound].} =
   ## Sets the header as the canonical chain HEAD.
   let header = db.getBlockHeader(headerHash)
 
@@ -272,8 +271,6 @@ proc setAsCanonicalChainHead(
   db.newKvt.put(canonicalHeadHash.toOpenArray, rlp.encode(headerHash)).isOkOr:
     warn logTxt "setAsCanonicalChainHead()",
       canonicalHeadHash, action="put()", error=($$error)
-
-  return newCanonicalHeaders
 
 proc markCanonicalChain(
     db: CoreDbRef;
@@ -720,13 +717,28 @@ proc getWithdrawals*(
   for encodedWd in db.getWithdrawalsData(withdrawalsRoot):
     result.add(rlp.decode(encodedWd, Withdrawal))
 
+proc getTransactions*(
+    db: CoreDbRef;
+    header: BlockHeader;
+    output: var seq[Transaction])
+      {.gcsafe, raises: [RlpError].} =
+  for encodedTx in db.getBlockTransactionData(header.txRoot):
+    output.add(rlp.decode(encodedTx, Transaction))
+
+proc getTransactions*(
+    db: CoreDbRef;
+    header: BlockHeader;
+    ): seq[Transaction]
+      {.gcsafe, raises: [RlpError].} =
+  db.getTransactions(header, result)
+
 proc getBlockBody*(
     db: CoreDbRef;
     header: BlockHeader;
     output: var BlockBody;
       ): bool
       {.gcsafe, raises: [RlpError].} =
-  output.transactions = @[]
+  db.getTransactions(header, output.transactions)
   output.uncles = @[]
   for encodedTx in db.getBlockTransactionData(header.txRoot):
     output.transactions.add(rlp.decode(encodedTx, Transaction))
@@ -762,6 +774,27 @@ proc getBlockBody*(
       {.gcsafe, raises: [RlpError,ValueError].} =
   if not db.getBlockBody(hash, result):
     raise newException(ValueError, "Error when retrieving block body")
+
+proc getEthBlock*(
+    db: CoreDbRef;
+    hash: Hash256;
+      ): EthBlock
+      {.gcsafe, raises: [BlockNotFound, RlpError,ValueError].} =
+  var
+    header = db.getBlockHeader(hash)
+    blockBody = db.getBlockBody(hash)
+  EthBlock.init(move(header), move(blockBody))
+
+proc getEthBlock*(
+    db: CoreDbRef;
+    blockNumber: BlockNumber;
+      ): EthBlock
+      {.gcsafe, raises: [BlockNotFound, RlpError,ValueError].} =
+  var
+    header = db.getBlockHeader(blockNumber)
+    headerHash = header.blockHash
+    blockBody = db.getBlockBody(headerHash)
+  EthBlock.init(move(header), move(blockBody))
 
 proc getUncleHashes*(
     db: CoreDbRef;
@@ -876,8 +909,7 @@ proc persistHeaderToDb*(
     header: BlockHeader;
     forceCanonical: bool;
     startOfHistory = GENESIS_PARENT_HASH;
-      ): seq[BlockHeader]
-      {.gcsafe, raises: [RlpError,EVMError].} =
+      ) {.gcsafe, raises: [RlpError,EVMError].} =
   let isStartOfHistory = header.parentHash == startOfHistory
   let headerHash = header.blockHash
   if not isStartOfHistory and not db.headerExists(header.parentHash):
@@ -887,7 +919,7 @@ proc persistHeaderToDb*(
   kvt.put(genericHashKey(headerHash).toOpenArray, rlp.encode(header)).isOkOr:
     warn logTxt "persistHeaderToDb()",
       headerHash, action="put()", `error`=($$error)
-    return @[]
+    return
 
   let score = if isStartOfHistory: header.difficulty
               else: db.getScore(header.parentHash) + header.difficulty
@@ -895,17 +927,18 @@ proc persistHeaderToDb*(
   kvt.put(scoreKey.toOpenArray, rlp.encode(score)).isOkOr:
     warn logTxt "persistHeaderToDb()",
       scoreKey, action="put()", `error`=($$error)
-    return @[]
+    return
 
   db.addBlockNumberToHashLookup(header)
 
-  var canonHeader: BlockHeader
-  if not db.getCanonicalHead canonHeader:
-    return db.setAsCanonicalChainHead(headerHash)
+  if not forceCanonical:
+    var canonHeader: BlockHeader
+    if db.getCanonicalHead canonHeader:
+      let headScore = db.getScore(canonHeader.hash)
+      if score < headScore:
+        return
 
-  let headScore = db.getScore(canonHeader.hash)
-  if score > headScore or forceCanonical:
-    return db.setAsCanonicalChainHead(headerHash)
+  db.setAsCanonicalChainHead(headerHash)
 
 proc persistHeaderToDbWithoutSetHead*(
     db: CoreDbRef;

--- a/nimbus/db/core_db/core_apps_newapi.nim
+++ b/nimbus/db/core_db/core_apps_newapi.nim
@@ -935,7 +935,7 @@ proc persistHeaderToDb*(
     var canonHeader: BlockHeader
     if db.getCanonicalHead canonHeader:
       let headScore = db.getScore(canonHeader.hash)
-      if score < headScore:
+      if score <= headScore:
         return
 
   db.setAsCanonicalChainHead(headerHash)

--- a/nimbus/db/era1_db/db_desc.nim
+++ b/nimbus/db/era1_db/db_desc.nim
@@ -80,6 +80,11 @@ proc init*(
 
   ok Era1DbRef(path: path, network: network, filenames: filenames)
 
+proc getEthBlock*(db: Era1DbRef, blockNumber: uint64): Result[EthBlock, string] =
+  let f = ?db.getEra1File(blockNumber.era)
+
+  f.getEthBlock(blockNumber)
+
 proc getBlockTuple*(db: Era1DbRef, blockNumber: uint64): Result[BlockTuple, string] =
   let f = ?db.getEra1File(blockNumber.era)
 

--- a/nimbus/evm/state.nim
+++ b/nimbus/evm/state.nim
@@ -12,6 +12,7 @@
 
 import
   std/[options, sets, strformat],
+  stew/assign2,
   eth/keys,
   ../db/ledger,
   ../common/[common, evmforks],
@@ -28,7 +29,7 @@ proc init(
       tracer:       TracerRef,
       flags:        set[VMFlag] = self.flags) =
   ## Initialisation helper
-  self.parent = parent
+  assign(self.parent, parent)
   self.blockCtx = blockCtx
   self.gasPool = blockCtx.gasLimit
   self.com = com

--- a/nimbus/rpc/debug.nim
+++ b/nimbus/rpc/debug.nim
@@ -87,11 +87,9 @@ proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, rpcsrv: RpcServer) =
     ## data: Hash of a block.
     var
       h = data.ethHash
-      header = chainDB.getBlockHeader(h)
-      blockHash = chainDB.getBlockHash(header.blockNumber)
-      body = chainDB.getBlockBody(blockHash)
+      blk = chainDB.getEthBlock(h)
 
-    dumpBlockState(com, EthBlock.init(move(header), move(body)))
+    dumpBlockState(com, blk)
 
   rpcsrv.rpc("debug_traceBlockByNumber") do(quantityTag: BlockTag, options: Option[TraceOptions]) -> JsonNode:
     ## The traceBlock method will return a full stack trace of all invoked opcodes of all transaction

--- a/nimbus/rpc/experimental.nim
+++ b/nimbus/rpc/experimental.nim
@@ -52,7 +52,7 @@ proc getMultiKeys*(
   defer: dbTx.dispose()
 
   # Execute the block of transactions and collect the keys of the touched account state
-  let processBlockResult = processBlock(vmState, blockHeader, blockBody)
+  let processBlockResult = processBlock(vmState, EthBlock.init(blockHeader, blockBody))
   doAssert processBlockResult == ValidationResult.OK
 
   let mkeys = vmState.stateDB.makeMultiKeys()

--- a/nimbus/rpc/experimental.nim
+++ b/nimbus/rpc/experimental.nim
@@ -37,12 +37,11 @@ proc getMultiKeys*(
 
   let
     chainDB = com.db
-    blockHash = chainDB.getBlockHash(blockHeader.blockNumber)
-    blockBody = chainDB.getBlockBody(blockHash)
+    blk = chainDB.getEthBlock(blockHeader.blockNumber)
     # Initializing the VM will throw a Defect if the state doesn't exist.
     # Once we enable pruning we will need to check if the block state has been pruned
     # before trying to initialize the VM as we do here.
-    vmState = BaseVMState.new(blockHeader, com).valueOr:
+    vmState = BaseVMState.new(blk.header, com).valueOr:
                 raise newException(ValueError, "Cannot create vm state")
 
   vmState.collectWitnessData = true # Enable saving witness data
@@ -52,7 +51,7 @@ proc getMultiKeys*(
   defer: dbTx.dispose()
 
   # Execute the block of transactions and collect the keys of the touched account state
-  let processBlockResult = processBlock(vmState, EthBlock.init(blockHeader, blockBody))
+  let processBlockResult = processBlock(vmState, blk)
   doAssert processBlockResult == ValidationResult.OK
 
   let mkeys = vmState.stateDB.makeMultiKeys()

--- a/nimbus/sync/beacon/skeleton_db.nim
+++ b/nimbus/sync/beacon/skeleton_db.nim
@@ -196,11 +196,10 @@ proc resetCanonicalHead*(sk: SkeletonRef, newHead, oldHead: uint64) =
   sk.chain.com.syncCurrent = newHead.toBlockNumber
 
 proc insertBlocks*(sk: SkeletonRef,
-                   headers: openArray[BlockHeader],
-                   body: openArray[BlockBody],
+                   blocks: openArray[EthBlock],
                    fromEngine: bool): Result[uint64, string] =
-  discard ? sk.chain.persistBlocks(headers, body)
-  ok(headers.len.uint64)
+  discard ? sk.chain.persistBlocks(blocks)
+  ok(blocks.len.uint64)
 
 proc insertBlock*(sk: SkeletonRef,
                   header: BlockHeader,
@@ -209,4 +208,4 @@ proc insertBlock*(sk: SkeletonRef,
     return err(error)
   if maybeBody.isNone:
     return err("insertBlock: Block body not found: " & $header.u64)
-  sk.insertBlocks([header], [maybeBody.get], fromEngine)
+  sk.insertBlocks([EthBlock.init(header, maybeBody.get)], fromEngine)

--- a/premix/debug.nim
+++ b/premix/debug.nim
@@ -60,7 +60,7 @@ proc executeBlock(blockEnv: JsonNode, memoryDB: CoreDbRef, blockNumber: UInt256)
 
   # prestate data goes to debug tool and contains data
   # needed to execute single block
-  generatePrestate(nimbus, geth, blockNumber, parent, header, body)
+  generatePrestate(nimbus, geth, blockNumber, parent, blk)
 
 proc main() =
   if paramCount() == 0:

--- a/premix/debug.nim
+++ b/premix/debug.nim
@@ -29,19 +29,19 @@ proc prepareBlockEnv(node: JsonNode, memoryDB: CoreDbRef) =
       raiseAssert "prepareBlockEnv(): put() (loop) failed " & $$error
 
 proc executeBlock(blockEnv: JsonNode, memoryDB: CoreDbRef, blockNumber: UInt256) =
-  let
+  var
     parentNumber = blockNumber - 1
     com = CommonRef.new(memoryDB)
     parent = com.db.getBlockHeader(parentNumber)
     header = com.db.getBlockHeader(blockNumber)
     body   = com.db.getBlockBody(header.blockHash)
-
+    blk    = EthBlock.init(move(header), move(body))
   let transaction = memoryDB.newTransaction()
   defer: transaction.dispose()
 
   let
     vmState = BaseVMState.new(parent, header, com)
-    validationResult = vmState.processBlock(header, body)
+    validationResult = vmState.processBlock(blk)
 
   if validationResult != ValidationResult.OK:
     error "block validation error", validationResult
@@ -49,7 +49,7 @@ proc executeBlock(blockEnv: JsonNode, memoryDB: CoreDbRef, blockNumber: UInt256)
     info "block validation success", validationResult, blockNumber
 
   transaction.rollback()
-  vmState.dumpDebuggingMetaData(header, body, false)
+  vmState.dumpDebuggingMetaData(blk, false)
   let
     fileName = "debug" & $blockNumber & ".json"
     nimbus   = json.parseFile(fileName)

--- a/premix/debug.nim
+++ b/premix/debug.nim
@@ -33,14 +33,12 @@ proc executeBlock(blockEnv: JsonNode, memoryDB: CoreDbRef, blockNumber: UInt256)
     parentNumber = blockNumber - 1
     com = CommonRef.new(memoryDB)
     parent = com.db.getBlockHeader(parentNumber)
-    header = com.db.getBlockHeader(blockNumber)
-    body   = com.db.getBlockBody(header.blockHash)
-    blk    = EthBlock.init(move(header), move(body))
+    blk = com.db.getEthBlock(blockNumber)
   let transaction = memoryDB.newTransaction()
   defer: transaction.dispose()
 
   let
-    vmState = BaseVMState.new(parent, header, com)
+    vmState = BaseVMState.new(parent, blk.header, com)
     validationResult = vmState.processBlock(blk)
 
   if validationResult != ValidationResult.OK:

--- a/premix/dumper.nim
+++ b/premix/dumper.nim
@@ -43,7 +43,7 @@ proc dumpDebug(com: CommonRef, blockNumber: UInt256) =
     vmState = BaseVMState.new(parent, header, captureCom)
 
   discard captureCom.db.setHead(parent, true)
-  discard vmState.processBlock(blk, body)
+  discard vmState.processBlock(blk)
 
   transaction.rollback()
   vmState.dumpDebuggingMetaData(blk, false)

--- a/premix/dumper.nim
+++ b/premix/dumper.nim
@@ -36,11 +36,8 @@ proc dumpDebug(com: CommonRef, blockNumber: UInt256) =
   var
     parentNumber = blockNumber - 1
     parent = captureCom.db.getBlockHeader(parentNumber)
-    header = captureCom.db.getBlockHeader(blockNumber)
-    headerHash = header.blockHash
-    body = captureCom.db.getBlockBody(headerHash)
-    blk = EthBlock.init(move(header), move(body))
-    vmState = BaseVMState.new(parent, header, captureCom)
+    blk = captureCom.db.getEthBlock(blockNumber)
+    vmState = BaseVMState.new(parent, blk.header, captureCom)
 
   discard captureCom.db.setHead(parent, true)
   discard vmState.processBlock(blk)

--- a/premix/dumper.nim
+++ b/premix/dumper.nim
@@ -33,19 +33,20 @@ proc dumpDebug(com: CommonRef, blockNumber: UInt256) =
   defer: transaction.dispose()
 
 
-  let
+  var
     parentNumber = blockNumber - 1
     parent = captureCom.db.getBlockHeader(parentNumber)
     header = captureCom.db.getBlockHeader(blockNumber)
     headerHash = header.blockHash
     body = captureCom.db.getBlockBody(headerHash)
+    blk = EthBlock.init(move(header), move(body))
     vmState = BaseVMState.new(parent, header, captureCom)
 
   discard captureCom.db.setHead(parent, true)
-  discard vmState.processBlock(header, body)
+  discard vmState.processBlock(blk, body)
 
   transaction.rollback()
-  vmState.dumpDebuggingMetaData(header, body, false)
+  vmState.dumpDebuggingMetaData(blk, false)
 
 proc main() {.used.} =
   let conf = getConfiguration()

--- a/premix/persist.nim
+++ b/premix/persist.nim
@@ -78,8 +78,8 @@ proc main() {.used.} =
 
   let numBlocksToCommit = conf.numCommits
 
-  var headers = newSeqOfCap[EthBlock](numBlocksToCommit)
-  var one     = 1.u256
+  var blocks = newSeqOfCap[EthBlock](numBlocksToCommit)
+  var one    = 1.u256
 
   var numBlocks = 0
   var counter = 0

--- a/premix/premix.nim
+++ b/premix/premix.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Copyright (c) 2020-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/premix/premix.nim
+++ b/premix/premix.nim
@@ -62,7 +62,9 @@ proc main() =
 
     # prestate data goes to debug tool and contains data
     # needed to execute single block
-    generatePrestate(nimbus, geth, blockNumber, parentBlock.header, thisBlock.header, thisBlock.body)
+    generatePrestate(
+      nimbus, geth, blockNumber, parentBlock.header,
+      EthBlock.init(thisBlock.header, thisBlock.body))
 
     printDebugInstruction(blockNumber)
   except CatchableError:

--- a/premix/prestate.nim
+++ b/premix/prestate.nim
@@ -14,7 +14,8 @@ import
   ../nimbus/db/[core_db, storage_types], eth/[rlp, common],
   ../nimbus/tracer
 
-proc generatePrestate*(nimbus, geth: JsonNode, blockNumber: UInt256, parent, header: BlockHeader, body: BlockBody) =
+proc generatePrestate*(nimbus, geth: JsonNode, blockNumber: UInt256, parent: BlockHeader, blk: EthBlock) =
+  template header: BlockHeader = blk.header
   let
     state = nimbus["state"]
     headerHash = rlpHash(header)
@@ -22,8 +23,8 @@ proc generatePrestate*(nimbus, geth: JsonNode, blockNumber: UInt256, parent, hea
     kvt = chainDB.newKvt()
 
   discard chainDB.setHead(parent, true)
-  discard chainDB.persistTransactions(blockNumber, body.transactions)
-  discard chainDB.persistUncles(body.uncles)
+  discard chainDB.persistTransactions(blockNumber, blk.transactions)
+  discard chainDB.persistUncles(blk.uncles)
 
   kvt.put(genericHashKey(headerHash).toOpenArray, rlp.encode(header)).isOkOr:
     raiseAssert "generatePrestate(): put() failed " & $$error

--- a/premix/regress.nim
+++ b/premix/regress.nim
@@ -27,8 +27,7 @@ proc validateBlock(com: CommonRef, blockNumber: BlockNumber): BlockNumber =
     blocks = newSeq[EthBlock](numBlocks)
 
   for i in 0 ..< numBlocks:
-    let header = com.db.getBlockHeader(blockNumber + i.u256)
-    blocks[i]  = EthBlock.init(header, com.db.getBlockBody(header.blockHash))
+    blocks[i] = com.db.getEthBlock(blockNumber + i.u256)
 
   let transaction = com.db.newTransaction()
   defer: transaction.dispose()

--- a/tests/persistBlockTestGen.nim
+++ b/tests/persistBlockTestGen.nim
@@ -28,13 +28,11 @@ proc dumpTest(com: CommonRef, blockNumber: int) =
 
   let
     parent = captureCom.db.getBlockHeader(parentNumber)
-    header = captureCom.db.getBlockHeader(blockNumber)
-    headerHash = header.blockHash
-    blockBody = captureCom.db.getBlockBody(headerHash)
+    blk = captureCom.db.getEthBlock(blockNumber)
     chain = newChain(captureCom)
 
   discard captureCom.db.setHead(parent, true)
-  discard chain.persistBlocks([EthBlock.init(header, blockBody)])
+  discard chain.persistBlocks([blk])
 
   var metaData = %{
     "blockNumber": %blockNumber.toHex

--- a/tests/persistBlockTestGen.nim
+++ b/tests/persistBlockTestGen.nim
@@ -32,11 +32,9 @@ proc dumpTest(com: CommonRef, blockNumber: int) =
     headerHash = header.blockHash
     blockBody = captureCom.db.getBlockBody(headerHash)
     chain = newChain(captureCom)
-    headers = @[header]
-    bodies = @[blockBody]
 
   discard captureCom.db.setHead(parent, true)
-  discard chain.persistBlocks(headers, bodies)
+  discard chain.persistBlocks([EthBlock.init(header, blockBody)])
 
   var metaData = %{
     "blockNumber": %blockNumber.toHex

--- a/tests/replay/undump_blocks.nim
+++ b/tests/replay/undump_blocks.nim
@@ -21,7 +21,7 @@ iterator undumpBlocks*(
     file: string;
     least = low(uint64);                     # First block to extract
     stopAfter = high(uint64);                # Last block to extract
-      ): (seq[BlockHeader],seq[BlockBody]) =
+      ): seq[EthBlock] =
   if file.dirExists:
     for w in file.undumpBlocksEra1(least, stopAfter):
       yield w
@@ -38,7 +38,7 @@ iterator undumpBlocks*(
     files: seq[string];
     least = low(uint64);                     # First block to extract
     stopAfter = high(uint64);                # Last block to extract
-      ): (seq[BlockHeader],seq[BlockBody]) =
+      ): seq[EthBlock] =
   for f in files:
     for w in f.undumpBlocks(least, stopAfter):
       yield w

--- a/tests/replay/undump_helpers.nim
+++ b/tests/replay/undump_helpers.nim
@@ -17,34 +17,32 @@ import
 # ------------------------------------------------------------------------------
 
 proc startAt*(
-    h: openArray[BlockHeader];
-    b: openArray[BlockBody];
+    h: openArray[EthBlock];
     start: uint64;
-      ): (seq[BlockHeader],seq[BlockBody]) =
+      ): seq[EthBlock] =
   ## Filter out blocks with smaller `blockNumber`
-  if start.toBlockNumber <= h[0].blockNumber:
-    return (h.toSeq,b.toSeq)
-  if start.toBlockNumber <= h[^1].blockNumber:
+  if start.toBlockNumber <= h[0].header.blockNumber:
+    return h.toSeq()
+  if start.toBlockNumber <= h[^1].header.blockNumber:
     # There are at least two headers, find the least acceptable one
     var n = 1
-    while h[n].blockNumber < start.toBlockNumber:
+    while h[n].header.blockNumber < start.toBlockNumber:
       n.inc
-    return (h[n ..< h.len], b[n ..< b.len])
+    return h[n ..< h.len]
 
 proc stopAfter*(
-    h: openArray[BlockHeader];
-    b: openArray[BlockBody];
+    h: openArray[EthBlock];
     last: uint64;
-      ): (seq[BlockHeader],seq[BlockBody]) =
+      ): seq[EthBlock] =
   ## Filter out blocks with larger `blockNumber`
-  if h[^1].blockNumber <= last.toBlockNumber:
-    return (h.toSeq,b.toSeq)
-  if h[0].blockNumber <= last.toBlockNumber:
+  if h[^1].header.blockNumber <= last.toBlockNumber:
+    return h.toSeq()
+  if h[0].header.blockNumber <= last.toBlockNumber:
     # There are at least two headers, find the last acceptable one
     var n = 1
-    while h[n].blockNumber <= last.toBlockNumber:
+    while h[n].header.blockNumber <= last.toBlockNumber:
       n.inc
-    return (h[0 ..< n], b[0 ..< n])
+    return h[0 ..< n]
 
 # ------------------------------------------------------------------------------
 # End

--- a/tests/test_accounts_cache.nim
+++ b/tests/test_accounts_cache.nim
@@ -295,8 +295,8 @@ proc runner(noisy = true; capture = goerliCapture) =
     test &"Import from {fileInfo}":
       # Import minimum amount of blocks, then collect transactions
       for chain in filePath.undumpBlocks:
-        let leadBlkNum = chain[0][0].blockNumber
-        topNumber = chain[0][^1].blockNumber
+        let leadBlkNum = chain[0].header.blockNumber
+        topNumber = chain[^1].header.blockNumber
 
         if loadTxs <= txs.len:
           break
@@ -308,16 +308,16 @@ proc runner(noisy = true; capture = goerliCapture) =
 
         # Import block chain blocks
         if leadBlkNum < loadBlocks:
-          com.importBlocks(chain[0],chain[1])
+          com.importBlocks(chain)
           continue
 
         # Import transactions
-        for inx in 0 ..< chain[0].len:
-          let blkTxs = chain[1][inx].transactions
+        for inx in 0 ..< chain.len:
+          let blkTxs = chain[inx].transactions
 
           # Continue importing up until first non-trivial block
           if txs.len == 0 and blkTxs.len == 0:
-            com.importBlocks(@[chain[0][inx]],@[chain[1][inx]])
+            com.importBlocks([chain[inx]])
             continue
 
           # Load transactions

--- a/tests/test_beacon/test_5_canonical_past_genesis.nim
+++ b/tests/test_beacon/test_5_canonical_past_genesis.nim
@@ -19,7 +19,7 @@ proc test5*() =
   suite "should fill the canonical chain after being linked to a canonical block past genesis":
     let env = setupEnv()
     let skel = SkeletonRef.new(env.chain)
-    
+
     test "skel open ok":
       let res = skel.open()
       check res.isOk
@@ -43,7 +43,8 @@ proc test5*() =
         check res.isOk
 
     test "canonical height should be at block 2":
-      let r = skel.insertBlocks([block1, block2], [emptyBody, emptyBody], false)
+      let r = skel.insertBlocks([
+        EthBlock.init(block1, emptyBody), EthBlock.init(block2, emptyBody)], false)
       check r.isOk
       check r.get == 2
 

--- a/tests/test_beacon/test_5_canonical_past_genesis.nim
+++ b/tests/test_beacon/test_5_canonical_past_genesis.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at
 #     https://opensource.org/licenses/MIT).

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -254,7 +254,7 @@ proc collectDebugData(ctx: var TestCtx) =
   }
 
 proc runTestCtx(ctx: var TestCtx, com: CommonRef, testStatusIMPL: var TestStatus) =
-  discard com.db.persistHeaderToDb(ctx.genesisHeader,
+  com.db.persistHeaderToDb(ctx.genesisHeader,
     com.consensus == ConsensusType.POS)
   check com.db.getCanonicalHead().blockHash == ctx.genesisHeader.blockHash
   let checkSeal = ctx.shouldCheckSeal

--- a/tests/test_persistblock_json.nim
+++ b/tests/test_persistblock_json.nim
@@ -30,16 +30,12 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus) =
   let
     parentNumber = blockNumber - 1
     parent = com.db.getBlockHeader(parentNumber)
-    header = com.db.getBlockHeader(blockNumber)
-    headerHash = header.blockHash
-    blockBody = com.db.getBlockBody(headerHash)
+    blk = com.db.getEthBlock(blockNumber)
     chain = newChain(com)
-    headers = @[header]
-    bodies = @[blockBody]
 
   # it's ok if setHead fails here because of missing ancestors
   discard com.db.setHead(parent, true)
-  let validationResult = chain.persistBlocks(headers, bodies)
+  let validationResult = chain.persistBlocks([blk])
   check validationResult.isOk()
 
 proc persistBlockJsonMain*() =

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -192,7 +192,7 @@ proc setupEnv(com: CommonRef, signer, ks2: EthAddress, ctx: EthContext): TestEnv
   let uncles = [header]
   header.ommersHash = com.db.persistUncles(uncles)
 
-  discard com.db.persistHeaderToDb(header,
+  com.db.persistHeaderToDb(header,
     com.consensus == ConsensusType.POS)
   com.db.persistFixtureBlock()
   result = TestEnv(

--- a/tests/test_rpc_experimental_json.nim
+++ b/tests/test_rpc_experimental_json.nim
@@ -41,19 +41,15 @@ proc importBlockData(node: JsonNode): (CommonRef, Hash256, Hash256, UInt256) {. 
   let
     parentNumber = blockNumber - 1
     parent = com.db.getBlockHeader(parentNumber)
-    header = com.db.getBlockHeader(blockNumber)
-    headerHash = header.blockHash
-    blockBody = com.db.getBlockBody(headerHash)
+    blk = com.db.getEthBlock(blockNumber)
     chain = newChain(com)
-    headers = @[header]
-    bodies = @[blockBody]
 
   # it's ok if setHead fails here because of missing ancestors
   discard com.db.setHead(parent, true)
-  let validationResult = chain.persistBlocks(headers, bodies)
+  let validationResult = chain.persistBlocks([blk])
   doAssert validationResult.isOk()
 
-  return (com, parent.stateRoot, header.stateRoot, blockNumber)
+  return (com, parent.stateRoot, blk.header.stateRoot, blockNumber)
 
 proc checkAndValidateProofs(
     db: CoreDbRef,

--- a/tests/test_tracer_json.nim
+++ b/tests/test_tracer_json.nim
@@ -92,13 +92,11 @@ proc testFixtureImpl(node: JsonNode, testStatusIMPL: var TestStatus, memoryDB: C
   # Some hack for `Aristo` using the `snap` protocol proof-loader
   memoryDB.preLoadAristoDb(state, blockNumber)
 
-  var header = com.db.getBlockHeader(blockNumber)
-  var headerHash = header.blockHash
-  var blockBody = com.db.getBlockBody(headerHash)
+  var blk = com.db.getEthBlock(blockNumber)
 
-  let txTraces = traceTransactions(com, header, blockBody)
-  let stateDump = dumpBlockState(com, header, blockBody)
-  let blockTrace = traceBlock(com, header, blockBody, {DisableState})
+  let txTraces = traceTransactions(com, blk.header, blk.transactions)
+  let stateDump = dumpBlockState(com, blk)
+  let blockTrace = traceBlock(com, blk, {DisableState})
 
   check node["txTraces"] == txTraces
   check node["stateDump"] == stateDump

--- a/tests/test_txpool2.nim
+++ b/tests/test_txpool2.nim
@@ -172,7 +172,7 @@ proc runTxPoolPosTest() =
       check blk.txs.len == 1
 
     test "PoS persistBlocks":
-      let rr = chain.persistBlocks([blk.header], [body])
+      let rr = chain.persistBlocks([EthBlock.init(blk.header, body)])
       check rr.isOk()
 
     test "validate TxPool prevRandao setter":
@@ -235,7 +235,7 @@ proc runTxPoolBlobhashTest() =
       check blk.txs.len == 2
 
     test "Blobhash persistBlocks":
-      let rr = chain.persistBlocks([blk.header], [body])
+      let rr = chain.persistBlocks([EthBlock.init(blk.header, body)])
       check rr.isOk()
 
     test "validate TxPool prevRandao setter":
@@ -317,7 +317,7 @@ proc runTxHeadDelta(noisy = true) =
             uncles: blk.uncles)
 
           # Commit to block chain
-          check chain.persistBlocks([blk.header], [body]).isOk
+          check chain.persistBlocks([EthBlock.init(blk.header, body)]).isOk
 
           # Synchronise TxPool against new chain head, register txs differences.
           # In this particular case, these differences will simply flush the

--- a/tests/tracerTestGen.nim
+++ b/tests/tracerTestGen.nim
@@ -25,13 +25,11 @@ proc dumpTest(com: CommonRef, blockNumber: int) =
     captureCom = com.clone(capture.recorder)
 
   let
-    header = captureCom.db.getBlockHeader(blockNumber)
-    headerHash = header.blockHash
-    blockBody = captureCom.db.getBlockBody(headerHash)
-    txTrace = traceTransactions(captureCom, header, blockBody)
-    stateDump = dumpBlockState(captureCom, header, blockBody)
-    blockTrace = traceBlock(captureCom, header, blockBody, {DisableState})
-    receipts = dumpReceipts(captureCom.db, header)
+    blk = captureCom.db.getEthBlock(blockNumber)
+    txTrace = traceTransactions(captureCom, blk)
+    stateDump = dumpBlockState(captureCom, blk)
+    blockTrace = traceBlock(captureCom, blk, {DisableState})
+    receipts = dumpReceipts(captureCom.db, blk.header)
 
   var metaData = %{
     "blockNumber": %blockNumber.toHex,

--- a/tests/tracerTestGen.nim
+++ b/tests/tracerTestGen.nim
@@ -26,7 +26,7 @@ proc dumpTest(com: CommonRef, blockNumber: int) =
 
   let
     blk = captureCom.db.getEthBlock(blockNumber)
-    txTrace = traceTransactions(captureCom, blk)
+    txTrace = traceTransactions(captureCom, blk.header, blk.transactions)
     stateDump = dumpBlockState(captureCom, blk)
     blockTrace = traceBlock(captureCom, blk, {DisableState})
     receipts = dumpReceipts(captureCom.db, blk.header)


### PR DESCRIPTION
This PR consolidates the split header-body sequences into a single EthBlock sequence and cleans up the fallout from that which significantly reduces block processing overhead during import thanks to less garbage collection and fewer copies of things all around.

Notably, since the number of headers must always match the number of bodies, we also get rid of a pointless degree of freedom that in the future could introduce unnecessary bugs.

* only read header and body from era file
* avoid several unnecessary copies along the block processing way
* simplify signatures, cleaning up unused arguemnts and returns
* use `stew/assign2` in a few strategic places where the generated nim assignent is slow and add a few `move` to work around poor analysis in nim 1.6 (will need to be revisited for 2.0)

```
stats-20240607_2223-a814aa0b.csv vs stats-20240608_0714-21c1d0a9.csv
                       bps_x     bps_y     tps_x        tps_y    bpsd    tpsd    timed
block_number
(498305, 713245]    1,540.52  1,809.73  2,361.58  2775.340189  17.63%  17.63%  -14.92%
(713245, 928185]      730.36    865.26  1,715.90  2028.973852  18.01%  18.01%  -15.21%
(928185, 1143126]     663.03    789.10  2,529.26  3032.490771  19.79%  19.79%  -16.28%
(1143126, 1358066]    393.46    508.05  2,152.50  2777.578119  29.13%  29.13%  -22.50%
(1358066, 1573007]    370.88    440.72  2,351.31  2791.896052  18.81%  18.81%  -15.80%
(1573007, 1787947]    283.65    335.11  2,068.93  2441.373402  17.60%  17.60%  -14.91%
(1787947, 2002888]    287.29    342.11  2,078.39  2474.179448  18.99%  18.99%  -15.91%
(2002888, 2217828]    293.38    343.16  2,208.83   2584.77457  17.16%  17.16%  -14.61%
(2217828, 2432769]    140.09    167.86  1,081.87  1296.336926  18.82%  18.82%  -15.80%

blocks: 1934464, baseline: 3h13m1s, contender: 2h43m47s
bpsd (mean): 19.55%
tpsd (mean): 19.55%
Time (total): -29m13s, -15.14%
```