### PR TITLE
Vm2Ctx -> VmCtx, Vm2Op -> VmOp

### DIFF
--- a/nimbus/evm/interpreter/op_dispatcher.nim
+++ b/nimbus/evm/interpreter/op_dispatcher.nim
@@ -36,7 +36,7 @@ export
 # Helpers
 # ------------------------------------------------------------------------------
 
-template handleStopDirective(k: var Vm2Ctx) =
+template handleStopDirective(k: var VmCtx) =
   #trace "op: Stop"
   if not k.cpt.code.atEnd() and k.cpt.tracingEnabled:
     # we only trace `REAL STOP` and ignore `FAKE STOP`
@@ -44,7 +44,7 @@ template handleStopDirective(k: var Vm2Ctx) =
     k.cpt.traceOpCodeEnded(Stop, k.cpt.opIndex)
 
 
-template handleFixedGasCostsDirective(fork: EVMFork; op: Op; k: var Vm2Ctx) =
+template handleFixedGasCostsDirective(fork: EVMFork; op: Op; k: var VmCtx) =
   if k.cpt.tracingEnabled:
     k.cpt.opIndex = k.cpt.traceOpCodeStarted(op)
 
@@ -56,7 +56,7 @@ template handleFixedGasCostsDirective(fork: EVMFork; op: Op; k: var Vm2Ctx) =
     k.cpt.traceOpCodeEnded(op, k.cpt.opIndex)
 
 
-template handleOtherDirective(fork: EVMFork; op: Op; k: var Vm2Ctx) =
+template handleOtherDirective(fork: EVMFork; op: Op; k: var VmCtx) =
   if k.cpt.tracingEnabled:
     k.cpt.opIndex = k.cpt.traceOpCodeStarted(op)
 
@@ -124,11 +124,11 @@ proc toCaseStmt(forkArg, opArg, k: NimNode): NimNode =
 # Public macros/functions
 # ------------------------------------------------------------------------------
 
-macro genOptimisedDispatcher*(fork: EVMFork; op: Op; k: Vm2Ctx): untyped =
+macro genOptimisedDispatcher*(fork: EVMFork; op: Op; k: VmCtx): untyped =
   result = fork.toCaseStmt(op, k)
 
 
-template genLowMemDispatcher*(fork: EVMFork; op: Op; k: Vm2Ctx) =
+template genLowMemDispatcher*(fork: EVMFork; op: Op; k: VmCtx) =
   if op == Stop:
     handleStopDirective(k)
     break
@@ -155,7 +155,7 @@ when isMainModule and isChatty:
   import ../types
 
   proc optimised(c: Computation, fork: EVMFork): EvmResultVoid {.compileTime.} =
-    var desc: Vm2Ctx
+    var desc: VmCtx
     while true:
       genOptimisedDispatcher(fork, desc.cpt.instr, desc)
 

--- a/nimbus/evm/interpreter/op_handlers.nim
+++ b/nimbus/evm/interpreter/op_handlers.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -28,25 +28,25 @@ import
 
 const
   allHandlersList = @[
-    (vm2OpExecArithmetic, "Arithmetic"),
-    (vm2OpExecHash,       "Hash"),
-    (vm2OpExecEnvInfo,    "EnvInfo"),
-    (vm2OpExecBlockData,  "BlockData"),
-    (vm2OpExecMemory,     "Memory"),
-    (vm2OpExecPush,       "Push"),
-    (vm2OpExecPushZero,   "PushZero"),
-    (vm2OpExecDup,        "Dup"),
-    (vm2OpExecSwap,       "Swap"),
-    (vm2OpExecLog,        "Log"),
-    (vm2OpExecCreate,     "Create"),
-    (vm2OpExecCall,       "Call"),
-    (vm2OpExecSysOp,      "SysOp")]
+    (VmOpExecArithmetic, "Arithmetic"),
+    (VmOpExecHash,       "Hash"),
+    (VmOpExecEnvInfo,    "EnvInfo"),
+    (VmOpExecBlockData,  "BlockData"),
+    (VmOpExecMemory,     "Memory"),
+    (VmOpExecPush,       "Push"),
+    (VmOpExecPushZero,   "PushZero"),
+    (VmOpExecDup,        "Dup"),
+    (VmOpExecSwap,       "Swap"),
+    (VmOpExecLog,        "Log"),
+    (VmOpExecCreate,     "Create"),
+    (VmOpExecCall,       "Call"),
+    (VmOpExecSysOp,      "SysOp")]
 
 # ------------------------------------------------------------------------------
 # Helper
 # ------------------------------------------------------------------------------
 
-proc mkOpTable(selected: EVMFork): array[Op,Vm2OpExec] {.compileTime.} =
+proc mkOpTable(selected: EVMFork): array[Op,VmOpExec] {.compileTime.} =
 
   # Collect selected <fork> entries
   for (subList,subName) in allHandlersList:
@@ -75,8 +75,8 @@ proc mkOpTable(selected: EVMFork): array[Op,Vm2OpExec] {.compileTime.} =
 # ------------------------------------------------------------------------------
 
 #const
-#  vm2OpHandlers* = block:
-#    var rc: array[Fork, array[Op, Vm2OpExec]]
+#  VmOpHandlers* = block:
+#    var rc: array[Fork, array[Op, VmOpExec]]
 #    for w in Fork:
 #      rc[w] = w.mkOpTable
 #    rc
@@ -85,7 +85,7 @@ type
   vmOpHandlersRec* = tuple
     name: string    ## Name (or ID) of op handler
     info: string    ## Some op handler info
-    run:  Vm2OpFn   ## Executable handler
+    run:  VmOpFn    ## Executable handler
 
 const
   # Pack handler record.
@@ -97,12 +97,12 @@ const
   #
   #   to pick right function when <op> is a variable . Using
   #
-  #      vm2OpHandlers[fork][op].exec.run
+  #      VmOpHandlers[fork][op].exec.run
   #
   #   only works when <op> is a constant. There seems to be some optimisation
   #   that garbles the <exec> sub-structures elements <prep>, <run>, and <post>.
   #   Moreover, <post> is seen NULL under the debugger. It is untested yet
-  #   under what circumstances the vm2OpHandlers[] matrix is set up correctly.
+  #   under what circumstances the VmOpHandlers[] matrix is set up correctly.
   #   Linearising/flattening the index has no effect here.
   #
   vmOpHandlers* = ## Op handler records matrix indexed `fork` x `op`
@@ -122,7 +122,7 @@ const
 
 when isMainModule and isChatty:
 
-  proc opHandlersRun(fork: EVMFork; op: Op; d: var Vm2Ctx) {.used.} =
+  proc opHandlersRun(fork: EVMFork; op: Op; d: var VmCtx) {.used.} =
     ## Given a particular `fork` and an `op`-code, run the associated handler
     vmOpHandlers[fork][op].run(d)
 
@@ -140,10 +140,10 @@ when isMainModule and isChatty:
   echo ">>> berlin[swap16]:         ", FkBerlin.opHandlersInfo(Swap16)
   echo ">>> berlin[log4]:           ", FkBerlin.opHandlersInfo(Log4)
 
-  echo ">>>       frontier[sstore]: ",       FkFrontier.opHandlersInfo(Sstore)
+  echo ">>>       frontier[sstore]: ", FkFrontier.opHandlersInfo(Sstore)
   echo ">>> constantinople[sstore]: ", FkConstantinople.opHandlersInfo(Sstore)
-  echo ">>>         berlin[sstore]: ",         FkBerlin.opHandlersInfo(Sstore)
-  echo ">>>          paris[sstore]: ",          FkParis.opHandlersInfo(Sstore)
+  echo ">>>         berlin[sstore]: ", FkBerlin.opHandlersInfo(Sstore)
+  echo ">>>          paris[sstore]: ", FkParis.opHandlersInfo(Sstore)
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_arithmetic.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_arithmetic.nim
@@ -38,22 +38,22 @@ func slt(x, y: UInt256): bool =
 # ------------------------------------------------------------------------------
 
 const
-  addOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  addOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x01, Addition
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
     k.cpt.stack.push(lhs + rhs)
 
-  mulOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  mulOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x02, Multiplication
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
     k.cpt.stack.push(lhs * rhs)
 
-  subOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  subOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x03, Substraction
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
     k.cpt.stack.push(lhs - rhs)
 
-  divideOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  divideOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x04, Division
     let
       (lhs, rhs) = ? k.cpt.stack.popInt(2)
@@ -66,7 +66,7 @@ const
     k.cpt.stack.push value
 
 
-  sdivOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  sdivOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x05, Signed division
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
 
@@ -82,7 +82,7 @@ const
     k.cpt.stack.push(r)
 
 
-  moduloOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  moduloOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x06, Modulo
     let
       (lhs, rhs) = ? k.cpt.stack.popInt(2)
@@ -94,7 +94,7 @@ const
     k.cpt.stack.push value
 
 
-  smodOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  smodOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x07, Signed modulo
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
 
@@ -110,7 +110,7 @@ const
     k.cpt.stack.push(r)
 
 
-  addmodOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  addmodOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x08, Modulo addition
     ## Intermediate computations do not roll over at 2^256
     let
@@ -123,7 +123,7 @@ const
     k.cpt.stack.push value
 
 
-  mulmodOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  mulmodOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x09, Modulo multiplication
     ## Intermediate computations do not roll over at 2^256
     let
@@ -136,7 +136,7 @@ const
     k.cpt.stack.push value
 
 
-  expOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  expOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x0A, Exponentiation
     let (base, exponent) = ? k.cpt.stack.popInt(2)
 
@@ -157,7 +157,7 @@ const
     k.cpt.stack.push value
 
 
-  signExtendOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  signExtendOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x0B, Sign extend
     ## Extend length of two’s complement signed integer.
     let (bits, value) = ? k.cpt.stack.popInt(2)
@@ -178,58 +178,58 @@ const
     k.cpt.stack.push res
 
 
-  ltOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  ltOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x10, Less-than comparison
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
     k.cpt.stack.push((lhs < rhs).uint.u256)
 
-  gtOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  gtOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x11, Greater-than comparison
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
     k.cpt.stack.push((lhs > rhs).uint.u256)
 
-  sltOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  sltOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x12, Signed less-than comparison
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
     k.cpt.stack.push(slt(lhs, rhs).uint.u256)
 
-  sgtOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  sgtOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x13, Signed greater-than comparison
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
     # Arguments are swapped and SLT is used.
     k.cpt.stack.push(slt(rhs, lhs).uint.u256)
 
-  eqOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  eqOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x14, Equality comparison
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
     k.cpt.stack.push((lhs == rhs).uint.u256)
 
-  isZeroOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  isZeroOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x15, Check if zero
     let value = ? k.cpt.stack.popInt()
     k.cpt.stack.push(value.isZero.uint.u256)
 
-  andOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  andOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x16, Bitwise AND
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
     k.cpt.stack.push(lhs and rhs)
 
-  orOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  orOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x17, Bitwise OR
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
     k.cpt.stack.push(lhs or rhs)
 
-  xorOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  xorOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x18, Bitwise XOR
     let (lhs, rhs) = ? k.cpt.stack.popInt(2)
     k.cpt.stack.push(lhs xor rhs)
 
-  notOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  notOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x19, Check if zero
     let value = ? k.cpt.stack.popInt()
     k.cpt.stack.push(value.not)
 
-  byteOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  byteOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0x20, Retrieve single byte from word.
     let
       (position, value) = ? k.cpt.stack.popInt(2)
@@ -247,7 +247,7 @@ const
 
   # Constantinople's new opcodes
 
-  shlOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  shlOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     let (shift, num) = ? k.cpt.stack.popInt(2)
     let shiftLen = shift.safeInt
     if shiftLen >= 256:
@@ -255,7 +255,7 @@ const
     else:
       k.cpt.stack.push(num shl shiftLen)
 
-  shrOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  shrOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     let (shift, num) = ? k.cpt.stack.popInt(2)
     let shiftLen = shift.safeInt
     if shiftLen >= 256:
@@ -264,7 +264,7 @@ const
       # uint version of `shr`
       k.cpt.stack.push(num shr shiftLen)
 
-  sarOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  sarOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     let
       shiftLen = ? k.cpt.stack.popSafeInt()
       num256 = ? k.cpt.stack.popInt()
@@ -285,211 +285,211 @@ const
 # ------------------------------------------------------------------------------
 
 const
-  vm2OpExecArithmetic*: seq[Vm2OpExec] = @[
+  VmOpExecArithmetic*: seq[VmOpExec] = @[
 
     (opCode: Add,         ## 0x01, Addition
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "add",
      info: "Addition operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  addOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Mul,         ##  0x02, Multiplication
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "mul",
      info: "Multiplication operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  mulOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Sub,         ## 0x03, Subtraction
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "sub",
      info: "Subtraction operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  subOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Div,         ## 0x04, Division
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "divide",
      info: "Integer division operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  divideOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Sdiv,        ## 0x05, Signed division
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "sdiv",
      info: "Signed integer division operation (truncated)",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sdivOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Mod,         ## 0x06, Modulo
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "modulo",
      info: "Modulo remainder operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  moduloOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Smod,        ## 0x07, Signed modulo
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "smod",
      info: "Signed modulo remainder operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  smodOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Addmod,      ## 0x08, Modulo addition, Intermediate
                           ## computations do not roll over at 2^256
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "addmod",
      info: "Modulo addition operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  addmodOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Mulmod,      ## 0x09, Modulo multiplication, Intermediate
                           ## computations do not roll over at 2^256
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "mulmod",
      info: "Modulo multiplication operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  mulmodOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Exp,         ## 0x0a, Exponentiation
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "exp",
      info: "Exponentiation operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  expOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: SignExtend,  ## 0x0b, Extend 2's complemet length
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "signExtend",
      info: "Extend length of two’s complement signed integer",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  signExtendOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Lt,          ## 0x10, Less-than
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "lt",
      info: "Less-than comparison",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  ltOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Gt,          ## 0x11, Greater-than
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "gt",
      info: "Greater-than comparison",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  gtOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Slt,         ## 0x12, Signed less-than
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "slt",
      info: "Signed less-than comparison",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sltOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Sgt,         ## 0x13, Signed greater-than
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "sgt",
      info: "Signed greater-than comparison",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sgtOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Eq,          ## 0x14, Equality
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "eq",
      info: "Equality comparison",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  eqOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: IsZero,      ## 0x15, Not operator
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "isZero",
      info: "Simple not operator (Note: real Yellow Paper description)",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  isZeroOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: And,         ## 0x16, AND
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "andOp",
      info: "Bitwise AND operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  andOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Or,          ## 0x17, OR
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "orOp",
      info: "Bitwise OR operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  orOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Xor,         ## 0x18, XOR
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "xorOp",
      info: "Bitwise XOR operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  xorOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Not,         ## 0x19, NOT
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "notOp",
      info: "Bitwise NOT operation",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  notOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Byte,        ## 0x1a, Retrieve byte
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "byteOp",
      info: "Retrieve single byte from word",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  byteOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     # Constantinople's new opcodes
 
     (opCode: Shl,         ## 0x1b, Shift left
-     forks: Vm2OpConstantinopleAndLater,
+     forks: VmOpConstantinopleAndLater,
      name: "shlOp",
      info: "Shift left",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  shlOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Shr,         ## 0x1c, Shift right logical
-     forks: Vm2OpConstantinopleAndLater,
+     forks: VmOpConstantinopleAndLater,
      name: "shrOp",
      info: "Logical shift right",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  shrOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Sar,         ## 0x1d, Shift right arithmetic
-     forks: Vm2OpConstantinopleAndLater,
+     forks: VmOpConstantinopleAndLater,
      name: "sarOp",
      info: "Arithmetic shift right",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sarOp,
-            post: vm2OpIgnore))]
+            post: VmOpIgnore))]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_blockdata.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_blockdata.nim
@@ -30,7 +30,7 @@ when not defined(evmc_enabled):
 # ------------------------------------------------------------------------------
 
 const
-  blockhashOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  blockhashOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x40, Get the hash of one of the 256 most recent complete blocks.
     let
       cpt = k.cpt
@@ -39,40 +39,40 @@ const
 
     cpt.stack.push blockHash
 
-  coinBaseOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  coinBaseOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x41, Get the block's beneficiary address.
     k.cpt.stack.push k.cpt.getCoinbase
 
-  timestampOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  timestampOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x42, Get the block's timestamp.
     k.cpt.stack.push k.cpt.getTimestamp
 
-  blocknumberOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  blocknumberOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x43, Get the block's number.
     k.cpt.stack.push k.cpt.getBlockNumber
 
-  difficultyOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  difficultyOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x44, Get the block's difficulty
     k.cpt.stack.push k.cpt.getDifficulty
 
-  gasLimitOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  gasLimitOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x45, Get the block's gas limit
     k.cpt.stack.push k.cpt.getGasLimit
 
-  chainIdOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  chainIdOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x46, Get current chain’s EIP-155 unique identifier.
     k.cpt.stack.push k.cpt.getChainId
 
-  selfBalanceOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  selfBalanceOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x47, Get current contract's balance.
     let cpt = k.cpt
     cpt.stack.push cpt.getBalance(cpt.msg.contractAddress)
 
-  baseFeeOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  baseFeeOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x48, Get the block's base fee.
     k.cpt.stack.push k.cpt.getBaseFee
 
-  blobHashOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  blobHashOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x49, Get current transaction's EIP-4844 versioned hash.
     let
       index = ? k.cpt.stack.popSafeInt()
@@ -83,7 +83,7 @@ const
     else:
       k.cpt.stack.push 0
 
-  blobBaseFeeOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  blobBaseFeeOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x4a, Get the block's base fee.
     k.cpt.stack.push k.cpt.getBlobBaseFee
 
@@ -93,95 +93,95 @@ const
 # ------------------------------------------------------------------------------
 
 const
-  vm2OpExecBlockData*: seq[Vm2OpExec] = @[
+  VmOpExecBlockData*: seq[VmOpExec] = @[
 
     (opCode: Blockhash,       ## 0x40, Hash of some most recent complete block
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "blockhash",
      info: "Get the hash of one of the 256 most recent complete blocks",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  blockhashOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Coinbase,        ## 0x41, Beneficiary address
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "coinbase",
      info: "Get the block's beneficiary address",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  coinBaseOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Timestamp,       ## 0x42, Block timestamp.
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "timestamp",
      info: "Get the block's timestamp",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  timestampOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Number,          ## 0x43, Block number
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "blockNumber",
      info: "Get the block's number",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  blocknumberOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Difficulty,      ## 0x44, Block difficulty
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "difficulty",
      info: "Get the block's difficulty",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  difficultyOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: GasLimit,        ## 0x45, Block gas limit
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "gasLimit",
      info: "Get the block's gas limit",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  gasLimitOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: ChainIdOp,       ## 0x46, EIP-155 chain identifier
-     forks: Vm2OpIstanbulAndLater,
+     forks: VmOpIstanbulAndLater,
      name: "chainId",
      info: "Get current chain’s EIP-155 unique identifier",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  chainIdOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: SelfBalance,     ## 0x47, Contract balance.
-     forks: Vm2OpIstanbulAndLater,
+     forks: VmOpIstanbulAndLater,
      name: "selfBalance",
      info: "Get current contract's balance",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  selfBalanceOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: BaseFee,         ## 0x48, EIP-1559 Block base fee.
-     forks: Vm2OpLondonAndLater,
+     forks: VmOpLondonAndLater,
      name: "baseFee",
      info: "Get current block's EIP-1559 base fee",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  baseFeeOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: BlobHash,        ## 0x49, EIP-4844 Transaction versioned hash
-     forks: Vm2OpCancunAndLater,
+     forks: VmOpCancunAndLater,
      name: "blobHash",
      info: "Get current transaction's EIP-4844 versioned hash",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  blobHashOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: BlobBaseFee,     ## 0x4a, EIP-7516 Returns the current data-blob base-fee
-     forks: Vm2OpCancunAndLater,
+     forks: VmOpCancunAndLater,
      name: "blobBaseFee",
      info: "Returns the current data-blob base-fee",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  blobBaseFeeOp,
-            post: vm2OpIgnore))]
+            post: VmOpIgnore))]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_call.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_call.nim
@@ -199,7 +199,7 @@ else:
 # ------------------------------------------------------------------------------
 
 const
-  callOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  callOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0xf1, Message-Call into an account
     let cpt = k.cpt
 
@@ -283,7 +283,7 @@ const
 
   # ---------------------
 
-  callCodeOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  callCodeOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0xf2, Message-call into this account with an alternative account's code.
     let
       cpt = k.cpt
@@ -360,7 +360,7 @@ const
 
   # ---------------------
 
-  delegateCallOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  delegateCallOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0xf4, Message-call into this account with an alternative account's
     ##       code, but persisting the current values for sender and value.
     let
@@ -432,7 +432,7 @@ const
 
   # ---------------------
 
-  staticCallOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  staticCallOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0xfa, Static message-call into an account.
 
     let
@@ -508,40 +508,40 @@ const
 # ------------------------------------------------------------------------------
 
 const
-  vm2OpExecCall*: seq[Vm2OpExec] = @[
+  VmOpExecCall*: seq[VmOpExec] = @[
 
     (opCode: Call,         ## 0xf1, Message-Call into an account
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "call",
      info: "Message-Call into an account",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run: callOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: CallCode,     ## 0xf2, Message-Call with alternative code
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "callCode",
      info: "Message-call into this account with alternative account's code",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run: callCodeOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: DelegateCall, ## 0xf4, CallCode with persisting sender and value
-     forks: Vm2OpHomesteadAndLater,
+     forks: VmOpHomesteadAndLater,
      name: "delegateCall",
      info: "Message-call into this account with an alternative account's " &
            "code but persisting the current values for sender and value.",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run: delegateCallOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: StaticCall,   ## 0xfa, Static message-call into an account
-     forks: Vm2OpByzantiumAndLater,
+     forks: VmOpByzantiumAndLater,
      name: "staticCall",
      info: "Static message-call into an account",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run: staticCallOp,
-            post: vm2OpIgnore))]
+            post: VmOpIgnore))]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_create.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_create.nim
@@ -12,7 +12,7 @@
 ## ======================================
 ##
 
-{.push raises: [].} # basically the annotation type of a `Vm2OpFn`
+{.push raises: [].} # basically the annotation type of a `VmOpFn`
 
 import
   ../../../constants,
@@ -82,7 +82,7 @@ else:
 # ------------------------------------------------------------------------------
 
 const
-  createOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  createOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0xf0, Create a new account with associated code
     ? checkInStaticContext(k.cpt)
 
@@ -161,7 +161,7 @@ const
 
   # ---------------------
 
-  create2Op: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  create2Op: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0xf5, Behaves identically to CREATE, except using keccak256
     ? checkInStaticContext(k.cpt)
 
@@ -248,23 +248,23 @@ const
 # ------------------------------------------------------------------------------
 
 const
-  vm2OpExecCreate*: seq[Vm2OpExec] = @[
+  VmOpExecCreate*: seq[VmOpExec] = @[
 
     (opCode: Create,    ## 0xf0, Create a new account with associated code
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "create",
      info: "Create a new account with associated code",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run: createOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Create2,   ## 0xf5, Create using keccak256
-     forks: Vm2OpConstantinopleAndLater,
+     forks: VmOpConstantinopleAndLater,
      name: "create2",
      info: "Behaves identically to CREATE, except using keccak256",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run: create2Op,
-            post: vm2OpIgnore))]
+            post: VmOpIgnore))]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_defs.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_defs.nim
@@ -21,75 +21,75 @@ import
   ../op_codes
 
 type
-  Vm2Ctx* = tuple
+  VmCtx* = tuple
     cpt: Computation          ## computation text
 
-  Vm2OpFn* =                  ## general op handler, return codes are passed
+  VmOpFn* =                   ## general op handler, return codes are passed
                               ## back via argument descriptor ``k``
-    proc(k: var Vm2Ctx): EvmResultVoid {.nimcall, gcsafe, raises:[].}
+    proc(k: var VmCtx): EvmResultVoid {.nimcall, gcsafe, raises:[].}
 
 
-  Vm2OpHanders* = tuple       ## three step op code execution, typically
+  VmOpHanders* = tuple        ## three step op code execution, typically
                               ## only the ``run`` entry is activated
-    prep: Vm2OpFn
-    run:  Vm2OpFn
-    post: Vm2OpFn
+    prep: VmOpFn
+    run:  VmOpFn
+    post: VmOpFn
 
 
-  Vm2OpExec* = tuple          ## op code handler entry
+  VmOpExec* = tuple           ## op code handler entry
     opCode: Op                ## index back-reference
     forks: set[EVMFork]       ## forks applicable for this operation
     name: string              ## handler name
     info: string              ## handter info, explainer
-    exec: Vm2OpHanders
+    exec: VmOpHanders
 
 # ------------------------------------------------------------------------------
 # Public
 # ------------------------------------------------------------------------------
 
 const
-  vm2OpIgnore*: Vm2OpFn =      ## No operation, placeholder function
-    proc(k: var Vm2Ctx): EvmResultVoid = ok()
+  VmOpIgnore*: VmOpFn =      ## No operation, placeholder function
+    proc(k: var VmCtx): EvmResultVoid = ok()
 
   # similar to: toSeq(Fork).mapIt({it}).foldl(a+b)
-  Vm2OpAllForks* =
+  VmOpAllForks* =
     {EVMFork.low .. EVMFork.high}
 
-  Vm2OpHomesteadAndLater* =    ## Set of all fork symbols
-    Vm2OpAllForks - {FkFrontier}
+  VmOpHomesteadAndLater* =    ## Set of all fork symbols
+    VmOpAllForks - {FkFrontier}
 
-  Vm2OpTangerineAndLater* =    ## Set of fork symbols starting from Homestead
-    Vm2OpHomesteadAndLater - {FkHomestead}
+  VmOpTangerineAndLater* =    ## Set of fork symbols starting from Homestead
+    VmOpHomesteadAndLater - {FkHomestead}
 
-  Vm2OpSpuriousAndLater* =     ## ditto ...
-    Vm2OpTangerineAndLater - {FkTangerine}
+  VmOpSpuriousAndLater* =     ## ditto ...
+    VmOpTangerineAndLater - {FkTangerine}
 
-  Vm2OpByzantiumAndLater* =
-    Vm2OpSpuriousAndLater - {FkSpurious}
+  VmOpByzantiumAndLater* =
+    VmOpSpuriousAndLater - {FkSpurious}
 
-  Vm2OpConstantinopleAndLater* =
-    Vm2OpByzantiumAndLater - {FkByzantium}
+  VmOpConstantinopleAndLater* =
+    VmOpByzantiumAndLater - {FkByzantium}
 
-  Vm2OpPetersburgAndLater* =
-    Vm2OpConstantinopleAndLater - {FkConstantinople}
+  VmOpPetersburgAndLater* =
+    VmOpConstantinopleAndLater - {FkConstantinople}
 
-  Vm2OpIstanbulAndLater* =
-    Vm2OpPetersburgAndLater - {FkPetersburg}
+  VmOpIstanbulAndLater* =
+    VmOpPetersburgAndLater - {FkPetersburg}
 
-  Vm2OpBerlinAndLater* =
-    Vm2OpIstanbulAndLater - {FkIstanbul}
+  VmOpBerlinAndLater* =
+    VmOpIstanbulAndLater - {FkIstanbul}
 
-  Vm2OpLondonAndLater* =
-    Vm2OpBerlinAndLater - {FkBerlin}
+  VmOpLondonAndLater* =
+    VmOpBerlinAndLater - {FkBerlin}
 
-  Vm2OpParisAndLater* =
-    Vm2OpLondonAndLater - {FkLondon}
+  VmOpParisAndLater* =
+    VmOpLondonAndLater - {FkLondon}
 
-  Vm2OpShanghaiAndLater* =
-    Vm2OpParisAndLater - {FkParis}
+  VmOpShanghaiAndLater* =
+    VmOpParisAndLater - {FkParis}
 
-  Vm2OpCancunAndLater* =
-    Vm2OpShanghaiAndLater - {FkShanghai}
+  VmOpCancunAndLater* =
+    VmOpShanghaiAndLater - {FkShanghai}
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_dup.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_dup.nim
@@ -41,7 +41,7 @@ proc fnInfo(n: int): string {.compileTime.} =
   "Duplicate " & blurb & " item in the stack"
 
 
-proc dupImpl(k: var Vm2Ctx; n: int): EvmResultVoid =
+proc dupImpl(k: var VmCtx; n: int): EvmResultVoid =
   k.cpt.stack.dup(n)
 
 const
@@ -57,7 +57,7 @@ genOphHandlers fnName, fnInfo, inxRange, dupImpl
 # Public, op exec table entries
 # ------------------------------------------------------------------------------
 
-genOphList fnName, fnInfo, inxRange, "vm2OpExecDup", opName
+genOphList fnName, fnInfo, inxRange, "VmOpExecDup", opName
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_envinfo.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_envinfo.nim
@@ -36,20 +36,20 @@ when not defined(evmc_enabled):
 # ------------------------------------------------------------------------------
 
 const
-  addressOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  addressOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x30, Get address of currently executing account.
     k.cpt.stack.push k.cpt.msg.contractAddress
 
   # ------------------
 
-  balanceOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  balanceOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x31, Get balance of the given account.
     let
       cpt = k.cpt
       address = ? cpt.stack.popAddress
     cpt.stack.push cpt.getBalance(address)
 
-  balanceEIP2929Op: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  balanceEIP2929Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x31, EIP292: Get balance of the given account for Berlin and later
     let
       cpt = k.cpt
@@ -61,20 +61,20 @@ const
 
   # ------------------
 
-  originOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  originOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x32, Get execution origination address.
     k.cpt.stack.push k.cpt.getOrigin()
 
-  callerOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  callerOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x33, Get caller address.
     k.cpt.stack.push k.cpt.msg.sender
 
-  callValueOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  callValueOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x34, Get deposited value by the instruction/transaction
     ##       responsible for this execution
     k.cpt.stack.push k.cpt.msg.value
 
-  callDataLoadOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  callDataLoadOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x35, Get input data of current environment
     let
       startPos = ? k.cpt.stack.popInt()
@@ -94,12 +94,12 @@ const
     k.cpt.stack.push value
 
 
-  callDataSizeOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  callDataSizeOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x36, Get size of input data in current environment.
     k.cpt.stack.push k.cpt.msg.data.len.u256
 
 
-  callDataCopyOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  callDataCopyOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x37, Copy input data in current environment to memory.
     let (memStartPos, copyStartPos, size) = ? k.cpt.stack.popInt(3)
 
@@ -115,13 +115,13 @@ const
     ok()
 
 
-  codeSizeOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  codeSizeOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x38, Get size of code running in current environment.
     let cpt = k.cpt
     cpt.stack.push cpt.code.len
 
 
-  codeCopyOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  codeCopyOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x39, Copy code running in current environment to memory.
     let
       cpt = k.cpt
@@ -138,13 +138,13 @@ const
     cpt.memory.writePadded(cpt.code.bytes, memPos, copyPos, len)
     ok()
 
-  gasPriceOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  gasPriceOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x3A, Get price of gas in current environment.
     k.cpt.stack.push k.cpt.getGasPrice()
 
   # -----------
 
-  extCodeSizeOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  extCodeSizeOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x3b, Get size of an account's code
     let
       cpt = k.cpt
@@ -152,7 +152,7 @@ const
 
     cpt.stack.push cpt.getCodeSize(address)
 
-  extCodeSizeEIP2929Op: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  extCodeSizeEIP2929Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x3b, Get size of an account's code
     let
       cpt = k.cpt
@@ -164,7 +164,7 @@ const
 
   # -----------
 
-  extCodeCopyOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  extCodeCopyOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x3c, Copy an account's code to memory.
     let
       cpt = k.cpt
@@ -182,7 +182,7 @@ const
     ok()
 
 
-  extCodeCopyEIP2929Op: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  extCodeCopyEIP2929Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x3c, Copy an account's code to memory.
     let
       cpt = k.cpt
@@ -201,13 +201,13 @@ const
 
   # -----------
 
-  returnDataSizeOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  returnDataSizeOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x3d, Get size of output data from the previous call from the
     ##       current environment.
     k.cpt.stack.push k.cpt.returnData.len
 
 
-  returnDataCopyOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  returnDataCopyOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x3e, Copy output data from the previous call to memory.
     let
       (memStartPos, copyStartPos, size) = ? k.cpt.stack.popInt(3)
@@ -225,7 +225,7 @@ const
 
   # ---------------
 
-  extCodeHashOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  extCodeHashOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x3f, Returns the keccak256 hash of a contract’s code
     let
       cpt = k.cpt
@@ -233,7 +233,7 @@ const
 
     cpt.stack.push cpt.getCodeHash(address)
 
-  extCodeHashEIP2929Op: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  extCodeHashEIP2929Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x3f, EIP2929: Returns the keccak256 hash of a contract’s code
     let
       cpt = k.cpt
@@ -248,169 +248,169 @@ const
 # ------------------------------------------------------------------------------
 
 const
-  vm2OpExecEnvInfo*: seq[Vm2OpExec] = @[
+  VmOpExecEnvInfo*: seq[VmOpExec] = @[
 
     (opCode: Address,         ## 0x20, Address
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "address",
      info: "Get address of currently executing account",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  addressOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Balance,         ## 0x31, Balance
-     forks: Vm2OpAllForks - Vm2OpBerlinAndLater,
+     forks: VmOpAllForks - VmOpBerlinAndLater,
      name: "balance",
      info: "Get balance of the given account",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  balanceOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Balance,         ## 0x31, Balance for Berlin and later
-     forks: Vm2OpBerlinAndLater,
+     forks: VmOpBerlinAndLater,
      name: "balanceEIP2929",
      info: "EIP2929: Get balance of the given account",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  balanceEIP2929Op,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Origin,          ## 0x32, Origination address
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "origin",
      info: "Get execution origination address",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  originOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Caller,          ## 0x33, Caller address
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "caller",
      info: "Get caller address",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  callerOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: CallValue,       ## 0x34, Execution deposited value
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "callValue",
      info: "Get deposited value by the instruction/transaction " &
            "responsible for this execution",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  callValueOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: CallDataLoad,    ## 0x35, Input data
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "callDataLoad",
      info: "Get input data of current environment",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  callDataLoadOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: CallDataSize,    ## 0x36, Size of input data
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "callDataSize",
      info: "Get size of input data in current environment",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  callDataSizeOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: CallDataCopy,    ## 0x37, Copy input data to memory.
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "callDataCopy",
      info: "Copy input data in current environment to memory",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  callDataCopyOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: CodeSize,       ## 0x38, Size of code
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "codeSize",
      info: "Get size of code running in current environment",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  codeSizeOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: CodeCopy,       ## 0x39, Copy code to memory.
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "codeCopy",
      info: "Copy code running in current environment to memory",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  codeCopyOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: GasPrice,       ## 0x3a, Gas price
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "gasPrice",
      info: "Get price of gas in current environment",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  gasPriceOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: ExtCodeSize,    ## 0x3b, Account code size
-     forks: Vm2OpAllForks - Vm2OpBerlinAndLater,
+     forks: VmOpAllForks - VmOpBerlinAndLater,
      name: "extCodeSize",
      info: "Get size of an account's code",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  extCodeSizeOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: ExtCodeSize,    ## 0x3b, Account code size for Berlin and later
-     forks: Vm2OpBerlinAndLater,
+     forks: VmOpBerlinAndLater,
      name: "extCodeSizeEIP2929",
      info: "EIP2929: Get size of an account's code",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  extCodeSizeEIP2929Op,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: ExtCodeCopy,    ## 0x3c, Account code copy to memory.
-     forks: Vm2OpAllForks - Vm2OpBerlinAndLater,
+     forks: VmOpAllForks - VmOpBerlinAndLater,
      name: "extCodeCopy",
      info: "Copy an account's code to memory",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  extCodeCopyOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: ExtCodeCopy,    ## 0x3c, Account Code-copy for Berlin and later
-     forks: Vm2OpBerlinAndLater,
+     forks: VmOpBerlinAndLater,
      name: "extCodeCopyEIP2929",
      info: "EIP2929: Copy an account's code to memory",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  extCodeCopyEIP2929Op,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: ReturnDataSize, ## 0x3d, Previous call output data size
-     forks: Vm2OpByzantiumAndLater,
+     forks: VmOpByzantiumAndLater,
      name: "returnDataSize",
      info: "Get size of output data from the previous call " &
            "from the current environment",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  returnDataSizeOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: ReturnDataCopy, ## 0x3e, Previous call output data copy to memory
-     forks: Vm2OpByzantiumAndLater,
+     forks: VmOpByzantiumAndLater,
      name: "returnDataCopy",
      info: "Copy output data from the previous call to memory",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  returnDataCopyOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: ExtCodeHash,    ## 0x3f, Contract hash
-     forks: Vm2OpConstantinopleAndLater - Vm2OpBerlinAndLater,
+     forks: VmOpConstantinopleAndLater - VmOpBerlinAndLater,
      name: "extCodeHash",
      info: "Returns the keccak256 hash of a contract’s code",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  extCodeHashOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: ExtCodeHash,    ## 0x3f, Contract hash for berlin and later
-     forks: Vm2OpBerlinAndLater,
+     forks: VmOpBerlinAndLater,
      name: "extCodeHashEIP2929",
      info: "EIP2929: Returns the keccak256 hash of a contract’s code",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  extCodeHashEIP2929Op,
-            post: vm2OpIgnore))]
+            post: VmOpIgnore))]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_gen_handlers.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_gen_handlers.nim
@@ -19,10 +19,10 @@ import
 
 type
   OphNumToTextFn* = proc(n: int): string
-  OpHanldlerImplFn* = proc(k: var Vm2Ctx; n: int): EvmResultVoid
+  OpHanldlerImplFn* = proc(k: var VmCtx; n: int): EvmResultVoid
 
 const
-  recForkSet = "Vm2OpAllForks"
+  recForkSet = "VmOpAllForks"
 
 # ------------------------------------------------------------------------------
 # Private helpers
@@ -48,7 +48,7 @@ macro genOphHandlers*(runHandler: static[OphNumToTextFn];
                       body: static[OpHanldlerImplFn]): untyped =
   ## Generate the equivalent of
   ## ::
-  ##  const <runHandler>: Vm2OpFn = proc (k: var Vm2Ctx) =
+  ##  const <runHandler>: VmOpFn = proc (k: var VmCtx) =
   ##    ## <itemInfo(n)>,
   ##    <body(k,n)>
   ##
@@ -61,9 +61,9 @@ macro genOphHandlers*(runHandler: static[OphNumToTextFn];
       fnName = ident(n.runHandler)
       comment = newCommentStmtNode(n.itemInfo)
 
-    # => push##Op: Vm2OpFn = proc (k: var Vm2Ctx) = ...
+    # => push##Op: VmOpFn = proc (k: var VmCtx) = ...
     result.add quote do:
-      const `fnName`: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+      const `fnName`: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
         `comment`
         `body`(k,`n`)
   # echo ">>>", result.repr
@@ -76,16 +76,16 @@ macro genOphList*(runHandler: static[OphNumToTextFn];
                   opCode: static[OphNumToTextFn]): untyped =
   ## Generate
   ## ::
-  ##   const <varName>*: seq[Vm2OpExec] = @[ <records> ]
+  ##   const <varName>*: seq[VmOpExec] = @[ <records> ]
   ##
   ## where <records> is a sequence of <record(n)> items like
   ## ::
   ##   (opCode: <opCode(n)>,
-  ##    forks: Vm2OpAllForks,
+  ##    forks: VmOpAllForks,
   ##    info: <handlerInfo(n)>,
-  ##    exec: (prep: vm2OpIgnore,
+  ##    exec: (prep: VmOpIgnore,
   ##           run: <runHandler(n)>,
-  ##           post: vm2OpIgnore))
+  ##           post: VmOpIgnore))
   ##
   ## for all `n` in `inxList`
   ##
@@ -100,11 +100,11 @@ macro genOphList*(runHandler: static[OphNumToTextFn];
                   nnkExprColonExpr.newTree(
                     newIdentNode("exec"),
                     nnkPar.newTree(
-                      "prep".asIdent("vm2OpIgnore"),
+                      "prep".asIdent("VmOpIgnore"),
                       "run".asIdent(n.runHandler),
-                      "post".asIdent("vm2OpIgnore"))))
+                      "post".asIdent("VmOpIgnore"))))
 
-  # => const <varName>*: seq[Vm2OpExec] = @[ <records> ]
+  # => const <varName>*: seq[VmOpExec] = @[ <records> ]
   result = nnkStmtList.newTree(
              nnkConstSection.newTree(
                nnkConstDef.newTree(
@@ -113,7 +113,7 @@ macro genOphList*(runHandler: static[OphNumToTextFn];
                    newIdentNode(varName)),
                  nnkBracketExpr.newTree(
                    newIdentNode("seq"),
-                   newIdentNode("Vm2OpExec")),
+                   newIdentNode("VmOpExec")),
                  nnkPrefix.newTree(
                    newIdentNode("@"), records))))
   # echo ">>> ", result.repr

--- a/nimbus/evm/interpreter/op_handlers/oph_hash.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_hash.nim
@@ -31,7 +31,7 @@ import
 # ------------------------------------------------------------------------------
 
 const
-  sha3Op: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  sha3Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x20, Compute Keccak-256 hash.
     let
       (startPos, length) = ? k.cpt.stack.popInt(2)
@@ -57,15 +57,15 @@ const
 # ------------------------------------------------------------------------------
 
 const
-  vm2OpExecHash*: seq[Vm2OpExec] = @[
+  VmOpExecHash*: seq[VmOpExec] = @[
 
     (opCode: Op.Sha3,     ## 0x20, Keccak-256
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "sha3",
      info: "Compute Keccak-256 hash",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sha3Op,
-            post: vm2OpIgnore))]
+            post: VmOpIgnore))]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_log.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_log.nim
@@ -95,7 +95,7 @@ const
 # Private, op handlers implementation
 # ------------------------------------------------------------------------------
 
-proc wrapperFn(k: var Vm2Ctx; n: int): EvmResultVoid =
+proc wrapperFn(k: var VmCtx; n: int): EvmResultVoid =
   logImpl(k.cpt, logOpArg[n], n)
 
 genOphHandlers fnName, fnInfo, inxRange, wrapperFn
@@ -104,7 +104,7 @@ genOphHandlers fnName, fnInfo, inxRange, wrapperFn
 # Public, op exec table entries
 # ------------------------------------------------------------------------------
 
-genOphList fnName, fnInfo, inxRange, "vm2OpExecLog", opName
+genOphList fnName, fnInfo, inxRange, "VmOpExecLog", opName
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_memory.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_memory.nim
@@ -123,13 +123,13 @@ func jumpImpl(c: Computation; jumpTarget: UInt256): EvmResultVoid =
 # ------------------------------------------------------------------------------
 
 const
-  popOp: Vm2OpFn = func (k: var Vm2Ctx): EvmResultVoid =
+  popOp: VmOpFn = func (k: var VmCtx): EvmResultVoid =
     ## 0x50, Remove item from stack.
     k.cpt.stack.popInt.isOkOr:
       return err(error)
     ok()
 
-  mloadOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  mloadOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x51, Load word from memory
     let memStartPos = ? k.cpt.stack.popInt()
 
@@ -142,7 +142,7 @@ const
     k.cpt.stack.push k.cpt.memory.read32Bytes(memPos)
 
 
-  mstoreOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  mstoreOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x52, Save word to memory
     let (memStartPos, value) = ? k.cpt.stack.popInt(2)
 
@@ -155,7 +155,7 @@ const
     k.cpt.memory.write(memPos, value.toBytesBE)
 
 
-  mstore8Op: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  mstore8Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x53, Save byte to memory
     let (memStartPos, value) = ? k.cpt.stack.popInt(2)
 
@@ -170,14 +170,14 @@ const
 
   # -------
 
-  sloadOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  sloadOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x54, Load word from storage.
     let
       cpt = k.cpt
       slot = ? cpt.stack.popInt()
     cpt.stack.push cpt.getStorage(slot)
 
-  sloadEIP2929Op: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  sloadEIP2929Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x54, EIP2929: Load word from storage for Berlin and later
     let
       cpt = k.cpt
@@ -188,7 +188,7 @@ const
 
   # -------
 
-  sstoreOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  sstoreOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x55, Save word to storage.
     let
       cpt = k.cpt
@@ -198,7 +198,7 @@ const
     sstoreEvmcOrSstore(cpt, slot, newValue)
 
 
-  sstoreEIP1283Op: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  sstoreEIP1283Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x55, EIP1283: sstore for Constantinople and later
     let
       cpt = k.cpt
@@ -208,7 +208,7 @@ const
     sstoreEvmcOrNetGasMetering(cpt, slot, newValue)
 
 
-  sstoreEIP2200Op: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  sstoreEIP2200Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x55, EIP2200: sstore for Istanbul and later
     let
       cpt = k.cpt
@@ -223,7 +223,7 @@ const
     sstoreEvmcOrNetGasMetering(cpt, slot, newValue)
 
 
-  sstoreEIP2929Op: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  sstoreEIP2929Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x55, EIP2929: sstore for Berlin and later
     let
       cpt = k.cpt
@@ -251,46 +251,46 @@ const
 
   # -------
 
-  jumpOp: Vm2OpFn = func (k: var Vm2Ctx): EvmResultVoid =
+  jumpOp: VmOpFn = func (k: var VmCtx): EvmResultVoid =
     ## 0x56, Alter the program counter
     let jumpTarget = ? k.cpt.stack.popInt()
     jumpImpl(k.cpt, jumpTarget)
 
 
-  jumpIOp: Vm2OpFn = func (k: var Vm2Ctx): EvmResultVoid =
+  jumpIOp: VmOpFn = func (k: var VmCtx): EvmResultVoid =
     ## 0x57, Conditionally alter the program counter.
     let (jumpTarget, testedValue) = ? k.cpt.stack.popInt(2)
     if testedValue.isZero:
       return ok()
     jumpImpl(k.cpt, jumpTarget)
 
-  pcOp: Vm2OpFn = func (k: var Vm2Ctx): EvmResultVoid =
+  pcOp: VmOpFn = func (k: var VmCtx): EvmResultVoid =
     ## 0x58, Get the value of the program counter prior to the increment
     ##       corresponding to this instruction.
     k.cpt.stack.push max(k.cpt.code.pc - 1, 0)
 
-  msizeOp: Vm2OpFn = func (k: var Vm2Ctx): EvmResultVoid =
+  msizeOp: VmOpFn = func (k: var VmCtx): EvmResultVoid =
     ## 0x59, Get the size of active memory in bytes.
     k.cpt.stack.push k.cpt.memory.len
 
-  gasOp: Vm2OpFn = func (k: var Vm2Ctx): EvmResultVoid =
+  gasOp: VmOpFn = func (k: var VmCtx): EvmResultVoid =
     ## 0x5a, Get the amount of available gas, including the corresponding
     ##       reduction for the cost of this instruction.
     k.cpt.stack.push k.cpt.gasMeter.gasRemaining
 
-  jumpDestOp: Vm2OpFn = func (k: var Vm2Ctx): EvmResultVoid =
+  jumpDestOp: VmOpFn = func (k: var VmCtx): EvmResultVoid =
     ## 0x5b, Mark a valid destination for jumps. This operation has no effect
     ##       on machine state during execution.
     ok()
 
-  tloadOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  tloadOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x5c, Load word from transient storage.
     let
       slot = ? k.cpt.stack.popInt()
       val  = k.cpt.getTransientStorage(slot)
     k.cpt.stack.push val
 
-  tstoreOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  tstoreOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x5d, Save word to transient storage.
     ? checkInStaticContext(k.cpt)
 
@@ -300,7 +300,7 @@ const
     k.cpt.setTransientStorage(slot, val)
     ok()
 
-  mCopyOp: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  mCopyOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x5e, Copy memory
     let (dst, src, size) = ? k.cpt.stack.popInt(3)
 
@@ -319,170 +319,170 @@ const
 # ------------------------------------------------------------------------------
 
 const
-  vm2OpExecMemory*: seq[Vm2OpExec] = @[
+  VmOpExecMemory*: seq[VmOpExec] = @[
 
     (opCode: Pop,       ## x50, Remove item from stack
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "pop",
      info: "Remove item from stack",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  popOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Mload,     ## 0x51, Load word from memory
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "mload",
      info: "Load word from memory",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  mloadOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Mstore,    ## 0x52, Save word to memory
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "mstore",
      info: "Save word to memory",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  mstoreOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Mstore8,   ## 0x53, Save byte to memory
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "mstore8",
      info: "Save byte to memory",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  mstore8Op,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Sload,     ## 0x54, Load word from storage
-     forks: Vm2OpAllForks - Vm2OpBerlinAndLater,
+     forks: VmOpAllForks - VmOpBerlinAndLater,
      name: "sload",
      info: "Load word from storage",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sloadOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Sload,     ## 0x54, sload for Berlin and later
-     forks: Vm2OpBerlinAndLater,
+     forks: VmOpBerlinAndLater,
      name: "sloadEIP2929",
      info: "EIP2929: sload for Berlin and later",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sloadEIP2929Op,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Sstore,    ## 0x55, Save word
-     forks: Vm2OpAllForks - Vm2OpConstantinopleAndLater,
+     forks: VmOpAllForks - VmOpConstantinopleAndLater,
      name: "sstore",
      info: "Save word to storage",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sstoreOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Sstore,    ## 0x55, sstore for Constantinople and later
-     forks: Vm2OpConstantinopleAndLater - Vm2OpPetersburgAndLater,
+     forks: VmOpConstantinopleAndLater - VmOpPetersburgAndLater,
      name: "sstoreEIP1283",
      info: "EIP1283: sstore for Constantinople and later",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sstoreEIP1283Op,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Sstore,    ## 0x55, sstore for Petersburg and later
-     forks: Vm2OpPetersburgAndLater - Vm2OpIstanbulAndLater,
+     forks: VmOpPetersburgAndLater - VmOpIstanbulAndLater,
      name: "sstore",
      info: "sstore for Constantinople and later",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sstoreOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Sstore,    ##  0x55, sstore for Istanbul and later
-     forks: Vm2OpIstanbulAndLater - Vm2OpBerlinAndLater,
+     forks: VmOpIstanbulAndLater - VmOpBerlinAndLater,
      name: "sstoreEIP2200",
      info: "EIP2200: sstore for Istanbul and later",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sstoreEIP2200Op,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Sstore,    ##  0x55, sstore for Berlin and later
-     forks: Vm2OpBerlinAndLater,
+     forks: VmOpBerlinAndLater,
      name: "sstoreEIP2929",
      info: "EIP2929: sstore for Istanbul and later",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  sstoreEIP2929Op,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Jump,      ## 0x56, Jump
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "jump",
      info: "Alter the program counter",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  jumpOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: JumpI,     ## 0x57, Conditional jump
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "jumpI",
      info: "Conditionally alter the program counter",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  jumpIOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Pc,        ## 0x58, Program counter prior to instruction
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "pc",
      info: "Get the value of the program counter prior to the increment "&
            "corresponding to this instruction",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  pcOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Msize,     ## 0x59, Memory size
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "msize",
      info: "Get the size of active memory in bytes",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  msizeOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Gas,       ##  0x5a, Get available gas
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "gas",
      info: "Get the amount of available gas, including the corresponding "&
            "reduction for the cost of this instruction",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  gasOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: JumpDest,  ## 0x5b, Mark jump target. This operation has no effect
                         ##       on machine state during execution
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "jumpDest",
      info: "Mark a valid destination for jumps",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  jumpDestOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Tload,     ## 0x5c, Load word from transient storage.
-     forks: Vm2OpCancunAndLater,
+     forks: VmOpCancunAndLater,
      name: "tLoad",
      info: "Load word from transient storage",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  tloadOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Tstore,     ## 0x5d, Save word to transient storage.
-     forks: Vm2OpCancunAndLater,
+     forks: VmOpCancunAndLater,
      name: "tStore",
      info: "Save word to transient storage",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  tstoreOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Mcopy,     ## 0x5e, Copy memory
-     forks: Vm2OpCancunAndLater,
+     forks: VmOpCancunAndLater,
      name: "MCopy",
      info: "Copy memory",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  mCopyOp,
-            post: vm2OpIgnore))]
+            post: VmOpIgnore))]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_push.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_push.nim
@@ -40,7 +40,7 @@ proc fnInfo(n: int): string {.compileTime.} =
   "Push " & blurb & " on the stack"
 
 
-proc pushImpl(k: var Vm2Ctx; n: int): EvmResultVoid =
+proc pushImpl(k: var VmCtx; n: int): EvmResultVoid =
   k.cpt.stack.push k.cpt.code.readVmWord(n)
 
 const
@@ -56,7 +56,7 @@ genOphHandlers fnName, fnInfo, inxRange, pushImpl
 # Public, op exec table entries
 # ------------------------------------------------------------------------------
 
-genOphList fnName, fnInfo, inxRange, "vm2OpExecPush", opName
+genOphList fnName, fnInfo, inxRange, "VmOpExecPush", opName
 
 
 # Push0 needs to be slightly different because it's only available after
@@ -66,19 +66,19 @@ genOphList fnName, fnInfo, inxRange, "vm2OpExecPush", opName
 # just adding Push0 here as a special case.)
 
 const
-  push0Op: Vm2OpFn = proc (k: var Vm2Ctx): EvmResultVoid =
+  push0Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
     ## 0x5f, push 0 onto the stack
     k.cpt.stack.push(0)
 
-  vm2OpExecPushZero*: seq[Vm2OpExec] = @[
+  VmOpExecPushZero*: seq[VmOpExec] = @[
 
     (opCode: Push0,       ## 0x5f, push 0 onto the stack
-     forks: Vm2OpShanghaiAndLater,
+     forks: VmOpShanghaiAndLater,
      name: "Push0",
      info: "Push 0 on the stack",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  push0Op,
-            post: vm2OpIgnore))]
+            post: VmOpIgnore))]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_swap.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_swap.nim
@@ -41,7 +41,7 @@ proc fnInfo(n: int): string {.compileTime.} =
   "Exchange first and " & blurb & " stack items"
 
 
-func swapImpl(k: var Vm2Ctx; n: int): EvmResultVoid =
+func swapImpl(k: var VmCtx; n: int): EvmResultVoid =
   k.cpt.stack.swap(n)
 
 const
@@ -57,7 +57,7 @@ genOphHandlers fnName, fnInfo, inxRange, swapImpl
 # Public, op exec table entries
 # ------------------------------------------------------------------------------
 
-genOphList fnName, fnInfo, inxRange, "vm2OpExecSwap", opName
+genOphList fnName, fnInfo, inxRange, "VmOpExecSwap", opName
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/op_handlers/oph_sysops.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_sysops.nim
@@ -38,7 +38,7 @@ when not defined(evmc_enabled):
 # ------------------------------------------------------------------------------
 
 const
-  returnOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  returnOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0xf3, Halt execution returning output data.
     let (startPos, size) = ? k.cpt.stack.popInt(2)
 
@@ -51,7 +51,7 @@ const
     ok()
 
 
-  revertOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  revertOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0xfd, Halt execution reverting state changes but returning data
     ##       and remaining gas.
     let (startPos, size) = ? k.cpt.stack.popInt(2)
@@ -67,12 +67,12 @@ const
     k.cpt.setError(EVMC_REVERT, "REVERT opcode executed", false)
     ok()
 
-  invalidOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  invalidOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     err(opErr(InvalidInstruction))
 
   # -----------
 
-  selfDestructOp: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  selfDestructOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## 0xff, Halt execution and register account for later deletion.
     let cpt = k.cpt
     let beneficiary = ? cpt.stack.popAddress()
@@ -84,7 +84,7 @@ const
         cpt.selfDestruct(beneficiary)
     ok()
 
-  selfDestructEIP150Op: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  selfDestructEIP150Op: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## selfDestructEip150 (auto generated comment)
     let cpt = k.cpt
     let beneficiary = ? cpt.stack.popAddress()
@@ -99,7 +99,7 @@ const
       cpt.selfDestruct(beneficiary)
     ok()
 
-  selfDestructEIP161Op: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  selfDestructEIP161Op: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## selfDestructEip161 (auto generated comment)
     let cpt = k.cpt
     ? checkInStaticContext(cpt)
@@ -120,7 +120,7 @@ const
       cpt.selfDestruct(beneficiary)
     ok()
 
-  selfDestructEIP2929Op: Vm2OpFn = proc(k: var Vm2Ctx): EvmResultVoid =
+  selfDestructEIP2929Op: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
     ## selfDestructEIP2929 (auto generated comment)
     let cpt = k.cpt
     ? checkInStaticContext(cpt)
@@ -158,64 +158,64 @@ const
 # ------------------------------------------------------------------------------
 
 const
-  vm2OpExecSysOp*: seq[Vm2OpExec] = @[
+  VmOpExecSysOp*: seq[VmOpExec] = @[
 
     (opCode: Return,       ## 0xf3, Halt execution returning output data.
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "returnOp",
      info: "Halt execution returning output data",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run: returnOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Revert,       ## 0xfd, Halt and revert state changes
-     forks: Vm2OpByzantiumAndLater,
+     forks: VmOpByzantiumAndLater,
      name: "revert",
      info: "Halt execution reverting state changes but returning data " &
            "and remaining gas",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run: revertOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: Invalid,      ## 0xfe, invalid instruction.
-     forks: Vm2OpAllForks,
+     forks: VmOpAllForks,
      name: "invalidInstruction",
      info: "Designated invalid instruction",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run: invalidOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: SelfDestruct, ## 0xff, Halt execution, prep for later deletion
-     forks: Vm2OpAllForks - Vm2OpTangerineAndLater,
+     forks: VmOpAllForks - VmOpTangerineAndLater,
      name: "selfDestruct",
      info: "Halt execution and register account for later deletion",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  selfDestructOp,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: SelfDestruct, ## 0xff, EIP150: self destruct, Tangerine
-     forks: Vm2OpTangerineAndLater - Vm2OpSpuriousAndLater,
+     forks: VmOpTangerineAndLater - VmOpSpuriousAndLater,
      name: "selfDestructEIP150",
      info: "EIP150: Halt execution and register account for later deletion",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  selfDestructEIP150Op,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: SelfDestruct, ## 0xff, EIP161: self destruct, Spurious and later
-     forks: Vm2OpSpuriousAndLater - Vm2OpBerlinAndLater,
+     forks: VmOpSpuriousAndLater - VmOpBerlinAndLater,
      name: "selfDestructEIP161",
      info: "EIP161: Halt execution and register account for later deletion",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  selfDestructEIP161Op,
-            post: vm2OpIgnore)),
+            post: VmOpIgnore)),
 
     (opCode: SelfDestruct, ## 0xff, EIP2929: self destruct, Berlin and later
-     forks: Vm2OpBerlinAndLater,
+     forks: VmOpBerlinAndLater,
      name: "selfDestructEIP2929",
      info: "EIP2929: Halt execution and register account for later deletion",
-     exec: (prep: vm2OpIgnore,
+     exec: (prep: VmOpIgnore,
             run:  selfDestructEIP2929Op,
-            post: vm2OpIgnore))]
+            post: VmOpIgnore))]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter_dispatch.nim
+++ b/nimbus/evm/interpreter_dispatch.nim
@@ -40,7 +40,7 @@ when optimizationCondition:
 
 proc selectVM(c: Computation, fork: EVMFork, shouldPrepareTracer: bool): EvmResultVoid =
   ## Op code execution handler main loop.
-  var desc: Vm2Ctx
+  var desc: VmCtx
   desc.cpt = c
 
   # It's important not to re-prepare the tracer after


### PR DESCRIPTION
Legacy evm  have been removed, no longer need to keep the Vm2 prefix.