### PR TITLE
Add basic validation for LC bootstraps + portal_bridge changes

### DIFF
--- a/fluffy/network/beacon/beacon_db.nim
+++ b/fluffy/network/beacon/beacon_db.nim
@@ -40,7 +40,7 @@ type
     kv: KvStoreRef
     bestUpdates: BestLightClientUpdateStore
     forkDigests: ForkDigests
-    cfg: RuntimeConfig
+    cfg*: RuntimeConfig
     finalityUpdateCache: Opt[LightClientFinalityUpdateCache]
     optimisticUpdateCache: Opt[LightClientOptimisticUpdateCache]
 

--- a/fluffy/network/beacon/beacon_validation.nim
+++ b/fluffy/network/beacon/beacon_validation.nim
@@ -1,0 +1,26 @@
+# Fluffy
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import
+  stew/bitops2,
+  beacon_chain/spec/presets,
+  beacon_chain/spec/forks,
+  beacon_chain/spec/forks_light_client
+
+func isValidBootstrap*(bootstrap: ForkyLightClientBootstrap, cfg: RuntimeConfig): bool =
+  ## Verify if the bootstrap is valid. This does not verify if the header is
+  ## part of the canonical chain.
+  is_valid_light_client_header(bootstrap.header, cfg) and
+    is_valid_merkle_branch(
+      hash_tree_root(bootstrap.current_sync_committee),
+      bootstrap.current_sync_committee_branch,
+      log2trunc(altair.CURRENT_SYNC_COMMITTEE_GINDEX),
+      get_subtree_index(altair.CURRENT_SYNC_COMMITTEE_GINDEX),
+      bootstrap.header.beacon.state_root,
+    )

--- a/fluffy/portal_node.nim
+++ b/fluffy/portal_node.nim
@@ -107,6 +107,7 @@ proc new*(
             beaconDb,
             streamManager,
             networkData.forks,
+            config.trustedBlockRoot,
             bootstrapRecords = bootstrapRecords,
             portalConfig = config.portalConfig,
           )

--- a/fluffy/tests/beacon_network_tests/beacon_test_helpers.nim
+++ b/fluffy/tests/beacon_network_tests/beacon_test_helpers.nim
@@ -24,8 +24,14 @@ proc newLCNode*(
     node = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(port))
     db = BeaconDb.new(networkData, "", inMemory = true)
     streamManager = StreamManager.new(node)
-    network =
-      BeaconNetwork.new(PortalNetwork.none, node, db, streamManager, networkData.forks)
+    network = BeaconNetwork.new(
+      PortalNetwork.none,
+      node,
+      db,
+      streamManager,
+      networkData.forks,
+      Opt.none(Eth2Digest),
+    )
 
   return BeaconNode(discoveryProtocol: node, beaconNetwork: network)
 

--- a/fluffy/tools/portal_bridge/portal_bridge_beacon.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_beacon.nim
@@ -140,7 +140,7 @@ proc gossipLCFinalityUpdate(
     portalRpcClient: RpcClient,
     cfg: RuntimeConfig,
     forkDigests: ref ForkDigests,
-): Future[Result[Slot, string]] {.async.} =
+): Future[Result[(Slot, Eth2Digest), string]] {.async.} =
   var update =
     try:
       info "Downloading LC finality update"
@@ -155,6 +155,7 @@ proc gossipLCFinalityUpdate(
     when lcDataFork > LightClientDataFork.None:
       let
         finalizedSlot = forkyObject.finalized_header.beacon.slot
+        blockRoot = hash_tree_root(forkyObject.finalized_header.beacon)
         contentKey = encode(finalityUpdateContentKey(finalizedSlot.uint64))
         forkDigest = forkDigestAtEpoch(
           forkDigests[], epoch(forkyObject.attested_header.beacon.slot), cfg
@@ -176,7 +177,7 @@ proc gossipLCFinalityUpdate(
 
       let res = await GossipRpcAndClose()
       if res.isOk():
-        return ok(finalizedSlot)
+        return ok((finalizedSlot, blockRoot))
       else:
         return err(res.error)
     else:
@@ -394,7 +395,14 @@ proc runBeacon*(config: PortalBridgeConf) {.raises: [CatchableError].} =
           if res.isErr():
             warn "Error gossiping LC finality update", error = res.error
           else:
-            lastFinalityUpdateEpoch = epoch(res.get())
+            let (slot, blockRoot) = res.value()
+            lastFinalityUpdateEpoch = epoch(slot)
+            let res = await gossipLCBootstrapUpdate(
+              restClient, portalRpcClient, blockRoot, cfg, forkDigests
+            )
+
+            if res.isErr():
+              warn "Error gossiping LC bootstrap", error = res.error
 
           let res2 = await gossipHistoricalSummaries(
             restClient, portalRpcClient, cfg, forkDigests


### PR DESCRIPTION
- Add basic validation for LC bootstrap gossip, validating either by trusted block root (only 1) when not synced, or by comparing with the header of the latest finality update when synced.

- Update portal_bridge beacon to also gossip bootstraps into the network on each end of epoch.


Resolves 1 part of https://github.com/status-im/nimbus-eth1/issues/2214