### PR TITLE
storage hike cache

### DIFF
--- a/nimbus/db/aristo/aristo_delta.nim
+++ b/nimbus/db/aristo/aristo_delta.nim
@@ -83,10 +83,15 @@ proc deltaPersistent*(
   ? be.putEndFn writeBatch                       # Finalise write batch
 
   # Copy back updated payloads
-  for accPath, pyl in db.balancer.accLeaves:
+  for accPath, vtx in db.balancer.accLeaves:
     let accKey = accPath.to(AccountKey)
-    if not db.accLeaves.lruUpdate(accKey, pyl):
-      discard db.accLeaves.lruAppend(accKey, pyl, accLruSize)
+    if not db.accLeaves.lruUpdate(accKey, vtx):
+      discard db.accLeaves.lruAppend(accKey, vtx, accLruSize)
+
+  for mixPath, vtx in db.balancer.stoLeaves:
+    let mixKey = mixPath.to(AccountKey)
+    if not db.stoLeaves.lruUpdate(mixKey, vtx):
+      discard db.stoLeaves.lruAppend(mixKey, vtx, accLruSize)
 
   # Update dudes and this descriptor
   ? updateSiblings.update().commit()

--- a/nimbus/db/aristo/aristo_desc/desc_structural.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_structural.nim
@@ -115,7 +115,8 @@ type
     kMap*: Table[RootedVertexID,HashKey]   ## Merkle hash key mapping
     vTop*: VertexID                        ## Last used vertex ID
 
-    accLeaves*: Table[Hash256, VertexRef]    ## Account path -> VertexRef
+    accLeaves*: Table[Hash256, VertexRef]  ## Account path -> VertexRef
+    stoLeaves*: Table[Hash256, VertexRef]  ## Storage path -> VertexRef
 
   LayerRef* = ref LayerObj
   LayerObj* = object

--- a/nimbus/db/aristo/aristo_merge.nim
+++ b/nimbus/db/aristo/aristo_merge.nim
@@ -137,6 +137,8 @@ proc mergeStorageData*(
         # Mark account path Merkle keys for update
         resetKeys()
 
+        db.layersPutStoLeaf(AccountKey.mixUp(accPath, stoPath), rc.value)
+
         if not stoID.isValid:
           # Make sure that there is an account that refers to that storage trie
           let leaf = vtx.dup # Dup on modify


### PR DESCRIPTION
This PR adds a storage hike cache similar to the account hike cache already present - this cache is less efficient because account storage is already partically cached in the account ledger but nonetheless helps keep hiking down.

Notably, there's an opportunity to optimise this cache and the others so that they cooperate better insteado of overlapping, which is left for a future PR.

This PR also fixes an O(N) memory usage for storage slots where the delete would keep the full storage in a work list which on mainnet can grow very large - the work list is replaced with a more conventional recursive `O(log N)` approach.