### PR TITLE
avoid digest when loading era block

### DIFF
--- a/nimbus/nimbus_import.nim
+++ b/nimbus/nimbus_import.nim
@@ -162,10 +162,7 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
     start + imported
 
   func f(value: float): string =
-    try:
-      &"{value:4.3f}"
-    except ValueError:
-      raiseAssert "valid fmt string"
+    &"{value:4.3f}"
 
   template process() =
     let


### PR DESCRIPTION
Computing the digest is unnecessary but takes a little bit of time - remove computation and reduce mem usage slightly when loading era blocks