### PR TITLE
Simplify txpool baseFeeGet

### DIFF
--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -306,10 +306,6 @@ func isLondonOrLater*(com: CommonRef, number: BlockNumber): bool =
   # TODO: Fixme, use only London comparator
   com.toHardFork(number.forkDeterminationInfo) >= London
 
-func isLondonOrLater*(com: CommonRef, number: BlockNumber, timestamp: EthTime): bool =
-  # TODO: Fixme, use only London comparator
-  com.toHardFork(forkDeterminationInfo(number, timestamp)) >= London
-
 func forkGTE*(com: CommonRef, fork: HardFork): bool =
   com.currentFork >= fork
 

--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -302,11 +302,11 @@ func toEVMFork*(com: CommonRef, forkDeterminer: ForkDeterminationInfo): EVMFork 
 func toEVMFork*(com: CommonRef): EVMFork =
   ToEVMFork[com.currentFork]
 
-func isLondon*(com: CommonRef, number: BlockNumber): bool =
+func isLondonOrLater*(com: CommonRef, number: BlockNumber): bool =
   # TODO: Fixme, use only London comparator
   com.toHardFork(number.forkDeterminationInfo) >= London
 
-func isLondon*(com: CommonRef, number: BlockNumber, timestamp: EthTime): bool =
+func isLondonOrLater*(com: CommonRef, number: BlockNumber, timestamp: EthTime): bool =
   # TODO: Fixme, use only London comparator
   com.toHardFork(forkDeterminationInfo(number, timestamp)) >= London
 

--- a/nimbus/core/gaslimit.nim
+++ b/nimbus/core/gaslimit.nim
@@ -51,7 +51,7 @@ proc calcEip1599BaseFee*(com: CommonRef; parent: BlockHeader): UInt256 =
 
   # If the current block is the first EIP-1559 block, return the
   # initial base fee.
-  if com.isLondon(parent.number):
+  if com.isLondonOrLater(parent.number):
     eip1559.calcEip1599BaseFee(parent.gasLimit, parent.gasUsed, parent.baseFeePerGas.get(0.u256))
   else:
     EIP1559_INITIAL_BASE_FEE
@@ -61,7 +61,7 @@ proc verifyEip1559Header(com: CommonRef;
                          parent, header: BlockHeader): Result[void, string]
                         {.raises: [].} =
   ## Verify that the gas limit remains within allowed bounds
-  let limit = if com.isLondon(parent.number):
+  let limit = if com.isLondonOrLater(parent.number):
                 parent.gasLimit
               else:
                 parent.gasLimit * EIP1559_ELASTICITY_MULTIPLIER
@@ -91,7 +91,7 @@ proc verifyEip1559Header(com: CommonRef;
 proc validateGasLimitOrBaseFee*(com: CommonRef;
                                 header, parent: BlockHeader): Result[void, string] =
 
-  if not com.isLondon(header.number):
+  if not com.isLondonOrLater(header.number):
     # Verify BaseFee not present before EIP-1559 fork.
     let baseFeePerGas = header.baseFeePerGas.get(0.u256)
     if not baseFeePerGas.isZero:

--- a/nimbus/core/tx_pool/tx_chain.nim
+++ b/nimbus/core/tx_pool/tx_chain.nim
@@ -123,10 +123,9 @@ proc update(dh: TxChainRef; parent: BlockHeader)
     {.gcsafe,raises: [].} =
 
   let
-    timestamp = dh.getTimestamp(parent)
     db  = dh.com.db
     acc = LedgerRef.init(db, parent.stateRoot)
-    fee = baseFeeGet(dh.com, parent, timestamp)
+    fee = baseFeeGet(dh.com, parent)
 
   # Keep a separate accounts descriptor positioned at the sync point
   dh.roAcc = ReadOnlyStateDB(acc)

--- a/nimbus/core/tx_pool/tx_chain.nim
+++ b/nimbus/core/tx_pool/tx_chain.nim
@@ -126,10 +126,7 @@ proc update(dh: TxChainRef; parent: BlockHeader)
     timestamp = dh.getTimestamp(parent)
     db  = dh.com.db
     acc = LedgerRef.init(db, parent.stateRoot)
-    fee = if dh.com.isLondon(parent.number + 1, timestamp):
-            Opt.some(dh.com.baseFeeGet(parent).uint64.u256)
-          else:
-            Opt.none UInt256
+    fee = baseFeeGet(dh.com, parent, timestamp)
 
   # Keep a separate accounts descriptor positioned at the sync point
   dh.roAcc = ReadOnlyStateDB(acc)
@@ -293,7 +290,7 @@ func `baseFee=`*(dh: TxChainRef; val: GasPrice) =
   ## Setter, temorarily overwrites parameter until next `head=` update. This
   ## function would be called in exceptional cases only as this parameter is
   ## determined by the `head=` update.
-  if 0 < val or dh.com.isLondon(dh.txEnv.vmState.blockNumber):
+  if 0 < val or dh.com.isLondonOrLater(dh.txEnv.vmState.blockNumber):
     dh.txEnv.vmState.blockCtx.baseFeePerGas = Opt.some(val.uint64.u256)
   else:
     dh.txEnv.vmState.blockCtx.baseFeePerGas = Opt.none UInt256

--- a/nimbus/core/tx_pool/tx_chain/tx_basefee.nim
+++ b/nimbus/core/tx_pool/tx_chain/tx_basefee.nim
@@ -24,16 +24,16 @@ import
 # ------------------------------------------------------------------------------
 
 proc baseFeeGet*(com: CommonRef;
-                 parent: BlockHeader, timestamp: EthTime): Opt[UInt256] =
+                 parent: BlockHeader): Opt[UInt256] =
   ## Calculates the `baseFee` of the head assuming this is the parent of a
   ## new block header to generate.
 
   # Note that the baseFee is calculated for the next header
-  if not com.isLondonOrLater(parent.number+1, timestamp):
+  if not com.isLondonOrLater(parent.number+1):
     return Opt.none(UInt256)
 
   # If the new block is the first EIP-1559 block, return initial base fee.
-  if not com.isLondonOrLater(parent.number, timestamp):
+  if not com.isLondonOrLater(parent.number):
     return Opt.some(EIP1559_INITIAL_BASE_FEE)
 
   Opt.some calcEip1599BaseFee(

--- a/nimbus/core/tx_pool/tx_chain/tx_gaslimits.nim
+++ b/nimbus/core/tx_pool/tx_chain/tx_gaslimits.nim
@@ -95,7 +95,7 @@ proc gasLimitsGet*(com: CommonRef; parent: BlockHeader; parentLimit: GasInt;
   ## Calculate gas limits for the next block header.
   result.gasLimit = parentLimit
 
-  if com.isLondon(parent.number+1):
+  if com.isLondonOrLater(parent.number+1):
     result.setPostLondonLimits
   else:
     result.setPreLondonLimits
@@ -108,9 +108,9 @@ proc gasLimitsGet*(com: CommonRef; parent: BlockHeader; parentLimit: GasInt;
     result.trgLimit, (result.maxLimit * pc.hwmMax + 50) div 100)
 
   # override trgLimit, see https://github.com/status-im/nimbus-eth1/issues/1032
-  if com.isLondon(parent.number+1):
+  if com.isLondonOrLater(parent.number+1):
     var parentGasLimit = parent.gasLimit
-    if not com.isLondon(parent.number):
+    if not com.isLondonOrLater(parent.number):
       # Bump by 2x
       parentGasLimit = parent.gasLimit * EIP1559_ELASTICITY_MULTIPLIER
     result.trgLimit = calcGasLimit1559(parentGasLimit, desiredLimit = pc.gasCeil)

--- a/nimbus/rpc/oracle.nim
+++ b/nimbus/rpc/oracle.nim
@@ -85,7 +85,7 @@ func toBytes(list: openArray[float64]): seq[byte] =
     result.add(cast[uint64](x).toBytesLE)
 
 func calcBaseFee(com: CommonRef, bc: BlockContent): UInt256 =
-  if com.isLondon(bc.blockNumber + 1):
+  if com.isLondonOrLater(bc.blockNumber + 1):
     calcEip1599BaseFee(
       bc.header.gasLimit,
       bc.header.gasUsed,

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -436,7 +436,7 @@ proc transitionAction*(ctx: var TransContext, conf: T8NConf) =
     )
 
     # Sanity check, to not `panic` in state_transition
-    if com.isLondon(ctx.env.currentNumber):
+    if com.isLondonOrLater(ctx.env.currentNumber):
       if ctx.env.currentBaseFee.isSome:
         # Already set, currentBaseFee has precedent over parentBaseFee.
         discard


### PR DESCRIPTION
- Avoid using toEVMFork because we are not in EVM
- Rename `isLondon` to `isLondonOrLater`