### PR TITLE
Rename to EpochRecord and other accumulator spec changes

### DIFF
--- a/fluffy/database/era1_db.nim
+++ b/fluffy/database/era1_db.nim
@@ -62,9 +62,9 @@ proc getBlockTuple*(db: Era1DB, blockNumber: uint64): Result[BlockTuple, string]
 
 proc getAccumulator*(
     db: Era1DB, blockNumber: uint64
-): Result[EpochAccumulatorCached, string] =
-  ## Get the Epoch Accumulator that the block with `blockNumber` is part of.
-  # TODO: Probably want this `EpochAccumulatorCached` also actually cached in
+): Result[EpochRecordCached, string] =
+  ## Get the Epoch Record that the block with `blockNumber` is part of.
+  # TODO: Probably want this `EpochRecordCached` also actually cached in
   # the Era1File or EraDB object.
   let f = ?db.getEra1File(blockNumber.era)
 

--- a/fluffy/docs/the_fluffy_book/docs/history-content-bridging.md
+++ b/fluffy/docs/the_fluffy_book/docs/history-content-bridging.md
@@ -95,18 +95,18 @@ the assigned `--data-dir`.
 3. Build the master accumulator and the epoch accumulators:
 
 ```bash
-./build/eth_data_exporter history exportAccumulatorData --writeEpochAccumulators --data-dir:"./user_data_dir/"
+./build/eth_data_exporter history exportAccumulatorData --write-epoch-records --data-dir:"./user_data_dir/"
 ```
 
 #### Step 2: Seed the epoch accumulators into the Portal network
 Run Fluffy and trigger the propagation of data with the
-`portal_history_propagateEpochAccumulators` JSON-RPC API call:
+`portal_history_propagateEpochRecords` JSON-RPC API call:
 
 ```bash
 ./build/fluffy --rpc
 
 # From another terminal
-curl -s -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":"1","method":"portal_history_propagateEpochAccumulators","params":["./user_data_dir/"]}' http://localhost:8545 | jq
+curl -s -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":"1","method":"portal_history_propagateEpochRecords","params":["./user_data_dir/"]}' http://localhost:8545 | jq
 ```
 
 

--- a/fluffy/eth_data/era1.nim
+++ b/fluffy/eth_data/era1.nim
@@ -438,7 +438,7 @@ proc getAccumulatorRoot*(f: Era1File): Result[Digest, string] =
 
   ok(Digest(data: array[32, byte].initCopyFrom(bytes)))
 
-proc buildAccumulator*(f: Era1File): Result[EpochAccumulatorCached, string] =
+proc buildAccumulator*(f: Era1File): Result[EpochRecordCached, string] =
   let
     startNumber = f.blockIdx.startNumber
     endNumber = f.blockIdx.endNumber()
@@ -453,7 +453,7 @@ proc buildAccumulator*(f: Era1File): Result[EpochAccumulatorCached, string] =
       HeaderRecord(blockHash: blockHeader.blockHash(), totalDifficulty: totalDifficulty)
     )
 
-  ok(EpochAccumulatorCached.init(headerRecords))
+  ok(EpochRecordCached.init(headerRecords))
 
 proc verify*(f: Era1File): Result[Digest, string] =
   let
@@ -483,7 +483,7 @@ proc verify*(f: Era1File): Result[Digest, string] =
     )
 
   let expectedRoot = ?f.getAccumulatorRoot()
-  let accumulatorRoot = getEpochAccumulatorRoot(headerRecords)
+  let accumulatorRoot = getEpochRecordRoot(headerRecords)
 
   if accumulatorRoot != expectedRoot:
     err("Invalid accumulator root")

--- a/fluffy/eth_data/history_data_ssz_e2s.nim
+++ b/fluffy/eth_data/history_data_ssz_e2s.nim
@@ -27,19 +27,19 @@ proc readAccumulator*(file: string): Result[FinishedAccumulator, string] =
   except SerializationError as e:
     err("Failed decoding accumulator: " & e.msg)
 
-proc readEpochAccumulator*(file: string): Result[EpochAccumulator, string] =
+proc readEpochRecord*(file: string): Result[EpochRecord, string] =
   let encodedAccumulator = ?readAllFile(file).mapErr(toString)
 
   try:
-    ok(SSZ.decode(encodedAccumulator, EpochAccumulator))
+    ok(SSZ.decode(encodedAccumulator, EpochRecord))
   except SerializationError as e:
     err("Decoding epoch accumulator failed: " & e.msg)
 
-proc readEpochAccumulatorCached*(file: string): Result[EpochAccumulatorCached, string] =
+proc readEpochRecordCached*(file: string): Result[EpochRecordCached, string] =
   let encodedAccumulator = ?readAllFile(file).mapErr(toString)
 
   try:
-    ok(SSZ.decode(encodedAccumulator, EpochAccumulatorCached))
+    ok(SSZ.decode(encodedAccumulator, EpochRecordCached))
   except SerializationError as e:
     err("Decoding epoch accumulator failed: " & e.msg)
 

--- a/fluffy/network/history/content/content_keys.nim
+++ b/fluffy/network/history/content/content_keys.nim
@@ -31,12 +31,12 @@ type
     blockHeader = 0x00
     blockBody = 0x01
     receipts = 0x02
-    epochAccumulator = 0x03
+    epochRecord = 0x03
 
   BlockKey* = object
     blockHash*: BlockHash
 
-  EpochAccumulatorKey* = object
+  EpochRecordKey* = object
     epochHash*: Digest
 
   ContentKey* = object
@@ -47,8 +47,8 @@ type
       blockBodyKey*: BlockKey
     of receipts:
       receiptsKey*: BlockKey
-    of epochAccumulator:
-      epochAccumulatorKey*: EpochAccumulatorKey
+    of epochRecord:
+      epochRecordKey*: EpochRecordKey
 
 func init*(T: type ContentKey, contentType: ContentType, hash: BlockHash | Digest): T =
   case contentType
@@ -58,10 +58,9 @@ func init*(T: type ContentKey, contentType: ContentType, hash: BlockHash | Diges
     ContentKey(contentType: contentType, blockBodyKey: BlockKey(blockHash: hash))
   of receipts:
     ContentKey(contentType: contentType, receiptsKey: BlockKey(blockHash: hash))
-  of epochAccumulator:
+  of epochRecord:
     ContentKey(
-      contentType: contentType,
-      epochAccumulatorKey: EpochAccumulatorKey(epochHash: hash),
+      contentType: contentType, epochRecordKey: EpochRecordKey(epochHash: hash)
     )
 
 func encode*(contentKey: ContentKey): ByteList =
@@ -97,8 +96,8 @@ func `$`*(x: ContentKey): string =
     res.add($x.blockBodyKey)
   of receipts:
     res.add($x.receiptsKey)
-  of epochAccumulator:
-    let key = x.epochAccumulatorKey
+  of epochRecord:
+    let key = x.epochRecordKey
     res.add("epochHash: " & $key.epochHash)
 
   res.add(")")

--- a/fluffy/network_metadata.nim
+++ b/fluffy/network_metadata.nim
@@ -47,13 +47,14 @@ const
   angelfoodBootstrapNodes* =
     loadCompileTimeBootstrapNodes(portalConfigDir / "bootstrap_nodes_angelfood.txt")
 
-  finishedAccumulatorSSZ* = slurp(portalConfigDir / "finished_accumulator.ssz")
+  historicalHashesAccumulatorSSZ* =
+    slurp(portalConfigDir / "historical_hashes_accumulator.ssz")
 
   historicalRootsSSZ* = slurp(portalConfigDir / "historical_roots.ssz")
 
 func loadAccumulator*(): FinishedAccumulator =
   try:
-    SSZ.decode(finishedAccumulatorSSZ, FinishedAccumulator)
+    SSZ.decode(historicalHashesAccumulatorSSZ, FinishedAccumulator)
   except SerializationError as err:
     raiseAssert "Invalid baked-in accumulator: " & err.msg
 

--- a/fluffy/rpc/rpc_calls/rpc_portal_debug_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_debug_calls.nim
@@ -25,8 +25,8 @@ createRpcSigsFromNim(RpcClient):
   proc portal_history_propagate(dataFile: string): bool
   proc portal_history_propagateHeaders(dataFile: string): bool
   proc portal_history_propagateBlock(dataFile: string, blockHash: string): bool
-  proc portal_history_propagateEpochAccumulator(dataFile: string): bool
-  proc portal_history_propagateEpochAccumulators(path: string): bool
+  proc portal_history_propagateEpochRecord(dataFile: string): bool
+  proc portal_history_propagateEpochRecords(path: string): bool
   proc portal_history_storeContentInNodeRange(
     dbPath: string, max: uint32, starting: uint32
   ): bool

--- a/fluffy/rpc/rpc_portal_debug_api.nim
+++ b/fluffy/rpc/rpc_portal_debug_api.nim
@@ -23,9 +23,9 @@ proc installPortalDebugApiHandlers*(
 ) =
   ## Portal debug API calls related to storage and seeding from Era1 files.
   rpcServer.rpc("portal_" & network & "GossipHeaders") do(
-    era1File: string, epochAccumulatorFile: Opt[string]
+    era1File: string, epochRecordFile: Opt[string]
   ) -> bool:
-    let res = await p.historyGossipHeadersWithProof(era1File, epochAccumulatorFile)
+    let res = await p.historyGossipHeadersWithProof(era1File, epochRecordFile)
     if res.isOk():
       return true
     else:
@@ -62,10 +62,10 @@ proc installPortalDebugApiHandlers*(
       raise newException(ValueError, $res.error)
 
   rpcServer.rpc("portal_" & network & "_propagateHeaders") do(
-    epochHeadersFile: string, epochAccumulatorFile: string
+    epochHeadersFile: string, epochRecordFile: string
   ) -> bool:
     let res =
-      await p.historyPropagateHeadersWithProof(epochHeadersFile, epochAccumulatorFile)
+      await p.historyPropagateHeadersWithProof(epochHeadersFile, epochRecordFile)
     if res.isOk():
       return true
     else:
@@ -80,19 +80,17 @@ proc installPortalDebugApiHandlers*(
     else:
       raise newException(ValueError, $res.error)
 
-  rpcServer.rpc("portal_" & network & "_propagateEpochAccumulator") do(
+  rpcServer.rpc("portal_" & network & "_propagateEpochRecord") do(
     dataFile: string
   ) -> bool:
-    let res = await p.propagateEpochAccumulator(dataFile)
+    let res = await p.propagateEpochRecord(dataFile)
     if res.isOk():
       return true
     else:
       raise newException(ValueError, $res.error)
 
-  rpcServer.rpc("portal_" & network & "_propagateEpochAccumulators") do(
-    path: string
-  ) -> bool:
-    let res = await p.propagateEpochAccumulators(path)
+  rpcServer.rpc("portal_" & network & "_propagateEpochRecords") do(path: string) -> bool:
+    let res = await p.propagateEpochRecords(path)
     if res.isOk():
       return true
     else:

--- a/fluffy/scripts/test_portal_testnet.nim
+++ b/fluffy/scripts/test_portal_testnet.nim
@@ -248,14 +248,15 @@ procSuite "Portal testnet tests":
         "./vendor/portal-spec-tests/tests/mainnet/history/headers/1000001-1000010.e2s"
       accumulatorFile =
         "./vendor/portal-spec-tests/tests/mainnet/history/accumulator/epoch-accumulator-00122.ssz"
+        # TODO: rename
       blockDataFile = "./fluffy/tests/blocks/mainnet_blocks_1000001_1000010.json"
 
     let
       blockHeaders = readBlockHeaders(headerFile).valueOr:
         raiseAssert "Invalid header file: " & headerFile
-      epochAccumulator = readEpochAccumulatorCached(accumulatorFile).valueOr:
+      epochRecord = readEpochRecordCached(accumulatorFile).valueOr:
         raiseAssert "Invalid epoch accumulator file: " & accumulatorFile
-      blockHeadersWithProof = buildHeadersWithProof(blockHeaders, epochAccumulator).valueOr:
+      blockHeadersWithProof = buildHeadersWithProof(blockHeaders, epochRecord).valueOr:
         raiseAssert "Could not build headers with proof"
       blockData = readJsonType(blockDataFile, BlockDataTable).valueOr:
         raiseAssert "Invalid block data file" & blockDataFile

--- a/fluffy/tests/portal_spec_tests/mainnet/test_history_content.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_history_content.nim
@@ -28,15 +28,16 @@ suite "History Content Encodings":
         "./vendor/portal-spec-tests/tests/mainnet/history/headers/1000001-1000010.e2s"
       accumulatorFile =
         "./vendor/portal-spec-tests/tests/mainnet/history/accumulator/epoch-accumulator-00122.ssz"
+        # TODO: rename
       headersWithProofFile =
         "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/1000001-1000010.json"
 
     let
       blockHeaders = readBlockHeaders(headerFile).valueOr:
         raiseAssert "Invalid header file: " & headerFile
-      epochAccumulator = readEpochAccumulatorCached(accumulatorFile).valueOr:
+      epochRecord = readEpochRecordCached(accumulatorFile).valueOr:
         raiseAssert "Invalid epoch accumulator file: " & accumulatorFile
-      blockHeadersWithProof = buildHeadersWithProof(blockHeaders, epochAccumulator).valueOr:
+      blockHeadersWithProof = buildHeadersWithProof(blockHeaders, epochRecord).valueOr:
         raiseAssert "Could not build headers with proof"
       accumulator = loadAccumulator()
 

--- a/fluffy/tests/portal_spec_tests/mainnet/test_history_content_keys.nim
+++ b/fluffy/tests/portal_spec_tests/mainnet/test_history_content_keys.nim
@@ -136,8 +136,7 @@ suite "History ContentKey Encodings":
         "9fb2175e76c6989e0fdac3ee10c40d2a81eb176af32e1c16193e3904fe56896e"
 
     let contentKey = ContentKey(
-      contentType: epochAccumulator,
-      epochAccumulatorKey: EpochAccumulatorKey(epochHash: epochHash),
+      contentType: epochRecord, epochRecordKey: EpochRecordKey(epochHash: epochHash)
     )
 
     let encoded = encode(contentKey)
@@ -148,7 +147,7 @@ suite "History ContentKey Encodings":
     let contentKeyDecoded = decoded.get()
     check:
       contentKeyDecoded.contentType == contentKey.contentType
-      contentKeyDecoded.epochAccumulatorKey == contentKey.epochAccumulatorKey
+      contentKeyDecoded.epochRecordKey == contentKey.epochRecordKey
 
       toContentId(contentKey) == parse(contentId, StUint[256], 10)
       # In stint this does BE hex string

--- a/fluffy/tests/test_accumulator.nim
+++ b/fluffy/tests/test_accumulator.nim
@@ -26,13 +26,13 @@ suite "Header Accumulator":
       # Note: This test assumes at least 5 epochs
       headersToTest = [
         0,
-        epochSize - 1,
-        epochSize,
-        epochSize * 2 - 1,
-        epochSize * 2,
-        epochSize * 3 - 1,
-        epochSize * 3,
-        epochSize * 3 + 1,
+        EPOCH_SIZE - 1,
+        EPOCH_SIZE,
+        EPOCH_SIZE * 2 - 1,
+        EPOCH_SIZE * 2,
+        EPOCH_SIZE * 3 - 1,
+        EPOCH_SIZE * 3,
+        EPOCH_SIZE * 3 + 1,
         int(amount) - 1,
       ]
 
@@ -45,12 +45,12 @@ suite "Header Accumulator":
 
     let accumulatorRes = buildAccumulatorData(headers)
     check accumulatorRes.isOk()
-    let (accumulator, epochAccumulators) = accumulatorRes.get()
+    let (accumulator, epochRecords) = accumulatorRes.get()
 
     block: # Test valid headers
       for i in headersToTest:
         let header = headers[i]
-        let proof = buildProof(header, epochAccumulators)
+        let proof = buildProof(header, epochRecords)
         check:
           proof.isOk()
           verifyAccumulatorProof(accumulator, header, proof.get()).isOk()
@@ -63,7 +63,7 @@ suite "Header Accumulator":
 
       # Test altered block headers by altering the difficulty
       for i in headersToTest:
-        let proof = buildProof(headers[i], epochAccumulators)
+        let proof = buildProof(headers[i], epochRecords)
         check:
           proof.isOk()
         # Alter the block header so the proof no longer matches
@@ -89,7 +89,7 @@ suite "Header Accumulator":
 
     check accumulatorRes.isErr()
 
-  test "Header BlockNumber to EpochAccumulator Root":
+  test "Header BlockNumber to EpochRecord Root":
     # Note: This test assumes at least 3 epochs
     const amount = mergeBlockNumber
 
@@ -108,7 +108,7 @@ suite "Header Accumulator":
 
     # Valid response for block numbers in epoch 0
     block:
-      for i in 0 ..< epochSize:
+      for i in 0 ..< EPOCH_SIZE:
         let res = accumulator.getBlockEpochDataForBlockNumber(u256(i))
         check:
           res.isOk()
@@ -116,7 +116,7 @@ suite "Header Accumulator":
 
     # Valid response for block numbers in epoch 1
     block:
-      for i in epochSize ..< (2 * epochSize):
+      for i in EPOCH_SIZE ..< (2 * EPOCH_SIZE):
         let res = accumulator.getBlockEpochDataForBlockNumber(u256(i))
         check:
           res.isOk()
@@ -124,7 +124,7 @@ suite "Header Accumulator":
 
     # Valid response for block numbers in the incomplete (= last) epoch
     block:
-      const startIndex = mergeBlockNumber - (mergeBlockNumber mod epochSize)
+      const startIndex = mergeBlockNumber - (mergeBlockNumber mod EPOCH_SIZE)
       for i in startIndex ..< mergeBlockNumber:
         let res = accumulator.getBlockEpochDataForBlockNumber(u256(i))
         check:

--- a/fluffy/tests/test_history_network.nim
+++ b/fluffy/tests/test_history_network.nim
@@ -85,13 +85,13 @@ procSuite "History Content Network":
 
       headersToTest = [
         0,
-        epochSize - 1,
-        epochSize,
-        epochSize * 2 - 1,
-        epochSize * 2,
-        epochSize * 3 - 1,
-        epochSize * 3,
-        epochSize * 3 + 1,
+        EPOCH_SIZE - 1,
+        EPOCH_SIZE,
+        EPOCH_SIZE * 2 - 1,
+        EPOCH_SIZE * 2,
+        EPOCH_SIZE * 3 - 1,
+        EPOCH_SIZE * 3,
+        EPOCH_SIZE * 3 + 1,
         int(lastBlockNumber),
       ]
 
@@ -100,7 +100,7 @@ procSuite "History Content Network":
     check accumulatorRes.isOk()
 
     let
-      (masterAccumulator, epochAccumulators) = accumulatorRes.get()
+      (masterAccumulator, epochRecords) = accumulatorRes.get()
       historyNode1 = newHistoryNode(rng, 20302, masterAccumulator)
       historyNode2 = newHistoryNode(rng, 20303, masterAccumulator)
 
@@ -108,7 +108,7 @@ procSuite "History Content Network":
     for i in headersToTest:
       selectedHeaders.add(headers[i])
 
-    let headersWithProof = buildHeadersWithProof(selectedHeaders, epochAccumulators)
+    let headersWithProof = buildHeadersWithProof(selectedHeaders, epochRecords)
 
     check headersWithProof.isOk()
 
@@ -127,17 +127,17 @@ procSuite "History Content Network":
 
     # Need to store the epoch accumulators to be able to do the block to hash
     # mapping
-    for epochAccumulator in epochAccumulators:
+    for epochRecord in epochRecords:
       let
-        rootHash = epochAccumulator.hash_tree_root()
+        rootHash = epochRecord.hash_tree_root()
         contentKey = ContentKey(
-          contentType: ContentType.epochAccumulator,
-          epochAccumulatorKey: EpochAccumulatorKey(epochHash: rootHash),
+          contentType: ContentType.epochRecord,
+          epochRecordKey: EpochRecordKey(epochHash: rootHash),
         )
         encKey = encode(contentKey)
         contentId = toContentId(contentKey)
       historyNode2.portalProtocol().storeContent(
-        encKey, contentId, SSZ.encode(epochAccumulator)
+        encKey, contentId, SSZ.encode(epochRecord)
       )
 
     check:
@@ -172,7 +172,7 @@ procSuite "History Content Network":
     check accumulatorRes.isOk()
 
     let
-      (masterAccumulator, epochAccumulators) = accumulatorRes.get()
+      (masterAccumulator, epochRecords) = accumulatorRes.get()
       historyNode1 = newHistoryNode(rng, 20302, masterAccumulator)
       historyNode2 = newHistoryNode(rng, 20303, masterAccumulator)
 
@@ -191,7 +191,7 @@ procSuite "History Content Network":
       getMaxOfferedContentKeys(uint32(len(PortalProtocolId)), maxContentKeySize)
 
     let headersWithProof =
-      buildHeadersWithProof(headers[0 .. maxOfferedHistoryContent], epochAccumulators)
+      buildHeadersWithProof(headers[0 .. maxOfferedHistoryContent], epochRecords)
     check headersWithProof.isOk()
 
     # This is one header more than maxOfferedHistoryContent
@@ -251,14 +251,14 @@ procSuite "History Content Network":
     const
       lastBlockNumber = int(mergeBlockNumber - 1)
       headersToTest =
-        [0, 1, epochSize div 2, epochSize - 1, lastBlockNumber - 1, lastBlockNumber]
+        [0, 1, EPOCH_SIZE div 2, EPOCH_SIZE - 1, lastBlockNumber - 1, lastBlockNumber]
 
     let headers = createEmptyHeaders(0, lastBlockNumber)
     let accumulatorRes = buildAccumulatorData(headers)
     check accumulatorRes.isOk()
 
     let
-      (masterAccumulator, epochAccumulators) = accumulatorRes.get()
+      (masterAccumulator, epochRecords) = accumulatorRes.get()
       historyNode1 = newHistoryNode(rng, 20302, masterAccumulator)
       historyNode2 = newHistoryNode(rng, 20303, masterAccumulator)
 
@@ -277,7 +277,7 @@ procSuite "History Content Network":
     for i in headersToTest:
       selectedHeaders.add(headers[i])
 
-    let headersWithProof = buildHeadersWithProof(selectedHeaders, epochAccumulators)
+    let headersWithProof = buildHeadersWithProof(selectedHeaders, epochRecords)
     check headersWithProof.isOk()
 
     let contentKVs = headersToContentKV(headersWithProof.get())

--- a/fluffy/tests/test_history_util.nim
+++ b/fluffy/tests/test_history_util.nim
@@ -13,13 +13,13 @@ import
 export results, accumulator, history_content
 
 proc buildHeadersWithProof*(
-    blockHeaders: seq[BlockHeader], epochAccumulator: EpochAccumulatorCached
+    blockHeaders: seq[BlockHeader], epochRecord: EpochRecordCached
 ): Result[seq[(seq[byte], seq[byte])], string] =
   var blockHeadersWithProof: seq[(seq[byte], seq[byte])]
   for header in blockHeaders:
     if header.isPreMerge():
       let
-        content = ?buildHeaderWithProof(header, epochAccumulator)
+        content = ?buildHeaderWithProof(header, epochRecord)
         contentKey = ContentKey(
           contentType: blockHeader,
           blockHeaderKey: BlockKey(blockHash: header.blockHash()),

--- a/fluffy/tools/eth_data_exporter/exporter_conf.nim
+++ b/fluffy/tools/eth_data_exporter/exporter_conf.nim
@@ -32,7 +32,7 @@ type
 const
   defaultDataDirDesc* = defaultDataDir()
   defaultBlockFileName* = "eth-block-data"
-  defaultAccumulatorFileName* = "mainnet-master-accumulator.ssz"
+  defaultAccumulatorFileName* = "mainnet-historical-hashes-accumulator.ssz"
   defaultWeb3Url* = Web3Url(kind: HttpUrl, url: "http://127.0.0.1:8545")
 
 type
@@ -144,10 +144,10 @@ type
           defaultValueDesc: $defaultAccumulatorFileName,
           name: "accumulator-file-name"
         .}: string
-        writeEpochAccumulators* {.
-          desc: "Write also the SSZ encoded epoch accumulators to specific files",
+        writeEpochRecords* {.
+          desc: "Write also the SSZ encoded epoch records to specific files",
           defaultValue: false,
-          name: "write-epoch-accumulators"
+          name: "write-epoch-records"
         .}: bool
       of printAccumulatorData:
         accumulatorFileNamePrint* {.

--- a/fluffy/tools/portal_bridge/portal_bridge_history.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_history.nim
@@ -295,7 +295,7 @@ proc runLatestLoop(
 proc gossipHeadersWithProof(
     portalClient: RpcClient,
     era1File: string,
-    epochAccumulatorFile: Opt[string] = Opt.none(string),
+    epochRecordFile: Opt[string] = Opt.none(string),
     verifyEra = false,
 ): Future[Result[void, string]] {.async: (raises: []).} =
   let f = ?Era1File.open(era1File)
@@ -306,13 +306,13 @@ proc gossipHeadersWithProof(
   # Note: building the accumulator takes about 150ms vs 10ms for reading it,
   # so it is probably not really worth using the read version considering the
   # UX hassle it adds to provide the accumulator ssz files.
-  let epochAccumulator =
-    if epochAccumulatorFile.isNone:
+  let epochRecord =
+    if epochRecordFile.isNone:
       ?f.buildAccumulator()
     else:
-      ?readEpochAccumulatorCached(epochAccumulatorFile.get())
+      ?readEpochRecordCached(epochRecordFile.get())
 
-  for (contentKey, contentValue) in f.headersWithProof(epochAccumulator):
+  for (contentKey, contentValue) in f.headersWithProof(epochRecord):
     let peers =
       try:
         await portalClient.portal_historyGossip(
@@ -517,9 +517,9 @@ proc runBackfillLoopAuditMode(
     # Gossip missing content
     if not headerSuccess:
       let
-        epochAccumulator = db.getAccumulator(blockNumber).valueOr:
+        epochRecord = db.getAccumulator(blockNumber).valueOr:
           raiseAssert "Failed to get accumulator from EraDB: " & error
-        headerWithProof = buildHeaderWithProof(header, epochAccumulator).valueOr:
+        headerWithProof = buildHeaderWithProof(header, epochRecord).valueOr:
           raiseAssert "Failed to build header with proof: " & error
 
       (await portalClient.gossipBlockHeader(blockHash, headerWithProof)).isOkOr:


### PR DESCRIPTION
- EpochAccumulator got renamed to EpochRecord
- MasterAccumulator is not HistoricalHashesAccumulator
- The List size for the accumulator got a different maximum which also result in a different encoding and HTR