### PR TITLE
don't rewrite hash->slot map

### DIFF
--- a/nimbus/db/storage_types.nim
+++ b/nimbus/db/storage_types.nim
@@ -13,20 +13,21 @@ import
 
 type
   DBKeyKind* = enum
-    genericHash
-    blockNumberToHash
-    blockHashToScore
-    transactionHashToBlock
-    canonicalHeadHash
-    slotHashToSlot
-    contractHash
-    transitionStatus
-    safeHash
-    finalizedHash
-    skeletonProgress
-    skeletonBlockHashToNumber
-    skeletonHeader
-    skeletonBody
+    # Careful - changing the assigned ordinals will break existing databases
+    genericHash = 0
+    blockNumberToHash = 1
+    blockHashToScore = 2
+    transactionHashToBlock = 3
+    canonicalHeadHash = 4
+    slotHashToSlot = 5
+    contractHash = 6
+    transitionStatus = 7
+    safeHash = 8
+    finalizedHash = 9
+    skeletonProgress = 10
+    skeletonBlockHashToNumber = 11
+    skeletonHeader = 12
+    skeletonBody = 13
 
   DbKey* = object
     # The first byte stores the key type. The rest are key-specific values


### PR DESCRIPTION
Avoid writing the same slot/hash values to the hash->slot mapping to avoid spamming the rocksdb WAL and cause unnecessary compaction

In the same vein, avoid writing trivially detectable A-B-A storage changes which happen with surprising frequency.
