### PR TITLE
avoid unnecessary memory allocations and lookups

### DIFF
--- a/fluffy/eth_data/era1.nim
+++ b/fluffy/eth_data/era1.nim
@@ -453,7 +453,7 @@ proc buildAccumulator*(f: Era1File): Result[EpochAccumulatorCached, string] =
       HeaderRecord(blockHash: blockHeader.blockHash(), totalDifficulty: totalDifficulty)
     )
 
-  ok(EpochAccumulatorCached.init(@headerRecords))
+  ok(EpochAccumulatorCached.init(headerRecords))
 
 proc verify*(f: Era1File): Result[Digest, string] =
   let

--- a/nimbus/db/aristo/aristo_init/rocks_db.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db.nim
@@ -30,7 +30,6 @@ import
   eth/common,
   rocksdb,
   results,
-  ../aristo_constants,
   ../aristo_desc,
   ../aristo_desc/desc_backend,
   ../aristo_blobify,

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -32,9 +32,6 @@ type
     basePath*: string                  ## Database directory
     noFq*: bool                        ## No filter queues available
 
-  RdbKey* = array[1 + sizeof VertexID, byte]
-    ## Sub-table key, <pfx> + VertexID
-
   # Alien interface
   RdbGuest* = enum
     ## The guest CF was worth a try, but there are better solutions and this

--- a/nimbus/db/aristo/aristo_layers.nim
+++ b/nimbus/db/aristo/aristo_layers.nim
@@ -62,39 +62,39 @@ func nLayersKey*(db: AristoDbRef): int =
 # Public functions: getter variants
 # ------------------------------------------------------------------------------
 
-func layersGetVtx*(db: AristoDbRef; vid: VertexID): Result[VertexRef,void] =
+func layersGetVtx*(db: AristoDbRef; vid: VertexID): Opt[VertexRef] =
   ## Find a vertex on the cache layers. An `ok()` result might contain a
   ## `nil` vertex if it is stored on the cache  that way.
   ##
-  if db.top.delta.sTab.hasKey vid:
-    return ok(db.top.delta.sTab.getOrVoid vid)
+  db.top.delta.sTab.withValue(vid, item):
+    return Opt.some(item[])
 
   for w in db.rstack:
-    if w.delta.sTab.hasKey vid:
-      return ok(w.delta.sTab.getOrVoid vid)
+    w.delta.sTab.withValue(vid, item):
+      return Opt.some(item[])
 
-  err()
+  Opt.none(VertexRef)
 
 func layersGetVtxOrVoid*(db: AristoDbRef; vid: VertexID): VertexRef =
   ## Simplified version of `layersGetVtx()`
   db.layersGetVtx(vid).valueOr: VertexRef(nil)
 
 
-func layersGetKey*(db: AristoDbRef; vid: VertexID): Result[HashKey,void] =
+func layersGetKey*(db: AristoDbRef; vid: VertexID): Opt[HashKey] =
   ## Find a hash key on the cache layers. An `ok()` result might contain a void
   ## hash key if it is stored on the cache that way.
   ##
-  if db.top.delta.kMap.hasKey vid:
+  db.top.delta.kMap.withValue(vid, item):
     # This is ok regardless of the `dirty` flag. If this vertex has become
     # dirty, there is an empty `kMap[]` entry on this layer.
-    return ok(db.top.delta.kMap.getOrVoid vid)
+    return Opt.some(item[])
 
   for w in db.rstack:
-    if w.delta.kMap.hasKey vid:
+    w.delta.kMap.withValue(vid, item):
       # Same reasoning as above regarding the `dirty` flag.
-      return ok(w.delta.kMap.getOrVoid vid)
+      return ok(item[])
 
-  err()
+  Opt.none(HashKey)
 
 func layersGetKeyOrVoid*(db: AristoDbRef; vid: VertexID): HashKey =
   ## Simplified version of `layersGetkey()`

--- a/nimbus/db/aristo/aristo_merge/merge_proof.nim
+++ b/nimbus/db/aristo/aristo_merge/merge_proof.nim
@@ -162,9 +162,9 @@ proc mergeProof*(
     ## Check for embedded nodes, i.e. fully encoded node instead of a hash.
     ## They need to be treated as full nodes, here.
     if key.isValid and key.len < 32:
-      let lid = @(key.data).digestTo(HashKey)
+      let lid = key.data.digestTo(HashKey)
       if not seen.hasKey lid:
-        let node = @(key.data).decode(NodeRef)
+        let node = key.data.decode(NodeRef)
         discard todo.append node
         seen[lid] = node
 

--- a/nimbus/db/kvt/kvt_utils.nim
+++ b/nimbus/db/kvt/kvt_utils.nim
@@ -106,7 +106,7 @@ proc hasKey*(
   if key.len == 0:
     return err(KeyInvalid)
 
-  if db.layersHasKey @key:
+  if db.layersHasKey key:
     return ok(true)
 
   let rc = db.getBe key


### PR DESCRIPTION
* use `withValue` instead of `hasKey` + `[]`
* avoid `@` et al
* parse database data inside `onData` instead of making seq then parsing