### PR TITLE
Smaller in-database representations

### DIFF
--- a/nimbus/db/aristo/aristo_blobify.nim
+++ b/nimbus/db/aristo/aristo_blobify.nim
@@ -232,6 +232,8 @@ proc deblobify(
     pAcc.stoID = VertexID(? load64(data, start, int(len + 1)))
 
   if (mask and 0x08) > 0:
+    if data.len() < start + 32:
+      return err(DeblobCodeLenUnsupported)
     discard pAcc.account.codeHash.data.copyFrom(data.toOpenArray(start, start + 31))
   else:
     pAcc.account.codeHash = EMPTY_CODE_HASH

--- a/nimbus/db/aristo/aristo_constants.nim
+++ b/nimbus/db/aristo/aristo_constants.nim
@@ -25,9 +25,6 @@ const
   EmptyVidSet* = EmptyVidSeq.toHashSet
     ## Useful shortcut
 
-  VOID_CODE_HASH* = EMPTY_CODE_HASH
-    ## Equivalent of `nil` for `Account` object code hash field
-
   VOID_HASH_KEY* = HashKey()
     ## Void equivalent for Merkle hash value
 

--- a/nimbus/db/aristo/aristo_init/memory_db.nim
+++ b/nimbus/db/aristo/aristo_init/memory_db.nim
@@ -276,26 +276,6 @@ iterator walkKey*(
       yield (vid, key)
 
 
-iterator walk*(
-    be: MemBackendRef;
-      ): tuple[pfx: StorageType, xid: uint64, data: Blob] =
-  ## Walk over all key-value pairs of the database.
-  ##
-  ## Non-decodable entries are stepped over while the counter `n` of the
-  ## yield record is still incremented.
-  if be.mdb.tUvi.isSome:
-    yield(AdmPfx, AdmTabIdTuv.uint64, @(be.mdb.tUvi.unsafeGet.blobify.data()))
-  if be.mdb.lSst.isSome:
-    yield(AdmPfx, AdmTabIdLst.uint64, be.mdb.lSst.unsafeGet.blobify.value)
-
-  for vid in be.mdb.sTab.keys.toSeq.mapIt(it).sorted:
-    let data = be.mdb.sTab.getOrDefault(vid, EmptyBlob)
-    if 0 < data.len:
-      yield (VtxPfx, vid.uint64, data)
-
-  for (vid,key) in be.walkKey:
-    yield (KeyPfx, vid.uint64, @(key.data))
-
 # ------------------------------------------------------------------------------
 # End
 # ------------------------------------------------------------------------------

--- a/nimbus/db/aristo/aristo_init/memory_db.nim
+++ b/nimbus/db/aristo/aristo_init/memory_db.nim
@@ -284,7 +284,7 @@ iterator walk*(
   ## Non-decodable entries are stepped over while the counter `n` of the
   ## yield record is still incremented.
   if be.mdb.tUvi.isSome:
-    yield(AdmPfx, AdmTabIdTuv.uint64, be.mdb.tUvi.unsafeGet.blobify)
+    yield(AdmPfx, AdmTabIdTuv.uint64, @(be.mdb.tUvi.unsafeGet.blobify.data()))
   if be.mdb.lSst.isSome:
     yield(AdmPfx, AdmTabIdLst.uint64, be.mdb.lSst.unsafeGet.blobify.value)
 

--- a/nimbus/db/aristo/aristo_init/rocks_db.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db.nim
@@ -308,20 +308,6 @@ proc dup*(db: RdbBackendRef): RdbBackendRef =
 # Public iterators (needs direct backend access)
 # ------------------------------------------------------------------------------
 
-iterator walk*(
-    be: RdbBackendRef;
-      ): tuple[pfx: StorageType, xid: uint64, data: Blob] =
-  ## Walk over all key-value pairs of the database.
-  ##
-  ## Non-decodable entries are ignored
-  ##
-  for (xid, data) in be.rdb.walkAdm:
-    yield (AdmPfx, xid, data)
-  for (vid, data) in be.rdb.walkVtx:
-    yield (VtxPfx, vid, data)
-  for (vid, data) in be.rdb.walkKey:
-    yield (KeyPfx, vid, data)
-
 iterator walkVtx*(
     be: RdbBackendRef;
       ): tuple[vid: VertexID, vtx: VertexRef] =
@@ -329,7 +315,7 @@ iterator walkVtx*(
   for (vid, data) in be.rdb.walkVtx:
     let rc = data.deblobify VertexRef
     if rc.isOk:
-      yield (VertexID(vid), rc.value)
+      yield (vid, rc.value)
 
 iterator walkKey*(
     be: RdbBackendRef;
@@ -338,7 +324,7 @@ iterator walkKey*(
   for (vid, data) in be.rdb.walkKey:
     let lid = HashKey.fromBytes(data).valueOr:
       continue
-    yield (VertexID(vid), lid)
+    yield (vid, lid)
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/db/aristo/aristo_init/rocks_db.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db.nim
@@ -171,7 +171,7 @@ proc putTuvFn(db: RdbBackendRef): PutTuvFn =
       let hdl = hdl.getSession db
       if hdl.error.isNil:
         if vs.isValid:
-          db.rdb.putAdm(AdmTabIdTuv, vs.blobify).isOkOr:
+          db.rdb.putAdm(AdmTabIdTuv, vs.blobify.data()).isOkOr:
             hdl.error = TypedPutHdlErrRef(
               pfx:  AdmPfx,
               aid:  AdmTabIdTuv,

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -77,9 +77,6 @@ func dataDir*(rdb: RdbInst): string =
 template toOpenArray*(xid: AdminTabID): openArray[byte] =
   xid.uint64.toBytesBE.toOpenArray(0,7)
 
-template toOpenArray*(vid: VertexID): openArray[byte] =
-  vid.uint64.toBytesBE.toOpenArray(0,7)
-
 # ------------------------------------------------------------------------------
 # End
 # ------------------------------------------------------------------------------

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_get.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_get.nim
@@ -53,7 +53,6 @@ proc getAdm*(rdb: RdbInst; xid: AdminTabID): Result[Blob,(AristoError,string)] =
     res = EmptyBlob
   ok move(res)
 
-
 proc getKey*(
     rdb: var RdbInst;
     vid: VertexID;
@@ -69,7 +68,7 @@ proc getKey*(
     res = HashKey.fromBytes(data).mapErr(proc(): auto =
       (RdbHashKeyExpected,""))
 
-  let gotData = rdb.keyCol.get(vid.toOpenArray, onData).valueOr:
+  let gotData = rdb.keyCol.get(vid.blobify().data(), onData).valueOr:
      const errSym = RdbBeDriverGetKeyError
      when extraTraceMessages:
        trace logTxt "getKey", vid, error=errSym, info=error
@@ -99,7 +98,7 @@ proc getVtx*(
     res = data.deblobify(VertexRef).mapErr(proc(error: AristoError): auto =
       (error,""))
 
-  let gotData = rdb.vtxCol.get(vid.toOpenArray, onData).valueOr:
+  let gotData = rdb.vtxCol.get(vid.blobify().data(), onData).valueOr:
     const errSym = RdbBeDriverGetVtxError
     when extraTraceMessages:
       trace logTxt "getVtx", vid, error=errSym, info=error

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_walk.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_walk.nim
@@ -17,7 +17,9 @@ import
   eth/common,
   stew/endians2,
   rocksdb,
-  ./rdb_desc
+  ./rdb_desc,
+  ../../aristo_blobify,
+  ../../aristo_desc/desc_identifiers
 
 const
   extraTraceMessages = false
@@ -50,7 +52,7 @@ iterator walkAdm*(rdb: RdbInst): tuple[xid: uint64, data: Blob] =
       if key.len == 8 and val.len != 0:
         yield (uint64.fromBytesBE key, val)
 
-iterator walkKey*(rdb: RdbInst): tuple[vid: uint64, data: Blob] =
+iterator walkKey*(rdb: RdbInst): tuple[vid: VertexID, data: Blob] =
   ## Walk over key-value pairs of the hash key column of the database.
   ##
   ## Non-decodable entries are are ignored.
@@ -63,10 +65,10 @@ iterator walkKey*(rdb: RdbInst): tuple[vid: uint64, data: Blob] =
     defer: rit.close()
 
     for (key,val) in rit.pairs:
-      if key.len == 8 and val.len != 0:
-        yield (uint64.fromBytesBE key, val)
+      if key.len <= 8 and val.len != 0:
+        yield (key.deblobify(VertexID).value(), val)
 
-iterator walkVtx*(rdb: RdbInst): tuple[vid: uint64, data: Blob] =
+iterator walkVtx*(rdb: RdbInst): tuple[vid: VertexID, data: Blob] =
   ## Walk over key-value pairs of the hash key column of the database.
   ##
   ## Non-decodable entries are are ignored.
@@ -79,8 +81,8 @@ iterator walkVtx*(rdb: RdbInst): tuple[vid: uint64, data: Blob] =
     defer: rit.close()
 
     for (key,val) in rit.pairs:
-      if key.len == 8 and val.len != 0:
-        yield (uint64.fromBytesBE key, val)
+      if key.len <= 8 and val.len != 0:
+        yield (key.deblobify(VertexID).value(), val)
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/db/core_db/backend/aristo_db/handlers_aristo.nim
+++ b/nimbus/db/core_db/backend/aristo_db/handlers_aristo.nim
@@ -86,16 +86,6 @@ func toRc[T](
       return ok(rc.value)
   err((VertexID(0),rc.error).toError(base, info, error))
 
-func toVoidRc[T](
-    rc: Result[T,(VertexID,AristoError)];
-    base: AristoBaseRef;
-    info: string;
-    error = Unspecified;
-      ): CoreDbRc[void] =
-  if rc.isOk:
-    return ok()
-  err rc.error.toError(base, info, error)
-
 # ------------------------------------------------------------------------------
 # Private `MPT` call back functions
 # ------------------------------------------------------------------------------
@@ -191,7 +181,7 @@ proc accMethods(): CoreDbAccFns =
         return err(error.toError(base, info))
       return err(error.toError(base, info, AccNotFound))
     ok acc
-    
+
   proc accMerge(
       cAcc: AristoCoreDbAccRef;
       accPath: openArray[byte];
@@ -295,7 +285,7 @@ proc accMethods(): CoreDbAccFns =
   proc slotMerge(
       cAcc: AristoCoreDbAccRef;
       accPath: openArray[byte];
-      stoPath: openArray[byte]; 
+      stoPath: openArray[byte];
       stoData: openArray[byte];
         ): CoreDbRc[void] =
     const info = "slotMergeFn()"


### PR DESCRIPTION
These representations use ~15-20% less data compared to the status quo, mainly by removing redundant zeroes in the integer encodings - a significant effect of this change is that the various rocksdb caches see better efficiency since more items fit in the same amount of space.

* use RLP encoding for `VertexID` and `UInt256` wherever it appears
* pack `VertexRef`/`PayloadRef` more tightly