### PR TITLE
Add paths-ignore for Kurtosis CI tests

### DIFF
--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -14,9 +14,27 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'doc/**'
+      - 'docs/**'
+      - '**/*.md'
+      - 'hive_integration/**'
+      - 'fluffy/**'
+      - '.github/workflows/fluffy*.yml'
+      - 'nimbus_verified_proxy/**'
+      - '.github/workflows/nimbus_verified_proxy.yml'
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - 'doc/**'
+      - 'docs/**'
+      - '**/*.md'
+      - 'hive_integration/**'
+      - 'fluffy/**'
+      - '.github/workflows/fluffy*.yml'
+      - 'nimbus_verified_proxy/**'
+      - '.github/workflows/nimbus_verified_proxy.yml'
 
 jobs:
   build:


### PR DESCRIPTION
Avoiding this to run on docs changes, or changes to Fluffy or nimbus_verified_proxy.