### PR TITLE
Cache account path storage id

### DIFF
--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -346,6 +346,7 @@ proc deleteAccountRecord*(
   # Delete storage tree if present
   if stoID.isValid:
     ? db.delSubTreeImpl stoID
+    db.layersPutStoID(accPath, VertexID(0))
 
   db.deleteImpl(hike).isOkOr:
     return err(error[1])
@@ -442,6 +443,7 @@ proc deleteStorageData*(
   # De-register the deleted storage tree from the account record
   let leaf = wpAcc.vtx.dup           # Dup on modify
   leaf.lData.stoID = VertexID(0)
+  db.layersPutStoID(accPath, VertexID(0))
   db.layersPutVtx(VertexID(1), wpAcc.vid, leaf)
   db.layersResKey(VertexID(1), wpAcc.vid)
   ok(true)
@@ -472,6 +474,7 @@ proc deleteStorageTree*(
   # De-register the deleted storage tree from the accounts record
   let leaf = wpAcc.vtx.dup             # Dup on modify
   leaf.lData.stoID = VertexID(0)
+  db.layersPutStoID(accPath, VertexID(0))
   db.layersPutVtx(VertexID(1), wpAcc.vid, leaf)
   db.layersResKey(VertexID(1), wpAcc.vid)
   ok()

--- a/nimbus/db/aristo/aristo_desc.nim
+++ b/nimbus/db/aristo/aristo_desc.nim
@@ -37,7 +37,7 @@ export
   aristo_constants, desc_error, desc_identifiers, desc_structural, keyed_queue
 
 const
-  accLruSize* = 128 * 1024
+  accLruSize* = 1024 * 1024
     # LRU cache size for accounts that have storage
 
 type

--- a/nimbus/db/aristo/aristo_desc/desc_structural.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_structural.nim
@@ -112,6 +112,8 @@ type
     kMap*: Table[VertexID,HashKey]   ## Merkle hash key mapping
     vTop*: VertexID                  ## Last used vertex ID
 
+    accSids*: Table[Hash256, VertexID] ## Account path -> stoID
+
   LayerFinalRef* = ref object
     ## Final tables fully supersede tables on lower layers when stacked as a
     ## whole. Missing entries on a higher layers are the final state (for the

--- a/nimbus/db/aristo/aristo_merge.nim
+++ b/nimbus/db/aristo/aristo_merge.nim
@@ -136,6 +136,7 @@ proc mergeStorageData*(
       # Make sure that there is an account that refers to that storage trie
       let leaf = wpAcc.vtx.dup # Dup on modify
       leaf.lData.stoID = useID
+      db.layersPutStoID(accPath, useID)
       db.layersPutVtx(VertexID(1), wpAcc.vid, leaf)
       db.layersResKey(VertexID(1), wpAcc.vid)
       return ok()

--- a/nimbus/db/aristo/aristo_merge/merge_payload_helper.nim
+++ b/nimbus/db/aristo/aristo_merge/merge_payload_helper.nim
@@ -419,7 +419,7 @@ proc mergePayloadUpdate(
     if vid in db.pPrf:
       return err(MergeLeafProofModeLock)
 
-    # Update accounts storage root which is handled implicitely
+    # Update accounts storage root which is handled implicitly
     if hike.root == VertexID(1):
       payload.stoID = leafLeg.wp.vtx.lData.stoID
 

--- a/nimbus/db/aristo/aristo_utils.nim
+++ b/nimbus/db/aristo/aristo_utils.nim
@@ -14,7 +14,7 @@
 {.push raises: [].}
 
 import
-  std/[sequtils, typetraits],
+  std/sequtils,
   eth/common,
   results,
   "."/[aristo_constants, aristo_desc, aristo_get, aristo_hike, aristo_layers]


### PR DESCRIPTION
The storage id is frequently accessed when executing contract code and finding the path via the database requires several hops making the process slow - here, we add a cache to keep the most recently used account storage id:s in memory.

A possible future improvement would be to cache all account accesses so that for example updating the balance doesn't cause several hikes.