### PR TITLE
Set the routing table ip limits back to defaults

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -224,7 +224,7 @@ type
       desc:
         "Maximum amount of nodes with the same IP in the routing table. " &
         "This option is currently required as many nodes are running from " &
-        "the same machines. The option will be removed/adjusted in the future",
+        "the same machines. The option might be removed/adjusted in the future",
       defaultValue: defaultPortalProtocolConfig.tableIpLimits.tableIpLimit,
       defaultValueDesc: $defaultTableIpLimitDesc,
       name: "table-ip-limit"
@@ -235,7 +235,7 @@ type
       desc:
         "Maximum amount of nodes with the same IP in the routing table's buckets. " &
         "This option is currently required as many nodes are running from " &
-        "the same machines. The option will be removed/adjusted in the future",
+        "the same machines. The option might be removed/adjusted in the future",
       defaultValue: defaultPortalProtocolConfig.tableIpLimits.bucketIpLimit,
       defaultValueDesc: $defaultBucketIpLimitDesc,
       name: "bucket-ip-limit"

--- a/fluffy/network/wire/portal_protocol_config.nim
+++ b/fluffy/network/wire/portal_protocol_config.nim
@@ -48,12 +48,7 @@ const
   revalidationTimeout* = chronos.seconds(30)
 
   defaultPortalProtocolConfig* = PortalProtocolConfig(
-    # TODO / IMPORTANT NOTE:
-    # This must be set back to `DefaultTableIpLimits` as soon as there are
-    # enough nodes in the Portal network that we don't need to rely on the
-    # Fluffy fleet. Currently, during development, convenience is taken above
-    # security, this must not remain.
-    tableIpLimits: TableIpLimits(tableIpLimit: 32, bucketIpLimit: 16),
+    tableIpLimits: DefaultTableIpLimits,
     bitsPerHop: DefaultBitsPerHop,
     radiusConfig: defaultRadiusConfig,
   )


### PR DESCRIPTION
Our fleet now has unique IP per node, so we can go back to stronger default ip limits.