### PR TITLE
increase rdb cache sizes

### DIFF
--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -53,8 +53,10 @@ type
 const
   BaseFolder* = "nimbus"               ## Same as for Legacy DB
   DataFolder* = "aristo"               ## Legacy DB has "data"
-  RdKeyLruMaxSize* = 4096              ## Max size of read cache for keys
-  RdVtxLruMaxSize* = 2048              ## Max size of read cache for vertex IDs
+  RdKeyLruMaxSize* = 80000
+    ## Max size of read cache for keys - ~4 levels of MPT
+  RdVtxLruMaxSize* = 80000
+    ## Max size of read cache for vertex IDs - ~4 levels of MPT
 
 # ------------------------------------------------------------------------------
 # Public functions


### PR DESCRIPTION
This trivial bump should improve performance a bit without costing too much memory - as the trie grows, so does the number of levels in it and creating hikes becomes ever more expensive - hopefully this cache increase should give a nice little boost even if it's not a lot.