### PR TITLE
Avoid creating database transaction for every block

### DIFF
--- a/nimbus/core/executor/process_block.nim
+++ b/nimbus/core/executor/process_block.nim
@@ -165,10 +165,6 @@ proc processBlock*(
     skipUncles: bool = false,
 ): Result[void, string] =
   ## Generalised function to processes `blk` for any network.
-  var dbTx = vmState.com.db.newTransaction()
-  defer:
-    dbTx.dispose()
-
   ?vmState.procBlkPreamble(blk, skipValidation, skipReceipts, skipUncles)
 
   # EIP-3675: no reward for miner in POA/POS
@@ -176,8 +172,6 @@ proc processBlock*(
     vmState.calculateReward(blk.header, blk.uncles)
 
   ?vmState.procBlkEpilogue(blk.header, skipValidation)
-
-  dbTx.commit()
 
   ok()
 


### PR DESCRIPTION
Broadly, when importing blocks we don't need a transaction / frame per block because we can simply abort the whole update and try again with a smaller range if we find a faulty block.

Of course, this applies mainly to semi-trusted blocks where we're not expected to fail in applying them - this could be blocks either from files or header-verified blocks as given by consensus.