### PR TITLE
don't write hash->slot map

### DIFF
--- a/nimbus/db/ledger/base_iterators.nim
+++ b/nimbus/db/ledger/base_iterators.nim
@@ -58,15 +58,6 @@ iterator pairs*(ldg: LedgerRef): (EthAddress,Account) =
   ldg.ifTrackApi: debug apiTxt, api, elapsed
 
 
-iterator storage*(
-    ldg: LedgerRef;
-    eAddr: EthAddress;
-      ): (UInt256,UInt256) =
-  ldg.beginTrackApi LdgStorageIt
-  for w in ldg.ac.storage(eAddr):
-    yield w
-  ldg.ifTrackApi: debug apiTxt, api, elapsed, eAddr
-
 # ------------------------------------------------------------------------------
 # End
 # ------------------------------------------------------------------------------

--- a/nimbus/db/storage_types.nim
+++ b/nimbus/db/storage_types.nim
@@ -13,20 +13,20 @@ import
 
 type
   DBKeyKind* = enum
-    genericHash
-    blockNumberToHash
-    blockHashToScore
-    transactionHashToBlock
-    canonicalHeadHash
-    slotHashToSlot
-    contractHash
-    transitionStatus
-    safeHash
-    finalizedHash
-    skeletonProgress
-    skeletonBlockHashToNumber
-    skeletonHeader
-    skeletonBody
+    # Careful - changing the assigned ordinals will break existing databases
+    genericHash = 0
+    blockNumberToHash = 1
+    blockHashToScore = 2
+    transactionHashToBlock = 3
+    canonicalHeadHash = 4
+    contractHash = 6
+    transitionStatus = 7
+    safeHash = 8
+    finalizedHash = 9
+    skeletonProgress = 10
+    skeletonBlockHashToNumber = 11
+    skeletonHeader = 12
+    skeletonBody = 13
 
   DbKey* = object
     # The first byte stores the key type. The rest are key-specific values
@@ -59,12 +59,6 @@ func blockNumberToHashKey*(u: BlockNumber): DbKey {.inline.} =
 func canonicalHeadHashKey*(): DbKey {.inline.} =
   result.data[0] = byte ord(canonicalHeadHash)
   result.dataEndPos = 1
-
-func slotHashToSlotKey*(h: openArray[byte]): DbKey {.inline.} =
-  doAssert(h.len == 32)
-  result.data[0] = byte ord(slotHashToSlot)
-  result.data[1 .. 32] = h
-  result.dataEndPos = uint8 32
 
 func contractHashKey*(h: Hash256): DbKey {.inline.} =
   result.data[0] = byte ord(contractHash)


### PR DESCRIPTION
This map is unused but because it's written for every storage update it causes a lot of database churn - even though the hashes are mostly the same, they are written both to the rocksdb WAL and SST files and then have to be "compacted away" which causes a lot of unnecessary disk activity.

Should we wish to re-implement it, it should (likely) be done in a way that only new hashes are written since most slots are the same.

In the same vein, avoid writing trivially detectable A-B-A storage changes which happen with surprising frequency.