### PR TITLE
Bump portal-spec-tests and update Fluffy state tests

### DIFF
--- a/fluffy/tests/state_network_tests/state_test_helpers.nim
+++ b/fluffy/tests/state_network_tests/state_test_helpers.nim
@@ -27,7 +27,7 @@ const testVectorDir* = "./vendor/portal-spec-tests/tests/mainnet/state/validatio
 
 type
   YamlTrieNodeKV* = object
-    state_root*: string
+    block_header*: string
     content_key*: string
     content_value_offer*: string
     content_value_retrieval*: string
@@ -35,7 +35,7 @@ type
   YamlTrieNodeKVs* = seq[YamlTrieNodeKV]
 
   YamlContractBytecodeKV* = object
-    state_root*: string
+    block_header*: string
     content_key*: string
     content_value_offer*: string
     content_value_retrieval*: string

--- a/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
@@ -13,7 +13,6 @@ import
   eth/common,
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   eth/p2p/discoveryv5/routing_table,
-  ../../common/common_utils,
   ../../network/wire/[portal_protocol, portal_stream],
   ../../network/state/
     [state_content, state_network, state_gossip, state_endpoints, state_utils],
@@ -50,7 +49,8 @@ procSuite "State Endpoints":
         continue
 
       let
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         leafData = testData
         contentKeyBytes = leafData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
@@ -158,7 +158,8 @@ procSuite "State Endpoints":
       # seed the account data
       let
         testData = accountTrieTestCase[0]
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         leafData = testData
         contentKeyBytes = leafData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
@@ -186,7 +187,8 @@ procSuite "State Endpoints":
       # seed the storage data
       let
         testData = contractTrieTestCase[0]
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         leafData = testData
         contentKeyBytes = leafData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
@@ -234,7 +236,8 @@ procSuite "State Endpoints":
         testCase = YamlContractBytecodeKVs.loadFromYaml(bytecodeFile).valueOr:
           raiseAssert "Cannot read test vector: " & error
         testData = testCase[0]
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)

--- a/fluffy/tests/state_network_tests/test_state_gossip_gossipoffer_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_gossip_gossipoffer_vectors.nim
@@ -13,7 +13,6 @@ import
   eth/common,
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   eth/p2p/discoveryv5/routing_table,
-  ../../common/common_utils,
   ../../network/wire/[portal_protocol, portal_stream],
   ../../network/state/[state_content, state_network, state_gossip],
   ../../database/content_db,
@@ -47,7 +46,8 @@ procSuite "State Gossip - Gossip Offer":
 
       let
         parentTestData = testCase[i + 1]
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -120,7 +120,8 @@ procSuite "State Gossip - Gossip Offer":
 
       let
         parentTestData = testCase[i + 1]
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -190,7 +191,8 @@ procSuite "State Gossip - Gossip Offer":
 
     for i, testData in testCase:
       let
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)

--- a/fluffy/tests/state_network_tests/test_state_network_offercontent_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_network_offercontent_vectors.nim
@@ -36,7 +36,8 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -104,7 +105,8 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -173,7 +175,8 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -243,7 +246,8 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -292,7 +296,8 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -342,7 +347,8 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+        stateRoot =
+          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)

--- a/fluffy/tests/state_network_tests/test_state_validation_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_validation_vectors.nim
@@ -135,7 +135,8 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      var stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+      let stateRoot =
+        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
 
       block:
         let contentKey = ContentKey
@@ -185,7 +186,8 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      var stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+      let stateRoot =
+        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
 
       let contentKey =
         ContentKey.decode(testData.content_key.hexToSeqByte().ContentKeyByteList).get()
@@ -204,7 +206,8 @@ suite "State Validation - Test Vectors":
     for i, testData in testCase:
       if i == 2:
         continue # second test case only has root node
-      var stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+      let stateRoot =
+        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
 
       let contentKey =
         ContentKey.decode(testData.content_key.hexToSeqByte().ContentKeyByteList).get()
@@ -221,7 +224,8 @@ suite "State Validation - Test Vectors":
         "hash of next node doesn't match the expected" in res.error()
 
     for i, testData in testCase:
-      var stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+      let stateRoot =
+        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
 
       let contentKey =
         ContentKey.decode(testData.content_key.hexToSeqByte().ContentKeyByteList).get()
@@ -245,7 +249,8 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      var stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+      let stateRoot =
+        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
 
       block:
         let contentKey = ContentKey
@@ -294,7 +299,8 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      var stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+      let stateRoot =
+        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
 
       block:
         let contentKey = ContentKey
@@ -387,7 +393,8 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      var stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+      let stateRoot =
+        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
 
       let contentKey =
         ContentKey.decode(testData.content_key.hexToSeqByte().ContentKeyByteList).get()
@@ -430,7 +437,8 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      var stateRoot = KeccakHash.fromBytes(testData.state_root.hexToSeqByte())
+      let stateRoot =
+        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
 
       block:
         let contentKey = ContentKey


### PR DESCRIPTION
Changes in this PR:
- Updated portal-spec-tests to latest.
- Updated Fluffy state network tests to use the block_header field instead of state_root. 