### PR TITLE
Use RocksDb column family handles instead of name strings.

### DIFF
--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
@@ -74,14 +74,14 @@ proc initImpl(
     raiseAssert initFailed & " cannot create base descriptor: " & error
 
   # Initialise column handlers (this stores implicitely `baseDb`)
-  rdb.admCol = baseDb.withColFamily($AdmCF).valueOr:
+  rdb.admCol = baseDb.getColFamily($AdmCF).valueOr:
     raiseAssert initFailed & " cannot initialise AdmCF descriptor: " & error
-  rdb.vtxCol = baseDb.withColFamily($VtxCF).valueOr:
+  rdb.vtxCol = baseDb.getColFamily($VtxCF).valueOr:
     raiseAssert initFailed & " cannot initialise VtxCF descriptor: " & error
-  rdb.keyCol = baseDb.withColFamily($KeyCF).valueOr:
+  rdb.keyCol = baseDb.getColFamily($KeyCF).valueOr:
     raiseAssert initFailed & " cannot initialise KeyCF descriptor: " & error
 
-  ok(guestCFs.mapIt(baseDb.withColFamily(it.name).expect("loaded cf")))
+  ok(guestCFs.mapIt(baseDb.getColFamily(it.name).expect("loaded cf")))
 
 # ------------------------------------------------------------------------------
 # Public constructor

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_put.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_put.nim
@@ -72,13 +72,13 @@ proc putAdm*(
       ): Result[void,(AdminTabID,AristoError,string)] =
   let dsc = rdb.session
   if data.len == 0:
-    dsc.delete(xid.toOpenArray, $AdmCF).isOkOr:
+    dsc.delete(xid.toOpenArray, rdb.admCol.handle()).isOkOr:
       const errSym = RdbBeDriverDelAdmError
       when extraTraceMessages:
         trace logTxt "putAdm()", xid, error=errSym, info=error
       return err((xid,errSym,error))
   else:
-    dsc.put(xid.toOpenArray, data, $AdmCF).isOkOr:
+    dsc.put(xid.toOpenArray, data, rdb.admCol.handle()).isOkOr:
       const errSym = RdbBeDriverPutAdmError
       when extraTraceMessages:
         trace logTxt "putAdm()", xid, error=errSym, info=error
@@ -92,7 +92,7 @@ proc putKey*(
       ): Result[void,(VertexID,AristoError,string)] =
   let dsc = rdb.session
   if key.isValid:
-    dsc.put(vid.toOpenArray, key.data, $KeyCF).isOkOr:
+    dsc.put(vid.toOpenArray, key.data, rdb.keyCol.handle()).isOkOr:
       # Caller must `rollback()` which will flush the `rdKeyLru` cache
       const errSym = RdbBeDriverPutKeyError
       when extraTraceMessages:
@@ -104,7 +104,7 @@ proc putKey*(
       discard rdb.rdKeyLru.lruAppend(vid, key, RdKeyLruMaxSize)
 
   else:
-    dsc.delete(vid.toOpenArray, $KeyCF).isOkOr:
+    dsc.delete(vid.toOpenArray, rdb.keyCol.handle()).isOkOr:
       # Caller must `rollback()` which will flush the `rdKeyLru` cache
       const errSym = RdbBeDriverDelKeyError
       when extraTraceMessages:
@@ -128,7 +128,7 @@ proc putVtx*(
       # Caller must `rollback()` which will flush the `rdVtxLru` cache
       return err((vid,rc.error,""))
 
-    dsc.put(vid.toOpenArray, rc.value, $VtxCF).isOkOr:
+    dsc.put(vid.toOpenArray, rc.value, rdb.vtxCol.handle()).isOkOr:
       # Caller must `rollback()` which will flush the `rdVtxLru` cache
       const errSym = RdbBeDriverPutVtxError
       when extraTraceMessages:
@@ -140,7 +140,7 @@ proc putVtx*(
       discard rdb.rdVtxLru.lruAppend(vid, vtx, RdVtxLruMaxSize)
 
   else:
-    dsc.delete(vid.toOpenArray, $VtxCF).isOkOr:
+    dsc.delete(vid.toOpenArray, rdb.vtxCol.handle()).isOkOr:
       # Caller must `rollback()` which will flush the `rdVtxLru` cache
       const errSym = RdbBeDriverDelVtxError
       when extraTraceMessages:

--- a/nimbus/db/kvstore_rocksdb.nim
+++ b/nimbus/db/kvstore_rocksdb.nim
@@ -137,5 +137,4 @@ proc openNamespace*(
     name: string): KvResult[RocksNamespaceRef] =
   doAssert not store.db.isClosed()
 
-  let cf = ? store.db.withColFamily(name)
-  ok(RocksNamespaceRef(colFamily: cf))
+  ok(RocksNamespaceRef(colFamily: ?store.db.getColFamily(name)))

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_desc.nim
@@ -30,7 +30,7 @@ type
     ## Column family symbols/handles and names used on the database
     KvtGeneric = "KvtGen"            ## Generic column family
 
-  KvtCfStore* = array[KvtCFs,ColFamilyReadWrite]
+  KvtCfStore* = array[KvtCFs, ColFamilyReadWrite]
     ## List of column family handlers
 
 const

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_init.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_init.nim
@@ -56,7 +56,7 @@ proc init*(
 
   # Initialise column handlers (this stores implicitely `baseDb`)
   for col in KvtCFs:
-    rdb.store[col] = baseDb.withColFamily($col).valueOr:
+    rdb.store[col] = baseDb.getColFamily($col).valueOr:
       raiseAssert initFailed & " cannot initialise " &
         $col & " descriptor: " & error
   ok()

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_put.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_put.nim
@@ -72,13 +72,13 @@ proc put*(
       ): Result[void,(Blob,KvtError,string)] =
   for (key,val) in data:
     if val.len == 0:
-      rdb.session.delete(key, $KvtGeneric).isOkOr:
+      rdb.session.delete(key, rdb.store[KvtGeneric].handle()).isOkOr:
         const errSym = RdbBeDriverDelError
         when extraTraceMessages:
           trace logTxt "del", key, error=errSym, info=error
         return err((key,errSym,error))
     else:
-      rdb.session.put(key, val, $KvtGeneric).isOkOr:
+      rdb.session.put(key, val, rdb.store[KvtGeneric].handle()).isOkOr:
         const errSym = RdbBeDriverPutError
         when extraTraceMessages:
           trace logTxt "put", key, error=errSym, info=error


### PR DESCRIPTION
Bump RocksDb to latest and update Nimbus database to pass column family handles to RocksDb API.