### PR TITLE
small cleanups

### DIFF
--- a/nimbus/core/chain/forked_chain.nim
+++ b/nimbus/core/chain/forked_chain.nim
@@ -357,12 +357,9 @@ proc setHead(c: ForkedChainRef,
              headHash: Hash256,
              number: BlockNumber) =
   # TODO: db.setHead should not read from db anymore
-  # and raise RlpError, all canonical chain marking
+  # all canonical chain marking
   # should be done from here.
-  try:
-    discard c.db.setHead(headHash)
-  except RlpError as exc:
-    raiseAssert(exc.msg)
+  discard c.db.setHead(headHash)
 
   # update global syncHighest
   c.com.syncHighest = number

--- a/nimbus/core/executor/process_transaction.nim
+++ b/nimbus/core/executor/process_transaction.nim
@@ -11,7 +11,7 @@
 {.push raises: [].}
 
 import
-  std/strutils,
+  std/strformat,
   results,
   ../../common/common,
   ../../db/ledger,
@@ -48,12 +48,8 @@ proc commitOrRollbackDependingOnGasUsed(
   # an early stop. It would rather detect differing values for the  block
   # header `gasUsed` and the `vmState.cumulativeGasUsed` at a later stage.
   if header.gasLimit < vmState.cumulativeGasUsed + gasBurned:
-    try:
-      vmState.stateDB.rollback(accTx)
-      return err("invalid tx: block header gasLimit reached. gasLimit=$1, gasUsed=$2, addition=$3" % [
-        $header.gasLimit, $vmState.cumulativeGasUsed, $gasBurned])
-    except ValueError as ex:
-      return err(ex.msg)
+    vmState.stateDB.rollback(accTx)
+    return err(&"invalid tx: block header gasLimit reached. gasLimit={header.gasLimit}, gasUsed={vmState.cumulativeGasUsed}, addition={gasBurned}")
   else:
     # Accept transaction and collect mining fee.
     vmState.stateDB.commit(accTx)

--- a/nimbus/core/gaslimit.nim
+++ b/nimbus/core/gaslimit.nim
@@ -32,11 +32,7 @@ proc validateGasLimit(header: BlockHeader; limit: GasInt): Result[void,string] =
   let upperLimit = limit div GAS_LIMIT_ADJUSTMENT_FACTOR
 
   if diff >= upperLimit:
-    try:
-      return err(&"invalid gas limit: have {header.gasLimit}, want {limit} +-= {upperLimit-1}")
-    except ValueError:
-      # TODO deprecate-strformat
-      raiseAssert "strformat cannot fail"
+    return err(&"invalid gas limit: have {header.gasLimit}, want {limit} +-= {upperLimit-1}")
   if header.gasLimit < GAS_LIMIT_MINIMUM:
     return err("invalid gas limit below 5000")
   ok()
@@ -77,14 +73,10 @@ proc verifyEip1559Header(com: CommonRef;
   # Verify the baseFee is correct based on the parent header.
   var expectedBaseFee = com.calcEip1599BaseFee(parent)
   if headerBaseFee != expectedBaseFee:
-    try:
-      return err(&"invalid baseFee: have {expectedBaseFee}, "&
-                 &"want {header.baseFeePerGas}, " &
-                 &"parent.baseFee {parent.baseFeePerGas}, "&
-                 &"parent.gasUsed {parent.gasUsed}")
-    except ValueError:
-      # TODO deprecate-strformat
-      raiseAssert "strformat cannot fail"
+    return err(&"invalid baseFee: have {expectedBaseFee}, "&
+                &"want {header.baseFeePerGas}, " &
+                &"parent.baseFee {parent.baseFeePerGas}, "&
+                &"parent.gasUsed {parent.gasUsed}")
 
   return ok()
 

--- a/nimbus/core/tx_pool/tx_tasks/tx_head.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_head.nim
@@ -47,7 +47,7 @@ logScope:
 
 # use it as a stack/lifo as the ordering is reversed
 proc insert(xp: TxPoolRef; kq: TxHeadDiffRef; blockHash: Hash256)
-    {.gcsafe,raises: [CatchableError].} =
+    {.raises: [BlockNotFound].} =
   let db = xp.chain.com.db
   for tx in db.getBlockBody(blockHash).transactions:
     if tx.versionedHashes.len > 0:
@@ -59,7 +59,7 @@ proc insert(xp: TxPoolRef; kq: TxHeadDiffRef; blockHash: Hash256)
     kq.addTxs[tx.itemID] = PooledTransaction(tx: tx)
 
 proc remove(xp: TxPoolRef; kq: TxHeadDiffRef; blockHash: Hash256)
-    {.gcsafe,raises: [CatchableError].} =
+    {.gcsafe,raises: [BlockNotFound].} =
   let db = xp.chain.com.db
   for tx in db.getBlockBody(blockHash).transactions:
     kq.remTxs[tx.itemID] = true

--- a/nimbus/core/validate.nim
+++ b/nimbus/core/validate.nim
@@ -71,7 +71,7 @@ proc validateHeader(
 
   if header.gasLimit > GAS_LIMIT_MAXIMUM:
     return err("gasLimit exceeds GAS_LIMIT_MAXIMUM")
-    
+
   if com.daoForkSupport and inDAOExtraRange(header.number):
     if header.extraData != daoForkBlockExtraData:
       return err("header extra data should be marked DAO")

--- a/nimbus/db/core_db/base.nim
+++ b/nimbus/db/core_db/base.nim
@@ -15,7 +15,6 @@ import
   eth/common,
   "../.."/[constants, errors],
   ".."/[kvt, aristo],
-  ./backend/aristo_db,
   ./base/[api_tracking, base_config, base_desc, base_helpers]
 
 export

--- a/nimbus/db/kvt/kvt_delta.nim
+++ b/nimbus/db/kvt/kvt_delta.nim
@@ -13,7 +13,7 @@
 ##
 
 import
-  std/[sequtils, tables],
+  std/tables,
   results,
   ./kvt_desc,
   ./kvt_desc/desc_backend,
@@ -78,7 +78,8 @@ proc deltaPersistent*(
 
   # Store structural single trie entries
   let writeBatch = ? be.putBegFn()
-  be.putKvpFn(writeBatch, db.balancer.sTab.pairs.toSeq)
+  for k,v in db.balancer.sTab:
+    be.putKvpFn(writeBatch, k, v)
   ? be.putEndFn writeBatch
 
   # Done with balancer, all saved to backend

--- a/nimbus/db/kvt/kvt_desc/desc_backend.nim
+++ b/nimbus/db/kvt/kvt_desc/desc_backend.nim
@@ -40,7 +40,7 @@ type
       ## Generic transaction initialisation function
 
   PutKvpFn* =
-    proc(hdl: PutHdlRef; kvps: openArray[(Blob,Blob)]) {.gcsafe, raises: [].}
+    proc(hdl: PutHdlRef; k, v: openArray[byte]) {.gcsafe, raises: [].}
       ## Generic backend database bulk storage function.
 
   PutEndFn* =

--- a/nimbus/db/kvt/kvt_init/memory_db.nim
+++ b/nimbus/db/kvt/kvt_init/memory_db.nim
@@ -101,14 +101,13 @@ proc putBegFn(db: MemBackendRef): PutBegFn =
 
 proc putKvpFn(db: MemBackendRef): PutKvpFn =
   result =
-    proc(hdl: PutHdlRef; kvps: openArray[(Blob,Blob)]) =
+    proc(hdl: PutHdlRef; k, v: openArray[byte]) =
       let hdl = hdl.getSession db
       if hdl.error == KvtError(0):
-        for (k,v) in kvps:
-          if k.isValid:
-            hdl.tab[k] = v
-          else:
-            hdl.error = KeyInvalid
+        if k.len > 0:
+          hdl.tab[@k] = @v
+        else:
+          hdl.tab.del @k
 
 proc putEndFn(db: MemBackendRef): PutEndFn =
   result =

--- a/nimbus/db/kvt/kvt_init/rocks_db.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db.nim
@@ -119,14 +119,14 @@ proc putBegFn(db: RdbBackendRef): PutBegFn =
 
 proc putKvpFn(db: RdbBackendRef): PutKvpFn =
   result =
-    proc(hdl: PutHdlRef; kvps: openArray[(Blob,Blob)]) =
+    proc(hdl: PutHdlRef; k, v: openArray[byte]) =
       let hdl = hdl.getSession db
       if hdl.error == KvtError(0):
 
         # Collect batch session arguments
-        db.rdb.put(kvps).isOkOr:
-          hdl.error = error[1]
-          hdl.info = error[2]
+        db.rdb.put(k, v).isOkOr:
+          hdl.error = error[0]
+          hdl.info = error[1]
           return
 
 

--- a/nimbus/db/kvt/kvt_init/rocks_db/rdb_put.nim
+++ b/nimbus/db/kvt/kvt_init/rocks_db/rdb_put.nim
@@ -68,21 +68,20 @@ proc commit*(rdb: var RdbInst): Result[void,(KvtError,string)] =
 
 proc put*(
     rdb: RdbInst;
-    data: openArray[(Blob,Blob)];
-      ): Result[void,(Blob,KvtError,string)] =
-  for (key,val) in data:
-    if val.len == 0:
-      rdb.session.delete(key, rdb.store[KvtGeneric].handle()).isOkOr:
-        const errSym = RdbBeDriverDelError
-        when extraTraceMessages:
-          trace logTxt "del", key, error=errSym, info=error
-        return err((key,errSym,error))
-    else:
-      rdb.session.put(key, val, rdb.store[KvtGeneric].handle()).isOkOr:
-        const errSym = RdbBeDriverPutError
-        when extraTraceMessages:
-          trace logTxt "put", key, error=errSym, info=error
-        return err((key,errSym,error))
+    key, val: openArray[byte];
+      ): Result[void,(KvtError,string)] =
+  if val.len == 0:
+    rdb.session.delete(key, rdb.store[KvtGeneric].handle()).isOkOr:
+      const errSym = RdbBeDriverDelError
+      when extraTraceMessages:
+        trace logTxt "del", key, error=errSym, info=error
+      return err((errSym,error))
+  else:
+    rdb.session.put(key, val, rdb.store[KvtGeneric].handle()).isOkOr:
+      const errSym = RdbBeDriverPutError
+      when extraTraceMessages:
+        trace logTxt "put", key, error=errSym, info=error
+      return err((errSym,error))
   ok()
 
 # ------------------------------------------------------------------------------

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -519,7 +519,7 @@ proc setupEthRpc*(
       hash: Hash256,
       header: BlockHeader,
       opts: FilterOptions): seq[FilterLog]
-        {.gcsafe, raises: [RlpError,ValueError].} =
+        {.gcsafe, raises: [RlpError,BlockNotFound].} =
     if headerBloomFilter(header, opts.address, opts.topics):
       let blockBody = chain.getBlockBody(hash)
       let receipts = chain.getReceipts(header.receiptsRoot)
@@ -538,7 +538,7 @@ proc setupEthRpc*(
       start: common.BlockNumber,
       finish: common.BlockNumber,
       opts: FilterOptions): seq[FilterLog]
-        {.gcsafe, raises: [RlpError,ValueError].} =
+        {.gcsafe, raises: [RlpError,BlockNotFound].} =
     var logs = newSeq[FilterLog]()
     var i = start
     while i <= finish:

--- a/nimbus/sync/handlers/eth.nim
+++ b/nimbus/sync/handlers/eth.nim
@@ -451,19 +451,16 @@ method getBlockBodies*(ctx: EthWireRef,
                        hashes: openArray[Hash256]):
                         Result[seq[BlockBody], string]
     {.gcsafe.} =
-  try:
-    let db = ctx.db
-    var body: BlockBody
-    var list: seq[BlockBody]
-    for blockHash in hashes:
-      if db.getBlockBody(blockHash, body):
-        list.add body
-      else:
-        list.add BlockBody()
-        trace "handlers.getBlockBodies: blockBody not found", blockHash
-    return ok(list)
-  except RlpError as exc:
-    return err(exc.msg)
+  let db = ctx.db
+  var body: BlockBody
+  var list: seq[BlockBody]
+  for blockHash in hashes:
+    if db.getBlockBody(blockHash, body):
+      list.add body
+    else:
+      list.add BlockBody()
+      trace "handlers.getBlockBodies: blockBody not found", blockHash
+  return ok(list)
 
 method getBlockHeaders*(ctx: EthWireRef,
                         req: BlocksRequest):


### PR DESCRIPTION
* remove some redundant EH
* avoid pessimising move (introduces a copy in this case!)
* shift less data around when reading era files (reduces stack usage)