### PR TITLE
Don't write slot hashes on import

### DIFF
--- a/hive_integration/nodocker/engine/node.nim
+++ b/hive_integration/nodocker/engine/node.nim
@@ -81,7 +81,7 @@ proc getVmState(c: ChainRef, header: BlockHeader):
     return ok(c.vmState)
 
   let vmState = BaseVMState()
-  if not vmState.init(header, c.com):
+  if not vmState.init(header, c.com, storeSlotHash = storeSlotHash):
     debug "Cannot initialise VmState",
       number = header.number
     return err()

--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -550,6 +550,12 @@ type
         defaultValue: false
         name: "debug-store-receipts".}: bool
 
+      storeSlotHashes* {.
+        hidden
+        desc: "Store reverse slot hashes in database"
+        defaultValue: false
+        name: "debug-store-slot-hashes".}: bool
+
 func parseCmdArg(T: type NetworkId, p: string): T
     {.gcsafe, raises: [ValueError].} =
   parseInt(p).T

--- a/nimbus/db/ledger.nim
+++ b/nimbus/db/ledger.nim
@@ -22,18 +22,16 @@ import
   ./ledger/base/[base_config, base_desc, base_helpers],
   ./ledger/[base, base_iterators]
 
-export
-  AccountsLedgerRef,
-  base,
-  base_config,
-  base_iterators
+export AccountsLedgerRef, base, base_config, base_iterators
 
 # ------------------------------------------------------------------------------
 # Public constructor
 # ------------------------------------------------------------------------------
 
-proc init*(_: type LedgerRef, db: CoreDbRef; root: Hash256): LedgerRef =
-  LedgerRef(ac: AccountsLedgerRef.init(db, root)).bless(db)
+proc init*(
+    _: type LedgerRef, db: CoreDbRef, root: Hash256, storeSlotHash: bool = false
+): LedgerRef =
+  LedgerRef(ac: AccountsLedgerRef.init(db, root, storeSlotHash)).bless(db)
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/nimbus_import.nim
+++ b/nimbus/nimbus_import.nim
@@ -103,7 +103,8 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
       boolFlag({PersistBlockFlag.NoValidation}, conf.noValidation) +
       boolFlag({PersistBlockFlag.NoFullValidation}, not conf.fullValidation) +
       boolFlag(NoPersistBodies, not conf.storeBodies) +
-      boolFlag({PersistBlockFlag.NoPersistReceipts}, not conf.storeReceipts)
+      boolFlag({PersistBlockFlag.NoPersistReceipts}, not conf.storeReceipts) +
+      boolFlag({PersistBlockFlag.NoPersistSlotHashes}, not conf.storeSlotHashes)
     blocks: seq[EthBlock]
     clConfig: Eth2NetworkMetadata
     genesis_validators_root: Eth2Digest

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -675,7 +675,7 @@ proc runLedgerBasicOperationsTests() =
       check ac.contractCollision(addr4) == true
 
     test "Ledger storage iterator":
-      var ac = LedgerRef.init(memDB, EMPTY_ROOT_HASH)
+      var ac = LedgerRef.init(memDB, EMPTY_ROOT_HASH, storeSlotHash = true)
       let addr2 = initAddr(2)
       ac.setStorage(addr2, 1.u256, 2.u256)
       ac.setStorage(addr2, 2.u256, 3.u256)


### PR DESCRIPTION
The reverse slot hash mechanism causes quite a bit of database traffic but is broadly not useful except for iterating the storage of an account, something that a validator never does (it's used by the tracers).

This flag adds one more thing that is not stored in the database, to be explored more comprehensively when designing full, validator and archive modes with different pruning options in the future.

`ldb` says this is 60gb of data (!):
```
ldb --db=. --ignore_unknown_options --column_family=KvtGen approxsize
--hex --from=0x05
--to=0x05ffffffffffffffffffffffffffffffffffffffffffffff
66488353954
```