### PR TITLE
avoid intermediate const in opcodes

### DIFF
--- a/nimbus/evm/interpreter/op_handlers/oph_arithmetic.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_arithmetic.nim
@@ -37,248 +37,247 @@ func slt(x, y: UInt256): bool =
 # Private, op handlers implementation
 # ------------------------------------------------------------------------------
 
-const
-  addOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x01, Addition
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-    k.cpt.stack.push(lhs + rhs)
+proc addOp (k: var VmCtx): EvmResultVoid =
+  ## 0x01, Addition
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+  k.cpt.stack.push(lhs + rhs)
 
-  mulOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x02, Multiplication
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-    k.cpt.stack.push(lhs * rhs)
+proc mulOp(k: var VmCtx): EvmResultVoid =
+  ## 0x02, Multiplication
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+  k.cpt.stack.push(lhs * rhs)
 
-  subOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x03, Substraction
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-    k.cpt.stack.push(lhs - rhs)
+proc subOp(k: var VmCtx): EvmResultVoid =
+  ## 0x03, Substraction
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+  k.cpt.stack.push(lhs - rhs)
 
-  divideOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x04, Division
-    let
-      (lhs, rhs) = ? k.cpt.stack.popInt(2)
-      value = if rhs.isZero:
-                # EVM special casing of div by 0
-                zero(UInt256)
-              else:
-                lhs div rhs
-
-    k.cpt.stack.push value
-
-
-  sdivOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x05, Signed division
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-
-    var r: UInt256
-    if rhs.isZero.not:
-      var a = lhs
-      var b = rhs
-      var signA, signB: bool
-      extractSign(a, signA)
-      extractSign(b, signB)
-      r = a div b
-      setSign(r, signA xor signB)
-    k.cpt.stack.push(r)
-
-
-  moduloOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x06, Modulo
-    let
-      (lhs, rhs) = ? k.cpt.stack.popInt(2)
-      value = if rhs.isZero:
-                zero(UInt256)
-              else:
-                lhs mod rhs
-
-    k.cpt.stack.push value
-
-
-  smodOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x07, Signed modulo
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-
-    var r: UInt256
-    if rhs.isZero.not:
-      var sign: bool
-      var v = lhs
-      var m = rhs
-      extractSign(m, sign)
-      extractSign(v, sign)
-      r = v mod m
-      setSign(r, sign)
-    k.cpt.stack.push(r)
-
-
-  addmodOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x08, Modulo addition
-    ## Intermediate computations do not roll over at 2^256
-    let
-      (lhs, rhs, modulus) = ? k.cpt.stack.popInt(3)
-      value = if modulus.isZero:
-                zero(UInt256)
-              else:
-                addmod(lhs, rhs, modulus)
-
-    k.cpt.stack.push value
-
-
-  mulmodOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x09, Modulo multiplication
-    ## Intermediate computations do not roll over at 2^256
-    let
-      (lhs, rhs, modulus) = ? k.cpt.stack.popInt(3)
-      value = if modulus.isZero:
-                zero(UInt256)
-              else:
-                mulmod(lhs, rhs, modulus)
-
-    k.cpt.stack.push value
-
-
-  expOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x0A, Exponentiation
-    let (base, exponent) = ? k.cpt.stack.popInt(2)
-
-    ? k.cpt.opcodeGastCost(Exp,
-      k.cpt.gasCosts[Exp].d_handler(exponent),
-      reason = "EXP: exponent bytes")
-
-    let value = if not base.isZero:
-                  base.pow(exponent)
-                elif exponent.isZero:
-                  # https://github.com/ethereum/yellowpaper/issues/257
-                  # https://github.com/ethereum/tests/pull/460
-                  # https://github.com/ewasm/evm2wasm/issues/137
-                  1.u256
-                else:
-                  zero(UInt256)
-
-    k.cpt.stack.push value
-
-
-  signExtendOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x0B, Sign extend
-    ## Extend length of two’s complement signed integer.
-    let (bits, value) = ? k.cpt.stack.popInt(2)
-
-    var res: UInt256
-    if bits <= 31.u256:
-      let
-        one = 1.u256
-        testBit = bits.truncate(int) * 8 + 7
-        bitPos = one shl testBit
-        mask = bitPos - one
-      if not isZero(value and bitPos):
-        res = value or (not mask)
-      else:
-        res = value and mask
-    else:
-      res = value
-    k.cpt.stack.push res
-
-
-  ltOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x10, Less-than comparison
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-    k.cpt.stack.push((lhs < rhs).uint.u256)
-
-  gtOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x11, Greater-than comparison
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-    k.cpt.stack.push((lhs > rhs).uint.u256)
-
-  sltOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x12, Signed less-than comparison
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-    k.cpt.stack.push(slt(lhs, rhs).uint.u256)
-
-  sgtOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x13, Signed greater-than comparison
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-    # Arguments are swapped and SLT is used.
-    k.cpt.stack.push(slt(rhs, lhs).uint.u256)
-
-  eqOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x14, Equality comparison
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-    k.cpt.stack.push((lhs == rhs).uint.u256)
-
-  isZeroOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x15, Check if zero
-    let value = ? k.cpt.stack.popInt()
-    k.cpt.stack.push(value.isZero.uint.u256)
-
-  andOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x16, Bitwise AND
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-    k.cpt.stack.push(lhs and rhs)
-
-  orOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x17, Bitwise OR
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-    k.cpt.stack.push(lhs or rhs)
-
-  xorOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x18, Bitwise XOR
-    let (lhs, rhs) = ? k.cpt.stack.popInt(2)
-    k.cpt.stack.push(lhs xor rhs)
-
-  notOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x19, Check if zero
-    let value = ? k.cpt.stack.popInt()
-    k.cpt.stack.push(value.not)
-
-  byteOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0x20, Retrieve single byte from word.
-    let
-      (position, value) = ? k.cpt.stack.popInt(2)
-      val = if position >= 32.u256:
+proc divideOp(k: var VmCtx): EvmResultVoid =
+  ## 0x04, Division
+  let
+    (lhs, rhs) = ? k.cpt.stack.popInt(2)
+    value = if rhs.isZero:
+              # EVM special casing of div by 0
               zero(UInt256)
             else:
-              let pos = position.truncate(int)
-              when system.cpuEndian == bigEndian:
-                cast[array[32, byte]](value)[pos].u256
+              lhs div rhs
+
+  k.cpt.stack.push value
+
+
+proc sdivOp(k: var VmCtx): EvmResultVoid =
+  ## 0x05, Signed division
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+
+  var r: UInt256
+  if rhs.isZero.not:
+    var a = lhs
+    var b = rhs
+    var signA, signB: bool
+    extractSign(a, signA)
+    extractSign(b, signB)
+    r = a div b
+    setSign(r, signA xor signB)
+  k.cpt.stack.push(r)
+
+
+proc moduloOp(k: var VmCtx): EvmResultVoid =
+  ## 0x06, Modulo
+  let
+    (lhs, rhs) = ? k.cpt.stack.popInt(2)
+    value = if rhs.isZero:
+              zero(UInt256)
+            else:
+              lhs mod rhs
+
+  k.cpt.stack.push value
+
+
+proc smodOp(k: var VmCtx): EvmResultVoid =
+  ## 0x07, Signed modulo
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+
+  var r: UInt256
+  if rhs.isZero.not:
+    var sign: bool
+    var v = lhs
+    var m = rhs
+    extractSign(m, sign)
+    extractSign(v, sign)
+    r = v mod m
+    setSign(r, sign)
+  k.cpt.stack.push(r)
+
+
+proc addmodOp(k: var VmCtx): EvmResultVoid =
+  ## 0x08, Modulo addition
+  ## Intermediate computations do not roll over at 2^256
+  let
+    (lhs, rhs, modulus) = ? k.cpt.stack.popInt(3)
+    value = if modulus.isZero:
+              zero(UInt256)
+            else:
+              addmod(lhs, rhs, modulus)
+
+  k.cpt.stack.push value
+
+
+proc mulmodOp(k: var VmCtx): EvmResultVoid =
+  ## 0x09, Modulo multiplication
+  ## Intermediate computations do not roll over at 2^256
+  let
+    (lhs, rhs, modulus) = ? k.cpt.stack.popInt(3)
+    value = if modulus.isZero:
+              zero(UInt256)
+            else:
+              mulmod(lhs, rhs, modulus)
+
+  k.cpt.stack.push value
+
+
+proc expOp(k: var VmCtx): EvmResultVoid =
+  ## 0x0A, Exponentiation
+  let (base, exponent) = ? k.cpt.stack.popInt(2)
+
+  ? k.cpt.opcodeGastCost(Exp,
+    k.cpt.gasCosts[Exp].d_handler(exponent),
+    reason = "EXP: exponent bytes")
+
+  let value = if not base.isZero:
+                base.pow(exponent)
+              elif exponent.isZero:
+                # https://github.com/ethereum/yellowpaper/issues/257
+                # https://github.com/ethereum/tests/pull/460
+                # https://github.com/ewasm/evm2wasm/issues/137
+                1.u256
               else:
-                cast[array[32, byte]](value)[31 - pos].u256
+                zero(UInt256)
 
-    k.cpt.stack.push val
+  k.cpt.stack.push value
 
 
-  # Constantinople's new opcodes
+proc signExtendOp(k: var VmCtx): EvmResultVoid =
+  ## 0x0B, Sign extend
+  ## Extend length of two’s complement signed integer.
+  let (bits, value) = ? k.cpt.stack.popInt(2)
 
-  shlOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    let (shift, num) = ? k.cpt.stack.popInt(2)
-    let shiftLen = shift.safeInt
-    if shiftLen >= 256:
-      k.cpt.stack.push 0
-    else:
-      k.cpt.stack.push(num shl shiftLen)
-
-  shrOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    let (shift, num) = ? k.cpt.stack.popInt(2)
-    let shiftLen = shift.safeInt
-    if shiftLen >= 256:
-      k.cpt.stack.push 0
-    else:
-      # uint version of `shr`
-      k.cpt.stack.push(num shr shiftLen)
-
-  sarOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
+  var res: UInt256
+  if bits <= 31.u256:
     let
-      shiftLen = ? k.cpt.stack.popSafeInt()
-      num256 = ? k.cpt.stack.popInt()
-      num = cast[Int256](num256)
-
-    if shiftLen >= 256:
-      if num.isNegative:
-        k.cpt.stack.push(cast[UInt256]((-1).i256))
-      else:
-        k.cpt.stack. push 0
+      one = 1.u256
+      testBit = bits.truncate(int) * 8 + 7
+      bitPos = one shl testBit
+      mask = bitPos - one
+    if not isZero(value and bitPos):
+      res = value or (not mask)
     else:
-      # int version of `shr` then force the result
-      # into uint256
-      k.cpt.stack.push(cast[UInt256](num shr shiftLen))
+      res = value and mask
+  else:
+    res = value
+  k.cpt.stack.push res
+
+
+proc ltOp(k: var VmCtx): EvmResultVoid =
+  ## 0x10, Less-than comparison
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+  k.cpt.stack.push((lhs < rhs).uint.u256)
+
+proc gtOp(k: var VmCtx): EvmResultVoid =
+  ## 0x11, Greater-than comparison
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+  k.cpt.stack.push((lhs > rhs).uint.u256)
+
+proc sltOp(k: var VmCtx): EvmResultVoid =
+  ## 0x12, Signed less-than comparison
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+  k.cpt.stack.push(slt(lhs, rhs).uint.u256)
+
+proc sgtOp(k: var VmCtx): EvmResultVoid =
+  ## 0x13, Signed greater-than comparison
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+  # Arguments are swapped and SLT is used.
+  k.cpt.stack.push(slt(rhs, lhs).uint.u256)
+
+proc eqOp(k: var VmCtx): EvmResultVoid =
+  ## 0x14, Equality comparison
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+  k.cpt.stack.push((lhs == rhs).uint.u256)
+
+proc isZeroOp(k: var VmCtx): EvmResultVoid =
+  ## 0x15, Check if zero
+  let value = ? k.cpt.stack.popInt()
+  k.cpt.stack.push(value.isZero.uint.u256)
+
+proc andOp(k: var VmCtx): EvmResultVoid =
+  ## 0x16, Bitwise AND
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+  k.cpt.stack.push(lhs and rhs)
+
+proc orOp(k: var VmCtx): EvmResultVoid =
+  ## 0x17, Bitwise OR
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+  k.cpt.stack.push(lhs or rhs)
+
+proc xorOp(k: var VmCtx): EvmResultVoid =
+  ## 0x18, Bitwise XOR
+  let (lhs, rhs) = ? k.cpt.stack.popInt(2)
+  k.cpt.stack.push(lhs xor rhs)
+
+proc notOp(k: var VmCtx): EvmResultVoid =
+  ## 0x19, Check if zero
+  let value = ? k.cpt.stack.popInt()
+  k.cpt.stack.push(value.not)
+
+proc byteOp(k: var VmCtx): EvmResultVoid =
+  ## 0x20, Retrieve single byte from word.
+  let
+    (position, value) = ? k.cpt.stack.popInt(2)
+    val = if position >= 32.u256:
+            zero(UInt256)
+          else:
+            let pos = position.truncate(int)
+            when system.cpuEndian == bigEndian:
+              cast[array[32, byte]](value)[pos].u256
+            else:
+              cast[array[32, byte]](value)[31 - pos].u256
+
+  k.cpt.stack.push val
+
+
+# Constantinople's new opcodes
+
+proc shlOp(k: var VmCtx): EvmResultVoid =
+  let (shift, num) = ? k.cpt.stack.popInt(2)
+  let shiftLen = shift.safeInt
+  if shiftLen >= 256:
+    k.cpt.stack.push 0
+  else:
+    k.cpt.stack.push(num shl shiftLen)
+
+proc shrOp(k: var VmCtx): EvmResultVoid =
+  let (shift, num) = ? k.cpt.stack.popInt(2)
+  let shiftLen = shift.safeInt
+  if shiftLen >= 256:
+    k.cpt.stack.push 0
+  else:
+    # uint version of `shr`
+    k.cpt.stack.push(num shr shiftLen)
+
+proc sarOp(k: var VmCtx): EvmResultVoid =
+  let
+    shiftLen = ? k.cpt.stack.popSafeInt()
+    num256 = ? k.cpt.stack.popInt()
+    num = cast[Int256](num256)
+
+  if shiftLen >= 256:
+    if num.isNegative:
+      k.cpt.stack.push(cast[UInt256]((-1).i256))
+    else:
+      k.cpt.stack. push 0
+  else:
+    # int version of `shr` then force the result
+    # into uint256
+    k.cpt.stack.push(cast[UInt256](num shr shiftLen))
 
 # ------------------------------------------------------------------------------
 # Public, op exec table entries
@@ -292,7 +291,7 @@ const
      name: "add",
      info: "Addition operation",
      exec: (prep: VmOpIgnore,
-            run:  addOp,
+            run:  VmOpFn addOp,
             post: VmOpIgnore)),
 
     (opCode: Mul,         ##  0x02, Multiplication

--- a/nimbus/evm/interpreter/op_handlers/oph_blockdata.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_blockdata.nim
@@ -29,63 +29,62 @@ when not defined(evmc_enabled):
 # Private, op handlers implementation
 # ------------------------------------------------------------------------------
 
-const
-  blockhashOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x40, Get the hash of one of the 256 most recent complete blocks.
-    let
-      cpt = k.cpt
-      blockNumber = ? cpt.stack.popInt()
-      blockHash = cpt.getBlockHash(blockNumber.truncate(BlockNumber))
+proc blockhashOp (k: var VmCtx): EvmResultVoid =
+  ## 0x40, Get the hash of one of the 256 most recent complete blocks.
+  let
+    cpt = k.cpt
+    blockNumber = ? cpt.stack.popInt()
+    blockHash = cpt.getBlockHash(blockNumber.truncate(BlockNumber))
 
-    cpt.stack.push blockHash
+  cpt.stack.push blockHash
 
-  coinBaseOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x41, Get the block's beneficiary address.
-    k.cpt.stack.push k.cpt.getCoinbase
+proc coinBaseOp (k: var VmCtx): EvmResultVoid =
+  ## 0x41, Get the block's beneficiary address.
+  k.cpt.stack.push k.cpt.getCoinbase
 
-  timestampOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x42, Get the block's timestamp.
-    k.cpt.stack.push k.cpt.getTimestamp
+proc timestampOp (k: var VmCtx): EvmResultVoid =
+  ## 0x42, Get the block's timestamp.
+  k.cpt.stack.push k.cpt.getTimestamp
 
-  blocknumberOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x43, Get the block's number.
-    k.cpt.stack.push k.cpt.getBlockNumber
+proc blocknumberOp (k: var VmCtx): EvmResultVoid =
+  ## 0x43, Get the block's number.
+  k.cpt.stack.push k.cpt.getBlockNumber
 
-  difficultyOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x44, Get the block's difficulty
-    k.cpt.stack.push k.cpt.getDifficulty
+proc difficultyOp (k: var VmCtx): EvmResultVoid =
+  ## 0x44, Get the block's difficulty
+  k.cpt.stack.push k.cpt.getDifficulty
 
-  gasLimitOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x45, Get the block's gas limit
-    k.cpt.stack.push k.cpt.getGasLimit
+proc gasLimitOp (k: var VmCtx): EvmResultVoid =
+  ## 0x45, Get the block's gas limit
+  k.cpt.stack.push k.cpt.getGasLimit
 
-  chainIdOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x46, Get current chain’s EIP-155 unique identifier.
-    k.cpt.stack.push k.cpt.getChainId
+proc chainIdOp (k: var VmCtx): EvmResultVoid =
+  ## 0x46, Get current chain’s EIP-155 unique identifier.
+  k.cpt.stack.push k.cpt.getChainId
 
-  selfBalanceOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x47, Get current contract's balance.
-    let cpt = k.cpt
-    cpt.stack.push cpt.getBalance(cpt.msg.contractAddress)
+proc selfBalanceOp (k: var VmCtx): EvmResultVoid =
+  ## 0x47, Get current contract's balance.
+  let cpt = k.cpt
+  cpt.stack.push cpt.getBalance(cpt.msg.contractAddress)
 
-  baseFeeOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x48, Get the block's base fee.
-    k.cpt.stack.push k.cpt.getBaseFee
+proc baseFeeOp (k: var VmCtx): EvmResultVoid =
+  ## 0x48, Get the block's base fee.
+  k.cpt.stack.push k.cpt.getBaseFee
 
-  blobHashOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x49, Get current transaction's EIP-4844 versioned hash.
-    let
-      index = ? k.cpt.stack.popSafeInt()
-      len = k.cpt.getVersionedHashesLen
+proc blobHashOp (k: var VmCtx): EvmResultVoid =
+  ## 0x49, Get current transaction's EIP-4844 versioned hash.
+  let
+    index = ? k.cpt.stack.popSafeInt()
+    len = k.cpt.getVersionedHashesLen
 
-    if index < len:
-      k.cpt.stack.push k.cpt.getVersionedHash(index)
-    else:
-      k.cpt.stack.push 0
+  if index < len:
+    k.cpt.stack.push k.cpt.getVersionedHash(index)
+  else:
+    k.cpt.stack.push 0
 
-  blobBaseFeeOp: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x4a, Get the block's base fee.
-    k.cpt.stack.push k.cpt.getBlobBaseFee
+proc blobBaseFeeOp (k: var VmCtx): EvmResultVoid =
+  ## 0x4a, Get the block's base fee.
+  k.cpt.stack.push k.cpt.getBlobBaseFee
 
 
 # ------------------------------------------------------------------------------

--- a/nimbus/evm/interpreter/op_handlers/oph_hash.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_hash.nim
@@ -30,27 +30,26 @@ import
 # Private, op handlers implementation
 # ------------------------------------------------------------------------------
 
-const
-  sha3Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x20, Compute Keccak-256 hash.
-    let
-      (startPos, length) = ? k.cpt.stack.popInt(2)
-      (pos, len) = (startPos.safeInt, length.safeInt)
+proc sha3Op(k: var VmCtx): EvmResultVoid =
+  ## 0x20, Compute Keccak-256 hash.
+  let
+    (startPos, length) = ? k.cpt.stack.popInt(2)
+    (pos, len) = (startPos.safeInt, length.safeInt)
 
-    if pos < 0 or len < 0 or pos > 2147483648'i64:
-      return err(opErr(OutOfBounds))
+  if pos < 0 or len < 0 or pos > 2147483648'i64:
+    return err(opErr(OutOfBounds))
 
-    ? k.cpt.opcodeGastCost(Op.Sha3,
-      k.cpt.gasCosts[Op.Sha3].m_handler(k.cpt.memory.len, pos, len),
-      reason = "SHA3: word gas cost")
+  ? k.cpt.opcodeGastCost(Op.Sha3,
+    k.cpt.gasCosts[Op.Sha3].m_handler(k.cpt.memory.len, pos, len),
+    reason = "SHA3: word gas cost")
 
-    k.cpt.memory.extend(pos, len)
+  k.cpt.memory.extend(pos, len)
 
-    let endRange = min(pos + len, k.cpt.memory.len) - 1
-    if endRange == -1 or pos >= k.cpt.memory.len:
-      k.cpt.stack.push(EMPTY_SHA3)
-    else:
-      k.cpt.stack.push keccakHash k.cpt.memory.bytes.toOpenArray(pos, endRange)
+  let endRange = min(pos + len, k.cpt.memory.len) - 1
+  if endRange == -1 or pos >= k.cpt.memory.len:
+    k.cpt.stack.push(EMPTY_SHA3)
+  else:
+    k.cpt.stack.push keccakHash k.cpt.memory.bytes.toOpenArray(pos, endRange)
 
 # ------------------------------------------------------------------------------
 # Public, op exec table entries

--- a/nimbus/evm/interpreter/op_handlers/oph_push.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_push.nim
@@ -65,11 +65,11 @@ genOphList fnName, fnInfo, inxRange, "VmOpExecPush", opName
 # about which opcodes are for which forks, but that seems uglier than
 # just adding Push0 here as a special case.)
 
-const
-  push0Op: VmOpFn = proc (k: var VmCtx): EvmResultVoid =
-    ## 0x5f, push 0 onto the stack
-    k.cpt.stack.push(0)
+proc push0Op(k: var VmCtx): EvmResultVoid =
+  ## 0x5f, push 0 onto the stack
+  k.cpt.stack.push(0)
 
+const
   VmOpExecPushZero*: seq[VmOpExec] = @[
 
     (opCode: Push0,       ## 0x5f, push 0 onto the stack

--- a/nimbus/evm/interpreter/op_handlers/oph_sysops.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_sysops.nim
@@ -37,121 +37,120 @@ when not defined(evmc_enabled):
 # Private
 # ------------------------------------------------------------------------------
 
-const
-  returnOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0xf3, Halt execution returning output data.
-    let (startPos, size) = ? k.cpt.stack.popInt(2)
+proc returnOp(k: var VmCtx): EvmResultVoid =
+  ## 0xf3, Halt execution returning output data.
+  let (startPos, size) = ? k.cpt.stack.popInt(2)
 
-    let (pos, len) = (startPos.cleanMemRef, size.cleanMemRef)
-    ? k.cpt.opcodeGastCost(Return,
-      k.cpt.gasCosts[Return].m_handler(k.cpt.memory.len, pos, len),
-      reason = "RETURN")
-    k.cpt.memory.extend(pos, len)
-    k.cpt.output = k.cpt.memory.read(pos, len)
-    ok()
+  let (pos, len) = (startPos.cleanMemRef, size.cleanMemRef)
+  ? k.cpt.opcodeGastCost(Return,
+    k.cpt.gasCosts[Return].m_handler(k.cpt.memory.len, pos, len),
+    reason = "RETURN")
+  k.cpt.memory.extend(pos, len)
+  k.cpt.output = k.cpt.memory.read(pos, len)
+  ok()
 
 
-  revertOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0xfd, Halt execution reverting state changes but returning data
-    ##       and remaining gas.
-    let (startPos, size) = ? k.cpt.stack.popInt(2)
+proc revertOp(k: var VmCtx): EvmResultVoid =
+  ## 0xfd, Halt execution reverting state changes but returning data
+  ##       and remaining gas.
+  let (startPos, size) = ? k.cpt.stack.popInt(2)
 
-    let (pos, len) = (startPos.cleanMemRef, size.cleanMemRef)
-    ? k.cpt.opcodeGastCost(Revert,
-      k.cpt.gasCosts[Revert].m_handler(k.cpt.memory.len, pos, len),
-      reason = "REVERT")
+  let (pos, len) = (startPos.cleanMemRef, size.cleanMemRef)
+  ? k.cpt.opcodeGastCost(Revert,
+    k.cpt.gasCosts[Revert].m_handler(k.cpt.memory.len, pos, len),
+    reason = "REVERT")
 
-    k.cpt.memory.extend(pos, len)
-    k.cpt.output = k.cpt.memory.read(pos, len)
-    # setError(msg, false) will signal cheap revert
-    k.cpt.setError(EVMC_REVERT, "REVERT opcode executed", false)
-    ok()
+  k.cpt.memory.extend(pos, len)
+  k.cpt.output = k.cpt.memory.read(pos, len)
+  # setError(msg, false) will signal cheap revert
+  k.cpt.setError(EVMC_REVERT, "REVERT opcode executed", false)
+  ok()
 
-  invalidOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    err(opErr(InvalidInstruction))
+proc invalidOp(k: var VmCtx): EvmResultVoid =
+  err(opErr(InvalidInstruction))
 
-  # -----------
+# -----------
 
-  selfDestructOp: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## 0xff, Halt execution and register account for later deletion.
-    let cpt = k.cpt
-    let beneficiary = ? cpt.stack.popAddress()
-    when defined(evmc_enabled):
-      block:
-        cpt.selfDestruct(beneficiary)
-    else:
-      block:
-        cpt.selfDestruct(beneficiary)
-    ok()
-
-  selfDestructEIP150Op: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## selfDestructEip150 (auto generated comment)
-    let cpt = k.cpt
-    let beneficiary = ? cpt.stack.popAddress()
+proc selfDestructOp(k: var VmCtx): EvmResultVoid =
+  ## 0xff, Halt execution and register account for later deletion.
+  let cpt = k.cpt
+  let beneficiary = ? cpt.stack.popAddress()
+  when defined(evmc_enabled):
     block:
-      let gasParams = GasParams(
-        kind: SelfDestruct,
-        sd_condition: not cpt.accountExists(beneficiary))
-
-      let res = ? cpt.gasCosts[SelfDestruct].c_handler(0.u256, gasParams)
-      ? cpt.opcodeGastCost(SelfDestruct,
-          res.gasCost, reason = "SELFDESTRUCT EIP150")
       cpt.selfDestruct(beneficiary)
-    ok()
-
-  selfDestructEIP161Op: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## selfDestructEip161 (auto generated comment)
-    let cpt = k.cpt
-    ? checkInStaticContext(cpt)
-
-    let beneficiary = ? cpt.stack.popAddress()
+  else:
     block:
-      let
-        isDead = not cpt.accountExists(beneficiary)
-        balance = cpt.getBalance(cpt.msg.contractAddress)
+      cpt.selfDestruct(beneficiary)
+  ok()
 
-      let gasParams = GasParams(
+proc selfDestructEIP150Op(k: var VmCtx): EvmResultVoid =
+  ## selfDestructEip150 (auto generated comment)
+  let cpt = k.cpt
+  let beneficiary = ? cpt.stack.popAddress()
+  block:
+    let gasParams = GasParams(
+      kind: SelfDestruct,
+      sd_condition: not cpt.accountExists(beneficiary))
+
+    let res = ? cpt.gasCosts[SelfDestruct].c_handler(0.u256, gasParams)
+    ? cpt.opcodeGastCost(SelfDestruct,
+        res.gasCost, reason = "SELFDESTRUCT EIP150")
+    cpt.selfDestruct(beneficiary)
+  ok()
+
+proc selfDestructEIP161Op(k: var VmCtx): EvmResultVoid =
+  ## selfDestructEip161 (auto generated comment)
+  let cpt = k.cpt
+  ? checkInStaticContext(cpt)
+
+  let beneficiary = ? cpt.stack.popAddress()
+  block:
+    let
+      isDead = not cpt.accountExists(beneficiary)
+      balance = cpt.getBalance(cpt.msg.contractAddress)
+
+    let gasParams = GasParams(
+      kind: SelfDestruct,
+      sd_condition: isDead and not balance.isZero)
+
+    let res = ? cpt.gasCosts[SelfDestruct].c_handler(0.u256, gasParams)
+    ? cpt.opcodeGastCost(SelfDestruct,
+      res.gasCost, reason = "SELFDESTRUCT EIP161")
+    cpt.selfDestruct(beneficiary)
+  ok()
+
+proc selfDestructEIP2929Op(k: var VmCtx): EvmResultVoid =
+  ## selfDestructEIP2929 (auto generated comment)
+  let cpt = k.cpt
+  ? checkInStaticContext(cpt)
+
+  let beneficiary = ? cpt.stack.popAddress()
+  block:
+    let
+      isDead = not cpt.accountExists(beneficiary)
+      balance = cpt.getBalance(cpt.msg.contractAddress)
+
+    let
+      gasParams = GasParams(
         kind: SelfDestruct,
         sd_condition: isDead and not balance.isZero)
+      res = ? cpt.gasCosts[SelfDestruct].c_handler(0.u256, gasParams)
 
-      let res = ? cpt.gasCosts[SelfDestruct].c_handler(0.u256, gasParams)
-      ? cpt.opcodeGastCost(SelfDestruct,
-        res.gasCost, reason = "SELFDESTRUCT EIP161")
-      cpt.selfDestruct(beneficiary)
-    ok()
+    var gasCost = res.gasCost
 
-  selfDestructEIP2929Op: VmOpFn = proc(k: var VmCtx): EvmResultVoid =
-    ## selfDestructEIP2929 (auto generated comment)
-    let cpt = k.cpt
-    ? checkInStaticContext(cpt)
-
-    let beneficiary = ? cpt.stack.popAddress()
-    block:
-      let
-        isDead = not cpt.accountExists(beneficiary)
-        balance = cpt.getBalance(cpt.msg.contractAddress)
-
-      let
-        gasParams = GasParams(
-          kind: SelfDestruct,
-          sd_condition: isDead and not balance.isZero)
-        res = ? cpt.gasCosts[SelfDestruct].c_handler(0.u256, gasParams)
-
-      var gasCost = res.gasCost
-
-      when evmc_enabled:
-        if cpt.host.accessAccount(beneficiary) == EVMC_ACCESS_COLD:
+    when evmc_enabled:
+      if cpt.host.accessAccount(beneficiary) == EVMC_ACCESS_COLD:
+        gasCost = gasCost + ColdAccountAccessCost
+    else:
+      cpt.vmState.mutateStateDB:
+        if not db.inAccessList(beneficiary):
+          db.accessList(beneficiary)
           gasCost = gasCost + ColdAccountAccessCost
-      else:
-        cpt.vmState.mutateStateDB:
-          if not db.inAccessList(beneficiary):
-            db.accessList(beneficiary)
-            gasCost = gasCost + ColdAccountAccessCost
 
-      ? cpt.opcodeGastCost(SelfDestruct,
-        gasCost, reason = "SELFDESTRUCT EIP2929")
-      cpt.selfDestruct(beneficiary)
-    ok()
+    ? cpt.opcodeGastCost(SelfDestruct,
+      gasCost, reason = "SELFDESTRUCT EIP2929")
+    cpt.selfDestruct(beneficiary)
+  ok()
 
 # ------------------------------------------------------------------------------
 # Public, op exec table entries


### PR DESCRIPTION
The extra layer of `const` makes the function name harder to see a debugger / profiler

Before:
![image](https://github.com/status-im/nimbus-eth1/assets/1382986/0d9ff00d-c9ee-4a9d-83f5-c99ab003a3e2)


After:
![image](https://github.com/status-im/nimbus-eth1/assets/1382986/461c1af2-8dd3-4583-b430-82986a3f3065)
