### PR TITLE
Clear account cache after each block

### DIFF
--- a/nimbus/core/executor/process_block.nim
+++ b/nimbus/core/executor/process_block.nim
@@ -124,7 +124,11 @@ proc procBlkEpilogue(
     if vmState.collectWitnessData:
       db.collectWitnessData()
 
-    db.persist(clearEmptyAccount = vmState.determineFork >= FkSpurious)
+    # Clearing the account cache here helps manage its size when replaying
+    # large ranges of blocks, implicitly limiting its size using the gas limit
+    db.persist(
+      clearEmptyAccount = vmState.determineFork >= FkSpurious,
+      clearCache = true)
 
   if not skipValidation:
     let stateDB = vmState.stateDB

--- a/nimbus/db/ledger/base.nim
+++ b/nimbus/db/ledger/base.nim
@@ -270,10 +270,10 @@ proc makeMultiKeys*(ldg: LedgerRef): MultiKeysRef =
   result = ldg.ac.makeMultiKeys()
   ldg.ifTrackApi: debug apiTxt, api, elapsed
 
-proc persist*(ldg: LedgerRef, clearEmptyAccount = false) =
+proc persist*(ldg: LedgerRef, clearEmptyAccount = false, clearCache = false) =
   ldg.beginTrackApi LdgPersistFn
-  ldg.ac.persist(clearEmptyAccount)
-  ldg.ifTrackApi: debug apiTxt, api, elapsed, clearEmptyAccount
+  ldg.ac.persist(clearEmptyAccount, clearCache)
+  ldg.ifTrackApi: debug apiTxt, api, elapsed, clearEmptyAccount, clearCache
 
 proc ripemdSpecial*(ldg: LedgerRef) =
   ldg.beginTrackApi LdgRipemdSpecialFn

--- a/nimbus/db/opts.nim
+++ b/nimbus/db/opts.nim
@@ -18,7 +18,7 @@ const
   # https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning
   defaultMaxOpenFiles* = 512
   defaultWriteBufferSize* = 64 * 1024 * 1024
-  defaultRowCacheSize* = 512 * 1024 * 1024
+  defaultRowCacheSize* = 2048 * 1024 * 1024
   defaultBlockCacheSize* = 256 * 1024 * 1024
 
 type DbOptions* = object # Options that are transported to the database layer


### PR DESCRIPTION
When processing long ranges of blocks, the account cache grows unbounded which causes huge memory spikes.

Here, we move the cache to a second-level cache after each block - the second-level cache is cleared on the next block after that which creates a simple LRU effect.

There's a small performance cost of course, though overall the freed-up memory can now be reassigned to the rocksdb row cache which not only makes up for the loss but overall leads to a performance increase.

The bump to 2gb of rocksdb row cache here needs more testing but is slightly less and loosely based on the savings from this PR and the circular ref fix in #2408 - another way to phrase this is that it's better to give rocksdb more breathing room than let the memory sit unused until circular ref collection happens ;)