### PR TITLE
Use `Hash256` directly for account path

### DIFF
--- a/nimbus/db/aristo/aristo_api.nim
+++ b/nimbus/db/aristo/aristo_api.nim
@@ -50,7 +50,7 @@ type
 
   AristoApiDeleteAccountRecordFn* =
     proc(db: AristoDbRef;
-         accPath: openArray[byte];
+         accPath: Hash256;
         ): Result[void,AristoError]
         {.noRaise.}
       ## Delete the account leaf entry addressed by the argument `path`. If
@@ -80,7 +80,7 @@ type
 
   AristoApiDeleteStorageDataFn* =
     proc(db: AristoDbRef;
-         accPath: openArray[byte];
+         accPath: Hash256;
          stoPath: openArray[byte];
         ): Result[bool,AristoError]
         {.noRaise.}
@@ -93,7 +93,7 @@ type
 
   AristoApiDeleteStorageTreeFn* =
     proc(db: AristoDbRef;
-         accPath: openArray[byte];
+         accPath: Hash256;
         ): Result[void,AristoError]
         {.noRaise.}
       ## Variant of `deleteStorageData()` for purging the whole storage tree
@@ -109,7 +109,7 @@ type
 
   AristoApiFetchAccountRecordFn* =
     proc(db: AristoDbRef;
-         accPath: openArray[byte];
+         accPath: Hash256;
         ): Result[AristoAccount,AristoError]
         {.noRaise.}
       ## Fetch an account record from the database indexed by `accPath`.
@@ -142,7 +142,7 @@ type
 
   AristoApiFetchStorageDataFn* =
     proc(db: AristoDbRef;
-         accPath: openArray[byte];
+         accPath: Hash256;
          stoPath: openArray[byte];
         ): Result[Blob,AristoError]
         {.noRaise.}
@@ -151,7 +151,7 @@ type
 
   AristoApiFetchStorageStateFn* =
     proc(db: AristoDbRef;
-         accPath: openArray[byte];
+         accPath: Hash256;
          updateOk: bool;
         ): Result[Hash256,AristoError]
         {.noRaise.}
@@ -239,7 +239,7 @@ type
 
   AristoApiHasPathAccountFn* =
     proc(db: AristoDbRef;
-         accPath: openArray[byte];
+         accPath: Hash256;
         ): Result[bool,AristoError]
         {.noRaise.}
       ## For an account record indexed by `accPath` query whether this record
@@ -256,7 +256,7 @@ type
 
   AristoApiHasPathStorageFn* =
     proc(db: AristoDbRef;
-         accPath: openArray[byte];
+         accPath: Hash256;
          stoPath: openArray[byte];
         ): Result[bool,AristoError]
         {.noRaise.}
@@ -265,7 +265,7 @@ type
 
   AristoApiHasStorageDataFn* =
     proc(db: AristoDbRef;
-         accPath: openArray[byte];
+         accPath: Hash256;
         ): Result[bool,AristoError]
         {.noRaise.}
       ## For a storage tree related to account `accPath`, query whether there
@@ -295,7 +295,7 @@ type
 
   AristoApiMergeAccountRecordFn* =
     proc(db: AristoDbRef;
-         accPath: openArray[byte];
+         accPath: Hash256;
          accRec: AristoAccount;
         ): Result[bool,AristoError]
         {.noRaise.}
@@ -314,7 +314,7 @@ type
 
   AristoApiMergeStorageDataFn* =
     proc(db: AristoDbRef;
-         accPath: openArray[byte];
+         accPath: Hash256;
          stoPath: openArray[byte];
          stoData: openArray[byte];
         ): Result[void,AristoError]

--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -331,7 +331,7 @@ proc deleteImpl(
 
 proc deleteAccountRecord*(
     db: AristoDbRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ): Result[void,AristoError] =
   ## Delete the account leaf entry addressed by the argument `path`. If this
   ## leaf entry referres to a storage tree, this one will be deleted as well.
@@ -403,7 +403,7 @@ proc deleteGenericTree*(
 
 proc deleteStorageData*(
     db: AristoDbRef;
-    accPath: openArray[byte];          # Implies storage data tree
+    accPath: Hash256;          # Implies storage data tree
     stoPath: openArray[byte];
       ): Result[bool,AristoError] =
   ## For a given account argument `accPath`, this function deletes the
@@ -448,7 +448,7 @@ proc deleteStorageData*(
 
 proc deleteStorageTree*(
     db: AristoDbRef;                   # Database, top layer
-    accPath: openArray[byte];          # Implies storage data tree
+    accPath: Hash256;          # Implies storage data tree
       ): Result[void,AristoError] =
   ## Variant of `deleteStorageData()` for purging the whole storage tree
   ## associated to the account argument `accPath`.

--- a/nimbus/db/aristo/aristo_fetch.nim
+++ b/nimbus/db/aristo/aristo_fetch.nim
@@ -95,7 +95,7 @@ proc hasPayload(
 
 proc fetchAccountHike*(
     db: AristoDbRef;                   # Database
-    accPath: openArray[byte];          # Implies a storage ID (if any)
+    accPath: Hash256;          # Implies a storage ID (if any)
       ): Result[Hike,AristoError] =
   ## Verify that the `accPath` argument properly referres to a storage root
   ## vertex ID. The function will reset the keys along the `accPath` for
@@ -119,12 +119,12 @@ proc fetchAccountHike*(
 
 proc fetchStorageID*(
     db: AristoDbRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ): Result[VertexID,AristoError] =
   ## Public helper function fro retrieving a storage (vertex) ID for a
   ## given account.
   let
-    payload = db.retrievePayload(VertexID(1), accPath).valueOr:
+    payload = db.retrievePayload(VertexID(1), accPath.data).valueOr:
       if error == FetchAccInaccessible:
         return err(FetchPathNotFound)
       return err(error)
@@ -151,11 +151,11 @@ proc fetchLastSavedState*(
 
 proc fetchAccountRecord*(
     db: AristoDbRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ): Result[AristoAccount,AristoError] =
   ## Fetch an account record from the database indexed by `accPath`.
   ##
-  let pyl = ? db.retrievePayload(VertexID(1), accPath)
+  let pyl = ? db.retrievePayload(VertexID(1), accPath.data)
   assert pyl.pType == AccountData   # debugging only
   ok pyl.account
 
@@ -168,12 +168,12 @@ proc fetchAccountState*(
 
 proc hasPathAccount*(
     db: AristoDbRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ): Result[bool,AristoError] =
   ## For an account record indexed by `accPath` query whether this record exists
   ## on the database.
   ##
-  db.hasPayload(VertexID(1), accPath)
+  db.hasPayload(VertexID(1), accPath.data)
 
 
 proc fetchGenericData*(
@@ -211,7 +211,7 @@ proc hasPathGeneric*(
 
 proc fetchStorageData*(
     db: AristoDbRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
     stoPath: openArray[byte];
       ): Result[Blob,AristoError] =
   ## For a storage tree related to account `accPath`, fetch the data record
@@ -223,7 +223,7 @@ proc fetchStorageData*(
 
 proc fetchStorageState*(
     db: AristoDbRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
     updateOk: bool;
       ): Result[Hash256,AristoError] =
   ## Fetch the Merkle hash of the storage root related to `accPath`.
@@ -235,7 +235,7 @@ proc fetchStorageState*(
 
 proc hasPathStorage*(
     db: AristoDbRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
     stoPath: openArray[byte];
       ): Result[bool,AristoError] =
   ## For a storage tree related to account `accPath`, query whether the data
@@ -245,7 +245,7 @@ proc hasPathStorage*(
 
 proc hasStorageData*(
     db: AristoDbRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ): Result[bool,AristoError] =
   ## For a storage tree related to account `accPath`, query whether there
   ## is a non-empty data storage area at all.

--- a/nimbus/db/aristo/aristo_hike.nim
+++ b/nimbus/db/aristo/aristo_hike.nim
@@ -204,6 +204,14 @@ proc hikeUp*(
   ## Variant of `hike()`
   NibblesBuf.fromBytes(path).hikeUp(root, db)
 
+proc hikeUp*(
+    path: Hash256;
+    root: VertexID;
+    db: AristoDbRef;
+      ): Result[Hike,(VertexID,AristoError,Hike)] =
+  ## Variant of `hike()`
+  NibblesBuf.fromBytes(path.data).hikeUp(root, db)
+
 # ------------------------------------------------------------------------------
 # End
 # ------------------------------------------------------------------------------

--- a/nimbus/db/aristo/aristo_merge.nim
+++ b/nimbus/db/aristo/aristo_merge.nim
@@ -43,7 +43,7 @@ const
 
 proc mergeAccountRecord*(
     db: AristoDbRef;                   # Database, top layer
-    accPath: openArray[byte];          # Even nibbled byte path
+    accPath: Hash256;          # Even nibbled byte path
     accRec: AristoAccount;             # Account data
       ): Result[bool,AristoError] =
   ## Merge the  key-value-pair argument `(accKey,accPayload)` as an account
@@ -59,7 +59,7 @@ proc mergeAccountRecord*(
   ##
   let
     pyl =  PayloadRef(pType: AccountData, account: accRec)
-    rc = db.mergePayloadImpl(VertexID(1), accPath, pyl)
+    rc = db.mergePayloadImpl(VertexID(1), accPath.data, pyl)
   if rc.isOk:
     ok true
   elif rc.error in MergeNoAction:
@@ -102,7 +102,7 @@ proc mergeGenericData*(
 
 proc mergeStorageData*(
     db: AristoDbRef;                   # Database, top layer
-    accPath: openArray[byte];          # Needed for accounts payload
+    accPath: Hash256;          # Needed for accounts payload
     stoPath: openArray[byte];          # Storage data path (aka key)
     stoData: openArray[byte];          # Storage data payload value
       ): Result[void,AristoError] =

--- a/nimbus/db/aristo/aristo_nearby.nim
+++ b/nimbus/db/aristo/aristo_nearby.nim
@@ -472,7 +472,7 @@ iterator rightPairsGeneric*(
 
 iterator rightPairsStorage*(
     db: AristoDbRef;                    # Database layer
-    accPath: openArray[byte];           # Account the storage data belong to
+    accPath: Hash256;           # Account the storage data belong to
     start = low(PathID);                # Before or at first value
       ): (PathID,Blob) =
   ## Variant of `rightPairs()` for a storage tree

--- a/nimbus/db/core_db/backend/aristo_db.nim
+++ b/nimbus/db/core_db/backend/aristo_db.nim
@@ -283,7 +283,7 @@ iterator aristoMptPairs*(dsc: CoreDbMptRef): (Blob,Blob) {.noRaise.} =
 
 iterator aristoSlotPairs*(
     dsc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ): (Blob,Blob)
       {.noRaise.} =
   let

--- a/nimbus/db/core_db/backend/aristo_db/handlers_aristo.nim
+++ b/nimbus/db/core_db/backend/aristo_db/handlers_aristo.nim
@@ -172,7 +172,7 @@ proc accMethods(): CoreDbAccFns =
 
   proc accFetch(
       cAcc: AristoCoreDbAccRef;
-      accPath: openArray[byte];
+      accPath: Hash256;
         ): CoreDbRc[CoreDbAccount] =
     const info = "acc/fetchFn()"
 
@@ -184,7 +184,7 @@ proc accMethods(): CoreDbAccFns =
 
   proc accMerge(
       cAcc: AristoCoreDbAccRef;
-      accPath: openArray[byte];
+      accPath: Hash256;
       accRec: CoreDbAccount;
         ): CoreDbRc[void] =
     const info = "acc/mergeFn()"
@@ -199,7 +199,7 @@ proc accMethods(): CoreDbAccFns =
 
   proc accDelete(
       cAcc: AristoCoreDbAccRef;
-      accPath: openArray[byte];
+      accPath: Hash256;
         ): CoreDbRc[void] =
     const info = "acc/deleteFn()"
 
@@ -212,7 +212,7 @@ proc accMethods(): CoreDbAccFns =
 
   proc accClearStorage(
       cAcc: AristoCoreDbAccRef;
-      accPath: openArray[byte];
+      accPath: Hash256;
         ): CoreDbRc[void] =
     const info = "acc/clearStoFn()"
 
@@ -223,7 +223,7 @@ proc accMethods(): CoreDbAccFns =
 
   proc accHasPath(
       cAcc: AristoCoreDbAccRef;
-      accPath: openArray[byte];
+      accPath: Hash256;
         ): CoreDbRc[bool] =
     const info = "hasPathFn()"
 
@@ -243,7 +243,7 @@ proc accMethods(): CoreDbAccFns =
 
   proc slotFetch(
       cAcc: AristoCoreDbAccRef;
-      accPath: openArray[byte];
+      accPath: Hash256;
       stoPath: openArray[byte];
         ): CoreDbRc[Blob] =
     const info = "slotFetchFn()"
@@ -256,7 +256,7 @@ proc accMethods(): CoreDbAccFns =
 
   proc slotDelete(
       cAcc: AristoCoreDbAccRef;
-      accPath: openArray[byte];
+      accPath: Hash256;
       stoPath: openArray[byte];
         ): CoreDbRc[void] =
     const info = "slotDeleteFn()"
@@ -273,7 +273,7 @@ proc accMethods(): CoreDbAccFns =
 
   proc slotHasPath(
       cAcc: AristoCoreDbAccRef;
-      accPath: openArray[byte];
+      accPath: Hash256;
       stoPath: openArray[byte];
         ): CoreDbRc[bool] =
     const info = "slotHasPathFn()"
@@ -284,7 +284,7 @@ proc accMethods(): CoreDbAccFns =
 
   proc slotMerge(
       cAcc: AristoCoreDbAccRef;
-      accPath: openArray[byte];
+      accPath: Hash256;
       stoPath: openArray[byte];
       stoData: openArray[byte];
         ): CoreDbRc[void] =
@@ -296,7 +296,7 @@ proc accMethods(): CoreDbAccFns =
 
   proc slotState(
       cAcc: AristoCoreDbAccRef;
-      accPath: openArray[byte];
+      accPath: Hash256;
       updateOk: bool;
         ): CoreDbRc[Hash256] =
     const info = "slotStateFn()"
@@ -306,7 +306,7 @@ proc accMethods(): CoreDbAccFns =
 
   proc slotStateEmpty(
       cAcc: AristoCoreDbAccRef;
-      accPath: openArray[byte];
+      accPath: Hash256;
         ): CoreDbRc[bool] =
     const info = "slotStateEmptyFn()"
 
@@ -321,32 +321,32 @@ proc accMethods(): CoreDbAccFns =
 
     fetchFn: proc(
         cAcc: CoreDbAccRef;
-        accPath: openArray[byte];
+        accPath: Hash256;
           ): CoreDbRc[CoreDbAccount] =
       accFetch(AristoCoreDbAccRef(cAcc), accPath),
 
     deleteFn: proc(
         cAcc: CoreDbAccRef;
-        accPath: openArray[byte];
+        accPath: Hash256;
           ): CoreDbRc[void] =
       accDelete(AristoCoreDbAccRef(cAcc), accPath),
 
     clearStorageFn: proc(
         cAcc: CoreDbAccRef;
-        accPath: openArray[byte];
+        accPath: Hash256;
           ): CoreDbRc[void] =
       accClearStorage(AristoCoreDbAccRef(cAcc), accPath),
 
     mergeFn: proc(
         cAcc: CoreDbAccRef;
-        accPath: openArray[byte];
+        accPath: Hash256;
         accRec: CoreDbAccount;
           ): CoreDbRc[void] =
       accMerge(AristoCoreDbAccRef(cAcc), accPath, accRec),
 
     hasPathFn: proc(
         cAcc: CoreDbAccRef;
-        accPath: openArray[byte];
+        accPath: Hash256;
           ): CoreDbRc[bool] =
       accHasPath(AristoCoreDbAccRef(cAcc), accPath),
 
@@ -358,28 +358,28 @@ proc accMethods(): CoreDbAccFns =
 
     slotFetchFn: proc(
         cAcc: CoreDbAccRef;
-        accPath: openArray[byte];
+        accPath: Hash256;
         stoPath: openArray[byte];
           ): CoreDbRc[Blob] =
       slotFetch(AristoCoreDbAccRef(cAcc), accPath, stoPath),
 
     slotDeleteFn: proc(
         cAcc: CoreDbAccRef;
-        accPath: openArray[byte];
+        accPath: Hash256;
         stoPath: openArray[byte];
           ): CoreDbRc[void] =
       slotDelete(AristoCoreDbAccRef(cAcc), accPath, stoPath),
 
     slotHasPathFn: proc(
         cAcc: CoreDbAccRef;
-        accPath: openArray[byte];
+        accPath: Hash256;
         stoPath: openArray[byte];
           ): CoreDbRc[bool] =
       slotHasPath(AristoCoreDbAccRef(cAcc), accPath, stoPath),
 
     slotMergeFn: proc(
         cAcc: CoreDbAccRef;
-        accPath: openArray[byte];
+        accPath: Hash256;
         stoPath: openArray[byte];
         stoData: openArray[byte];
           ): CoreDbRc[void] =
@@ -387,14 +387,14 @@ proc accMethods(): CoreDbAccFns =
 
     slotStateFn: proc(
         cAcc: CoreDbAccRef;
-        accPath: openArray[byte];
+        accPath: Hash256;
         updateOk: bool;
            ): CoreDbRc[Hash256] =
       slotState(AristoCoreDbAccRef(cAcc), accPath, updateOk),
 
     slotStateEmptyFn: proc(
         cAcc: CoreDbAccRef;
-        accPath: openArray[byte];
+        accPath: Hash256;
            ): CoreDbRc[bool] =
       slotStateEmpty(AristoCoreDbAccRef(cAcc), accPath))
 

--- a/nimbus/db/core_db/base.nim
+++ b/nimbus/db/core_db/base.nim
@@ -407,7 +407,7 @@ proc getAccounts*(ctx: CoreDbCtxRef): CoreDbAccRef =
 
 proc fetch*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ): CoreDbRc[CoreDbAccount] =
   ## Fetch the account data record for the particular account indexed by
   ## the key `accPath`.
@@ -421,7 +421,7 @@ proc fetch*(
 
 proc delete*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ): CoreDbRc[void] =
   ## Delete the particular account indexed by the key `accPath`. This
   ## will also destroy an associated storage area.
@@ -435,7 +435,7 @@ proc delete*(
 
 proc clearStorage*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ): CoreDbRc[void] =
   ## Delete all data slots from the storage area associated with the
   ## particular account indexed by the key `accPath`.
@@ -449,7 +449,7 @@ proc clearStorage*(
 
 proc merge*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
     accRec: CoreDbAccount;
       ): CoreDbRc[void] =
   ## Add or update the argument account data record `account`. Note that the
@@ -462,7 +462,7 @@ proc merge*(
 
 proc hasPath*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ): CoreDbRc[bool] =
   ## Would be named `contains` if it returned `bool` rather than `Result[]`.
   ##
@@ -488,7 +488,7 @@ proc state*(acc: CoreDbAccRef; updateOk = false): CoreDbRc[Hash256] =
 
 proc slotFetch*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
     slot: openArray[byte];
       ):  CoreDbRc[Blob] =
   ## Like `fetch()` but with cascaded index `(accPath,slot)`.
@@ -501,7 +501,7 @@ proc slotFetch*(
 
 proc slotDelete*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
     slot: openArray[byte];
       ):  CoreDbRc[void] =
   ## Like `delete()` but with cascaded index `(accPath,slot)`.
@@ -515,7 +515,7 @@ proc slotDelete*(
 
 proc slotHasPath*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
     slot: openArray[byte];
       ):  CoreDbRc[bool] =
   ## Like `hasPath()` but with cascaded index `(accPath,slot)`.
@@ -529,7 +529,7 @@ proc slotHasPath*(
 
 proc slotMerge*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
     slot: openArray[byte];
     data: openArray[byte];
       ):  CoreDbRc[void] =
@@ -544,7 +544,7 @@ proc slotMerge*(
 
 proc slotState*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
     updateOk = false;
       ):  CoreDbRc[Hash256] =
   ## This function retrieves the Merkle state hash of the storage data
@@ -563,7 +563,7 @@ proc slotState*(
 
 proc slotStateEmpty*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ):  CoreDbRc[bool] =
   ## This function returns `true` if the storage data column is empty or
   ## missing.
@@ -577,7 +577,7 @@ proc slotStateEmpty*(
 
 proc slotStateEmptyOrVoid*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
       ): bool =
   ## Convenience wrapper, returns `true` where `slotStateEmpty()` would fail.
   when EnableAccountKeyValidation:
@@ -591,7 +591,7 @@ proc slotStateEmptyOrVoid*(
 
 proc recast*(
     acc: CoreDbAccRef;
-    accPath: openArray[byte];
+    accPath: Hash256;
     accRec: CoreDbAccount;
     updateOk = false;
       ): CoreDbRc[Account] =

--- a/nimbus/db/core_db/base/base_desc.nim
+++ b/nimbus/db/core_db/base/base_desc.nim
@@ -174,37 +174,37 @@ type
   CoreDbAccBackendFn* = proc(
     cAcc: CoreDbAccRef): CoreDbAccBackendRef {.noRaise.}
   CoreDbAccFetchFn* = proc(
-    cAcc: CoreDbAccRef; accPath: openArray[byte];
+    cAcc: CoreDbAccRef; accPath: Hash256;
     ): CoreDbRc[CoreDbAccount] {.noRaise.}
   CoreDbAccDeleteFn* = proc(
-    cAcc: CoreDbAccRef, accPath: openArray[byte]): CoreDbRc[void] {.noRaise.}
+    cAcc: CoreDbAccRef, accPath: Hash256): CoreDbRc[void] {.noRaise.}
   CoreDbAccClearStorageFn* = proc(
-    cAcc: CoreDbAccRef; accPath: openArray[byte]): CoreDbRc[void] {.noRaise.}
+    cAcc: CoreDbAccRef; accPath: Hash256): CoreDbRc[void] {.noRaise.}
   CoreDbAccMergeFn* = proc(
-    cAcc: CoreDbAccRef; accPath: openArray[byte]; accRec: CoreDbAccount;
+    cAcc: CoreDbAccRef; accPath: Hash256; accRec: CoreDbAccount;
     ): CoreDbRc[void] {.noRaise.}
   CoreDbAccHasPathFn* = proc(
-    cAcc: CoreDbAccRef; accPath: openArray[byte]): CoreDbRc[bool] {.noRaise.}
+    cAcc: CoreDbAccRef; accPath: Hash256): CoreDbRc[bool] {.noRaise.}
   CoreDbAccStateFn* = proc(
     cAcc: CoreDbAccRef; updateOk: bool): CoreDbRc[Hash256] {.noRaise.}
 
   CoreDbSlotFetchFn* = proc(
-    cAcc: CoreDbAccRef; accPath, stoPath: openArray[byte];
+    cAcc: CoreDbAccRef; accPath: Hash256, stoPath: openArray[byte];
     ): CoreDbRc[Blob] {.noRaise.}
   CoreDbSlotDeleteFn* = proc(
-    cAcc: CoreDbAccRef; accPath, stoPath: openArray[byte];
+    cAcc: CoreDbAccRef; accPath: Hash256, stoPath: openArray[byte];
     ): CoreDbRc[void] {.noRaise.}
   CoreDbSlotHasPathFn* = proc(
-    cAcc: CoreDbAccRef; accPath, stoPath: openArray[byte];
+    cAcc: CoreDbAccRef; accPath: Hash256, stoPath: openArray[byte];
     ): CoreDbRc[bool] {.noRaise.}
   CoreDbSlotMergeFn* = proc(
-    cAcc: CoreDbAccRef; accPath, stoPath, stoData: openArray[byte];
+    cAcc: CoreDbAccRef; accPath: Hash256, stoPath, stoData: openArray[byte];
     ): CoreDbRc[void] {.noRaise.}
   CoreDbSlotStateFn* = proc(
-    cAcc: CoreDbAccRef; accPath: openArray[byte]; updateOk: bool;
+    cAcc: CoreDbAccRef; accPath: Hash256; updateOk: bool;
     ): CoreDbRc[Hash256] {.noRaise.}
   CoreDbSlotStateEmptyFn* = proc(
-    cAcc: CoreDbAccRef; accPath: openArray[byte];
+    cAcc: CoreDbAccRef; accPath: Hash256;
     ): CoreDbRc[bool] {.noRaise.}
 
   CoreDbAccFns* = object

--- a/nimbus/db/core_db/base_iterators.nim
+++ b/nimbus/db/core_db/base_iterators.nim
@@ -58,7 +58,7 @@ iterator pairs*(mpt: CoreDbMptRef): (Blob, Blob) =
     raiseAssert: "Unsupported database type: " & $mpt.parent.dbType
   mpt.ifTrackNewApi: debug newApiTxt, api, elapsed
 
-iterator slotPairs*(acc: CoreDbAccRef; accPath: openArray[byte]): (Blob, Blob) =
+iterator slotPairs*(acc: CoreDbAccRef; accPath: Hash256): (Blob, Blob) =
   ## Trie traversal, only supported for `CoreDbMptRef`
   ##
   acc.setTrackNewApi AccSlotPairsIt

--- a/nimbus/db/ledger/accounts_ledger.nim
+++ b/nimbus/db/ledger/accounts_ledger.nim
@@ -125,11 +125,11 @@ when debugAccountsLedgerRef:
 template logTxt(info: static[string]): static[string] =
   "AccountsLedgerRef " & info
 
-template toAccountKey(acc: AccountRef): openArray[byte] =
-  acc.accPath.data.toOpenArray(0,31)
+template toAccountKey(acc: AccountRef): Hash256 =
+  acc.accPath
 
-template toAccountKey(eAddr: EthAddress): openArray[byte] =
-  eAddr.keccakHash.data.toOpenArray(0,31)
+template toAccountKey(eAddr: EthAddress): Hash256 =
+  eAddr.keccakHash
 
 
 proc beginSavepoint*(ac: AccountsLedgerRef): LedgerSavePoint {.gcsafe.}

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -329,7 +329,7 @@ proc verifyAsmResult(vmState: BaseVMState, boa: Assembler, asmResult: CallResult
 
   let
     al = com.db.ctx.getAccounts()
-    accPath = codeAddress.keccakHash.data
+    accPath = codeAddress.keccakHash
 
   for kv in boa.storage:
     let key = kv[0].toHex()

--- a/tests/test_aristo/test_helpers.nim
+++ b/tests/test_aristo/test_helpers.nim
@@ -242,7 +242,7 @@ proc mergeDummyAccLeaf*(
   # Add a dummy entry so the balancer logic can be triggered
   let
     acc = AristoAccount(nonce: nonce.AccountNonce)
-    rc = db.mergeAccountRecord(pathID.uint64.toBytesBE, acc)
+    rc = db.mergeAccountRecord(pathID.uint64.toBytesBE.keccakHash, acc)
   if rc.isOk:
     ok()
   else:


### PR DESCRIPTION
Account paths are always a hash - passing it around as such helps avoid confusion as to how long it is