### PR TITLE
Avoid unnecessary layer copy

### DIFF
--- a/nimbus/db/aristo/aristo_tx/tx_frame.nim
+++ b/nimbus/db/aristo/aristo_tx/tx_frame.nim
@@ -122,14 +122,16 @@ proc txFrameCommit*(
   let db = ? tx.getDbDescFromTopTx()
 
   # Pop layer from stack and merge database top layer onto it
-  let merged = db.stack[^1]
-  db.stack.setLen(db.stack.len-1)
-  if not db.top.isEmpty():
-    # Only call `layersMergeOnto()` if layer is empty
-    db.top.layersMergeOnto merged[]
+  let merged = db.stack.pop()
+  if not merged.isEmpty():
+    # No need to update top if we popped an empty layer
+    if not db.top.isEmpty():
+      # Only call `layersMergeOnto()` if layer is empty
+      db.top.layersMergeOnto merged[]
 
-  # Install `merged` stack top layer and update stack
-  db.top = merged
+    # Install `merged` stack top layer and update stack
+    db.top = merged
+
   db.txRef = tx.parent
   if 0 < db.stack.len:
     db.txRef.txUid = db.getTxUid


### PR DESCRIPTION
When the stack has an empty layer on top, there's no need to copy the contents of `top` to it since it would be the same.

~13% processing saved (!)

pre
```
INF 2024-08-17 19:11:31.748+02:00 Imported blocks
blockNumber=18667648 blocks=12000 importedSlot=7860043 txs=1797812
mgas=181135.177 bps=8.763 tps=1375.062 mgps=132.125 avgBps=6.798
avgTps=1018.501 avgMGps=102.617 elapsed=29m25s154ms
```

post
```
INF 2024-08-17 18:22:52.513+02:00 Imported blocks
blockNumber=18667648 blocks=12000 importedSlot=7860043 txs=1797812
mgas=181135.177 bps=9.648 tps=1513.961 mgps=145.472 avgBps=7.876
avgTps=1179.998 avgMGps=118.888 elapsed=25m23s572ms
```