### PR TITLE
avoid closure environment for mpt methods

### DIFF
--- a/nimbus/db/core_db/base/base_desc.nim
+++ b/nimbus/db/core_db/base/base_desc.nim
@@ -160,16 +160,14 @@ type
   # --------------------------------------------------
   # Sub-descriptor: MPT context methods
   # --------------------------------------------------
-  CoreDbCtxFromTxFn* =
-    proc(root: Hash256; kind: CoreDbColType): CoreDbRc[CoreDbCtxRef] {.noRaise.}
   CoreDbCtxNewColFn* = proc(
-    colType: CoreDbColType; colState: Hash256; address: Opt[EthAddress];
+    cCtx: CoreDbCtxRef; colType: CoreDbColType; colState: Hash256; address: Opt[EthAddress];
     ): CoreDbRc[CoreDbColRef] {.noRaise.}
   CoreDbCtxGetMptFn* = proc(
-    root: CoreDbColRef): CoreDbRc[CoreDbMptRef] {.noRaise.}
+    cCtx: CoreDbCtxRef; root: CoreDbColRef): CoreDbRc[CoreDbMptRef] {.noRaise.}
   CoreDbCtxGetAccFn* = proc(
-    root: CoreDbColRef): CoreDbRc[CoreDbAccRef] {.noRaise.}
-  CoreDbCtxForgetFn* = proc() {.noRaise.}
+    cCtx: CoreDbCtxRef; root: CoreDbColRef): CoreDbRc[CoreDbAccRef] {.noRaise.}
+  CoreDbCtxForgetFn* = proc(cCtx: CoreDbCtxRef) {.noRaise.}
 
   CoreDbCtxFns* = object
     ## Methods for context maniulation
@@ -181,20 +179,20 @@ type
   # --------------------------------------------------
   # Sub-descriptor: generic  Mpt/hexary trie methods
   # --------------------------------------------------
-  CoreDbMptBackendFn* = proc(): CoreDbMptBackendRef {.noRaise.}
+  CoreDbMptBackendFn* = proc(cMpt: CoreDbMptRef): CoreDbMptBackendRef {.noRaise.}
   CoreDbMptFetchFn* =
-    proc(k: openArray[byte]): CoreDbRc[Blob] {.noRaise.}
+    proc(cMpt: CoreDbMptRef, k: openArray[byte]): CoreDbRc[Blob] {.noRaise.}
   CoreDbMptFetchAccountFn* =
-    proc(k: openArray[byte]): CoreDbRc[CoreDbAccount] {.noRaise.}
+    proc(cMpt: CoreDbMptRef, k: openArray[byte]): CoreDbRc[CoreDbAccount] {.noRaise.}
   CoreDbMptDeleteFn* =
-    proc(k: openArray[byte]): CoreDbRc[void] {.noRaise.}
+    proc(cMpt: CoreDbMptRef, k: openArray[byte]): CoreDbRc[void] {.noRaise.}
   CoreDbMptMergeFn* =
-    proc(k: openArray[byte]; v: openArray[byte]): CoreDbRc[void] {.noRaise.}
+    proc(cMpt: CoreDbMptRef, k: openArray[byte]; v: openArray[byte]): CoreDbRc[void] {.noRaise.}
   CoreDbMptMergeAccountFn* =
-    proc(k: openArray[byte]; v: CoreDbAccount): CoreDbRc[void] {.noRaise.}
-  CoreDbMptHasPathFn* = proc(k: openArray[byte]): CoreDbRc[bool] {.noRaise.}
-  CoreDbMptGetColFn* = proc(): CoreDbColRef {.noRaise.}
-  CoreDbMptForgetFn* = proc(): CoreDbRc[void] {.noRaise.}
+    proc(cMpt: CoreDbMptRef, k: openArray[byte]; v: CoreDbAccount): CoreDbRc[void] {.noRaise.}
+  CoreDbMptHasPathFn* = proc(cMpt: CoreDbMptRef, k: openArray[byte]): CoreDbRc[bool] {.noRaise.}
+  CoreDbMptGetColFn* = proc(cMpt: CoreDbMptRef): CoreDbColRef {.noRaise.}
+  CoreDbMptForgetFn* = proc(cMpt: CoreDbMptRef): CoreDbRc[void] {.noRaise.}
 
   CoreDbMptFns* = object
     ## Methods for trie objects
@@ -209,14 +207,13 @@ type
   # ----------------------------------------------------
   # Sub-descriptor: Mpt/hexary trie methods for accounts
   # ------------------------------------------------------
-  CoreDbAccGetMptFn* = proc(): CoreDbRc[CoreDbMptRef] {.noRaise.}
-  CoreDbAccFetchFn* = proc(k: EthAddress): CoreDbRc[CoreDbAccount] {.noRaise.}
-  CoreDbAccDeleteFn* = proc(k: EthAddress): CoreDbRc[void] {.noRaise.}
-  CoreDbAccStoDeleteFn* = proc(k: EthAddress): CoreDbRc[void] {.noRaise.}
-  CoreDbAccMergeFn* = proc(v: CoreDbAccount): CoreDbRc[void] {.noRaise.}
-  CoreDbAccHasPathFn* = proc(k: EthAddress): CoreDbRc[bool] {.noRaise.}
-  CoreDbAccGetColFn* = proc(): CoreDbColRef {.noRaise.}
-  CoreDbAccForgetFn* = proc(): CoreDbRc[void] {.noRaise.}
+  CoreDbAccGetMptFn* = proc(cAcc: CoreDbAccRef): CoreDbRc[CoreDbMptRef] {.noRaise.}
+  CoreDbAccFetchFn* = proc(cAcc: CoreDbAccRef, k: EthAddress): CoreDbRc[CoreDbAccount] {.noRaise.}
+  CoreDbAccDeleteFn* = proc(cAcc: CoreDbAccRef, k: EthAddress): CoreDbRc[void] {.noRaise.}
+  CoreDbAccStoDeleteFn* = proc(cAcc: CoreDbAccRef,k: EthAddress): CoreDbRc[void] {.noRaise.}
+  CoreDbAccMergeFn* = proc(cAcc: CoreDbAccRef, v: CoreDbAccount): CoreDbRc[void] {.noRaise.}
+  CoreDbAccHasPathFn* = proc(cAcc: CoreDbAccRef, k: EthAddress): CoreDbRc[bool] {.noRaise.}
+  CoreDbAccGetColFn* = proc(cAcc: CoreDbAccRef): CoreDbColRef {.noRaise.}
 
   CoreDbAccFns* = object
     ## Methods for trie objects

--- a/nimbus/nimbus_import.nim
+++ b/nimbus/nimbus_import.nim
@@ -21,6 +21,9 @@ import
   ./db/era1_db,
   beacon_chain/era_db
 
+declareGauge nec_import_block_number,
+  "Latest imported block number"
+
 declareCounter nec_imported_blocks,
   "Blocks processed during import"
 
@@ -105,6 +108,8 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
     if csv != nil:
       close(csv)
 
+  nec_import_block_number.set(start.int64)
+
   template blockNumber(): uint64 =
     start + imported
 
@@ -155,6 +160,7 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
           avgMGps = f(gas.float / 1000000 / diff0),
           elapsed = shortLog(time2 - time0, 3)
 
+        metrics.set(nec_import_block_number, int64(blockNumber))
         nec_imported_blocks.inc(blocks.len)
         nec_imported_transactions.inc(statsRes[].txs)
         nec_imported_gas.inc(statsRes[].gas)


### PR DESCRIPTION
An instance of `CoreDbMptRef` is created for and stored in every account
- when we are processing blocks and have many accounts in memory, this closure environment takes up hundreds of mb of memory (around block 5M, it is the 4:th largest memory consumer!) - incidentally, this also removes a circular reference in the setup that causes the `AristoCodeDbMptRef` to linger in memory much longer than it has to which is the core reason why it takes so much.

The real solution here is to remove the methods indirection entirely, but this PR provides relief until that has been done.

Similar treatment is given to some of the other core api functions to avoid circulars there too.