### PR TITLE
move db init to init

### DIFF
--- a/hive_integration/nodocker/consensus/consensus_sim.nim
+++ b/hive_integration/nodocker/consensus/consensus_sim.nim
@@ -26,8 +26,6 @@ proc processChainData(cd: ChainData): TestStatus =
       cd.params
     )
 
-  com.initializeEmptyDb()
-
   for bytes in cd.blocksRlp:
     # ignore return value here
     # because good blocks maybe interleaved with

--- a/hive_integration/nodocker/engine/engine_env.nim
+++ b/hive_integration/nodocker/engine/engine_env.nim
@@ -90,7 +90,6 @@ proc newEngineEnv*(conf: var NimbusConf, chainFile: string, enableAuth: bool): E
     com   = makeCom(conf)
     chain = newChain(com)
 
-  com.initializeEmptyDb()
   let txPool = TxPoolRef.new(com)
 
   node.addEthHandlerCapability(

--- a/hive_integration/nodocker/graphql/graphql_sim.nim
+++ b/hive_integration/nodocker/graphql/graphql_sim.nim
@@ -83,7 +83,6 @@ proc main() =
       conf.networkParams
     )
 
-  com.initializeEmptyDb()
   let txPool = TxPoolRef.new(com)
   discard importRlpBlock(blocksFile, com)
   let ctx = setupGraphqlContext(com, ethNode, txPool)

--- a/hive_integration/nodocker/rpc/test_env.nim
+++ b/hive_integration/nodocker/rpc/test_env.nim
@@ -81,7 +81,6 @@ proc setupEnv*(): TestEnv =
     )
 
   manageAccounts(ethCtx, conf)
-  com.initializeEmptyDb()
 
   let chainRef = newChain(com)
   let txPool = TxPoolRef.new(com)

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -243,8 +243,6 @@ proc run(nimbus: NimbusNode, conf: NimbusConf) =
   defer:
     com.db.finish()
 
-  com.initializeEmptyDb()
-
   case conf.cmd
   of NimbusCmd.`import`:
     importBlocks(conf, com)

--- a/premix/persist.nim
+++ b/premix/persist.nim
@@ -67,11 +67,6 @@ proc main() {.used.} =
     discard com.db.setHead(parentBlock.header)
 
   let kvt = com.db.ctx.getKvt()
-  if canonicalHeadHashKey().toOpenArray notin kvt:
-    persistToDb(com.db):
-      com.initializeEmptyDb()
-    doAssert(canonicalHeadHashKey().toOpenArray in kvt)
-
   var head = com.db.getCanonicalHead()
   var blockNumber = head.number + 1
   var chain = newChain(com)

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -280,7 +280,6 @@ proc initVMEnv*(network: string): BaseVMState =
       gasLimit: 100_000
     )
 
-  com.initializeEmptyDb()
   BaseVMState.new(parent, header, com)
 
 proc verifyAsmResult(vmState: BaseVMState, boa: Assembler, asmResult: CallResult): bool =

--- a/tests/test_beacon/setup_env.nim
+++ b/tests/test_beacon/setup_env.nim
@@ -69,7 +69,6 @@ proc setupEnv*(extraValidation: bool = false, ccm: CCModify = nil): TestEnv =
     )
     chain = newChain(com, extraValidation)
 
-  com.initializeEmptyDb()
   TestEnv(
     conf : conf,
     chain: chain,

--- a/tests/test_coredb.nim
+++ b/tests/test_coredb.nim
@@ -185,8 +185,6 @@ proc initRunnerDB(
     params = params,
     pruneHistory = pruneHistory)
 
-  result.initializeEmptyDb
-
   setErrorLevel()
   when CoreDbEnableApiTracking:
     coreDB.trackCoreDbApi = false

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -34,15 +34,11 @@ proc setupEnv(): TestEnv =
   TestEnv(conf: conf)
 
 proc newCom(env: TestEnv): CommonRef =
-  let
-    com = CommonRef.new(
+  CommonRef.new(
       newCoreDbRef DefaultDbMemory,
       env.conf.networkId,
       env.conf.networkParams
     )
-
-  com.initializeEmptyDb()
-  com
 
 proc makeBlk(com: CommonRef, number: BlockNumber, parentBlk: EthBlock): EthBlock =
   template parent(): BlockHeader =

--- a/tests/test_graphql.nim
+++ b/tests/test_graphql.nim
@@ -73,7 +73,6 @@ proc setupChain(): CommonRef =
     CustomNet,
     customNetwork
   )
-  com.initializeEmptyDb()
 
   let blocks = jn["blocks"]
   var headers: seq[BlockHeader]

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -102,7 +102,6 @@ proc initEnv(): TestEnv =
       conf.networkId,
       conf.networkParams
     )
-  com.initializeEmptyDb()
 
   TestEnv(
     com     : com,

--- a/tests/test_merge.nim
+++ b/tests/test_merge.nim
@@ -71,8 +71,6 @@ proc runTest(steps: Steps) =
     )
     chainRef = newChain(com)
 
-  com.initializeEmptyDb()
-
   var
     rpcServer = newRpcSocketServer(["127.0.0.1:0"])
     client = newRpcSocketClient()

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -238,7 +238,6 @@ proc rpcMain*() =
       debugEcho unlock.error
     doAssert(unlock.isOk)
 
-    com.initializeEmptyDb()
     let env = setupEnv(com, signer, ks2, ctx)
 
     # Create Ethereum RPCs

--- a/tests/test_rpc_getproofs_track_state_changes.nim
+++ b/tests/test_rpc_getproofs_track_state_changes.nim
@@ -121,7 +121,6 @@ proc rpcGetProofsTrackStateChangesMain*() =
 
       let com = CommonRef.new(newCoreDbRef(
         DefaultDbPersistent, DATABASE_PATH, DbOptions.init()))
-      com.initializeEmptyDb()
 
       let
         blockHeader = waitFor client.eth_getBlockByNumber(blockId(START_BLOCK), false)

--- a/tests/test_txpool/setup.nim
+++ b/tests/test_txpool/setup.nim
@@ -96,7 +96,6 @@ proc setupTxPool*(getStatus: proc(): TxItemStatus): (CommonRef, TxPoolRef, int) 
     conf.networkParams
   )
 
-  com.initializeEmptyDb()
   let txPool = TxPoolRef.new(com)
 
   for n, tx in txEnv.txs:

--- a/tests/test_txpool2.nim
+++ b/tests/test_txpool2.nim
@@ -110,8 +110,6 @@ proc initEnv(envFork: HardFork): TestEnv =
     )
     chain = newChain(com)
 
-  com.initializeEmptyDb()
-
   result = TestEnv(
     conf: conf,
     com: com,


### PR DESCRIPTION
When using the common interface, the database always (potentially) needs init - take the opportunity to log some basic database info on startup.