### PR TITLE
Reduce EVM complexity by removing forkOverride

### DIFF
--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -302,6 +302,9 @@ func toEVMFork*(com: CommonRef, forkDeterminer: ForkDeterminationInfo): EVMFork 
 func toEVMFork*(com: CommonRef): EVMFork =
   ToEVMFork[com.currentFork]
 
+func isSpuriousOrLater*(com: CommonRef, number: BlockNumber): bool =
+  com.toHardFork(number.forkDeterminationInfo) >= Spurious
+
 func isLondonOrLater*(com: CommonRef, number: BlockNumber): bool =
   # TODO: Fixme, use only London comparator
   com.toHardFork(number.forkDeterminationInfo) >= London

--- a/nimbus/core/tx_pool/tx_chain.nim
+++ b/nimbus/core/tx_pool/tx_chain.nim
@@ -250,7 +250,7 @@ func excessBlobGas*(dh: TxChainRef): uint64 =
 
 func nextFork*(dh: TxChainRef): EVMFork =
   ## Getter, fork of next block
-  dh.com.toEVMFork(dh.txEnv.vmState.forkDeterminationInfoForVMState)
+  dh.txEnv.vmState.fork
 
 func gasUsed*(dh: TxChainRef): GasInt =
   ## Getter, accumulated gas burned for collected blocks

--- a/nimbus/core/tx_pool/tx_tasks/tx_packer.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_packer.nim
@@ -81,11 +81,10 @@ proc runTx(pst: TxPackerStateRef; item: TxItemRef): GasInt =
   ## Execute item transaction and update `vmState` book keeping. Returns the
   ## `gasUsed` after executing the transaction.
   let
-    fork = pst.xp.chain.nextFork
     baseFee = pst.xp.chain.baseFee
     tx = item.tx.eip1559TxNormalization(baseFee.GasInt)
 
-  let gasUsed = tx.txCallEvm(item.sender, pst.xp.chain.vmState, fork)
+  let gasUsed = tx.txCallEvm(item.sender, pst.xp.chain.vmState)
   pst.cleanState = false
   doAssert 0 <= gasUsed
   gasUsed

--- a/nimbus/evm/state_transactions.nim
+++ b/nimbus/evm/state_transactions.nim
@@ -9,10 +9,8 @@
 # according to those terms.
 
 import
-  eth/common/eth_types,
   ../constants,
   ../db/ledger,
-  ../transaction,
   ./computation,
   ./interpreter_dispatch,
   ./interpreter/gas_costs,
@@ -21,19 +19,6 @@ import
   ./types
 
 {.push raises: [].}
-
-proc setupTxContext*(vmState: BaseVMState,
-                     txCtx: sink TxContext,
-                     forkOverride=Opt.none(EVMFork)) =
-  ## this proc will be called each time a new transaction
-  ## is going to be executed
-  vmState.txCtx = system.move(txCtx)
-  vmState.fork =
-    if forkOverride.isSome:
-      forkOverride.get
-    else:
-      vmState.determineFork
-  vmState.gasCosts = vmState.fork.forkToSchedule
 
 # Using `proc` as `incNonce()` might be `proc` in logging mode
 proc preExecComputation(c: Computation) =

--- a/nimbus/rpc/params.nim
+++ b/nimbus/rpc/params.nim
@@ -32,8 +32,7 @@ func destination*(args: TransactionArgs): EthAddress =
   ethAddr args.to.get(ZeroAddr)
 
 proc toCallParams*(vmState: BaseVMState, args: TransactionArgs,
-                   globalGasCap: GasInt, baseFee: Opt[UInt256],
-                   forkOverride = Opt.none(EVMFork)): EvmResult[CallParams] =
+                   globalGasCap: GasInt, baseFee: Opt[UInt256]): EvmResult[CallParams] =
 
   # Reject invalid combinations of pre- and post-1559 fee styles
   if args.gasPrice.isSome and
@@ -74,7 +73,6 @@ proc toCallParams*(vmState: BaseVMState, args: TransactionArgs,
 
   ok(CallParams(
     vmState:         vmState,
-    forkOverride:    forkOverride,
     sender:          args.sender,
     to:              args.destination,
     isCreate:        args.to.isNone,

--- a/nimbus/transaction/call_common.nim
+++ b/nimbus/transaction/call_common.nim
@@ -31,7 +31,6 @@ type
   # Standard call parameters.
   CallParams* = object
     vmState*:      BaseVMState          # Chain, database, state, block, fork.
-    forkOverride*: Opt[EVMFork]         # Default fork is usually correct.
     origin*:       Opt[HostAddress]     # Default origin is `sender`.
     gasPrice*:     GasInt               # Gas price for this call.
     gasLimit*:     GasInt               # Maximum gas available for this call.
@@ -133,14 +132,11 @@ proc initialAccessListEIP2929(call: CallParams) =
 
 proc setupHost(call: CallParams): TransactionHost =
   let vmState = call.vmState
-  vmState.setupTxContext(
-    TxContext(
-      origin         : call.origin.get(call.sender),
-      gasPrice       : call.gasPrice,
-      versionedHashes: call.versionedHashes,
-      blobBaseFee    : getBlobBaseFee(vmState.blockCtx.excessBlobGas),
-    ),
-    forkOverride = call.forkOverride
+  vmState.txCtx = TxContext(
+    origin         : call.origin.get(call.sender),
+    gasPrice       : call.gasPrice,
+    versionedHashes: call.versionedHashes,
+    blobBaseFee    : getBlobBaseFee(vmState.blockCtx.excessBlobGas),
   )
 
   var intrinsicGas: GasInt = 0

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -395,12 +395,11 @@ proc createSignedTx(payload: Blob, chainId: ChainId): Transaction =
 proc runVM*(vmState: BaseVMState, boa: Assembler): bool =
   let
     com  = vmState.com
-    fork = com.toEVMFork()
   vmState.mutateStateDB:
     db.setCode(codeAddress, boa.code)
     db.setBalance(codeAddress, 1_000_000.u256)
   let tx = createSignedTx(boa.data, com.chainId)
-  let asmResult = testCallEvm(tx, tx.getSender, vmState, fork)
+  let asmResult = testCallEvm(tx, tx.getSender, vmState)
   verifyAsmResult(vmState, boa, asmResult)
 
 macro assembler*(list: untyped): untyped =

--- a/tests/test_evm_support.nim
+++ b/tests/test_evm_support.nim
@@ -19,7 +19,6 @@ import
   ../nimbus/evm/memory,
   ../nimbus/evm/code_stream,
   ../nimbus/evm/internals,
-  ../nimbus/evm/types,
   ../nimbus/constants,
   ../nimbus/core/pow/header,
   ../nimbus/db/ledger,
@@ -377,7 +376,7 @@ proc runTestOverflow() =
 
     let privateKey = PrivateKey.fromHex("0000000000000000000000000000000000000000000000000000001000000000")[]
     let tx = signTransaction(unsignedTx, privateKey, ChainId(1), false)
-    let res = testCallEvm(tx, tx.getSender, s, FkHomestead)
+    let res = testCallEvm(tx, tx.getSender, s)
 
     when defined(evmc_enabled):
       check res.error == "EVMC_FAILURE"

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -101,7 +101,6 @@ proc testFixtureIndexes(ctx: var TestCtx, testStatusIMPL: var TestStatus) =
 
   var gasUsed: GasInt
   let sender = ctx.tx.getSender()
-  let fork = com.toEVMFork(ctx.header.forkDeterminationInfo)
 
   vmState.mutateStateDB:
     setupStateDB(ctx.pre, db)
@@ -112,12 +111,12 @@ proc testFixtureIndexes(ctx: var TestCtx, testStatusIMPL: var TestStatus) =
     db.persist()
 
   let rc = vmState.processTransaction(
-                ctx.tx, sender, ctx.header, fork)
+                ctx.tx, sender, ctx.header)
   if rc.isOk:
     gasUsed = rc.value
 
   let miner = ctx.header.coinbase
-  coinbaseStateClearing(vmState, miner, fork)
+  coinbaseStateClearing(vmState, miner)
 
   block post:
     let obtainedHash = vmState.readOnlyStateDB.rootHash

--- a/tools/common/helpers.nim
+++ b/tools/common/helpers.nim
@@ -121,6 +121,8 @@ func getChainConfig*(network: string, c: ChainConfig) =
     c.assignTime(HardFork.Cancun, TimeZero)
   of $TestFork.ShanghaiToCancunAtTime15k:
     c.assignTime(HardFork.Cancun, EthTime(15000))
+  of $TestFork.Prague:
+    c.assignTime(HardFork.Prague, TimeZero)
   else:
     raise newException(ValueError, "unsupported network " & network)
 

--- a/tools/common/state_clearing.nim
+++ b/tools/common/state_clearing.nim
@@ -15,7 +15,6 @@ import
 
 proc coinbaseStateClearing*(vmState: BaseVMState,
                             miner: EthAddress,
-                            fork: EVMFork,
                             touched = true) =
   # This is necessary due to the manner in which the state tests are
   # generated. State tests are generated from the BlockChainTest tests
@@ -38,4 +37,4 @@ proc coinbaseStateClearing*(vmState: BaseVMState,
 
     # do not clear cache, we need the cache when constructing
     # post state
-    db.persist(clearEmptyAccount = fork >= FkSpurious)
+    db.persist(clearEmptyAccount = vmState.fork >= FkSpurious)

--- a/tools/common/types.nim
+++ b/tools/common/types.nim
@@ -37,6 +37,7 @@ type
     ParisToShanghaiAtTime15k
     Cancun
     ShanghaiToCancunAtTime15k
+    Prague
 
   LogLevel* = enum
     Silent

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -130,7 +130,6 @@ proc writeRootHashToStderr(vmState: BaseVMState) =
 proc runExecution(ctx: var StateContext, conf: StateConf, pre: JsonNode): StateResult =
   let
     com     = CommonRef.new(newCoreDbRef DefaultDbMemory, ctx.chainConfig)
-    fork    = com.toEVMFork(ctx.header.forkDeterminationInfo)
     stream  = newFileStream(stderr)
     tracer  = if conf.jsonEnabled:
                 newJsonTracer(stream, ctx.tracerFlags, conf.pretty)
@@ -175,12 +174,12 @@ proc runExecution(ctx: var StateContext, conf: StateConf, pre: JsonNode): StateR
 
   try:
     let rc = vmState.processTransaction(
-                  ctx.tx, sender, ctx.header, fork)
+                  ctx.tx, sender, ctx.header)
     if rc.isOk:
       gasUsed = rc.value
 
     let miner = ctx.header.coinbase
-    coinbaseStateClearing(vmState, miner, fork)
+    coinbaseStateClearing(vmState, miner)
   except CatchableError as ex:
     echo "FATAL: ", ex.msg
     quit(QuitFailure)

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -300,7 +300,7 @@ proc exec(ctx: var TransContext,
 
   let miner = ctx.env.currentCoinbase
   let fork = vmState.com.toEVMFork
-  coinbaseStateClearing(vmState, miner, fork, stateReward.isSome())
+  coinbaseStateClearing(vmState, miner, stateReward.isSome())
 
   let stateDB = vmState.stateDB
   stateDB.postState(result.alloc)


### PR DESCRIPTION
EVM `forkOverride` is one of legacy stuff remnants that is not needed anymore.
fix #1410
