### PR TITLE
Remove hashify calls when forking

### DIFF
--- a/nimbus/db/aristo/aristo_api.nim
+++ b/nimbus/db/aristo/aristo_api.nim
@@ -151,7 +151,6 @@ type
   AristoApiForkTxFn* =
     proc(db: AristoDbRef;
          backLevel: int;
-         dontHashify = false;
         ): Result[AristoDbRef,AristoError]
         {.noRaise.}
     ## Fork a new descriptor obtained from parts of the argument database
@@ -172,9 +171,6 @@ type
     ## The returned database descriptor will always have transaction level one.
     ## If there were no transactions that could be squashed, an empty
     ## transaction is added.
-    ##
-    ## If the arguent flag `dontHashify` is passed `true`, the forked descriptor
-    ## will *NOT* be hashified right after construction.
     ##
     ## Use `aristo_desc.forget()` to clean up this descriptor.
 
@@ -524,7 +520,7 @@ func init*(api: var AristoApiObj) =
   api.hashify = hashify
   api.hasPath = hasPath
   api.hikeUp = hikeUp
-  api.isTop = isTop 
+  api.isTop = isTop
   api.level = level
   api.nForked = nForked
   api.merge = merge

--- a/nimbus/db/aristo/aristo_tx.nim
+++ b/nimbus/db/aristo/aristo_tx.nim
@@ -51,7 +51,6 @@ func to*(tx: AristoTxRef; T: type[AristoDbRef]): T =
 proc forkTx*(
     db: AristoDbRef;
     backLevel: int;                   # Backward location of transaction
-    dontHashify = false;              # Process/fix MPT hashes
       ): Result[AristoDbRef,AristoError] =
   ## Fork a new descriptor obtained from parts of the argument database
   ## as described by arguments `db` and `backLevel`.
@@ -71,18 +70,15 @@ proc forkTx*(
   ## If there were no transactions that could be squashed, an empty
   ## transaction is added.
   ##
-  ## If the arguent flag `dontHashify` is passed `true`, the forked descriptor
-  ## will *NOT* be hashified right after construction.
-  ##
   ## Use `aristo_desc.forget()` to clean up this descriptor.
   ##
   # Fork top layer (with or without pending transaction)?
   if backLevel == 0:
-    return db.txForkTop dontHashify
+    return db.txForkTop()
 
   # Fork bottom layer (=> 0 < db.stack.len)
   if backLevel == db.stack.len:
-    return db.txForkBase dontHashify
+    return db.txForkBase()
 
   # Inspect transaction stack
   if 0 < backLevel:
@@ -95,7 +91,7 @@ proc forkTx*(
       tx = tx.parent
       if tx.isNil:
         return err(TxStackGarbled)
-    return tx.txFork dontHashify
+    return tx.txFork()
 
   # Plain fork, include `balancer`
   if backLevel == -1:

--- a/nimbus/db/aristo/aristo_tx/tx_fork.nim
+++ b/nimbus/db/aristo/aristo_tx/tx_fork.nim
@@ -16,7 +16,7 @@
 import
   results,
   ./tx_frame,
-  ".."/[aristo_desc, aristo_get, aristo_layers, aristo_hashify]
+  ".."/[aristo_desc, aristo_get, aristo_layers]
 
 # ------------------------------------------------------------------------------
 # Public functions
@@ -24,7 +24,6 @@ import
 
 proc txFork*(
     tx: AristoTxRef;                  # Transaction descriptor
-    dontHashify = false;              # Process/fix MPT hashes
       ): Result[AristoDbRef,AristoError] =
   ## Clone a transaction into a new DB descriptor accessing the same backend
   ## database (if any) as the argument `db`. The new descriptor is linked to
@@ -47,9 +46,6 @@ proc txFork*(
   ## The new DB descriptor will contain a copy of the argument transaction
   ## `tx` as top layer of level 1 (i.e. this is he only transaction.) Rolling
   ## back will end up at the backend layer (incl. backend filter.)
-  ##
-  ## If the arguent flag `dontHashify` is passed `true`, the clone descriptor
-  ## will *NOT* be hashified right after construction.
   ##
   ## Use `aristo_desc.forget()` to clean up this descriptor.
   ##
@@ -89,17 +85,11 @@ proc txFork*(
     txUid: 1,
     level: 1)
 
-  if not dontHashify:
-    txClone.hashify().isOkOr:
-      discard txClone.forget()
-      return err(error[1])
-
   ok(txClone)
 
 
 proc txForkTop*(
     db: AristoDbRef;
-    dontHashify = false;              # Process/fix MPT hashes
       ): Result[AristoDbRef,AristoError] =
   ## Variant of `forkTx()` for the top transaction if there is any. Otherwise
   ## the top layer is cloned, and an empty transaction is set up. After
@@ -111,21 +101,15 @@ proc txForkTop*(
     let txClone = ? db.fork(noToplayer=true, noFilter=false)
     txClone.top = db.layersCc         # Is a deep copy
 
-    if not dontHashify:
-      txClone.hashify().isOkOr:
-        discard txClone.forget()
-        return err(error[1])
-
     discard txClone.txFrameBegin()
     return ok(txClone)
     # End if()
 
-  db.txRef.txFork dontHashify
+  db.txRef.txFork()
 
 
 proc txForkBase*(
     db: AristoDbRef;
-    dontHashify = false;              # Process/fix MPT hashes
       ): Result[AristoDbRef,AristoError] =
   ## Variant of `forkTx()`, sort of the opposite of `forkTop()`. This is the
   ## equivalent of top layer forking after all tranactions have been rolled
@@ -134,15 +118,10 @@ proc txForkBase*(
   ## Use `aristo_desc.forget()` to clean up this descriptor.
   ##
   if db.txRef.isNil:
-    return db.txForkTop dontHashify
+    return db.txForkTop()
 
   let txClone = ? db.fork(noToplayer=true, noFilter=false)
   txClone.top = db.layersCc 0
-
-  if not dontHashify:
-    txClone.hashify().isOkOr:
-      discard txClone.forget()
-      return err(error[1])
 
   discard txClone.txFrameBegin()
   ok(txClone)


### PR DESCRIPTION
This appears to no longer be needed and we want to delay hashing as much as possible.