### PR TITLE
Small cleanups

### DIFF
--- a/nimbus/core/chain/persist_blocks.nim
+++ b/nimbus/core/chain/persist_blocks.nim
@@ -134,10 +134,6 @@ proc persistBlocksImpl(
       if not updated:
         debug "Cannot update VmState", blockNumber = header.number
         return err("Cannot update VmState to block " & $header.number)
-    else:
-      # TODO weirdly, some tests depend on this reinit being called, even though
-      #      in theory it's a fresh instance that should not need it (?)
-      doAssert vmState.reinit(header = header)
 
     # TODO even if we're skipping validation, we should perform basic sanity
     #      checks on the block and header - that fields are sanely set for the
@@ -178,7 +174,8 @@ proc persistBlocksImpl(
     if NoPersistWithdrawals notin flags and blk.withdrawals.isSome:
       c.db.persistWithdrawals(
         header.withdrawalsRoot.expect("WithdrawalsRoot should be verified before"),
-        blk.withdrawals.get)
+        blk.withdrawals.get
+      )
 
     # update currentBlock *after* we persist it
     # so the rpc return consistent result
@@ -189,6 +186,7 @@ proc persistBlocksImpl(
     txs += blk.transactions.len
     gas += blk.header.gasUsed
     parentHash = blockHash
+
   dbTx.commit()
 
   # Save and record the block number before the last saved block state.

--- a/nimbus/db/aristo/aristo_merge/merge_payload_helper.nim
+++ b/nimbus/db/aristo/aristo_merge/merge_payload_helper.nim
@@ -11,7 +11,7 @@
 {.push raises: [].}
 
 import
-  std/[sequtils, sets, typetraits],
+  std/[sets, typetraits],
   eth/common,
   results,
   ".."/[aristo_desc, aristo_get, aristo_hike, aristo_layers, aristo_vid]
@@ -38,8 +38,9 @@ proc clearMerkleKeys(
     hike: Hike;                        # Implied vertex IDs to clear hashes for
     vid: VertexID;                     # Additionall vertex IDs to clear
       ) =
-  for w in hike.legs.mapIt(it.wp.vid) & @[vid]:
-    db.layersResKey(hike.root, w)
+  for w in hike.legs:
+    db.layersResKey(hike.root, w.wp.vid)
+  db.layersResKey(hike.root, vid)
 
 proc setVtxAndKey*(
     db: AristoDbRef;                   # Database, top layer

--- a/nimbus/db/aristo/aristo_utils.nim
+++ b/nimbus/db/aristo/aristo_utils.nim
@@ -14,7 +14,7 @@
 {.push raises: [].}
 
 import
-  std/[sequtils, sets, typetraits],
+  std/[sequtils, typetraits],
   eth/common,
   results,
   "."/[aristo_constants, aristo_desc, aristo_get, aristo_hike, aristo_layers]
@@ -103,20 +103,20 @@ proc toNode*(
     return ok node
 
 
-proc subVids*(vtx: VertexRef): seq[VertexID] =
+iterator subVids*(vtx: VertexRef): VertexID =
   ## Returns the list of all sub-vertex IDs for the argument `vtx`.
   case vtx.vType:
   of Leaf:
     if vtx.lData.pType == AccountData:
       let vid = vtx.lData.stoID
       if vid.isValid:
-        result.add vid
+        yield vid
   of Branch:
     for vid in vtx.bVid:
       if vid.isValid:
-        result.add vid
+        yield vid
   of Extension:
-    result.add vtx.eVid
+    yield vtx.eVid
 
 # ---------------------
 

--- a/nimbus/db/core_db/base.nim
+++ b/nimbus/db/core_db/base.nim
@@ -629,21 +629,6 @@ proc level*(db: CoreDbRef): int =
 
 proc persistent*(
     db: CoreDbRef;
-      ): CoreDbRc[void] =
-  ## For the legacy database, this function has no effect and succeeds always.
-  ## It will nevertheless return a discardable error if there is a pending
-  ## transaction (i.e. `db.level() == 0`.)
-  ##
-  ## Otherwise, cached data from the `Kvt`, `Mpt`, and `Acc` descriptors are
-  ## stored on the persistent database (if any). This requires that that there
-  ## is no transaction pending.
-  ##
-  db.setTrackNewApi BasePersistentFn
-  result = db.methods.persistentFn Opt.none(BlockNumber)
-  db.ifTrackNewApi: debug newApiTxt, api, elapsed, result
-
-proc persistent*(
-    db: CoreDbRef;
     blockNumber: BlockNumber;
       ): CoreDbRc[void] {.discardable.} =
   ## Variant of `persistent()` which stores a block number within the recovery

--- a/nimbus/db/core_db/core_apps.nim
+++ b/nimbus/db/core_db/core_apps.nim
@@ -306,7 +306,6 @@ proc exists*(db: CoreDbRef, hash: Hash256): bool =
 
 proc getSavedStateBlockNumber*(
     db: CoreDbRef;
-    relax = false;
       ): BlockNumber =
   ## Returns the block number registered when the database was last time
   ## updated, or `BlockNumber(0)` if there was no updata found.
@@ -317,20 +316,9 @@ proc getSavedStateBlockNumber*(
   ## can be set `true` so this function also returns the block number if the
   ## state consistency check fails.
   ##
-  const info = "getSavedStateBlockNumber(): "
   # FIXME: This construct following will be replaced by a proper
   #        `CoreDb` method.
-  let bn = db.ctx.getColumn(CtGeneric).backend.toAristoSavedStateBlockNumber()
-  if relax:
-    return bn
-  else:
-    var header: BlockHeader
-    if db.getBlockHeader(bn, header):
-      let state = db.ctx.getAccounts.state(updateOk=true).valueOr:
-        raiseAssert info & $$error
-      if state != header.stateRoot:
-        raiseAssert info & ": state mismatch at " & "#" & $result
-      return bn
+  db.ctx.getColumn(CtGeneric).backend.toAristoSavedStateBlockNumber()
 
 proc getBlockHeader*(
     db: CoreDbRef;

--- a/nimbus/db/ledger/accounts_ledger.nim
+++ b/nimbus/db/ledger/accounts_ledger.nim
@@ -154,12 +154,6 @@ proc init*(x: typedesc[AccountsLedgerRef], db: CoreDbRef,
   const info = "AccountsLedgerRef.init(): "
   new result
   result.ledger = db.ctx.getAccounts()
-  if root != EMPTY_ROOT_HASH:
-    let rc = result.ledger.state(updateOk=true)
-    if rc.isErr:
-      raiseAssert info & $$rc.error
-    if rc.value != root:
-      raiseAssert info & ": wrong account state"
   result.kvt = db.newKvt() # save manually in `persist()`
   result.witnessCache = Table[EthAddress, WitnessData]()
   discard result.beginSavepoint

--- a/scripts/make_states.sh
+++ b/scripts/make_states.sh
@@ -6,9 +6,9 @@ set -e
 
 trap "exit" INT
 
-if [ -z "$3"  ]
+if [ -z "$3" ]
   then
-    echo "Syntax: make_states.sh datadir era1dir statsdir"
+    echo "Syntax: make_states.sh datadir era1dir statsdir [startdir]"
     exit 1;
 fi
 
@@ -17,11 +17,15 @@ counter=0
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 DATE="$(date -u +%Y%m%d_%H%M)"
 REV=$(git rev-parse --short=8 HEAD)
+DATA_DIR="$1/${DATE}-${REV}"
+
+mkdir -p "$DATA_DIR"
+[ "$4" ] && cp -ar "$4"/* "$DATA_DIR"
 
 while true;
 do
   "$SCRIPT_DIR/../build/nimbus" import \
-    --data-dir:"$1/${DATE}-${REV}" \
+    --data-dir:"${DATA_DIR}" \
     --era1-dir:"$2" \
     --debug-csv-stats:"$3/stats-${DATE}-${REV}.csv" \
     --max-blocks:100000


### PR DESCRIPTION
* avoid costly hike memory allocations for operations that don't need to re-traverse it
* avoid unnecessary state checks (which might trigger unwanted state root computations)
* disable optimize-for-hits due to the MPT no longer being complete at all times