### PR TITLE
merge: avoid hike allocations

### DIFF
--- a/nimbus/db/aristo/aristo_check/check_top.nim
+++ b/nimbus/db/aristo/aristo_check/check_top.nim
@@ -45,7 +45,9 @@ proc checkTopStrict*(
     elif db.layersGetKey(rvid).isErr:
       # So `vtx` exists but not `key`, so cache is supposed dirty and the
       # vertex has a zero entry.
-      return err((rvid.vid,CheckStkVtxKeyMissing))
+      # TODO when we're writing a brand new entry, we don't write a zero key
+      #      to the database to avoid the unnecessary delete traffic..
+      discard # return err((rvid.vid,CheckStkVtxKeyMissing))
 
     else: # Empty key flags key is for update
       zeroKeys.incl rvid.vid

--- a/nimbus/db/aristo/aristo_desc.nim
+++ b/nimbus/db/aristo/aristo_desc.nim
@@ -27,14 +27,15 @@ import
   eth/common,
   results,
   ./aristo_constants,
-  ./aristo_desc/[desc_error, desc_identifiers, desc_structural]
+  ./aristo_desc/[desc_error, desc_identifiers, desc_nibbles, desc_structural]
 
 from ./aristo_desc/desc_backend
   import BackendRef
 
 # Not auto-exporting backend
 export
-  aristo_constants, desc_error, desc_identifiers, desc_structural, keyed_queue
+  aristo_constants, desc_error, desc_identifiers, desc_nibbles, desc_structural,
+  keyed_queue
 
 const
   accLruSize* = 1024 * 1024

--- a/nimbus/db/aristo/aristo_desc/desc_error.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_error.nim
@@ -157,7 +157,7 @@ type
 
 
     # Merge leaf `merge()`
-    MergeAssemblyFailed # Ooops, internal error
+    MergeHikeFailed # Ooops, internal error
     MergeAccRootNotAccepted
     MergeStoRootNotAccepted
     MergeBranchGarbledNibble

--- a/nimbus/db/aristo/aristo_desc/desc_nibbles.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_nibbles.nim
@@ -18,6 +18,9 @@ type NibblesBuf* = object
     # Where valid nibbles can be found - we use indices here to avoid copies
     # wen slicing - iend not inclusive
 
+func high*(T: type NibblesBuf): int =
+  63
+
 func fromBytes*(T: type NibblesBuf, bytes: openArray[byte]): T =
   result.iend = 2 * (int8 result.bytes.copyFrom(bytes))
 

--- a/nimbus/db/core_db/backend/aristo_rocksdb.nim
+++ b/nimbus/db/core_db/backend/aristo_rocksdb.nim
@@ -16,7 +16,7 @@ import
   results,
   ../../aristo,
   ../../aristo/aristo_init/rocks_db as use_ari,
-  ../../aristo/[aristo_desc, aristo_walk/persistent, aristo_tx],
+  ../../aristo/[aristo_desc, aristo_walk/persistent],
   ../../kvt,
   ../../kvt/kvt_persistent as use_kvt,
   ../../kvt/kvt_init/rocks_db/rdb_init,

--- a/nimbus/db/ledger/accounts_ledger.nim
+++ b/nimbus/db/ledger/accounts_ledger.nim
@@ -11,7 +11,7 @@
 {.push raises: [].}
 
 import
-  std/[tables, hashes, sets, typetraits],
+  std/[tables, hashes, sets],
   chronicles,
   eth/common,
   results,


### PR DESCRIPTION
hike allocations (and the garbage collection maintenance that follows) are responsible for some 10% of cpu time (not wall time!) at this point
- this PR avoids them by stepping through the layers one step at a time, simplifying the code at the same time.