### PR TITLE
Use simpler schema when writing transactions, receipts, and withdrawals

### DIFF
--- a/hive_integration/nodocker/engine/node.nim
+++ b/hive_integration/nodocker/engine/node.nim
@@ -108,11 +108,11 @@ proc setBlock*(c: ChainRef; blk: EthBlock): Result[void, string] =
     return err("Could not persist header")
 
   try:
-    c.db.persistTransactions(header.number, blk.transactions)
-    c.db.persistReceipts(vmState.receipts)
+    c.db.persistTransactions(header.number, header.txRoot, blk.transactions)
+    c.db.persistReceipts(header.receiptsRoot, vmState.receipts)
 
     if blk.withdrawals.isSome:
-      c.db.persistWithdrawals(blk.withdrawals.get)
+      c.db.persistWithdrawals(header.withdrawalsRoot, blk.withdrawals.get)
   except CatchableError as exc:
     return err(exc.msg)
 

--- a/nimbus/core/chain/persist_blocks.nim
+++ b/nimbus/core/chain/persist_blocks.nim
@@ -170,13 +170,15 @@ proc persistBlocksImpl(
         return err("Could not persist header")
 
     if NoPersistTransactions notin flags:
-      c.db.persistTransactions(header.number, blk.transactions)
+      c.db.persistTransactions(header.number, header.txRoot, blk.transactions)
 
     if NoPersistReceipts notin flags:
-      c.db.persistReceipts(vmState.receipts)
+      c.db.persistReceipts(header.receiptsRoot, vmState.receipts)
 
     if NoPersistWithdrawals notin flags and blk.withdrawals.isSome:
-      c.db.persistWithdrawals(blk.withdrawals.get)
+      c.db.persistWithdrawals(
+        header.withdrawalsRoot.expect("WithdrawalsRoot should be verified before"),
+        blk.withdrawals.get)
 
     # update currentBlock *after* we persist it
     # so the rpc return consistent result

--- a/nimbus/db/core_db/base/base_desc.nim
+++ b/nimbus/db/core_db/base/base_desc.nim
@@ -61,9 +61,6 @@ type
 
   CoreDbColType* = enum
     CtGeneric = 2 # columns smaller than 2 are not provided
-    CtReceipts
-    CtTxs
-    CtWithdrawals
 
   CoreDbCaptFlags* {.pure.} = enum
     PersistPut

--- a/nimbus/db/core_db/core_apps.nim
+++ b/nimbus/db/core_db/core_apps.nim
@@ -114,30 +114,23 @@ iterator findNewAncestors(
 
 iterator getBlockTransactionData*(
     db: CoreDbRef;
-    transactionRoot: Hash256;
+    txRoot: Hash256;
       ): Blob =
   const info = "getBlockTransactionData()"
   block body:
-    if transactionRoot == EMPTY_ROOT_HASH:
+    if txRoot == EMPTY_ROOT_HASH:
       break body
-    let
-      transactionDb = db.ctx.getColumn CtTxs
-      state = transactionDb.state(updateOk=true).valueOr:
-        raiseAssert info & ": " & $$error
-    if state != transactionRoot:
-      warn logTxt info, transactionRoot, state, error="state mismatch"
-      break body
-    var transactionIdx = 0'u64
-    while true:
-      let transactionKey = rlp.encode(transactionIdx)
-      let data = transactionDb.fetch(transactionKey).valueOr:
-        if error.error != MptNotFound:
-          warn logTxt info, transactionRoot,
-            transactionKey, action="fetch()", error=($$error)
-        break body
-      yield data
-      inc transactionIdx
 
+    let kvt = db.newKvt()
+    for idx in 0'u16..<uint16.high:
+      let key = hashIndexKey(txRoot, idx)
+      let txData = kvt.getOrEmpty(key).valueOr:
+        warn logTxt "getBlockTransactionData()",
+          txRoot, key, action="getOrEmpty()", error=($$error)
+        break body
+      if txData.len == 0:
+        break body
+      yield txData
 
 iterator getBlockTransactions*(
     db: CoreDbRef;
@@ -158,32 +151,24 @@ iterator getBlockTransactionHashes*(
   for encodedTx in db.getBlockTransactionData(blockHeader.txRoot):
     yield keccakHash(encodedTx)
 
-iterator getWithdrawalsData*(
+iterator getWithdrawals*(
     db: CoreDbRef;
     withdrawalsRoot: Hash256;
-      ): Blob =
-  const info = "getWithdrawalsData()"
+      ): Withdrawal {.raises: [RlpError].} =
   block body:
     if withdrawalsRoot == EMPTY_ROOT_HASH:
       break body
-    let
-      wddb = db.ctx.getColumn CtWithdrawals
-      state = wddb.state(updateOk=true).valueOr:
-        raiseAssert info & ": " & $$error
-    if state != withdrawalsRoot:
-      warn logTxt info, withdrawalsRoot, state, error="state mismatch"
-      break body
-    var idx = 0
-    while true:
-      let wdKey = rlp.encode(idx.uint)
-      let data = wddb.fetch(wdKey).valueOr:
-        if error.error != MptNotFound:
-          warn logTxt "getWithdrawalsData()",
-            withdrawalsRoot, wdKey, action="fetch()", error=($$error)
-        break body
-      yield data
-      inc idx
 
+    let kvt = db.newKvt()
+    for idx in 0'u16..<uint16.high:
+      let key = hashIndexKey(withdrawalsRoot, idx)
+      let data = kvt.getOrEmpty(key).valueOr:
+        warn logTxt "getWithdrawals()",
+          withdrawalsRoot, key, action="getOrEmpty()", error=($$error)
+        break body
+      if data.len == 0:
+        break body
+      yield rlp.decode(data, Withdrawal)
 
 iterator getReceipts*(
     db: CoreDbRef;
@@ -194,23 +179,17 @@ iterator getReceipts*(
   block body:
     if receiptsRoot == EMPTY_ROOT_HASH:
       break body
-    let
-      receiptDb = db.ctx.getColumn CtReceipts
-      state = receiptDb.state(updateOk=true).valueOr:
-        raiseAssert info & ": " & $$error
-    if state != receiptsRoot:
-      warn logTxt info, receiptsRoot, state, error="state mismatch"
-      break body
-    var receiptIdx = 0
-    while true:
-      let receiptKey = rlp.encode(receiptIdx.uint)
-      let receiptData = receiptDb.fetch(receiptKey).valueOr:
-        if error.error != MptNotFound:
-          warn logTxt "getWithdrawalsData()",
-            receiptsRoot, receiptKey, action="hasKey()", error=($$error)
+
+    let kvt = db.newKvt()
+    for idx in 0'u16..<uint16.high:
+      let key = hashIndexKey(receiptsRoot, idx)
+      let data = kvt.getOrEmpty(key).valueOr:
+        warn logTxt "getReceipts()",
+          receiptsRoot, key, action="getOrEmpty()", error=($$error)
         break body
-      yield rlp.decode(receiptData, Receipt)
-      inc receiptIdx
+      if data.len == 0:
+        break body
+      yield rlp.decode(data, Receipt)
 
 # ------------------------------------------------------------------------------
 # Private helpers
@@ -535,6 +514,7 @@ proc addBlockNumberToHashLookup*(
 proc persistTransactions*(
     db: CoreDbRef;
     blockNumber: BlockNumber;
+    txRoot: Hash256;
     transactions: openArray[Transaction];
       ) =
   const
@@ -543,19 +523,16 @@ proc persistTransactions*(
   if transactions.len == 0:
     return
 
-  let
-    mpt = db.ctx.getColumn(CtTxs, clearData=true)
-    kvt = db.newKvt()
-
+  let kvt = db.newKvt()
   for idx, tx in transactions:
     let
-      encodedKey = rlp.encode(idx.uint)
       encodedTx = rlp.encode(tx)
       txHash = keccakHash(encodedTx)
       blockKey = transactionHashToBlockKey(txHash)
       txKey: TransactionKey = (blockNumber, idx.uint)
-    mpt.merge(encodedKey, encodedTx).isOkOr:
-      warn logTxt info, idx, action="merge()", error=($$error)
+      key = hashIndexKey(txRoot, idx.uint16)
+    kvt.put(key, encodedTx).isOkOr:
+      warn logTxt info, idx, action="put()", error=($$error)
       return
     kvt.put(blockKey.toOpenArray, rlp.encode(txKey)).isOkOr:
       trace logTxt info, blockKey, action="put()", error=($$error)
@@ -582,29 +559,26 @@ proc forgetHistory*(
 proc getTransaction*(
     db: CoreDbRef;
     txRoot: Hash256;
-    txIndex: uint64;
+    txIndex: uint16;
     res: var Transaction;
       ): bool =
   const
     info = "getTransaction()"
-  let
-    clearOk = txRoot == EMPTY_ROOT_HASH
-    mpt = db.ctx.getColumn(CtTxs, clearData=clearOk)
-  if not clearOk:
-    let state = mpt.state(updateOk=true).valueOr:
-      raiseAssert info & ": " & $$error
-    if state != txRoot:
-      warn logTxt info, txRoot, state, error="state mismatch"
-      return false
-  let
-    txData = mpt.fetch(rlp.encode(txIndex)).valueOr:
-      if error.error != MptNotFound:
-        warn logTxt info, txIndex, error=($$error)
-      return false
+
+  let kvt = db.newKvt()
+  let key = hashIndexKey(txRoot, txIndex)
+  let txData = kvt.getOrEmpty(key).valueOr:
+    warn logTxt "getTransaction()",
+      txRoot, key, action="getOrEmpty()", error=($$error)
+    return false
+  if txData.len == 0:
+    return false
+
   try:
     res = rlp.decode(txData, Transaction)
-  except RlpError as e:
-    warn logTxt info, txRoot, action="rlp.decode()", name=($e.name), msg=e.msg
+  except RlpError as exc:
+    warn logTxt info,
+      txRoot, action="rlp.decode()", error=exc.msg
     return false
   true
 
@@ -614,24 +588,19 @@ proc getTransactionCount*(
       ): int =
   const
     info = "getTransactionCount()"
-  let
-    clearOk = txRoot == EMPTY_ROOT_HASH
-    mpt = db.ctx.getColumn(CtTxs, clearData=clearOk)
-  if not clearOk:
-    let state = mpt.state(updateOk=true).valueOr:
-      raiseAssert info & ": " & $$error
-    if state != txRoot:
-      warn logTxt info, txRoot, state, error="state mismatch"
-      return 0
-  var txCount = 0
+
+  let kvt = db.newKvt()
+  var txCount = 0'u16
   while true:
-    let hasPath = mpt.hasPath(rlp.encode(txCount.uint)).valueOr:
-      warn logTxt info, txCount, action="hasPath()", error=($$error)
+    let key = hashIndexKey(txRoot, txCount)
+    let yes = kvt.hasKey(key).valueOr:
+      warn logTxt info,
+        txRoot, key, action="hasKey()", error=($$error)
       return 0
-    if hasPath:
+    if yes:
       inc txCount
     else:
-      return txCount
+      return txCount.int
 
   doAssert(false, "unreachable")
 
@@ -667,15 +636,17 @@ proc getUncles*(
 
 proc persistWithdrawals*(
     db: CoreDbRef;
+    withdrawalsRoot: Hash256;
     withdrawals: openArray[Withdrawal];
       ) =
   const info = "persistWithdrawals()"
   if withdrawals.len == 0:
     return
-  let mpt = db.ctx.getColumn(CtWithdrawals, clearData=true)
+  let kvt = db.newKvt()
   for idx, wd in withdrawals:
-    mpt.merge(rlp.encode(idx.uint), rlp.encode(wd)).isOkOr:
-      warn logTxt info, idx, error=($$error)
+    let key = hashIndexKey(withdrawalsRoot, idx.uint16)
+    kvt.put(key, rlp.encode(wd)).isOkOr:
+      warn logTxt info, idx, action="put()", error=($$error)
       return
 
 proc getWithdrawals*(
@@ -683,8 +654,8 @@ proc getWithdrawals*(
     withdrawalsRoot: Hash256;
       ): seq[Withdrawal]
       {.gcsafe, raises: [RlpError].} =
-  for encodedWd in db.getWithdrawalsData(withdrawalsRoot):
-    result.add(rlp.decode(encodedWd, Withdrawal))
+  for wd in db.getWithdrawals(withdrawalsRoot):
+    result.add(wd)
 
 proc getTransactions*(
     db: CoreDbRef;
@@ -837,14 +808,17 @@ proc setHead*(
 
 proc persistReceipts*(
     db: CoreDbRef;
+    receiptsRoot: Hash256;
     receipts: openArray[Receipt];
       ) =
   const info = "persistReceipts()"
   if receipts.len == 0:
     return
-  let mpt = db.ctx.getColumn(CtReceipts, clearData=true)
+
+  let kvt = db.newKvt()
   for idx, rec in receipts:
-    mpt.merge(rlp.encode(idx.uint), rlp.encode(rec)).isOkOr:
+    let key = hashIndexKey(receiptsRoot, idx.uint16)
+    kvt.put(key, rlp.encode(rec)).isOkOr:
       warn logTxt info, idx, action="merge()", error=($$error)
 
 proc getReceipts*(

--- a/nimbus/db/core_db/core_apps.nim
+++ b/nimbus/db/core_db/core_apps.nim
@@ -556,7 +556,7 @@ proc forgetHistory*(
       # delete blockHash->header, stateRoot->blockNum
       discard kvt.del(genericHashKey(blockHash).toOpenArray)
 
-proc getTransaction*(
+proc getTransactionByIndex*(
     db: CoreDbRef;
     txRoot: Hash256;
     txIndex: uint16;

--- a/nimbus/db/storage_types.nim
+++ b/nimbus/db/storage_types.nim
@@ -33,6 +33,8 @@ type
     data*: array[33, byte]
     dataEndPos*: uint8 # the last populated position in the data
 
+  HashIndexKey* = array[34, byte]
+
 func genericHashKey*(h: Hash256): DbKey {.inline.} =
   result.data[0] = byte ord(genericHash)
   result.data[1 .. 32] = h.data
@@ -101,6 +103,11 @@ func skeletonBodyKey*(h: Hash256): DbKey {.inline.} =
   result.data[0] = byte ord(skeletonBody)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
+
+func hashIndexKey*(hash: Hash256, index: uint16): HashIndexKey =
+  result[0..31] = hash.data
+  result[32] = byte(index and 0xFF)
+  result[33] = byte((index shl 8) and 0xFF)
 
 template toOpenArray*(k: DbKey): openArray[byte] =
   k.data.toOpenArray(0, int(k.dataEndPos))

--- a/nimbus/graphql/ethapi.nim
+++ b/nimbus/graphql/ethapi.nim
@@ -315,7 +315,7 @@ proc getWithdrawals(ctx: GraphqlContextRef, header: common.BlockHeader): RespRes
 proc getTxAt(ctx: GraphqlContextRef, header: common.BlockHeader, index: uint64): RespResult =
   try:
     var tx: Transaction
-    if getTransaction(ctx.chainDB, header.txRoot, index, tx):
+    if getTransaction(ctx.chainDB, header.txRoot, index.uint16, tx):
       let txn = txNode(ctx, tx, index, header.number, header.baseFeePerGas)
 
       var i = 0'u64

--- a/nimbus/graphql/ethapi.nim
+++ b/nimbus/graphql/ethapi.nim
@@ -315,7 +315,7 @@ proc getWithdrawals(ctx: GraphqlContextRef, header: common.BlockHeader): RespRes
 proc getTxAt(ctx: GraphqlContextRef, header: common.BlockHeader, index: uint64): RespResult =
   try:
     var tx: Transaction
-    if getTransaction(ctx.chainDB, header.txRoot, index.uint16, tx):
+    if getTransactionByIndex(ctx.chainDB, header.txRoot, index.uint16, tx):
       let txn = txNode(ctx, tx, index, header.number, header.baseFeePerGas)
 
       var i = 0'u64

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -11,8 +11,12 @@
 
 import
   std/[sequtils, times, tables, typetraits],
-  json_rpc/rpcserver, stint, stew/byteutils,
-  json_serialization, web3/conversions, json_serialization/stew/results,
+  json_rpc/rpcserver,
+  stint,
+  stew/byteutils,
+  json_serialization,
+  web3/conversions,
+  json_serialization/stew/results,
   eth/common/eth_types_json_serialization,
   eth/[keys, rlp, p2p],
   ".."/[transaction, evm/state, constants],
@@ -414,7 +418,7 @@ proc setupEthRpc*(
 
     let header = chainDB.getBlockHeader(txDetails.blockNumber)
     var tx: Transaction
-    if chainDB.getTransaction(header.txRoot, txDetails.index.uint16, tx):
+    if chainDB.getTransactionByIndex(header.txRoot, uint16(txDetails.index), tx):
       result = populateTransactionObject(tx, Opt.some(header), Opt.some(txDetails.index))
 
   server.rpc("eth_getTransactionByBlockHashAndIndex") do(data: Web3Hash, quantity: Web3Quantity) -> TransactionObject:
@@ -429,7 +433,7 @@ proc setupEthRpc*(
       return nil
 
     var tx: Transaction
-    if chainDB.getTransaction(header.txRoot, index.uint16, tx):
+    if chainDB.getTransactionByIndex(header.txRoot, uint16(index), tx):
       result = populateTransactionObject(tx, Opt.some(header), Opt.some(index))
     else:
       result = nil
@@ -444,7 +448,7 @@ proc setupEthRpc*(
       index  = uint64(quantity)
 
     var tx: Transaction
-    if chainDB.getTransaction(header.txRoot, index.uint16, tx):
+    if chainDB.getTransactionByIndex(header.txRoot, uint16(index), tx):
       result = populateTransactionObject(tx, Opt.some(header), Opt.some(index))
     else:
       result = nil
@@ -461,7 +465,7 @@ proc setupEthRpc*(
 
     let header = chainDB.getBlockHeader(txDetails.blockNumber)
     var tx: Transaction
-    if not chainDB.getTransaction(header.txRoot, txDetails.index.uint16, tx):
+    if not chainDB.getTransactionByIndex(header.txRoot, uint16(txDetails.index), tx):
       return nil
 
     var

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -414,7 +414,7 @@ proc setupEthRpc*(
 
     let header = chainDB.getBlockHeader(txDetails.blockNumber)
     var tx: Transaction
-    if chainDB.getTransaction(header.txRoot, txDetails.index, tx):
+    if chainDB.getTransaction(header.txRoot, txDetails.index.uint16, tx):
       result = populateTransactionObject(tx, Opt.some(header), Opt.some(txDetails.index))
 
   server.rpc("eth_getTransactionByBlockHashAndIndex") do(data: Web3Hash, quantity: Web3Quantity) -> TransactionObject:
@@ -429,7 +429,7 @@ proc setupEthRpc*(
       return nil
 
     var tx: Transaction
-    if chainDB.getTransaction(header.txRoot, index, tx):
+    if chainDB.getTransaction(header.txRoot, index.uint16, tx):
       result = populateTransactionObject(tx, Opt.some(header), Opt.some(index))
     else:
       result = nil
@@ -444,7 +444,7 @@ proc setupEthRpc*(
       index  = uint64(quantity)
 
     var tx: Transaction
-    if chainDB.getTransaction(header.txRoot, index, tx):
+    if chainDB.getTransaction(header.txRoot, index.uint16, tx):
       result = populateTransactionObject(tx, Opt.some(header), Opt.some(index))
     else:
       result = nil
@@ -461,7 +461,7 @@ proc setupEthRpc*(
 
     let header = chainDB.getBlockHeader(txDetails.blockNumber)
     var tx: Transaction
-    if not chainDB.getTransaction(header.txRoot, txDetails.index, tx):
+    if not chainDB.getTransaction(header.txRoot, txDetails.index.uint16, tx):
       return nil
 
     var

--- a/premix/prestate.nim
+++ b/premix/prestate.nim
@@ -24,7 +24,7 @@ proc generatePrestate*(nimbus, geth: JsonNode, blockNumber: BlockNumber, parent:
     kvt = chainDB.newKvt()
 
   discard chainDB.setHead(parent, true)
-  chainDB.persistTransactions(blockNumber, blk.transactions)
+  chainDB.persistTransactions(blockNumber, header.txRoot, blk.transactions)
   discard chainDB.persistUncles(blk.uncles)
 
   kvt.put(genericHashKey(headerHash).toOpenArray, rlp.encode(header)).isOkOr:


### PR DESCRIPTION
Using MPT not only slow but also take up more spaces than needed. Aristo will remove older tries and only keep the last block tries. Using simpler schema will avoid those problems.