### PR TITLE
Use vendor RocksDb dll on Windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,11 +224,9 @@ libbacktrace:
 
 ifneq ($(USE_SYSTEM_ROCKSDB), 0)
 ifeq ($(OS), Windows_NT)
-rocksdb: fetch-dlls
+rocksdb:
 	+ vendor/nim-rocksdb/scripts/build_dlls_windows.bat && \
-	rm build/librocksdb.dll
 	cp -a vendor/nim-rocksdb/build/librocksdb.dll build
-
 else
 rocksdb:
 	+ vendor/nim-rocksdb/scripts/build_static_deps.sh

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,10 @@ libbacktrace:
 ifneq ($(USE_SYSTEM_ROCKSDB), 0)
 ifeq ($(OS), Windows_NT)
 rocksdb: fetch-dlls
+	+ vendor/nim-rocksdb/scripts/build_dlls_windows.bat && \
+	rm build/librocksdb.dll
+	cp -a vendor/nim-rocksdb/build/librocksdb.dll build
+
 else
 rocksdb:
 	+ vendor/nim-rocksdb/scripts/build_static_deps.sh

--- a/README.md
+++ b/README.md
@@ -131,16 +131,22 @@ Install [Git for Windows](https://gitforwindows.org/) and use a "Git Bash" shell
 
 Install [cmake](https://cmake.org/).
 
-If you don't want to compile RocksDB and SQLite separately, you can fetch pre-compiled DLLs with:
+After adding the Git bin directory to your path you can open a bash shell which should be used when building Nimbus on Windows:
 ```bash
-mingw32-make fetch-dlls # this will place the right DLLs for your architecture in the "build/" directory
+bash
 ```
 
-You can now follow those instructions in the previous section by replacing `make` with `mingw32-make` (regardless of your 32-bit or 64-bit architecture):
+After installing Mingw-w64 and adding it to your path you should have the `mingw32-make` tool available. Next create a link from `make` to `mingw32-make`:
 
 ```bash
-mingw32-make nimbus # build the Nimbus binary
-mingw32-make test # run the test suite
+ln mingw32-make make
+```
+
+You can now follow those instructions in the previous section. For example:
+
+```bash
+make nimbus # build the Nimbus binary
+make test # run the test suite
 # etc.
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ installation directory to "C:\mingw-w64" and add it to your system PATH in "My
 Computer"/"This PC" -> Properties -> Advanced system settings -> Environment
 Variables -> Path -> Edit -> New -> C:\mingw-w64\mingw64\bin (it's "C:\mingw-w64\mingw32\bin" on 32-bit)
 
-Install [Git for Windows](https://gitforwindows.org/) and use a "Git Bash" shell to clone and build Nimbus.
+Install [Git for Windows](https://gitforwindows.org/) and use it to clone Nimbus.
 
 Install [cmake](https://cmake.org/).
 
-After adding the Git bin directory to your path you can open a bash shell which should be used when building Nimbus on Windows:
+After adding the Git bin directory to your path open a "Git Bash" shell:
 ```bash
 bash
 ```
@@ -139,7 +139,7 @@ bash
 After installing Mingw-w64 and adding it to your path you should have the `mingw32-make` tool available. Next create a link from `make` to `mingw32-make`:
 
 ```bash
-ln mingw32-make make
+ln -s mingw32-make.exe make.exe
 ```
 
 You can now follow those instructions in the previous section. For example:


### PR DESCRIPTION
This PR includes the following changes:
- Bump nim-rocksdb to latest version
- Update Makefile to build RocksDb DLL from vendor directory on Windows. No longer using fetched DLLs.
- Update Windows section of readme.