### PR TITLE
Fluffy state network fixes and improvements

### DIFF
--- a/fluffy/network/state/state_utils.nim
+++ b/fluffy/network/state/state_utils.nim
@@ -61,12 +61,12 @@ func rlpDecodeContractTrieNode*(contractTrieNode: TrieNode): Result[UInt256, str
     err(e.msg)
 
 func toAccount*(accountProof: TrieProof): Result[Account, string] {.inline.} =
-  doAssert(accountProof.len() > 1)
+  doAssert(accountProof.len() > 0)
 
   rlpDecodeAccountTrieNode(accountProof[^1])
 
 func toSlot*(storageProof: TrieProof): Result[UInt256, string] {.inline.} =
-  doAssert(storageProof.len() > 1)
+  doAssert(storageProof.len() > 0)
 
   rlpDecodeContractTrieNode(storageProof[^1])
 

--- a/fluffy/tests/state_network_tests/test_state_endpoints_genesis.nim
+++ b/fluffy/tests/state_network_tests/test_state_endpoints_genesis.nim
@@ -117,7 +117,6 @@ suite "State Endpoints - Genesis JSON Files":
             let
               storageProof = storageState.generateStorageProof(slotKey)
               leafNode = storageProof[^1]
-              slotKeyHash = keccakHash(toBytesBE(slotKey)).data
               path = removeLeafKeyEndNibbles(
                 Nibbles.init(keccakHash(toBytesBE(slotKey)).data, true), leafNode
               )

--- a/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
@@ -54,7 +54,6 @@ procSuite "State Endpoints":
         leafData = testData
         contentKeyBytes = leafData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
-        contentId = toContentId(contentKeyBytes)
         contentValueBytes = leafData.content_value_offer.hexToSeqByte()
         contentValue = AccountTrieNodeOffer.decode(contentValueBytes).get()
 
@@ -163,7 +162,6 @@ procSuite "State Endpoints":
         leafData = testData
         contentKeyBytes = leafData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
-        contentId = toContentId(contentKeyBytes)
         contentValueBytes = leafData.content_value_offer.hexToSeqByte()
         contentValue = AccountTrieNodeOffer.decode(contentValueBytes).get()
 
@@ -192,7 +190,6 @@ procSuite "State Endpoints":
         leafData = testData
         contentKeyBytes = leafData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
-        contentId = toContentId(contentKeyBytes)
         contentValueBytes = leafData.content_value_offer.hexToSeqByte()
         contentValue = ContractTrieNodeOffer.decode(contentValueBytes).get()
 

--- a/fluffy/tests/state_network_tests/test_state_gossip_gossipoffer_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_gossip_gossipoffer_vectors.nim
@@ -59,7 +59,6 @@ procSuite "State Gossip - Gossip Offer":
         parentContentKey = ContentKey.decode(parentContentKeyBytes).get()
         parentContentId = toContentId(parentContentKeyBytes)
         parentContentValueBytes = parentTestData.content_value_offer.hexToSeqByte()
-        parentContentValue = AccountTrieNodeOffer.decode(parentContentValueBytes).get()
 
       # set valid state root
       stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
@@ -133,7 +132,6 @@ procSuite "State Gossip - Gossip Offer":
         parentContentKey = ContentKey.decode(parentContentKeyBytes).get()
         parentContentId = toContentId(parentContentKeyBytes)
         parentContentValueBytes = parentTestData.content_value_offer.hexToSeqByte()
-        parentContentValue = ContractTrieNodeOffer.decode(parentContentValueBytes).get()
 
       # set valid state root
       stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)

--- a/fluffy/tests/state_network_tests/test_state_validation_genesis.nim
+++ b/fluffy/tests/state_network_tests/test_state_validation_genesis.nim
@@ -19,7 +19,7 @@ import
 template checkValidProofsForExistingLeafs(
     genAccounts: GenesisAlloc,
     accountState: HexaryTrie,
-    storageStates: Table[EthAddress, HexaryTrie],
+    storageStates: TableRef[EthAddress, HexaryTrie],
 ) =
   for address, account in genAccounts:
     var acc = newAccount(account.nonce, account.balance)
@@ -74,7 +74,7 @@ template checkValidProofsForExistingLeafs(
 template checkInvalidProofsWithBadValue(
     genAccounts: GenesisAlloc,
     accountState: HexaryTrie,
-    storageStates: Table[EthAddress, HexaryTrie],
+    storageStates: TableRef[EthAddress, HexaryTrie],
 ) =
   for address, account in genAccounts:
     var acc = newAccount(account.nonce, account.balance)

--- a/fluffy/tools/portal_bridge/portal_bridge_state.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_state.nim
@@ -282,7 +282,13 @@ proc runBackfillGossipBlockOffersLoop(
         yId = ContentKeyByteList.init(y[0]).toContentId()
         xDistance = portalNodeId xor xId
         yDistance = portalNodeId xor yId
-      if xDistance >= yDistance: 1 else: -1
+
+      if xDistance == yDistance:
+        0
+      elif xDistance > yDistance:
+        1
+      else:
+        -1
 
     # Sort the offers based on the distance from the node so that we will gossip
     # content that is closest to the node first


### PR DESCRIPTION
Changes in this PR:
- Minor clean in tests
- Improve offer sorting function in state bridge
- Fixed an issue in the state lookup logic used by the eth_* endpoints. Now checking nibble prefix for leaf and extension nodes so that correct data is returned for cases when looking up values that don't exist in the state.