### PR TITLE
Store cached hash at the layer corresponding to the source data

### DIFF
--- a/nimbus/db/aristo/aristo_check/check_be.nim
+++ b/nimbus/db/aristo/aristo_check/check_be.nim
@@ -81,7 +81,7 @@ proc checkBE*[T: RdbBackendRef|MemBackendRef|VoidBackendRef](
     for (rvid,vtx) in db.layersWalkVtx:
       if vtx.isValid and topVidCache.vid < rvid.vid:
         topVidCache = rvid
-      let key = db.layersGetKey(rvid).valueOr: VOID_HASH_KEY
+      let (key, _) = db.layersGetKey(rvid).valueOr: (VOID_HASH_KEY, 0)
       if not vtx.isValid:
         # Some vertex is to be deleted, the key must be empty
         if key.isValid:

--- a/nimbus/db/aristo/aristo_check/check_top.nim
+++ b/nimbus/db/aristo/aristo_check/check_top.nim
@@ -110,7 +110,7 @@ proc checkTopCommon*(
       let rc = db.layersGetKey rvid
       if rc.isErr:
         return err((rvid.vid,CheckAnyVtxEmptyKeyMissing))
-      if rc.value.isValid:
+      if rc.value[0].isValid:
         return err((rvid.vid,CheckAnyVtxEmptyKeyExpected))
 
   if vTop.distinctBase < LEAST_FREE_VID:

--- a/nimbus/db/aristo/aristo_compute.nim
+++ b/nimbus/db/aristo/aristo_compute.nim
@@ -13,34 +13,49 @@
 import
   eth/common,
   results,
-  "."/[aristo_desc, aristo_get, aristo_layers, aristo_serialise]
+  "."/[aristo_desc, aristo_get, aristo_serialise]
 
-proc computeKey*(
+proc putKeyAtLevel(
+    db: AristoDbRef, rvid: RootedVertexID, key: HashKey, level: int
+): Result[void, AristoError] =
+  ## Store a hash key in the same layer where the corresponding vertex exists -
+  ## if `rvid` is not found in the layers it will be written directly to the
+  ## database backend assuming the value the key corresponds to was taken from
+  ## there
+  if level == -2:
+    let be = db.backend
+    doAssert be != nil, "source data is from the backend"
+    # TODO long-running batch here?
+    let writeBatch = ?be.putBegFn()
+    be.putKeyFn(writeBatch, rvid, key)
+    ?be.putEndFn writeBatch
+    ok()
+  else:
+    db.deltaAtLevel(level).kMap[rvid] = key
+    ok()
+
+func maxLevel(cur, other: int): int =
+  # Compare two levels and return the topmost in the stack, taking into account
+  # the odd reversal of order around the zero point
+  if cur < 0:
+    max(cur, other) # >= 0 is always more topmost than <0
+  elif other < 0:
+    cur
+  else:
+    min(cur, other) # Here the order is reversed and 0 is the top layer
+
+proc computeKeyImpl(
     db: AristoDbRef;                  # Database, top layer
     rvid: RootedVertexID;             # Vertex to convert
-      ): Result[HashKey, AristoError] =
-  # This is a variation on getKeyRc which computes the key instead of returning
-  # an error
-  # TODO it should not always write the key to the persistent storage
+      ): Result[(HashKey, int), AristoError] =
+  db.getKeyRc(rvid).isErrOr:
+    # Value cached either in layers or database
+    return ok value
 
-  proc getKey(db: AristoDbRef; rvid: RootedVertexID): HashKey =
-    block body:
-      let key = db.layersGetKey(rvid).valueOr:
-        break body
-      if key.isValid:
-        return key
-      else:
-        return VOID_HASH_KEY
-    let rc = db.getKeyBE rvid
-    if rc.isOk:
-      return rc.value
-    VOID_HASH_KEY
+  let (vtx, vl) = ? db.getVtxRc rvid
 
-  let key = getKey(db, rvid)
-  if key.isValid():
-    return ok key
-
-  let vtx = ? db.getVtxRc rvid
+  # Top-most level of all the verticies this hash compution depends on
+  var level = vl
 
   # TODO this is the same code as when serializing NodeRef, without the NodeRef
   var writer = initRlpWriter()
@@ -54,15 +69,16 @@ proc computeKey*(
     of AccountData:
       let
         stoID = vtx.lData.stoID
-        key = if stoID.isValid:
-          ?db.computeKey((stoID, stoID))
+        (akey, kl) = if stoID.isValid:
+          ?db.computeKeyImpl((stoID, stoID))
         else:
-          VOID_HASH_KEY
+          (VOID_HASH_KEY, -2)
+      level = maxLevel(level, kl)
 
       writer.append(encode Account(
         nonce:       vtx.lData.account.nonce,
         balance:     vtx.lData.account.balance,
-        storageRoot: key.to(Hash256),
+        storageRoot: akey.to(Hash256),
         codeHash:    vtx.lData.account.codeHash)
       )
     of RawData:
@@ -77,7 +93,9 @@ proc computeKey*(
       for n in 0..15:
         let vid = vtx.bVid[n]
         if vid.isValid:
-          w.append(?db.computeKey((rvid.root, vid)))
+          let (bkey, bl) = ?db.computeKeyImpl((rvid.root, vid))
+          level = maxLevel(level, bl)
+          w.append(bkey)
         else:
           w.append(VOID_HASH_KEY)
       w.append EmptyBlob
@@ -92,13 +110,22 @@ proc computeKey*(
       writeBranch(writer)
 
   let h = writer.finish().digestTo(HashKey, rvid.root == rvid.vid)
-  # TODO This shouldn't necessarily go into the database if we're just computing
-  #      a key ephemerally - it should however be cached for some tiem since
-  #      deep hash computations are expensive
-  db.layersPutKey(rvid, h)
-  ok h
 
+  # Cache the hash to the same storage layer as the the top-most value that it
+  # depends on (recursively) - this could be an ephemeral in-memory layer or the
+  # underlying database backend - typically, values closer to the root are more
+  # likely to live in an in-memory layer since any leaf change will lead to the
+  # root key also changing while leaves that have never been hashed will see
+  # their hash being saved directly to the backend.
+  ? db.putKeyAtLevel(rvid, h, level)
 
+  ok (h, level)
+
+proc computeKey*(
+    db: AristoDbRef;                  # Database, top layer
+    rvid: RootedVertexID;             # Vertex to convert
+      ): Result[HashKey, AristoError] =
+  ok (?computeKeyImpl(db, rvid))[0]
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -61,7 +61,7 @@ proc delSubTreeImpl(
   ## Implementation of *delete* sub-trie.
   var
     dispose = @[root]
-    rootVtx = db.getVtxRc((root, root)).valueOr:
+    (rootVtx, _) = db.getVtxRc((root, root)).valueOr:
       if error == GetVtxNotFound:
         return ok()
       return err(error)
@@ -73,7 +73,7 @@ proc delSubTreeImpl(
     for vtx in follow:
       for vid in vtx.subVids:
         # Exiting here leaves the tree as-is
-        let vtx = ? db.getVtxRc((root, vid))
+        let vtx = (? db.getVtxRc((root, vid)))[0]
         redo.add vtx
         dispose.add vid
     redo.swap follow
@@ -92,7 +92,7 @@ proc delStoTreeImpl(
       ): Result[void,AristoError] =
   ## Implementation of *delete* sub-trie.
 
-  let vtx = db.getVtxRc(rvid).valueOr:
+  let (vtx, _) = db.getVtxRc(rvid).valueOr:
     if error == GetVtxNotFound:
       return ok()
     return err(error)

--- a/nimbus/db/aristo/aristo_desc.nim
+++ b/nimbus/db/aristo/aristo_desc.nim
@@ -313,6 +313,21 @@ iterator rstack*(db: AristoDbRef): LayerRef =
   for i in 0..<db.stack.len:
     yield db.stack[db.stack.len - i - 1]
 
+proc deltaAtLevel*(db: AristoDbRef, level: int): LayerDeltaRef =
+  if level == 0:
+    db.top.delta
+  elif level > 0:
+    doAssert level <= db.stack.len
+    db.stack[^level].delta
+  elif level == -1:
+    doAssert db.balancer != nil
+    db.balancer
+  elif level == -2:
+    nil
+  else:
+    raiseAssert "Unknown level " & $level
+
+
 # ------------------------------------------------------------------------------
 # End
 # ------------------------------------------------------------------------------

--- a/nimbus/db/aristo/aristo_desc.nim
+++ b/nimbus/db/aristo/aristo_desc.nim
@@ -34,8 +34,8 @@ from ./aristo_desc/desc_backend
 
 # Not auto-exporting backend
 export
-  aristo_constants, desc_error, desc_identifiers, desc_nibbles, desc_structural,
-  keyed_queue
+  tables, aristo_constants, desc_error, desc_identifiers, desc_nibbles,
+  desc_structural, keyed_queue
 
 const
   accLruSize* = 1024 * 1024

--- a/nimbus/db/aristo/aristo_fetch.nim
+++ b/nimbus/db/aristo/aristo_fetch.nim
@@ -85,17 +85,18 @@ proc retrieveMerkleHash(
     root: VertexID;
     updateOk: bool;
       ): Result[Hash256,AristoError] =
-  let key = block:
+  let key =
     if updateOk:
       db.computeKey((root, root)).valueOr:
         if error == GetVtxNotFound:
           return ok(EMPTY_ROOT_HASH)
         return err(error)
     else:
-      db.getKeyRc((root, root)).valueOr:
+      let (key, _) = db.getKeyRc((root, root)).valueOr:
         if error == GetKeyNotFound:
           return ok(EMPTY_ROOT_HASH) # empty sub-tree
         return err(error)
+      key
   ok key.to(Hash256)
 
 

--- a/nimbus/db/aristo/aristo_hike.nim
+++ b/nimbus/db/aristo/aristo_hike.nim
@@ -77,7 +77,7 @@ proc step*(
     path: NibblesBuf, rvid: RootedVertexID, db: AristoDbRef
       ): Result[(VertexRef, NibblesBuf, VertexID), AristoError] =
   # Fetch next vertex
-  let vtx = db.getVtxRc(rvid).valueOr:
+  let (vtx, _) = db.getVtxRc(rvid).valueOr:
     if error != GetVtxNotFound:
       return err(error)
 

--- a/nimbus/db/aristo/aristo_merge/merge_payload_helper.nim
+++ b/nimbus/db/aristo/aristo_merge/merge_payload_helper.nim
@@ -50,7 +50,7 @@ proc mergePayloadImpl*(
     cur = root
     touched: array[NibblesBuf.high + 1, VertexID]
     pos = 0
-    vtx = db.getVtxRc((root, cur)).valueOr:
+    (vtx, _) = db.getVtxRc((root, cur)).valueOr:
       if error != GetVtxNotFound:
         return err(error)
 
@@ -120,7 +120,7 @@ proc mergePayloadImpl*(
         if next.isValid:
           cur = next
           path = path.slice(n + 1)
-          vtx = ?db.getVtxRc((root, next))
+          (vtx, _) = ?db.getVtxRc((root, next))
         else:
           # There's no vertex at the branch point - insert the payload as a new
           # leaf and update the existing branch

--- a/nimbus/db/aristo/aristo_serialise.nim
+++ b/nimbus/db/aristo/aristo_serialise.nim
@@ -220,7 +220,7 @@ proc serialise*(
   ## account type, otherwise pass the data as is.
   ##
   proc getKey(vid: VertexID): Result[HashKey,AristoError] =
-    db.getKeyRc((root, vid))
+    ok (?db.getKeyRc((root, vid)))[0]
 
   pyl.serialise getKey
 

--- a/nimbus/db/aristo/aristo_tx/tx_stow.nim
+++ b/nimbus/db/aristo/aristo_tx/tx_stow.nim
@@ -33,7 +33,7 @@ proc getBeStateRoot(
   let srcRoot = block:
     let rc = db.getKeyBE rvid
     if rc.isOk:
-      rc.value
+      rc.value[0]
     elif rc.error == GetKeyNotFound:
       VOID_HASH_KEY
     else:

--- a/nimbus/db/aristo/aristo_utils.nim
+++ b/nimbus/db/aristo/aristo_utils.nim
@@ -44,14 +44,14 @@ proc toNode*(
     block body:
       let key = db.layersGetKey(rvid).valueOr:
         break body
-      if key.isValid:
-        return key
+      if key[0].isValid:
+        return key[0]
       else:
         return VOID_HASH_KEY
     if beOk:
       let rc = db.getKeyBE rvid
       if rc.isOk:
-        return rc.value
+        return rc.value[0]
     VOID_HASH_KEY
 
   case vtx.vType:


### PR DESCRIPTION
When lazily verifying state roots, we may end up with an entire state without roots that gets computed for the whole database - in the current design, that would result in hashes for the entire trie being held in memory.

Since the hash depends only on the data in the vertex, we can store it directly at the top-most level derived from the verticies it depends on
- be that memory or database - this makes the memory usage broadly linear with respect to the already-existing in-memory change set stored in the layers.

It also ensures that if we have multiple forks in memory, hashes get cached in the correct layer maximising reuse between forks.

The same layer numbering scheme as elsewhere is reused, where -2 is the backend, -1 is the balancer, then 0+ is the top of the stack and stack.

A downside of this approach is that we create many small batches - a future improvement could be to collect all such writes in a single batch, though the memory profile of this approach should be examined first (where is the batch kept, exactly?).