### PR TITLE
cache account payload

### DIFF
--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -340,10 +340,11 @@ proc deleteAccountRecord*(
   # Delete storage tree if present
   if stoID.isValid:
     ? db.delSubTreeImpl stoID
-    db.layersPutStoID(accPath, VertexID(0))
 
   db.deleteImpl(hike).isOkOr:
     return err(error[1])
+
+  db.layersPutAccPayload(accPath, nil)
 
   ok()
 
@@ -437,7 +438,7 @@ proc deleteStorageData*(
   # De-register the deleted storage tree from the account record
   let leaf = wpAcc.vtx.dup           # Dup on modify
   leaf.lData.stoID = VertexID(0)
-  db.layersPutStoID(accPath, VertexID(0))
+  db.layersPutAccPayload(accPath, leaf.lData)
   db.layersPutVtx((accHike.root, wpAcc.vid), leaf)
   db.layersResKey((accHike.root, wpAcc.vid))
   ok(true)
@@ -468,7 +469,7 @@ proc deleteStorageTree*(
   # De-register the deleted storage tree from the accounts record
   let leaf = wpAcc.vtx.dup             # Dup on modify
   leaf.lData.stoID = VertexID(0)
-  db.layersPutStoID(accPath, VertexID(0))
+  db.layersPutAccPayload(accPath, leaf.lData)
   db.layersPutVtx((accHike.root, wpAcc.vid), leaf)
   db.layersResKey((accHike.root, wpAcc.vid))
   ok()

--- a/nimbus/db/aristo/aristo_delta.nim
+++ b/nimbus/db/aristo/aristo_delta.nim
@@ -82,15 +82,11 @@ proc deltaPersistent*(
   be.putLstFn(writeBatch, lSst)
   ? be.putEndFn writeBatch                       # Finalise write batch
 
-  # Copy back updated payloads - these only change when storage is written to
-  # the first time or when storage is removed completely
-  for accPath, stoID in db.balancer.accSids:
+  # Copy back updated payloads
+  for accPath, pyl in db.balancer.accPyls:
     let accKey = accPath.to(AccountKey)
-    if stoID.isValid:
-      if not db.accSids.lruUpdate(accKey, stoID):
-        discard db.accSids.lruAppend(accKey, stoID, accLruSize)
-    else:
-      db.accSids.del(accKey)
+    if not db.accPyls.lruUpdate(accKey, pyl):
+      discard db.accPyls.lruAppend(accKey, pyl, accLruSize)
 
   # Update dudes and this descriptor
   ? updateSiblings.update().commit()

--- a/nimbus/db/aristo/aristo_desc.nim
+++ b/nimbus/db/aristo/aristo_desc.nim
@@ -84,12 +84,13 @@ type
     # Debugging data below, might go away in future
     xMap*: Table[HashKey,HashSet[RootedVertexID]] ## For pretty printing/debugging
 
-    accSids*: KeyedQueue[AccountKey, VertexID]
-      ## Account path to storage id cache, for contract accounts - storage is
-      ## frequently accessed by account path when contracts interact with it -
-      ## this cache ensures that we don't have to re-travers the storage trie
-      ## path for every such interaction - a better solution would probably be
-      ## to cache this in a type exposed to the high-level API
+    accPyls*: KeyedQueue[AccountKey, PayloadRef]
+      ## Account path to payload cache - accounts are frequently accessed by
+      ## account path when contracts interact with them - this cache ensures
+      ## that we don't have to re-traverse the storage trie for every such
+      ## interaction
+      ## TODO a better solution would probably be to cache this in a type
+      ## exposed to the high-level API
 
   AristoDbAction* = proc(db: AristoDbRef) {.gcsafe, raises: [].}
     ## Generic call back function/closure.

--- a/nimbus/db/aristo/aristo_desc/desc_structural.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_structural.nim
@@ -115,7 +115,7 @@ type
     kMap*: Table[RootedVertexID,HashKey]   ## Merkle hash key mapping
     vTop*: VertexID                        ## Last used vertex ID
 
-    accSids*: Table[Hash256, VertexID] ## Account path -> stoID
+    accPyls*: Table[Hash256, PayloadRef] ## Account path -> VertexRef
 
   LayerRef* = ref LayerObj
   LayerObj* = object


### PR DESCRIPTION
Instead of caching just the storage id, we can cache the full payload which further reduces expensive hikes