### PR TITLE
avoid re-reading balancer data

### DIFF
--- a/nimbus/db/kvt/kvt_delta.nim
+++ b/nimbus/db/kvt/kvt_delta.nim
@@ -77,9 +77,8 @@ proc deltaUpdate*(
   ? be.putEndFn writeBatch
 
   # Update peer filter balance.
-  let rev = db.deltaReverse db.balancer
   for w in db.forked:
-    db.merge(rev, w.balancer)
+    db.merge(db.balancer, w.balancer)
 
   db.balancer = LayerDeltaRef(nil)
   ok()


### PR DESCRIPTION
The balancer was written to the backend just a few lines above - the database read seems unnecessary