### PR TITLE
Fluffy state bridge - Add CLI parameters and implement workers for offer gossip.

### DIFF
--- a/fluffy/network/state/state_gossip.nim
+++ b/fluffy/network/state/state_gossip.nim
@@ -97,7 +97,7 @@ proc gossipOffer*(
   let req1Peers = await p.neighborhoodGossip(
     srcNodeId, ContentKeysList.init(@[keyBytes]), @[offerBytes]
   )
-  info "Offered content gossipped successfully with peers", keyBytes, peers = req1Peers
+  debug "Offered content gossipped successfully with peers", keyBytes, peers = req1Peers
 
 proc gossipOffer*(
     p: PortalProtocol,
@@ -110,7 +110,7 @@ proc gossipOffer*(
   let req1Peers = await p.neighborhoodGossip(
     srcNodeId, ContentKeysList.init(@[keyBytes]), @[offerBytes]
   )
-  info "Offered content gossipped successfully with peers", keyBytes, peers = req1Peers
+  debug "Offered content gossipped successfully with peers", keyBytes, peers = req1Peers
 
 proc gossipOffer*(
     p: PortalProtocol,
@@ -123,7 +123,7 @@ proc gossipOffer*(
   let peers = await p.neighborhoodGossip(
     srcNodeId, ContentKeysList.init(@[keyBytes]), @[offerBytes]
   )
-  info "Offered content gossipped successfully with peers", keyBytes, peers
+  debug "Offered content gossipped successfully with peers", keyBytes, peers
 
 # Currently only used for testing to gossip an entire account trie proof
 # This may also be useful for the state network bridge

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -173,7 +173,7 @@ proc processOffer*(
   n.portalProtocol.storeContent(
     contentKeyBytes, contentId, contentValue.toRetrievalValue().encode()
   )
-  info "Offered content validated successfully", contentKeyBytes
+  debug "Offered content validated successfully", contentKeyBytes
 
   await gossipOffer(
     n.portalProtocol, maybeSrcNodeId, contentKeyBytes, contentValueBytes, contentKey,

--- a/fluffy/tools/portal_bridge/portal_bridge_conf.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_conf.nim
@@ -145,17 +145,31 @@ type
         desc: "The block number to start from", defaultValue: 1, name: "start-block"
       .}: uint64
 
-      verifyState* {.
-        desc: "Verify the fetched state before gossiping it into the network",
-        defaultValue: true,
-        name: "verify-state"
+      verifyStateProofs* {.
+        desc: "Verify state proofs before gossiping them into the portal network",
+        defaultValue: false,
+        name: "verify-state-proofs"
       .}: bool
 
-      backfillState* {.
-        desc: "Backfill pre-merge state data into the network",
+      gossipGenesis* {.
+        desc: "Enable gossip of the genesis state into the portal network",
         defaultValue: true,
-        name: "backfill"
+        name: "gossip-genesis"
       .}: bool
+
+      verifyGossip* {.
+        desc:
+          "Enable verifying that the state was successfully gossipped by fetching it from the network",
+        defaultValue: false,
+        name: "verify-gossip"
+      .}: bool
+
+      gossipWorkersCount* {.
+        desc:
+          "The number of workers to use for gossiping the state into the portal network",
+        defaultValue: 2,
+        name: "gossip-workers"
+      .}: uint
 
 func parseCmdArg*(T: type TrustedDigest, input: string): T {.raises: [ValueError].} =
   TrustedDigest.fromHex(input)

--- a/fluffy/tools/portal_bridge/state_bridge/offers_builder.nim
+++ b/fluffy/tools/portal_bridge/state_bridge/offers_builder.nim
@@ -48,14 +48,19 @@ proc buildContractTrieNodeOffer(
     storageProof: TrieProof,
     accountProof: TrieProof,
 ) =
-  let
-    path = Nibbles.init(slotHash.data, isEven = true)
-    offerKey =
-      ContractTrieNodeKey.init(address, path, keccakHash(storageProof[^1].asSeq()))
-    offerValue =
-      ContractTrieNodeOffer.init(storageProof, accountProof, builder.blockHash)
+  try:
+    let
+      path = removeLeafKeyEndNibbles(
+        Nibbles.init(slotHash.data, isEven = true), storageProof[^1]
+      )
+      offerKey =
+        ContractTrieNodeKey.init(address, path, keccakHash(storageProof[^1].asSeq()))
+      offerValue =
+        ContractTrieNodeOffer.init(storageProof, accountProof, builder.blockHash)
 
-  builder.contractTrieOffers.add(offerValue.withKey(offerKey))
+    builder.contractTrieOffers.add(offerValue.withKey(offerKey))
+  except RlpError as e:
+    raiseAssert(e.msg) # Should never happen
 
 proc buildContractCodeOffer(
     builder: var OffersBuilder,


### PR DESCRIPTION
This PR includes the following changes:
- Tried using RPC batching for sending offers for entire block. This method doesn't work very well due to hitting the max HTTP payload size because each offer payload is rather large. Fluffy also isn't able to keep up when sending offers this fast in large chunks. 
- For now we continue to send offers one at a time but instead use multiple workers to process sending the offers for multiple blocks concurrently. There is no dependency between blocks for this part so it doesn't need to be done sequential.
- Fixed a bug in the contract trie offer building when constructing the path.
- Improved the Fluffy logging to reduce the amount of info logs when processing offers.
- Added debugging/testing function to verify correctness of state proofs before converting to offers.
- Added CLI parameters to support configuring the Fluffy state bridge.