### PR TITLE
Make portal_bridge cli options consistent and improve logging

### DIFF
--- a/fluffy/tools/portal_bridge/portal_bridge_common.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_common.nim
@@ -1,0 +1,30 @@
+# Fluffy
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import chronicles, json_rpc/rpcclient, ./portal_bridge_conf
+
+proc newRpcClientConnect*(url: JsonRpcUrl): RpcClient =
+  ## Instantiate a new JSON-RPC client and try to connect. Will quit on failure.
+  case url.kind
+  of HttpUrl:
+    let client = newRpcHttpClient()
+    try:
+      waitFor client.connect(url.value)
+    except CatchableError as e:
+      fatal "Failed to connect to JSON-RPC server", error = $e.msg, url = url.value
+      quit QuitFailure
+    client
+  of WsUrl:
+    let client = newRpcWebSocketClient()
+    try:
+      waitFor client.connect(url.value)
+    except CatchableError as e:
+      fatal "Failed to connect to JSON-RPC server", error = $e.msg, url = url.value
+      quit QuitFailure
+    client

--- a/fluffy/tools/portal_bridge/portal_bridge_state.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_state.nim
@@ -7,28 +7,12 @@
 
 {.push raises: [].}
 
-import chronos, chronicles, ../../rpc/portal_rpc_client, ./portal_bridge_conf
+import chronicles, ./[portal_bridge_conf, portal_bridge_common]
 
 proc runState*(config: PortalBridgeConf) =
   let
-    portalClient = newRpcHttpClient()
-    # TODO: Use Web3 object?
-    web3Client: RpcClient =
-      case config.web3UrlState.kind
-      of HttpUrl:
-        newRpcHttpClient()
-      of WsUrl:
-        newRpcWebSocketClient()
-  try:
-    waitFor portalClient.connect(config.rpcAddress, Port(config.rpcPort), false)
-  except CatchableError as e:
-    error "Failed to connect to portal RPC", error = $e.msg
-
-  if config.web3UrlState.kind == HttpUrl:
-    try:
-      waitFor (RpcHttpClient(web3Client)).connect(config.web3UrlState.url)
-    except CatchableError as e:
-      error "Failed to connect to web3 RPC", error = $e.msg
+    portalClient = newRpcClientConnect(config.portalRpcUrl)
+    web3Client = newRpcClientConnect(config.web3Url)
 
   # TODO:
   # Here we'd want to implement initially a loop that backfills the state


### PR DESCRIPTION
- Use --portal-rpc-url as url option to connect to Portal JSON-RPC interface, just as --web3-url for EL JSON RPC interface.
- Improve logging to know beter which call on which JSON-RPC interface fails