### PR TITLE
do not download Holesky genesis on git clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,15 +129,20 @@ ifeq ($(NIM_PARAMS),)
 # "variables.mk" was not included, so we update the submodules.
 # selectively download nimbus-eth2 submodules because we don't need all of it's modules
 # also holesky already exceeds github LFS quota
+
+# We don't need these `vendor/holesky` files but fetching them
+# may trigger 'This repository is over its data quota' from GitHub
+GIT_SUBMODULE_CONFIG := -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz
+
 GIT_SUBMODULE_UPDATE := git -c submodule."vendor/nimbus-eth2".update=none submodule update --init --recursive; \
-  git submodule update vendor/nimbus-eth2; \
+  git $(GIT_SUBMODULE_CONFIG) submodule update vendor/nimbus-eth2; \
   cd vendor/nimbus-eth2; \
-  git submodule update --init vendor/eth2-networks; \
-  git submodule update --init vendor/holesky; \
-  git submodule update --init vendor/sepolia; \
-  git submodule update --init vendor/gnosis-chain-configs; \
-  git submodule update --init --recursive vendor/nim-kzg4844; \
-  git submodule update --init vendor/mainnet; \
+  git $(GIT_SUBMODULE_CONFIG) submodule update --init vendor/eth2-networks; \
+  git $(GIT_SUBMODULE_CONFIG) submodule update --init vendor/holesky; \
+  git $(GIT_SUBMODULE_CONFIG) submodule update --init vendor/sepolia; \
+  git $(GIT_SUBMODULE_CONFIG) submodule update --init vendor/gnosis-chain-configs; \
+  git $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive vendor/nim-kzg4844; \
+  git $(GIT_SUBMODULE_CONFIG) submodule update --init vendor/mainnet; \
   cd ../..
 
 .DEFAULT:


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/pull/5573 for `nimbus-eth1`

Example error message:
```
#14 247.2 Downloading custom_config_data/genesis.ssz (206 MB)
#14 247.3 Error downloading object: custom_config_data/genesis.ssz (d750639): Smudge error: Error downloading custom_config_data/genesis.ssz (d750639607c337bbb192b15c27f447732267bf72d1650180a0e44c2d93a80741): batch response: This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data packs to restore access.
#14 247.3 
#14 247.3 Errors logged to '/root/nimbus-eth1/.git/modules/vendor/nimbus-eth2/modules/vendor/holesky/lfs/logs/20240617T041422.883269253.log'.
#14 247.3 Use `git lfs logs last` to view the log.
#14 247.3 error: external filter 'git-lfs filter-process' failed
#14 247.3 fatal: custom_config_data/genesis.ssz: smudge filter lfs failed
#14 247.3 fatal: run_command returned non-zero status for vendor/nimbus-eth2/vendor/holesky
#14 247.3 .
#14 247.3 fatal: run_command returned non-zero status while recursing in the nested submodules of vendor/nimbus-eth2
```