### PR TITLE
Add debug mode for disabling per-chunk state root validation

### DIFF
--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -524,6 +524,12 @@ type
         defaultValue: false
         name: "debug-full-validation".}: bool
 
+      noValidation* {.
+        hidden
+        desc: "Disble per-chunk validation"
+        defaultValue: true
+        name: "debug-no-validation".}: bool
+
       storeBodies* {.
         hidden
         desc: "Store block blodies in database"

--- a/nimbus/core/chain/persist_blocks.nim
+++ b/nimbus/core/chain/persist_blocks.nim
@@ -30,6 +30,7 @@ export results
 
 type
   PersistBlockFlag* = enum
+    NoValidation # Validate the batch instead of validating each block in it
     NoFullValidation # Validate the batch instead of validating each block in it
     NoPersistHeader
     NoPersistTransactions
@@ -115,7 +116,8 @@ proc persistBlocksImpl(
     #      can the state root of the last block still be correct? Dubious, but
     #      what would be the consequences? We would roll back the full set of
     #      blocks which is fairly low-cost.
-    let skipValidation = NoFullValidation in flags and header.number != toBlock
+    let skipValidation =
+      NoFullValidation in flags and header.number != toBlock or NoValidation in flags
 
     c.com.hardForkTransition(header)
 
@@ -174,7 +176,7 @@ proc persistBlocksImpl(
     if NoPersistWithdrawals notin flags and blk.withdrawals.isSome:
       c.db.persistWithdrawals(
         header.withdrawalsRoot.expect("WithdrawalsRoot should be verified before"),
-        blk.withdrawals.get
+        blk.withdrawals.get,
       )
 
     # update currentBlock *after* we persist it

--- a/nimbus/nimbus_import.nim
+++ b/nimbus/nimbus_import.nim
@@ -100,6 +100,7 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
       else:
         File(nil)
     flags =
+      boolFlag({PersistBlockFlag.NoValidation}, conf.noValidation) +
       boolFlag({PersistBlockFlag.NoFullValidation}, not conf.fullValidation) +
       boolFlag(NoPersistBodies, not conf.storeBodies) +
       boolFlag({PersistBlockFlag.NoPersistReceipts}, not conf.storeReceipts)


### PR DESCRIPTION
This significantly speeds up block import at the cost of less protection against invalid data, potentially resulting in an invalid database getting stored.

The risk is small given that import is used only for validated data - evaluating the right level of of validation vs performance is left for a future PR.

A side effect of this approach is that there is no cached stated root in the database - computing it currently requires a lot of memory since the intermediate roots get cached in memory in full while the computation is ongoing - a future PR will need to address this deficiency, for example by streaming the already-computed hashes directly to the database.