### PR TITLE
t8n: enable reverse slot hash map

### DIFF
--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -97,6 +97,7 @@ proc testFixtureIndexes(ctx: var TestCtx, testStatusIMPL: var TestStatus) =
       header = ctx.header,
       com    = com,
       tracer = tracer,
+      storeSlotHash = ctx.trace,
     )
 
   var gasUsed: GasInt

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -500,7 +500,8 @@ proc transitionAction*(ctx: var TransContext, conf: T8NConf) =
     vmState.init(
       parent      = parent,
       header      = header,
-      com         = com
+      com         = com,
+      storeSlotHash = true
     )
 
     vmState.mutateStateDB:


### PR DESCRIPTION
turns out tracer still needs it