### PR TITLE
Update Fluffy State Network to match Portal spec addressHash change

### DIFF
--- a/fluffy/docs/the_fluffy_book/docs/fluffy-with-portal-hive.md
+++ b/fluffy/docs/the_fluffy_book/docs/fluffy-with-portal-hive.md
@@ -17,11 +17,11 @@ go build .
 Example commands for running test suites:
 
 ```sh
-# Run the history tests with the 3 different clients
-./hive --sim history --client fluffy,trin,ultralight
+# Run the portal tests with only the fluffy client
+./hive --sim portal --client fluffy
 
-# Run the state tests with only the fluffy client
-./hive --sim state --client fluffy
+# Run the portal tests with the 3 different clients
+./hive --sim portal --client fluffy,trin,ultralight
 
 # Access results through web-ui:
 ```sh

--- a/fluffy/network/state/content/content_keys.nim
+++ b/fluffy/network/state/content/content_keys.nim
@@ -23,7 +23,7 @@ export ssz_serialization, common_types, hash, results
 type
   NodeHash* = KeccakHash
   CodeHash* = KeccakHash
-  Address* = EthAddress
+  AddressHash* = KeccakHash
 
   ContentType* = enum
     # Note: Need to add this unused value as a case object with an enum without
@@ -43,12 +43,12 @@ type
     nodeHash*: NodeHash
 
   ContractTrieNodeKey* = object
-    address*: Address
+    addressHash*: AddressHash
     path*: Nibbles
     nodeHash*: NodeHash
 
   ContractCodeKey* = object
-    address*: Address
+    addressHash*: AddressHash
     codeHash*: CodeHash
 
   ContentKey* = object
@@ -68,12 +68,15 @@ func init*(T: type AccountTrieNodeKey, path: Nibbles, nodeHash: NodeHash): T =
   AccountTrieNodeKey(path: path, nodeHash: nodeHash)
 
 func init*(
-    T: type ContractTrieNodeKey, address: Address, path: Nibbles, nodeHash: NodeHash
+    T: type ContractTrieNodeKey,
+    addressHash: AddressHash,
+    path: Nibbles,
+    nodeHash: NodeHash,
 ): T =
-  ContractTrieNodeKey(address: address, path: path, nodeHash: nodeHash)
+  ContractTrieNodeKey(addressHash: addressHash, path: path, nodeHash: nodeHash)
 
-func init*(T: type ContractCodeKey, address: Address, codeHash: CodeHash): T =
-  ContractCodeKey(address: address, codeHash: codeHash)
+func init*(T: type ContractCodeKey, addressHash: AddressHash, codeHash: CodeHash): T =
+  ContractCodeKey(addressHash: addressHash, codeHash: codeHash)
 
 func toContentKey*(key: AccountTrieNodeKey): ContentKey =
   ContentKey(contentType: accountTrieNode, accountTrieNodeKey: key)

--- a/fluffy/network/state/state_gossip.nim
+++ b/fluffy/network/state/state_gossip.nim
@@ -136,12 +136,12 @@ proc recursiveGossipOffer*(
     offerBytes: seq[byte],
     key: AccountTrieNodeKey,
     offer: AccountTrieNodeOffer,
-) {.async: (raises: [CancelledError]).} =
+): Future[ContentKeyByteList] {.async: (raises: [CancelledError]).} =
   await gossipOffer(p, srcNodeId, keyBytes, offerBytes, key, offer)
 
   # root node, recursive gossip is finished
   if key.path.unpackNibbles().len() == 0:
-    return
+    return keyBytes
 
   # continue the recursive gossip by sharing the parent offer with peers
   let
@@ -161,12 +161,12 @@ proc recursiveGossipOffer*(
     offerBytes: seq[byte],
     key: ContractTrieNodeKey,
     offer: ContractTrieNodeOffer,
-) {.async: (raises: [CancelledError]).} =
+): Future[ContentKeyByteList] {.async: (raises: [CancelledError]).} =
   await gossipOffer(p, srcNodeId, keyBytes, offerBytes, key, offer)
 
   # root node, recursive gossip is finished
   if key.path.unpackNibbles().len() == 0:
-    return
+    return keyBytes
 
   # continue the recursive gossip by sharing the parent offer with peers
   let

--- a/fluffy/network/state/state_gossip.nim
+++ b/fluffy/network/state/state_gossip.nim
@@ -79,7 +79,7 @@ func getParent*(offerWithKey: ContractTrieOfferWithKey): ContractTrieOfferWithKe
     (key, offer) = offerWithKey
     parent = offer.storageProof.withPath(key.path).getParent()
     parentKey = ContractTrieNodeKey.init(
-      key.address, parent.path, keccakHash(parent.proof[^1].asSeq())
+      key.addressHash, parent.path, keccakHash(parent.proof[^1].asSeq())
     )
     parentOffer =
       ContractTrieNodeOffer.init(parent.proof, offer.accountProof, offer.blockHash)

--- a/fluffy/network/state/state_gossip.nim
+++ b/fluffy/network/state/state_gossip.nim
@@ -60,7 +60,9 @@ func getParent(p: ProofWithPath): ProofWithPath =
     # leaf or extension node so we need to remove one or more nibbles
     let (_, _, prefixNibbles) = decodePrefix(parentEndNode.listElem(0))
 
-    parentProof.withPath(unpackedNibbles.dropN(prefixNibbles.len()).packNibbles())
+    parentProof.withPath(
+      unpackedNibbles.dropN(prefixNibbles.unpackNibbles().len()).packNibbles()
+    )
   except RlpError as e:
     raiseAssert(e.msg)
 

--- a/fluffy/network/state/state_utils.nim
+++ b/fluffy/network/state/state_utils.nim
@@ -87,7 +87,7 @@ func removeLeafKeyEndNibbles*(
 func toPath*(hash: KeccakHash): Nibbles {.inline.} =
   Nibbles.init(hash.data, isEven = true)
 
-func toPath*(address: Address): Nibbles {.inline.} =
+func toPath*(address: EthAddress): Nibbles {.inline.} =
   keccakHash(address).toPath()
 
 func toPath*(slotKey: UInt256): Nibbles {.inline.} =

--- a/fluffy/network/state/state_validation.nim
+++ b/fluffy/network/state/state_validation.nim
@@ -156,7 +156,7 @@ proc validateOffer*(
 ): Result[void, string] =
   ?validateTrieProof(
     trustedStateRoot,
-    key.address.toPath(),
+    key.addressHash.toPath(),
     offer.accountProof,
     allowKeyEndInPathForLeafs = true,
   )
@@ -172,7 +172,7 @@ proc validateOffer*(
 ): Result[void, string] =
   ?validateTrieProof(
     trustedStateRoot,
-    key.address.toPath(),
+    key.addressHash.toPath(),
     offer.accountProof,
     allowKeyEndInPathForLeafs = true,
   )

--- a/fluffy/tests/state_network_tests/all_state_network_tests.nim
+++ b/fluffy/tests/state_network_tests/all_state_network_tests.nim
@@ -13,11 +13,11 @@ import
   ./test_state_content_values_vectors,
   ./test_state_endpoints_genesis,
   ./test_state_endpoints_vectors,
-  ./test_state_gossip_getparent_genesis,
-  ./test_state_gossip_getparent_vectors,
-  ./test_state_gossip_gossipoffer_vectors,
-  ./test_state_network_getcontent_vectors,
-  ./test_state_network_offercontent_vectors,
-  ./test_state_validation_genesis,
-  ./test_state_validation_trieproof,
-  ./test_state_validation_vectors
+  ./test_state_gossip_getparent_genesis
+    # ./test_state_gossip_getparent_vectors,
+    # ./test_state_gossip_gossipoffer_vectors,
+    # ./test_state_network_getcontent_vectors,
+    # ./test_state_network_offercontent_vectors,
+    # ./test_state_validation_genesis,
+    # ./test_state_validation_trieproof,
+    # ./test_state_validation_vectors

--- a/fluffy/tests/state_network_tests/all_state_network_tests.nim
+++ b/fluffy/tests/state_network_tests/all_state_network_tests.nim
@@ -13,11 +13,11 @@ import
   ./test_state_content_values_vectors,
   ./test_state_endpoints_genesis,
   ./test_state_endpoints_vectors,
-  ./test_state_gossip_getparent_genesis
-    # ./test_state_gossip_getparent_vectors,
-    # ./test_state_gossip_gossipoffer_vectors,
-    # ./test_state_network_getcontent_vectors,
-    # ./test_state_network_offercontent_vectors,
-    # ./test_state_validation_genesis,
-    # ./test_state_validation_trieproof,
-    # ./test_state_validation_vectors
+  ./test_state_gossip_getparent_genesis,
+  ./test_state_gossip_getparent_vectors,
+  ./test_state_gossip_gossipoffer_vectors,
+  ./test_state_network_getcontent_vectors,
+  ./test_state_network_offercontent_vectors,
+  ./test_state_validation_genesis,
+  ./test_state_validation_trieproof,
+  ./test_state_validation_vectors

--- a/fluffy/tests/state_network_tests/state_test_helpers.nim
+++ b/fluffy/tests/state_network_tests/state_test_helpers.nim
@@ -26,17 +26,11 @@ export yaml_utils
 const testVectorDir* = "./vendor/portal-spec-tests/tests/mainnet/state/validation/"
 
 type
-  YamlTrieNodeRecursiveGossipKV* = ref object
-    content_key*: string
-    content_value_offer*: string
-    content_value_retrieval*: string
-
   YamlTrieNodeKV* = object
     state_root*: string
     content_key*: string
     content_value_offer*: string
     content_value_retrieval*: string
-    recursive_gossip*: YamlTrieNodeRecursiveGossipKV
 
   YamlTrieNodeKVs* = seq[YamlTrieNodeKV]
 
@@ -47,16 +41,6 @@ type
     content_value_retrieval*: string
 
   YamlContractBytecodeKVs* = seq[YamlContractBytecodeKV]
-
-  YamlRecursiveGossipKV* = object
-    content_key*: string
-    content_value*: string
-
-  YamlRecursiveGossipData* = object
-    state_root*: string
-    recursive_gossip*: seq[YamlRecursiveGossipKV]
-
-  YamlRecursiveGossipKVs* = seq[YamlRecursiveGossipData]
 
 func asNibbles*(key: openArray[byte], isEven = true): Nibbles =
   Nibbles.init(key, isEven)

--- a/fluffy/tests/state_network_tests/test_state_endpoints_genesis.nim
+++ b/fluffy/tests/state_network_tests/test_state_endpoints_genesis.nim
@@ -43,8 +43,8 @@ suite "State Endpoints - Genesis JSON Files":
         let
           proof = accountState.generateAccountProof(address)
           leafNode = proof[^1]
-          addressHash = keccakHash(address).data
-          path = removeLeafKeyEndNibbles(Nibbles.init(addressHash, true), leafNode)
+          addressHash = keccakHash(address)
+          path = removeLeafKeyEndNibbles(Nibbles.init(addressHash.data, true), leafNode)
           key = AccountTrieNodeKey.init(path, keccakHash(leafNode.asSeq()))
           offer = AccountTrieNodeOffer(proof: proof)
 
@@ -94,8 +94,9 @@ suite "State Endpoints - Genesis JSON Files":
           block:
             # store the code
             let
-              key =
-                ContractCodeKey(address: address, codeHash: keccakHash(account.code))
+              key = ContractCodeKey(
+                addressHash: addressHash, codeHash: keccakHash(account.code)
+              )
               value = ContractCodeRetrieval(code: Bytecode.init(account.code))
 
             let contentKey = key.toContentKey().encode()
@@ -121,7 +122,9 @@ suite "State Endpoints - Genesis JSON Files":
                 Nibbles.init(keccakHash(toBytesBE(slotKey)).data, true), leafNode
               )
               key = ContractTrieNodeKey(
-                address: address, path: path, nodeHash: keccakHash(leafNode.asSeq())
+                addressHash: addressHash,
+                path: path,
+                nodeHash: keccakHash(leafNode.asSeq()),
               )
               offer =
                 ContractTrieNodeOffer(storageProof: storageProof, accountProof: proof)

--- a/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
@@ -92,7 +92,7 @@ procSuite "State Endpoints":
           nonceRes = await stateNode1.stateNetwork.getTransactionCount(
             contentValue.blockHash, address
           )
-        echo balanceRes
+
         check:
           balanceRes.isOk()
           balanceRes.get() == expectedAccount.balance

--- a/fluffy/tests/state_network_tests/test_state_gossip_getparent_genesis.nim
+++ b/fluffy/tests/state_network_tests/test_state_gossip_getparent_genesis.nim
@@ -68,7 +68,9 @@ suite "State Gossip getParent - Genesis JSON Files":
         (accountState, storageStates) = accounts.toState()
 
       for address, account in accounts:
-        let accountProof = accountState.generateAccountProof(address)
+        let
+          addressHash = address.keccakHash()
+          accountProof = accountState.generateAccountProof(address)
 
         if account.code.len() > 0:
           let storageState = storageStates[address]
@@ -82,7 +84,9 @@ suite "State Gossip getParent - Genesis JSON Files":
                 Nibbles.init(keccakHash(toBytesBE(slotKey)).data, true), leafNode
               )
               key = ContractTrieNodeKey(
-                address: address, path: path, nodeHash: keccakHash(leafNode.asSeq())
+                addressHash: addressHash,
+                path: path,
+                nodeHash: keccakHash(leafNode.asSeq()),
               )
               offer = ContractTrieNodeOffer(
                 storageProof: storageProof, accountProof: accountProof

--- a/fluffy/tests/state_network_tests/test_state_validation_genesis.nim
+++ b/fluffy/tests/state_network_tests/test_state_validation_genesis.nim
@@ -83,9 +83,8 @@ template checkInvalidProofsWithBadValue(
     var
       addressHash = address.keccakHash()
       accountProof = accountState.generateAccountProof(address)
-      accountPath = removeLeafKeyEndNibbles(
-        Nibbles.init(addressHash.data, true), accountProof[^1]
-      )
+      accountPath =
+        removeLeafKeyEndNibbles(Nibbles.init(addressHash.data, true), accountProof[^1])
       accountTrieNodeKey = AccountTrieNodeKey(
         path: accountPath, nodeHash: keccakHash(accountProof[^1].asSeq())
       )
@@ -98,7 +97,8 @@ template checkInvalidProofsWithBadValue(
     check proofResult.isErr()
 
     let
-      contractCodeKey = ContractCodeKey(addressHash: addressHash, codeHash: acc.codeHash)
+      contractCodeKey =
+        ContractCodeKey(addressHash: addressHash, codeHash: acc.codeHash)
       contractCode = ContractCodeOffer(
         code: Bytecode.init(@[1u8, 2, 3]), # bad code value
         accountProof: accountProof,

--- a/fluffy/tests/state_network_tests/test_state_validation_genesis.nim
+++ b/fluffy/tests/state_network_tests/test_state_validation_genesis.nim
@@ -26,10 +26,10 @@ template checkValidProofsForExistingLeafs(
     acc.codeHash = keccakHash(account.code)
 
     let
+      addressHash = address.keccakHash()
       accountProof = accountState.generateAccountProof(address)
-      accountPath = removeLeafKeyEndNibbles(
-        Nibbles.init(keccakHash(address).data, true), accountProof[^1]
-      )
+      accountPath =
+        removeLeafKeyEndNibbles(Nibbles.init(addressHash.data, true), accountProof[^1])
       accountTrieNodeKey = AccountTrieNodeKey(
         path: accountPath, nodeHash: keccakHash(accountProof[^1].asSeq())
       )
@@ -40,7 +40,8 @@ template checkValidProofsForExistingLeafs(
     check proofResult.isOk()
 
     let
-      contractCodeKey = ContractCodeKey(address: address, codeHash: acc.codeHash)
+      contractCodeKey =
+        ContractCodeKey(addressHash: addressHash, codeHash: acc.codeHash)
       contractCode =
         ContractCodeOffer(code: Bytecode.init(account.code), accountProof: accountProof)
       codeResult =
@@ -58,7 +59,7 @@ template checkValidProofsForExistingLeafs(
             Nibbles.init(keccakHash(toBytesBE(slotKey)).data, true), storageProof[^1]
           )
           contractTrieNodeKey = ContractTrieNodeKey(
-            address: address,
+            addressHash: addressHash,
             path: slotPath,
             nodeHash: keccakHash(storageProof[^1].asSeq()),
           )
@@ -80,9 +81,10 @@ template checkInvalidProofsWithBadValue(
     acc.codeHash = keccakHash(account.code)
 
     var
+      addressHash = address.keccakHash()
       accountProof = accountState.generateAccountProof(address)
       accountPath = removeLeafKeyEndNibbles(
-        Nibbles.init(keccakHash(address).data, true), accountProof[^1]
+        Nibbles.init(addressHash.data, true), accountProof[^1]
       )
       accountTrieNodeKey = AccountTrieNodeKey(
         path: accountPath, nodeHash: keccakHash(accountProof[^1].asSeq())
@@ -96,7 +98,7 @@ template checkInvalidProofsWithBadValue(
     check proofResult.isErr()
 
     let
-      contractCodeKey = ContractCodeKey(address: address, codeHash: acc.codeHash)
+      contractCodeKey = ContractCodeKey(addressHash: addressHash, codeHash: acc.codeHash)
       contractCode = ContractCodeOffer(
         code: Bytecode.init(@[1u8, 2, 3]), # bad code value
         accountProof: accountProof,
@@ -116,7 +118,7 @@ template checkInvalidProofsWithBadValue(
             Nibbles.init(keccakHash(toBytesBE(slotKey)).data, true), storageProof[^1]
           )
           contractTrieNodeKey = ContractTrieNodeKey(
-            address: address,
+            addressHash: addressHash,
             path: slotPath,
             nodeHash: keccakHash(storageProof[^1].asSeq()),
           )

--- a/fluffy/tools/portal_bridge/portal_bridge_conf.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_conf.nim
@@ -152,7 +152,8 @@ type
       .}: bool
 
       gossipGenesis* {.
-        desc: "Enable gossip of the genesis state into the portal network when starting from block 1",
+        desc:
+          "Enable gossip of the genesis state into the portal network when starting from block 1",
         defaultValue: true,
         name: "gossip-genesis"
       .}: bool

--- a/fluffy/tools/portal_bridge/portal_bridge_conf.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_conf.nim
@@ -152,7 +152,7 @@ type
       .}: bool
 
       gossipGenesis* {.
-        desc: "Enable gossip of the genesis state into the portal network",
+        desc: "Enable gossip of the genesis state into the portal network when starting from block 1",
         defaultValue: true,
         name: "gossip-genesis"
       .}: bool


### PR DESCRIPTION
ContractTrieNodeKey and ContractCodeKey now define addressHash instead of address. See the related PR in the portal specs here: https://github.com/ethereum/portal-network-specs/pull/329

Changes included in this PR:
- Fluffy code updated to support addressHash instead of address for the ContractTrieNodeKey and ContractCodeKey types.
- Portal spec test vectors repo updated to latest.
- Fluffy tests refactored and updated based on latest changes in portal spec tests.
- Fluffy state bridge updated to use updated ContractTrieNodeKey and ContractCodeKey addressHash field.
