### PR TITLE
Fix memory usage spikes during sync, give memory to rocksdb

### DIFF
--- a/nimbus/db/aristo/aristo_delta.nim
+++ b/nimbus/db/aristo/aristo_delta.nim
@@ -75,8 +75,10 @@ proc deltaPersistent*(
 
   # Store structural single trie entries
   let writeBatch = ? be.putBegFn()
-  be.putVtxFn(writeBatch, db.balancer.sTab.pairs.toSeq)
-  be.putKeyFn(writeBatch, db.balancer.kMap.pairs.toSeq)
+  for vid, vtx in db.balancer.sTab:
+    be.putVtxFn(writeBatch, vid, vtx)
+  for vid, key in db.balancer.kMap:
+    be.putKeyFn(writeBatch, vid,key)
   be.putTuvFn(writeBatch, db.balancer.vTop)
   be.putLstFn(writeBatch, lSst)
   ? be.putEndFn writeBatch                       # Finalise write batch

--- a/nimbus/db/aristo/aristo_desc/desc_backend.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_backend.nim
@@ -52,13 +52,13 @@ type
       ## Generic transaction initialisation function
 
   PutVtxFn* =
-    proc(hdl: PutHdlRef; vrps: openArray[(VertexID,VertexRef)])
+    proc(hdl: PutHdlRef; vid: VertexID; vtx: VertexRef)
       {.gcsafe, raises: [].}
         ## Generic backend database bulk storage function, `VertexRef(nil)`
         ## values indicate that records should be deleted.
 
   PutKeyFn* =
-    proc(hdl: PutHdlRef; vkps: openArray[(VertexID,HashKey)])
+    proc(hdl: PutHdlRef; vid: VertexID, key: HashKey)
       {.gcsafe, raises: [].}
         ## Generic backend database bulk storage function, `VOID_HASH_KEY`
         ## values indicate that records should be deleted.

--- a/nimbus/db/aristo/aristo_init/memory_db.nim
+++ b/nimbus/db/aristo/aristo_init/memory_db.nim
@@ -132,29 +132,27 @@ proc putBegFn(db: MemBackendRef): PutBegFn =
 
 proc putVtxFn(db: MemBackendRef): PutVtxFn =
   result =
-    proc(hdl: PutHdlRef; vrps: openArray[(VertexID,VertexRef)]) =
+    proc(hdl: PutHdlRef; vid: VertexID; vtx: VertexRef) =
       let hdl = hdl.getSession db
       if hdl.error.isNil:
-        for (vid,vtx) in vrps:
-          if vtx.isValid:
-            let rc = vtx.blobify()
-            if rc.isErr:
-              hdl.error = TypedPutHdlErrRef(
-                pfx:  VtxPfx,
-                vid:  vid,
-                code: rc.error)
-              return
-            hdl.sTab[vid] = rc.value
-          else:
-            hdl.sTab[vid] = EmptyBlob
+        if vtx.isValid:
+          let rc = vtx.blobify()
+          if rc.isErr:
+            hdl.error = TypedPutHdlErrRef(
+              pfx:  VtxPfx,
+              vid:  vid,
+              code: rc.error)
+            return
+          hdl.sTab[vid] = rc.value
+        else:
+          hdl.sTab[vid] = EmptyBlob
 
 proc putKeyFn(db: MemBackendRef): PutKeyFn =
   result =
-    proc(hdl: PutHdlRef; vkps: openArray[(VertexID,HashKey)]) =
+    proc(hdl: PutHdlRef; vid: VertexID, key: HashKey) =
       let hdl = hdl.getSession db
       if hdl.error.isNil:
-        for (vid,key) in vkps:
-          hdl.kMap[vid] = key
+        hdl.kMap[vid] = key
 
 proc putTuvFn(db: MemBackendRef): PutTuvFn =
   result =

--- a/nimbus/db/aristo/aristo_init/rocks_db.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db.nim
@@ -143,10 +143,10 @@ proc putBegFn(db: RdbBackendRef): PutBegFn =
 
 proc putVtxFn(db: RdbBackendRef): PutVtxFn =
   result =
-    proc(hdl: PutHdlRef; vrps: openArray[(VertexID,VertexRef)]) =
+    proc(hdl: PutHdlRef; vid: VertexID; vtx: VertexRef) =
       let hdl = hdl.getSession db
       if hdl.error.isNil:
-        db.rdb.putVtx(vrps).isOkOr:
+        db.rdb.putVtx(vid, vtx).isOkOr:
           hdl.error = TypedPutHdlErrRef(
             pfx:  VtxPfx,
             vid:  error[0],
@@ -155,10 +155,10 @@ proc putVtxFn(db: RdbBackendRef): PutVtxFn =
 
 proc putKeyFn(db: RdbBackendRef): PutKeyFn =
   result =
-    proc(hdl: PutHdlRef; vkps: openArray[(VertexID,HashKey)]) =
+    proc(hdl: PutHdlRef; vid: VertexID, key: HashKey) =
       let hdl = hdl.getSession db
       if hdl.error.isNil:
-        db.rdb.putKey(vkps).isOkOr:
+        db.rdb.putKey(vid, key).isOkOr:
           hdl.error = TypedPutHdlErrRef(
             pfx:  KeyPfx,
             vid:  error[0],

--- a/nimbus/db/opts.nim
+++ b/nimbus/db/opts.nim
@@ -18,7 +18,7 @@ const
   # https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning
   defaultMaxOpenFiles* = 512
   defaultWriteBufferSize* = 64 * 1024 * 1024
-  defaultRowCacheSize* = 2048 * 1024 * 1024
+  defaultRowCacheSize* = 4096 * 1024 * 1024
   defaultBlockCacheSize* = 256 * 1024 * 1024
 
 type DbOptions* = object # Options that are transported to the database layer


### PR DESCRIPTION
* creating a seq from a table that holds lots of changes means copying all data into the table - this can be several GB of data while syncing blocks
* nim fails to optimize the moving of the `WidthFirstForest` - the real solution is to not construct a `wff` to begin with, but this PR provides relief while that is being worked on

This spike fix allows us to bump the rocksdb cache by another 2 GB and still have a significantly lower peak memory usage during sync.