### PR TITLE
rebalance rocksdb cache sizes

### DIFF
--- a/nimbus/db/opts.nim
+++ b/nimbus/db/opts.nim
@@ -18,8 +18,8 @@ const
   # https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning
   defaultMaxOpenFiles* = 512
   defaultWriteBufferSize* = 64 * 1024 * 1024
-  defaultRowCacheSize* = 4096 * 1024 * 1024
-  defaultBlockCacheSize* = 256 * 1024 * 1024
+  defaultRowCacheSize* = 1024 * 1024 * 1024
+  defaultBlockCacheSize* = 2 * 1024 * 1024 * 1024
 
 type DbOptions* = object # Options that are transported to the database layer
   maxOpenFiles*: int


### PR DESCRIPTION
Based on some simple testing done with a few combinations of cache sizes, it seems that the block cache has grown in importance compared to the where we were before changing on-disk format and adding a lot of other point caches.

With these settings, there's roughly a 15% performance increase when processing blocks in the 18M range over the status quo while memory usage decreases by more than 1gb!

Only a few values were tested so there's certainly more to do here but this change sets up a better baseline for any future optimizations.

In particular, since the initial defaults were chosen root vertex id:s were introduced as key prefixes meaning that storage for each account will be grouped together and thus it becomes more likely that a block loaded from disk will be hit multiple times - this seems to give the block cache an edge over the row cache, specially when traversing the storage trie.