### PR TITLE
Remove deprecated cli options for fluffy

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -83,15 +83,6 @@ type
       name: "listen-address"
     .}: IpAddress
 
-    portalNetworkDeprecated* {.
-      hidden,
-      desc:
-        "DEPRECATED: The --portal-network flag will be removed in the future, " &
-        "please use the drop in replacement --network flag instead",
-      defaultValue: none(PortalNetwork),
-      name: "portal-network"
-    .}: Option[PortalNetwork]
-
     network* {.
       desc:
         "Select which Portal network to join. This will set the " &
@@ -99,15 +90,6 @@ type
       defaultValue: PortalNetwork.mainnet,
       name: "network"
     .}: PortalNetwork
-
-    networksDeprecated* {.
-      hidden,
-      desc:
-        "DEPRECATED: The --networks flag will be removed in the future, " &
-        "please use the drop in replacement --portal-subnetworks flag instead",
-      defaultValue: {},
-      name: "networks"
-    .}: set[PortalSubnetwork]
 
     portalSubnetworks* {.
       desc: "Select which networks (Portal sub-protocols) to enable",

--- a/fluffy/docs/the_fluffy_book/docs/run-local-testnet.md
+++ b/fluffy/docs/the_fluffy_book/docs/run-local-testnet.md
@@ -27,5 +27,5 @@ any of the running nodes their ENR.
 E.g. to manually add a Fluffy node to the local testnet run:
 
 ```bash
-./build/fluffy --rpc --portal-network:none --udp-port:9010 --nat:extip:127.0.0.1 --bootstrap-node:`cat ./local_testnet_data/node0/fluffy_node.enr`
+./build/fluffy --rpc --network:none --udp-port:9010 --nat:extip:127.0.0.1 --bootstrap-node:`cat ./local_testnet_data/node0/fluffy_node.enr`
 ```

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -85,23 +85,7 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
   loadBootstrapFile(string config.bootstrapNodesFile, bootstrapRecords)
   bootstrapRecords.add(config.bootstrapNodes)
 
-  let portalNetwork =
-    if config.portalNetworkDeprecated.isNone():
-      config.network
-    else:
-      warn "DEPRECATED: The --portal-network flag will be removed in the future, " &
-        "please use the drop in replacement --network flag instead"
-      config.portalNetworkDeprecated.get()
-
-  let portalSubnetworks =
-    if config.networksDeprecated == {}:
-      config.portalSubnetworks
-    else:
-      warn "DEPRECATED: The --networks flag will be removed in the future, " &
-        "please use the drop in replacement --portal-subnetworks flag instead"
-      config.networksDeprecated
-
-  case portalNetwork
+  case config.network
   of PortalNetwork.none:
     discard # don't connect to any network bootstrap nodes
   of PortalNetwork.mainnet:
@@ -142,7 +126,7 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
   ## Force pruning - optional
   if config.forcePrune:
     let db = ContentDB.new(
-      config.dataDir / portalNetwork.getDbDirectory() / "contentdb_" &
+      config.dataDir / config.network.getDbDirectory() / "contentdb_" &
         d.localNode.id.toBytesBE().toOpenArray(0, 8).toHex(),
       storageCapacity = config.storageCapacityMB * 1_000_000,
       manualCheckpoint = true,
@@ -189,10 +173,10 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
     )
 
     node = PortalNode.new(
-      portalNetwork,
+      config.network,
       portalNodeConfig,
       d,
-      portalSubnetworks,
+      config.portalSubnetworks,
       bootstrapRecords = bootstrapRecords,
       rng = rng,
     )

--- a/fluffy/scripts/launch_local_testnet.sh
+++ b/fluffy/scripts/launch_local_testnet.sh
@@ -304,7 +304,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --log-level="${LOG_LEVEL}" \
     --udp-port=$(( BASE_PORT + NUM_NODE )) \
     --data-dir="${NODE_DATA_DIR}" \
-    --portal-network="none" \
+    --network="none" \
     ${BOOTSTRAP_ARG} \
     --rpc \
     --rpc-address="127.0.0.1" \
@@ -315,7 +315,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --table-ip-limit=1024 \
     --bucket-ip-limit=24 \
     --bits-per-hop=1 \
-    --networks:beacon,history,state \
+    --portal-subnetworks:beacon,history,state \
     ${TRUSTED_BLOCK_ROOT_ARG} \
     ${RADIUS_ARG} \
     ${EXTRA_ARGS} \


### PR DESCRIPTION
All external tooling that uses this has been updated a while back to used the updated cli options.
