### PR TITLE
Light verification and storage mode for import

### DIFF
--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -516,6 +516,29 @@ type
         desc: "Save performance statistics to CSV"
         name: "debug-csv-stats".}: Option[string]
 
+      # TODO validation and storage options should be made non-hidden when the
+      #      UX has stabilised and era1 storage is in the app
+      fullValidation* {.
+        hidden
+        desc: "Enable full per-block validation (slow)"
+        defaultValue: false
+        name: "debug-full-validation".}: bool
+
+      storeBodies* {.
+        hidden
+        desc: "Store block blodies in database"
+        defaultValue: false
+        name: "debug-store-bodies".}: bool
+
+      # TODO this option should probably only cover the redundant parts, ie
+      #      those that are in era1 files - era files presently do not store
+      #      receipts
+      storeReceipts* {.
+        hidden
+        desc: "Store receipts in database"
+        defaultValue: false
+        name: "debug-store-receipts".}: bool
+
 func parseCmdArg(T: type NetworkId, p: string): T
     {.gcsafe, raises: [ValueError].} =
   parseInt(p).T

--- a/nimbus/core/validate.nim
+++ b/nimbus/core/validate.nim
@@ -373,6 +373,7 @@ proc validateTransaction*(
 proc validateHeaderAndKinship*(
     com: CommonRef;
     blk: EthBlock;
+    parent: BlockHeader;
     checkSealOK: bool;
       ): Result[void, string]
       {.gcsafe, raises: [].} =
@@ -382,12 +383,6 @@ proc validateHeaderAndKinship*(
     if header.extraData.len > 32:
       return err("BlockHeader.extraData larger than 32 bytes")
     return ok()
-
-  let chainDB = com.db
-  let parent = try:
-    chainDB.getBlockHeader(header.parentHash)
-  except CatchableError as err:
-    return err("Failed to load block header from DB")
 
   ? com.validateHeader(blk, parent, checkSealOK)
 

--- a/nimbus/db/core_db/core_apps.nim
+++ b/nimbus/db/core_db/core_apps.nim
@@ -31,10 +31,6 @@ type
     blockNumber: BlockNumber
     index: uint
 
-const
-  extraTraceMessages = false
-    ## Enabled additional logging noise
-
 # ------------------------------------------------------------------------------
 # Forward declarations
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
When performing block import, we can batch state root verifications and header checks, doing them only once per chunk of blocks, assuming that the other blocks in the batch are valid by extension.

When we're not generating receipts, we can also skip per-transaction state root computation pre-byzantium, which is what provides a ~20% speedup in this PR, at least on those early blocks :)

We also stop storing transactions, receipts and uncles redundantly when importing from era1 - there is no need to waste database storage on this when we can load it from the era1 file (eventually).