### PR TITLE
create per-fork opcode dispatcher

### DIFF
--- a/nimbus/evm/code_stream.nim
+++ b/nimbus/evm/code_stream.nim
@@ -53,8 +53,10 @@ func readVmWord*(c: var CodeStream, n: static int): UInt256 =
 func len*(c: CodeStream): int =
   len(c.code)
 
-func next*(c: var CodeStream): Op =
-  if c.pc != c.code.len:
+func next*(c: var CodeStream): Op {.inline.} =
+  # The extra >= 0 check helps eliminate `IndexDefect` from the optimized code
+  # which keeps this hotspot in the EVM small, code-size-wise
+  if c.pc >= 0 and c.pc < c.code.len:
     result = Op(c.code.bytes[c.pc])
     inc c.pc
   else:

--- a/nimbus/evm/computation.nim
+++ b/nimbus/evm/computation.nim
@@ -452,6 +452,20 @@ func prepareTracer*(c: Computation) =
   c.vmState.capturePrepare(c, c.msg.depth)
 
 func opcodeGasCost*(
+    c: Computation, op: Op, gasCost: static GasInt, tracingEnabled: static bool,
+    reason: static string): EvmResultVoid {.inline.} =
+  # Special case of the opcodeGasCost function used for fixed-gas opcodes - since
+  # the parameters are known at compile time, we inline and specialize it
+  when tracingEnabled:
+    c.vmState.captureGasCost(
+      c,
+      op,
+      gasCost,
+      c.gasMeter.gasRemaining,
+      c.msg.depth + 1)
+  c.gasMeter.consumeGas(gasCost, reason)
+
+func opcodeGasCost*(
     c: Computation, op: Op, gasCost: GasInt, reason: static string): EvmResultVoid =
   if c.vmState.tracingEnabled:
     c.vmState.captureGasCost(

--- a/nimbus/evm/interpreter/gas_costs.nim
+++ b/nimbus/evm/interpreter/gas_costs.nim
@@ -801,32 +801,6 @@ gasCosts(FkBerlin, berlin, BerlinGasCosts)
 gasCosts(FkLondon, london, LondonGasCosts)
 gasCosts(FkShanghai, shanghai, ShanghaiGasCosts)
 
-type
-  OpGck* = array[Op, GasCostKind]
-
-func opGck(gc: GasCosts): OpGck {.compileTime.} =
-  for op, x in gc:
-    result[op] = x.kind
-
-# Map fork to GasCostKind
-# used in op_dispatcher.nim
-const forkToGck*: array[EVMFork, OpGck] = [
-  opGck BaseGasCosts          , # FkFrontier
-  opGck HomesteadGasCosts     , # FkHomestead
-  opGck TangerineGasCosts     , # kTangerine
-  opGck SpuriousGasCosts      , # FkSpurious
-  opGck SpuriousGasCosts      , # FkByzantium
-  opGck ConstantinopleGasCosts, # FkConstantinople
-  opGck SpuriousGasCosts      , # FkPetersburg
-  opGck IstanbulGasCosts      , # FkIstanbul
-  opGck BerlinGasCosts        , # FkBerlin
-  opGck LondonGasCosts        , # FkLondon
-  opGck LondonGasCosts        , # FkParis
-  opGck ShanghaiGasCosts      , # FkShanghai
-  opGck ShanghaiGasCosts      , # FkCancun
-  opGck ShanghaiGasCosts      , # FkPrague
-  ]
-
 proc forkToSchedule*(fork: EVMFork): GasCosts =
   if fork < FkHomestead:
     BaseGasCosts

--- a/nimbus/evm/interpreter/gas_meter.nim
+++ b/nimbus/evm/interpreter/gas_meter.nim
@@ -20,7 +20,9 @@ func init*(m: var GasMeter, startGas: GasInt) =
   m.gasRefunded = 0
 
 func consumeGas*(
-    gasMeter: var GasMeter; amount: GasInt; reason: static string): EvmResultVoid =
+    gasMeter: var GasMeter; amount: GasInt; reason: static string): EvmResultVoid {.inline.} =
+  # consumeGas is a hotspot in the vm due to it being called for every
+  # instruction
   # TODO report reason - consumeGas is a hotspot in EVM execution so it has to
   #      be done carefully
   if amount > gasMeter.gasRemaining:

--- a/nimbus/evm/interpreter/op_handlers.nim
+++ b/nimbus/evm/interpreter/op_handlers.nim
@@ -27,7 +27,7 @@ import
                  oph_create, oph_call, oph_sysops]
 
 const
-  allHandlersList = @[
+  allHandlersList = [
     (VmOpExecArithmetic, "Arithmetic"),
     (VmOpExecHash,       "Hash"),
     (VmOpExecEnvInfo,    "EnvInfo"),


### PR DESCRIPTION
In the current VM opcode dispatcher, a two-level case statement is generated that first matches the opcode and then uses another nested case statement to select the actual implementation based on which fork it is, causing the dispatcher to grow by `O(opcodes) * O(forks)`.

The fork does not change between instructions causing significant inefficiency for this approach - not only because it repeats the fork lookup but also because of code size bloat and missed optimizations.

A second source of inefficiency in dispatching is the tracer code which in the vast majority of cases is disabled but nevertheless sees multiple conditionals being evaluated for each instruction only to remain disabled throughout exeuction.

This PR rewrites the opcode dispatcher macro to generate a separate dispatcher for each fork and tracer setting and goes on to pick the right one at the start of the computation.

This has many advantages:

* much smaller dispatcher
* easier to compile
* better inlining
* fewer pointlessly repeated instruction
* simplified macro (!)
* slow "low-compiler-memory" dispatcher code can be removed

Net block import improvement at about 4-6% depending on the contract - synthetic EVM benchmnarks would show an even better result most likely.