### PR TITLE
Clean rocksdb on make update.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,10 @@ NIM_PARAMS := $(NIM_PARAMS) $(NIM_ETH_PARAMS)
 
 #- deletes and recreates "nimbus.nims" which on Windows is a copy instead of a proper symlink
 update: | update-common
+	+ vendor/nim-rocksdb/scripts/clean_build_artifacts.sh
 	rm -rf nimbus.nims && \
 		$(MAKE) nimbus.nims $(HANDLE_OUTPUT)
+
 
 update-from-ci: | sanity-checks update-test
 	rm -rf nimbus.nims && \

--- a/Makefile
+++ b/Makefile
@@ -193,10 +193,9 @@ NIM_PARAMS := $(NIM_PARAMS) $(NIM_ETH_PARAMS)
 
 #- deletes and recreates "nimbus.nims" which on Windows is a copy instead of a proper symlink
 update: | update-common
-	+ vendor/nim-rocksdb/scripts/clean_build_artifacts.sh
 	rm -rf nimbus.nims && \
 		$(MAKE) nimbus.nims $(HANDLE_OUTPUT)
-
+	+ vendor/nim-rocksdb/scripts/clean_build_artifacts.sh
 
 update-from-ci: | sanity-checks update-test
 	rm -rf nimbus.nims && \


### PR DESCRIPTION
Clean rocksdb on `make update` so that if rocksdb has been updated to a newer version, when running `make nimbus` rocksdb will be completely rebuilt from source. 