### PR TITLE
Fix issues introduced by #2325

### DIFF
--- a/nimbus/db/core_db/core_apps_newapi.nim
+++ b/nimbus/db/core_db/core_apps_newapi.nim
@@ -740,8 +740,6 @@ proc getBlockBody*(
       {.gcsafe, raises: [RlpError].} =
   db.getTransactions(header, output.transactions)
   output.uncles = @[]
-  for encodedTx in db.getBlockTransactionData(header.txRoot):
-    output.transactions.add(rlp.decode(encodedTx, Transaction))
 
   if header.withdrawalsRoot.isSome:
     output.withdrawals = some(db.getWithdrawals(header.withdrawalsRoot.get))

--- a/nimbus/sync/beacon/skeleton_db.nim
+++ b/nimbus/sync/beacon/skeleton_db.nim
@@ -208,4 +208,7 @@ proc insertBlock*(sk: SkeletonRef,
     return err(error)
   if maybeBody.isNone:
     return err("insertBlock: Block body not found: " & $header.u64)
-  sk.insertBlocks([EthBlock.init(header, maybeBody.get)], fromEngine)
+  # TODO: make `header` param become a sink and then fix caller
+  let headerCopy = header
+  # EthBlock.init will call `system.move` on both headerCopy and  maybeBody
+  sk.insertBlocks([EthBlock.init(headerCopy, maybeBody.get)], fromEngine)


### PR DESCRIPTION
With the introduction of `EthBlock.init`, everyone have to be careful with both header and block body reuse.

Looks like nim compiler is silent when sinked parameter is being reused. or the warning being turned off.