### PR TITLE
Store extension nodes together with the branch

### DIFF
--- a/nimbus/db/aristo/aristo_blobify.nim
+++ b/nimbus/db/aristo/aristo_blobify.nim
@@ -16,6 +16,8 @@ import
   stew/[arrayops, endians2],
   ./aristo_desc
 
+export aristo_desc
+
 # Allocation-free version short big-endian encoding that skips the leading
 # zeroes
 type
@@ -167,12 +169,8 @@ proc blobifyTo*(vtx: VertexRef; data: var Blob): Result[void,AristoError] =
   ## ::
   ##   Branch:
   ##     [VertexID, ...] -- list of up to 16 child vertices lookup keys
-  ##     uint64          -- lengths of each child vertex, each taking 4 bits
-  ##     0x08            -- marker(8)
-  ##
-  ##   Extension:
-  ##     VertexID       -- child vertex lookup key
-  ##     Blob           -- hex encoded partial path (at least one byte)
+  ##     Blob           -- hex encoded partial path (non-empty for extension nodes)
+  ##     uint64         -- lengths of each child vertex, each taking 4 bits
   ##     0x80 + xx      -- marker(2) + pathSegmentLen(6)
   ##
   ##   Leaf:
@@ -199,19 +197,21 @@ proc blobifyTo*(vtx: VertexRef; data: var Blob): Result[void,AristoError] =
         data &= tmp.data()
     if data.len == pos:
       return err(BlobifyBranchMissingRefs)
-    data &= lens.toBytesBE
-    data &= [0x08u8]
-  of Extension:
+
     let
-      pSegm = vtx.ePfx.toHexPrefix(isleaf = false)
+      pSegm =
+        if vtx.ePfx.len > 0:
+          vtx.ePfx.toHexPrefix(isleaf = false)
+        else:
+          @[]
       psLen = pSegm.len.byte
-    if psLen == 0 or 33 < psLen:
+    if 33 < psLen:
       return err(BlobifyExtPathOverflow)
-    if not vtx.eVid.isValid:
-      return err(BlobifyExtMissingRefs)
-    data &= vtx.eVid.blobify().data()
+
     data &= pSegm
+    data &= lens.toBytesBE
     data &= [0x80u8 or psLen]
+
   of Leaf:
     let
       pSegm = vtx.lPfx.toHexPrefix(isleaf = true)
@@ -296,12 +296,11 @@ proc deblobify*(
     return err(DeblobVtxTooShort)
 
   ok case record[^1] shr 6:
-  of 0: # `Branch` vertex
-    if record[^1] != 0x08u8:
-      return err(DeblobUnknown)
+  of 2: # `Branch` vertex
     if record.len < 11:                               # at least two edges
       return err(DeblobBranchTooShort)
     let
+      sLen = record[^1].int and 0x3f                  # length of path segment      aInx = record.len - 9
       aInx = record.len - 9
       aIny = record.len - 2
     var
@@ -316,28 +315,16 @@ proc deblobify*(
       inc n
       lens = lens shr 4
 
-      # End `while`
-    VertexRef(
-      vType: Branch,
-      bVid:  vtxList)
-
-  of 2: # `Extension` vertex
-    let
-      sLen = record[^1].int and 0x3f                  # length of path segment
-      rLen = record.len - 1                           # `vertexID` + path segm
-      pLen = rLen - sLen                              # payload length
-    if rLen < sLen or pLen < 1:
-      return err(DeblobLeafSizeGarbled)
     let (isLeaf, pathSegment) =
-      NibblesBuf.fromHexPrefix record.toOpenArray(pLen, rLen - 1)
+      NibblesBuf.fromHexPrefix record.toOpenArray(offs, aInx - 1)
     if isLeaf:
       return err(DeblobExtGotLeafPrefix)
 
-    var offs = 0
+      # End `while`
     VertexRef(
-      vType: Extension,
-      eVid:  VertexID(?load64(record, offs, pLen)),
-      ePfx:  pathSegment)
+      vType: Branch,
+      ePfx:  pathSegment,
+      bVid:  vtxList)
 
   of 3: # `Leaf` vertex
     let

--- a/nimbus/db/aristo/aristo_check/check_be.nim
+++ b/nimbus/db/aristo/aristo_check/check_be.nim
@@ -48,9 +48,9 @@ proc checkBE*[T: RdbBackendRef|MemBackendRef|VoidBackendRef](
               break check42Links
             seen = true
         return err((rvid.vid,CheckBeVtxBranchLinksMissing))
-    of Extension:
-      if vtx.ePfx.len == 0:
-        return err((rvid.vid,CheckBeVtxExtPfxMissing))
+    # of Extension:
+    #   if vtx.ePfx.len == 0:
+    #     return err((rvid.vid,CheckBeVtxExtPfxMissing))
 
   for (rvid,key) in T.walkKeyBe db:
     if topVidBe.vid < rvid.vid:

--- a/nimbus/db/aristo/aristo_check/check_top.nim
+++ b/nimbus/db/aristo/aristo_check/check_top.nim
@@ -111,9 +111,9 @@ proc checkTopCommon*(
                 break check42Links
               seen = true
           return err((rvid.vid,CheckAnyVtxBranchLinksMissing))
-      of Extension:
-        if vtx.ePfx.len == 0:
-          return err((rvid.vid,CheckAnyVtxExtPfxMissing))
+      # of Extension:
+      #   if vtx.ePfx.len == 0:
+      #     return err((rvid.vid,CheckAnyVtxExtPfxMissing))
     else:
       nNilVtx.inc
       let rc = db.layersGetKey rvid

--- a/nimbus/db/aristo/aristo_compute.nim
+++ b/nimbus/db/aristo/aristo_compute.nim
@@ -72,19 +72,24 @@ proc computeKey*(
       writer.append(rlp.encode(vtx.lData.stoData))
 
   of Branch:
-    writer.startList(17)
-    for n in 0..15:
-      let vid = vtx.bVid[n]
-      if vid.isValid:
-        writer.append(?db.computeKey((rvid.root, vid)))
-      else:
-        writer.append(VOID_HASH_KEY)
-    writer.append EmptyBlob
+    template writeBranch(w: var RlpWriter) =
+      w.startList(17)
+      for n in 0..15:
+        let vid = vtx.bVid[n]
+        if vid.isValid:
+          w.append(?db.computeKey((rvid.root, vid)))
+        else:
+          w.append(VOID_HASH_KEY)
+      w.append EmptyBlob
+    if vtx.ePfx.len > 0: # Extension node
+      var bwriter = initRlpWriter()
+      writeBranch(bwriter)
 
-  of Extension:
-    writer.startList(2)
-    writer.append(vtx.ePfx.toHexPrefix(isleaf = false))
-    writer.append(?db.computeKey((rvid.root, vtx.eVid)))
+      writer.startList(2)
+      writer.append(vtx.ePfx.toHexPrefix(isleaf = false))
+      writer.append(bwriter.finish().digestTo(HashKey))
+    else:
+      writeBranch(writer)
 
   let h = writer.finish().digestTo(HashKey)
   # TODO This shouldn't necessarily go into the database if we're just computing

--- a/nimbus/db/aristo/aristo_debug.nim
+++ b/nimbus/db/aristo/aristo_debug.nim
@@ -206,9 +206,10 @@ proc ppVtx(nd: VertexRef, db: AristoDbRef, rvid: RootedVertexID): string =
     case nd.vType:
     of Leaf:
       result &= nd.lPfx.ppPathPfx & "," & nd.lData.ppPayload(db)
-    of Extension:
-      result &= nd.ePfx.ppPathPfx & "," & nd.eVid.ppVid
+    # of Extension:
+    #   result &= nd.ePfx.ppPathPfx & "," & nd.eVid.ppVid
     of Branch:
+      result &= nd.ePfx.ppPathPfx & ":"
       for n in 0..15:
         if nd.bVid[n].isValid:
           result &= nd.bVid[n].ppVid

--- a/nimbus/db/aristo/aristo_desc.nim
+++ b/nimbus/db/aristo/aristo_desc.nim
@@ -23,7 +23,7 @@
 
 import
   std/[hashes, sets, tables],
-  stew/[assign2, keyed_queue],
+  stew/keyed_queue,
   eth/common,
   results,
   ./aristo_constants,

--- a/nimbus/db/aristo/aristo_merge/merge_payload_helper.nim
+++ b/nimbus/db/aristo/aristo_merge/merge_payload_helper.nim
@@ -18,12 +18,8 @@ import eth/common, results, ".."/[aristo_desc, aristo_get, aristo_layers, aristo
 
 proc xPfx(vtx: VertexRef): NibblesBuf =
   case vtx.vType
-  of Leaf:
-    vtx.lPfx
-  of Extension:
-    vtx.ePfx
-  of Branch:
-    raiseAssert "oops"
+  of Leaf: vtx.lPfx
+  of Branch: vtx.ePfx
 
 # -----------
 
@@ -33,112 +29,6 @@ proc layersPutLeaf(
   let vtx = VertexRef(vType: Leaf, lPfx: path, lData: payload)
   db.layersPutVtx(rvid, vtx)
   vtx
-
-proc insertBranch(
-    db: AristoDbRef, # Database, top layer
-    linkID: RootedVertexID, # Vertex ID to insert
-    linkVtx: VertexRef, # Vertex to insert
-    path: NibblesBuf,
-    payload: LeafPayload, # Leaf data payload
-): Result[VertexRef, AristoError] =
-  ##
-  ## Insert `Extension->Branch` vertex chain or just a `Branch` vertex
-  ##
-  ##   ... --(linkID)--> <linkVtx>
-  ##
-  ##   <-- immutable --> <---- mutable ----> ..
-  ##
-  ## will become either
-  ##
-  ##   --(linkID)-->
-  ##        <extVtx>             --(local1)-->
-  ##          <forkVtx>[linkInx] --(local2)--> <linkVtx*>
-  ##                   [leafInx] --(local3)--> <leafVtx>
-  ##
-  ## or in case that there is no common prefix
-  ##
-  ##   --(linkID)-->
-  ##          <forkVtx>[linkInx] --(local2)--> <linkVtx*>
-  ##                   [leafInx] --(local3)--> <leafVtx>
-  ##
-  ## *) vertex was slightly modified or removed if obsolete `Extension`
-  ##
-  if linkVtx.xPfx.len == 0:
-    return err(MergeBranchLinkVtxPfxTooShort)
-
-  let n = linkVtx.xPfx.sharedPrefixLen path
-  # Verify minimum requirements
-  doAssert n < path.len
-
-  # Provide and install `forkVtx`
-  let
-    forkVtx = VertexRef(vType: Branch)
-    linkInx = linkVtx.xPfx[n]
-    leafInx = path[n]
-
-  # Install `forkVtx`
-  block:
-    if linkVtx.vType == Leaf:
-      let
-        local = db.vidFetch(pristine = true)
-        linkDup = linkVtx.dup
-
-      linkDup.lPfx = linkVtx.lPfx.slice(1 + n)
-      forkVtx.bVid[linkInx] = local
-      db.layersPutVtx((linkID.root, local), linkDup)
-    elif linkVtx.ePfx.len == n + 1:
-      # This extension `linkVtx` becomes obsolete
-      forkVtx.bVid[linkInx] = linkVtx.eVid
-    else:
-      let
-        local = db.vidFetch
-        linkDup = linkVtx.dup
-
-      linkDup.ePfx = linkDup.ePfx.slice(1 + n)
-      forkVtx.bVid[linkInx] = local
-      db.layersPutVtx((linkID.root, local), linkDup)
-
-  let leafVtx = block:
-    let local = db.vidFetch(pristine = true)
-    forkVtx.bVid[leafInx] = local
-    db.layersPutLeaf((linkID.root, local), path.slice(1 + n), payload)
-
-  # Update in-beween glue linking `branch --[..]--> forkVtx`
-  if 0 < n:
-    let
-      vid = db.vidFetch()
-      extVtx = VertexRef(vType: Extension, ePfx: path.slice(0, n), eVid: vid)
-    db.layersPutVtx(linkID, extVtx)
-    db.layersPutVtx((linkID.root, vid), forkVtx)
-  else:
-    db.layersPutVtx(linkID, forkVtx)
-
-  ok(leafVtx)
-
-proc concatBranchAndLeaf(
-    db: AristoDbRef, # Database, top layer
-    brVid: RootedVertexID, # Branch vertex ID from from `Hike` top
-    brVtx: VertexRef, # Branch vertex, linked to from `Hike`
-    path: NibblesBuf,
-    payload: LeafPayload, # Leaf data payload
-): Result[VertexRef, AristoError] =
-  ## Append argument branch vertex passed as argument `(brID,brVtx)` and then
-  ## a `Leaf` vertex derived from the argument `payload`.
-  ##
-  if path.len == 0:
-    return err(MergeBranchGarbledTail)
-
-  let nibble = path[0].int8
-  doAssert not brVtx.bVid[nibble].isValid
-
-  let
-    brDup = brVtx.dup
-    vid = db.vidFetch(pristine = true)
-
-  brDup.bVid[nibble] = vid
-
-  db.layersPutVtx(brVid, brDup)
-  ok db.layersPutLeaf((brVid.root, vid), path.slice(1), payload)
 
 # ------------------------------------------------------------------------------
 # Public functions
@@ -178,55 +68,92 @@ proc mergePayloadImpl*(
     touched[pos] = cur
     pos += 1
 
+    let n = path.sharedPrefixLen(vtx.xPfx)
     case vtx.vType
     of Leaf:
       let leafVtx =
-        if path == vtx.lPfx:
-          # Replace the current vertex with a new payload
+        if n == vtx.lPfx.len:
+          # Same path - replace the current vertex with a new payload
 
           if vtx.lData == payload:
             # TODO is this still needed? Higher levels should already be doing
             #      these checks
             return err(MergeLeafPathCachedAlready)
 
-          var payload = payload
           if root == VertexID(1):
+            var payload = payload.dup()
             # TODO can we avoid this hack? it feels like the caller should already
             #      have set an appropriate stoID - this "fixup" feels risky,
             #      specially from a caching point of view
             payload.stoID = vtx.lData.stoID
-
-          db.layersPutLeaf((root, cur), path, payload)
-
+            db.layersPutLeaf((root, cur), path, payload)
+          else:
+            db.layersPutLeaf((root, cur), path, payload)
         else:
-          # Turn leaf into branch, leaves with possible ext prefix
-          ? db.insertBranch((root, cur), vtx, path, payload)
+          # Turn leaf into a branch (or extension) then insert the two leaves
+          # into the branch
+          let branch = VertexRef(vType: Branch, ePfx: path.slice(0, n))
+          block: # Copy of existing leaf node, now one level deeper
+            let local = db.vidFetch()
+            branch.bVid[vtx.lPfx[n]] = local
+            discard db.layersPutLeaf((root, local), vtx.lPfx.slice(n + 1), vtx.lData)
+
+          let leafVtx = block: # Newly inserted leaf node
+            let local = db.vidFetch()
+            branch.bVid[path[n]] = local
+            db.layersPutLeaf((root, local), path.slice(n + 1), payload)
+
+          # Put the branch at the vid where the leaf was
+          db.layersPutVtx((root, cur), branch)
+
+          leafVtx
 
       resetKeys()
       return ok(leafVtx)
-
-    of Extension:
-      if vtx.ePfx.len == path.sharedPrefixLen(vtx.ePfx):
-        cur = vtx.eVid
-        path = path.slice(vtx.ePfx.len)
-        vtx = ?db.getVtxRc((root, cur))
-      else:
-        let leafVtx = ? db.insertBranch((root, cur), vtx, path, payload)
-
-        resetKeys()
-        return ok(leafVtx)
     of Branch:
-      let
-        nibble = path[0]
-        next = vtx.bVid[nibble]
+      if vtx.ePfx.len == n:
+        # The existing branch is a prefix of the new entry
+        let
+          nibble = path[vtx.ePfx.len]
+          next = vtx.bVid[nibble]
 
-      if next.isValid:
-        cur = next
-        path = path.slice(1)
-        vtx = ?db.getVtxRc((root, next))
+        if next.isValid:
+          cur = next
+          path = path.slice(n + 1)
+          vtx = ?db.getVtxRc((root, next))
+        else:
+          # There's no vertex at the branch point - insert the payload as a new
+          # leaf and update the existing branch
+          let
+            local = db.vidFetch()
+            leafVtx = db.layersPutLeaf((root, local), path.slice(n + 1), payload)
+            brDup = vtx.dup()
+
+          brDup.bVid[nibble] = local
+          db.layersPutVtx((root, cur), brDup)
+
+          resetKeys()
+          return ok(leafVtx)
       else:
-        let leafVtx = ? db.concatBranchAndLeaf((root, cur), vtx, path, payload)
-        resetKeys()
+        # Partial path match - we need to split the existing branch at
+        # the point of divergence, inserting a new branch
+        let branch = VertexRef(vType: Branch, ePfx: path.slice(0, n))
+        block: # Copy the existing vertex and add it to the new branch
+          let local = db.vidFetch()
+          branch.bVid[vtx.ePfx[n]] = local
+
+          db.layersPutVtx(
+            (root, local),
+            VertexRef(vType: Branch, ePfx: vtx.ePfx.slice(n + 1), bVid: vtx.bVid),
+          )
+
+        let leafVtx = block: # add the new entry
+          let local = db.vidFetch()
+          branch.bVid[path[n]] = local
+          db.layersPutLeaf((root, local), path.slice(n + 1), payload)
+
+        db.layersPutVtx((root, cur), branch)
+
         return ok(leafVtx)
 
   err(MergeHikeFailed)

--- a/nimbus/db/aristo/aristo_nearby.nim
+++ b/nimbus/db/aristo/aristo_nearby.nim
@@ -106,14 +106,14 @@ proc complete(
       uHike.legs.add leg
       return ok(uHike) # done
 
-    of Extension:
-      vid = vtx.eVid
-      if vid.isValid:
-        vtx = db.getVtx (hike.root, vid)
-        if vtx.isValid:
-          uHike.legs.add leg
-          continue
-      return err((vid,NearbyExtensionError)) # Oops, no way
+    # of Extension:
+    #   vid = vtx.eVid
+    #   if vid.isValid:
+    #     vtx = db.getVtx (hike.root, vid)
+    #     if vtx.isValid:
+    #       uHike.legs.add leg
+    #       continue
+    #   return err((vid,NearbyExtensionError)) # Oops, no way
 
     of Branch:
       when doLeast:
@@ -181,15 +181,15 @@ proc zeroAdjust(
           return err((hike.root,NearbyBeyondRange))
         pfx = NibblesBuf.nibble(n.byte)
 
-      of Extension:
-        let ePfx = root.ePfx
-        # Must be followed by a branch vertex
-        if not hike.accept ePfx:
-          break fail
-        let vtx = db.getVtx (hike.root, root.eVid)
-        if not vtx.isValid:
-          break fail
-        pfx =  ePfx
+      # of Extension:
+      #   let ePfx = root.ePfx
+      #   # Must be followed by a branch vertex
+      #   if not hike.accept ePfx:
+      #     break fail
+      #   let vtx = db.getVtx (hike.root, root.eVid)
+      #   if not vtx.isValid:
+      #     break fail
+      #   pfx =  ePfx
 
       of Leaf:
         pfx = root.lPfx
@@ -243,10 +243,8 @@ proc finalise(
       case vtx.vType:
       of Leaf:
         pfx = vtx.lPfx
-      of Extension:
-        pfx = vtx.ePfx
       of Branch:
-        pfx = NibblesBuf.nibble(vtx.branchBorderNibble.byte)
+        pfx = vtx.ePfx & NibblesBuf.nibble(vtx.branchBorderNibble.byte)
       if hike.beyond pfx:
         return err((vid,NearbyBeyondRange))
 
@@ -289,9 +287,9 @@ proc nearbyNext(
   # Some easy cases
   let hike = ? hike.zeroAdjust(db, doLeast=moveRight)
 
-  if hike.legs[^1].wp.vtx.vType == Extension:
-    let vid = hike.legs[^1].wp.vtx.eVid
-    return hike.complete(vid, db, hikeLenMax, doLeast=moveRight)
+  # if hike.legs[^1].wp.vtx.vType == Extension:
+  #   let vid = hike.legs[^1].wp.vtx.eVid
+  #   return hike.complete(vid, db, hikeLenMax, doLeast=moveRight)
 
   var
     uHike = hike
@@ -304,10 +302,10 @@ proc nearbyNext(
     of Branch:
       if top.nibble < 0 or uHike.tail.len == 0:
         return err((top.wp.vid,NearbyUnexpectedVtx))
-    of Extension:
-      uHike.tail = top.wp.vtx.ePfx & uHike.tail
-      uHike.legs.setLen(uHike.legs.len - 1)
-      continue
+    # of Extension:
+    #   uHike.tail = top.wp.vtx.ePfx & uHike.tail
+    #   uHike.legs.setLen(uHike.legs.len - 1)
+    #   continue
 
     var
       step = top
@@ -329,9 +327,9 @@ proc nearbyNext(
       of Leaf:
         if uHike.accept vtx.lPfx:
           return uHike.complete(vid, db, hikeLenMax, doLeast=moveRight)
-      of Extension:
-        if uHike.accept vtx.ePfx:
-          return uHike.complete(vid, db, hikeLenMax, doLeast=moveRight)
+      # of Extension:
+      #   if uHike.accept vtx.ePfx:
+      #     return uHike.complete(vid, db, hikeLenMax, doLeast=moveRight)
       of Branch:
         let nibble = uHike.tail[0].int8
         if start and accept nibble:
@@ -590,8 +588,8 @@ proc rightMissing*(
   case vtx.vType
   of Leaf:
     return ok(vtx.lPfx < hike.tail)
-  of Extension:
-    return ok(vtx.ePfx < hike.tail)
+  # of Extension:
+  #   return ok(vtx.ePfx < hike.tail)
   of Branch:
     return ok(vtx.branchNibbleMin(hike.tail[0].int8) < 0)
 

--- a/nimbus/db/aristo/aristo_serialise.nim
+++ b/nimbus/db/aristo/aristo_serialise.nim
@@ -109,12 +109,13 @@ proc read*(rlp: var Rlp; T: type NodeRef): T {.gcsafe, raises: [RlpError].} =
           pType:   RawData,
           rawBlob: blobs[1]))
     else:
-      var node = NodeRef(
-        vType: Extension,
-        ePfx:  pathSegment)
-      node.key[0] = HashKey.fromBytes(blobs[1]).valueOr:
-        return aristoError(RlpExtHashKeyExpected)
-      return node
+      raiseAssert "TODO"
+      # var node = NodeRef(
+      #   vType: Extension,
+      #   ePfx:  pathSegment)
+      # node.key[0] = HashKey.fromBytes(blobs[1]).valueOr:
+      #   return aristoError(RlpExtHashKeyExpected)
+      # return node
   of 17:
     for n in [0,1]:
       links[n] = HashKey.fromBytes(blobs[n]).valueOr:
@@ -147,10 +148,10 @@ proc append*(writer: var RlpWriter; node: NodeRef) =
         writer.append node.key[n]
       writer.append EmptyBlob
 
-    of Extension:
-      writer.startList(2)
-      writer.append node.ePfx.toHexPrefix(isleaf = false)
-      writer.append node.key[0]
+    # of Extension:
+    #   writer.startList(2)
+    #   writer.append node.ePfx.toHexPrefix(isleaf = false)
+    #   writer.append node.key[0]
 
     of Leaf:
       proc getKey0(vid: VertexID): Result[HashKey,AristoError] {.noRaise.} =

--- a/nimbus/db/aristo/aristo_sign.nim
+++ b/nimbus/db/aristo/aristo_sign.nim
@@ -16,7 +16,7 @@
 import
   eth/common,
   results,
-  "."/[aristo_compute, aristo_constants, aristo_desc, aristo_init, aristo_merge]
+  "."/[aristo_compute, aristo_constants, aristo_desc, aristo_init, aristo_delete, aristo_merge]
 
 # ------------------------------------------------------------------------------
 # Public functions, signature generator
@@ -41,6 +41,20 @@ proc merkleSignAdd*(
   if sdb.error == AristoError(0):
     sdb.count.inc
     discard sdb.db.mergeGenericData(sdb.root, key, val).valueOr:
+      sdb.`error` = error
+      sdb.errKey = @key
+      return
+
+
+proc merkleSignDelete*(
+    sdb: MerkleSignRef;
+    key: openArray[byte];
+    ) =
+  ## Add key-value item to the signature list. The order of the items to add
+  ## is irrelevant.
+  if sdb.error == AristoError(0):
+    sdb.count.inc
+    discard sdb.db.deleteGenericData(sdb.root, key).valueOr:
       sdb.`error` = error
       sdb.errKey = @key
       return

--- a/nimbus/db/aristo/aristo_utils.nim
+++ b/nimbus/db/aristo/aristo_utils.nim
@@ -84,15 +84,15 @@ proc toNode*(
       return err(missing)
     return ok node
 
-  of Extension:
-    let
-      vid = vtx.eVid
-      key = db.getKey((root, vid), beOk=beKeyOk)
-    if not key.isValid:
-      return err(@[vid])
-    let node = NodeRef(vType: Extension, ePfx: vtx.ePfx, eVid: vid)
-    node.key[0] = key
-    return ok node
+  # of Extension:
+  #   let
+  #     vid = vtx.eVid
+  #     key = db.getKey((root, vid), beOk=beKeyOk)
+  #   if not key.isValid:
+  #     return err(@[vid])
+  #   let node = NodeRef(vType: Extension, ePfx: vtx.ePfx, eVid: vid)
+  #   node.key[0] = key
+  #   return ok node
 
 
 iterator subVids*(vtx: VertexRef): VertexID =
@@ -107,8 +107,6 @@ iterator subVids*(vtx: VertexRef): VertexID =
     for vid in vtx.bVid:
       if vid.isValid:
         yield vid
-  of Extension:
-    yield vtx.eVid
 
 # ---------------------
 

--- a/nimbus/db/aristo/aristo_vid.nim
+++ b/nimbus/db/aristo/aristo_vid.nim
@@ -21,7 +21,7 @@ import
 # Public functions
 # ------------------------------------------------------------------------------
 
-proc vidFetch*(db: AristoDbRef; pristine = false): VertexID =
+proc vidFetch*(db: AristoDbRef): VertexID =
   ## Fetch next vertex ID.
   ##
   if db.top.delta.vTop  == 0:

--- a/tests/test_aristo.nim
+++ b/tests/test_aristo.nim
@@ -18,7 +18,7 @@ import
   unittest2,
   ../nimbus/db/aristo/aristo_desc,
   ./replay/[pp, undump_accounts, undump_storages],
-  ./test_aristo/[test_samples_xx, test_filter, test_helpers, test_misc, test_tx]
+  ./test_aristo/[test_samples_xx, test_filter, test_helpers, test_misc, test_tx, test_blobify]
 
 const
   baseDir = [".", "..", ".."/"..", $DirSep]

--- a/tests/test_aristo/test_blobify.nim
+++ b/tests/test_aristo/test_blobify.nim
@@ -1,0 +1,72 @@
+# Nimbus
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+{.used.}
+
+import unittest2, ../../nimbus/db/aristo/aristo_blobify
+
+suite "Aristo blobify":
+  test "VertexRef roundtrip":
+    let
+      leafRawData = VertexRef(vType: Leaf, lData: LeafPayload(pType: RawData))
+      leafAccount = VertexRef(vType: Leaf, lData: LeafPayload(pType: AccountData))
+      leafStoData =
+        VertexRef(vType: Leaf, lData: LeafPayload(pType: StoData, stoData: 42.u256))
+      branch = VertexRef(
+        vType: Branch,
+        bVid: [
+          VertexID(0),
+          VertexID(1),
+          VertexID(0),
+          VertexID(0),
+          VertexID(4),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+        ],
+      )
+
+      extension = VertexRef(
+        vType: Branch,
+        ePfx: NibblesBuf.nibble(2),
+        bVid: [
+          VertexID(0),
+          VertexID(0),
+          VertexID(2),
+          VertexID(0),
+          VertexID(0),
+          VertexID(5),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+          VertexID(0),
+        ],
+      )
+
+    check:
+      deblobify(blobify(leafRawData)[], VertexRef)[] == leafRawData
+      deblobify(blobify(leafAccount)[], VertexRef)[] == leafAccount
+      deblobify(blobify(leafStoData)[], VertexRef)[] == leafStoData
+      deblobify(blobify(branch)[], VertexRef)[] == branch
+      deblobify(blobify(extension)[], VertexRef)[] == extension

--- a/tests/test_genesis.nim
+++ b/tests/test_genesis.nim
@@ -12,7 +12,9 @@ import
   std/[os],
   unittest2,
   ../nimbus/config,
-  ../nimbus/common/common
+  ../nimbus/common/common,
+  ../nimbus/db/aristo/aristo_debug
+
 
 const
   baseDir = [".", "tests", ".."/"tests", $DirSep]  # path containg repo
@@ -28,6 +30,7 @@ proc findFilePath(file: string): string =
 
 proc makeGenesis(networkId: NetworkId): BlockHeader =
   let com = CommonRef.new(newCoreDbRef DefaultDbMemory, params = networkParams(networkId))
+  debugEcho pp(com.db.defCtx.mpt)
   com.genesisHeader
 
 proc genesisTest() =


### PR DESCRIPTION
Extension nodes must be followed by a branch - as such, it makes sense to store the two together both in the database and in memory:

* fewer reads, writes and updates to traverse the tree
* simpler logic for maintaining the node structure
* less space used, both memory and storage, because there are fewer nodes overall

There is also a downside: hashes can no longer be cached for an extension - instead, only the extension+branch hash can be cached - this seems like a fine tradeoff since computing it should be fast.

TODO: fix commented code