### PR TITLE
Fluffy state endpoint improvements

### DIFF
--- a/fluffy/network/state/content/content_keys.nim
+++ b/fluffy/network/state/content/content_keys.nim
@@ -64,27 +64,31 @@ type
 
   ContentKeyType* = AccountTrieNodeKey | ContractTrieNodeKey | ContractCodeKey
 
-func init*(T: type AccountTrieNodeKey, path: Nibbles, nodeHash: NodeHash): T =
-  AccountTrieNodeKey(path: path, nodeHash: nodeHash)
+func init*(
+    T: type AccountTrieNodeKey, path: Nibbles, nodeHash: NodeHash
+): T {.inline.} =
+  T(path: path, nodeHash: nodeHash)
 
 func init*(
     T: type ContractTrieNodeKey,
     addressHash: AddressHash,
     path: Nibbles,
     nodeHash: NodeHash,
-): T =
-  ContractTrieNodeKey(addressHash: addressHash, path: path, nodeHash: nodeHash)
+): T {.inline.} =
+  T(addressHash: addressHash, path: path, nodeHash: nodeHash)
 
-func init*(T: type ContractCodeKey, addressHash: AddressHash, codeHash: CodeHash): T =
-  ContractCodeKey(addressHash: addressHash, codeHash: codeHash)
+func init*(
+    T: type ContractCodeKey, addressHash: AddressHash, codeHash: CodeHash
+): T {.inline.} =
+  T(addressHash: addressHash, codeHash: codeHash)
 
-func toContentKey*(key: AccountTrieNodeKey): ContentKey =
+func toContentKey*(key: AccountTrieNodeKey): ContentKey {.inline.} =
   ContentKey(contentType: accountTrieNode, accountTrieNodeKey: key)
 
-func toContentKey*(key: ContractTrieNodeKey): ContentKey =
+func toContentKey*(key: ContractTrieNodeKey): ContentKey {.inline.} =
   ContentKey(contentType: contractTrieNode, contractTrieNodeKey: key)
 
-func toContentKey*(key: ContractCodeKey): ContentKey =
+func toContentKey*(key: ContractCodeKey): ContentKey {.inline.} =
   ContentKey(contentType: contractCode, contractCodeKey: key)
 
 proc readSszBytes*(data: openArray[byte], val: var ContentKey) {.raises: [SszError].} =
@@ -94,14 +98,16 @@ proc readSszBytes*(data: openArray[byte], val: var ContentKey) {.raises: [SszErr
 
   readSszValue(data, val)
 
-func encode*(contentKey: ContentKey): ContentKeyByteList =
+func encode*(contentKey: ContentKey): ContentKeyByteList {.inline.} =
   doAssert(contentKey.contentType != unused)
   ContentKeyByteList.init(SSZ.encode(contentKey))
 
-func decode*(T: type ContentKey, contentKey: ContentKeyByteList): Result[T, string] =
+func decode*(
+    T: type ContentKey, contentKey: ContentKeyByteList
+): Result[T, string] {.inline.} =
   decodeSsz(contentKey.asSeq(), T)
 
-func toContentId*(contentKey: ContentKeyByteList): ContentId =
+func toContentId*(contentKey: ContentKeyByteList): ContentId {.inline.} =
   # TODO: Should we try to parse the content key here for invalid ones?
   let idHash = sha256.digest(contentKey.asSeq())
   readUintBE[256](idHash.data)

--- a/fluffy/network/state/content/content_values.nim
+++ b/fluffy/network/state/content/content_values.nim
@@ -52,50 +52,59 @@ type
     AccountTrieNodeRetrieval | ContractTrieNodeRetrieval | ContractCodeRetrieval
   ContentValueType* = ContentOfferType | ContentRetrievalType
 
-func init*(T: type AccountTrieNodeOffer, proof: TrieProof, blockHash: BlockHash): T =
-  AccountTrieNodeOffer(proof: proof, blockHash: blockHash)
+func init*(
+    T: type AccountTrieNodeOffer, proof: TrieProof, blockHash: BlockHash
+): T {.inline.} =
+  T(proof: proof, blockHash: blockHash)
 
-func init*(T: type AccountTrieNodeRetrieval, node: TrieNode): T =
-  AccountTrieNodeRetrieval(node: node)
+func init*(T: type AccountTrieNodeRetrieval, node: TrieNode): T {.inline.} =
+  T(node: node)
 
 func init*(
     T: type ContractTrieNodeOffer,
     storageProof: TrieProof,
     accountProof: TrieProof,
     blockHash: BlockHash,
-): T =
-  ContractTrieNodeOffer(
-    storageProof: storageProof, accountProof: accountProof, blockHash: blockHash
-  )
+): T {.inline.} =
+  T(storageProof: storageProof, accountProof: accountProof, blockHash: blockHash)
 
-func init*(T: type ContractTrieNodeRetrieval, node: TrieNode): T =
-  ContractTrieNodeRetrieval(node: node)
+func init*(T: type ContractTrieNodeRetrieval, node: TrieNode): T {.inline.} =
+  T(node: node)
 
 func init*(
     T: type ContractCodeOffer,
     code: Bytecode,
     accountProof: TrieProof,
     blockHash: BlockHash,
-): T =
-  ContractCodeOffer(code: code, accountProof: accountProof, blockHash: blockHash)
+): T {.inline.} =
+  T(code: code, accountProof: accountProof, blockHash: blockHash)
 
-func init*(T: type ContractCodeRetrieval, code: Bytecode): T =
-  ContractCodeRetrieval(code: code)
+func init*(T: type ContractCodeRetrieval, code: Bytecode): T {.inline.} =
+  T(code: code)
 
-func toRetrievalValue*(offer: AccountTrieNodeOffer): AccountTrieNodeRetrieval =
+func toRetrievalValue*(
+    offer: AccountTrieNodeOffer
+): AccountTrieNodeRetrieval {.inline.} =
   AccountTrieNodeRetrieval.init(offer.proof[^1])
 
-func toRetrievalValue*(offer: ContractTrieNodeOffer): ContractTrieNodeRetrieval =
+func toRetrievalValue*(
+    offer: ContractTrieNodeOffer
+): ContractTrieNodeRetrieval {.inline.} =
   ContractTrieNodeRetrieval.init(offer.storageProof[^1])
 
-func toRetrievalValue*(offer: ContractCodeOffer): ContractCodeRetrieval =
+func toRetrievalValue*(offer: ContractCodeOffer): ContractCodeRetrieval {.inline.} =
   ContractCodeRetrieval.init(offer.code)
 
-func empty*(T: type TrieProof): T =
-  TrieProof.init(@[])
+func empty*(T: type TrieProof): T {.inline.} =
+  T.init(@[])
 
-func encode*(value: ContentValueType): seq[byte] =
+func empty*(T: type Bytecode): T {.inline.} =
+  T(@[])
+
+func encode*(value: ContentValueType): seq[byte] {.inline.} =
   SSZ.encode(value)
 
-func decode*(T: type ContentValueType, bytes: openArray[byte]): Result[T, string] =
+func decode*(
+    T: type ContentValueType, bytes: openArray[byte]
+): Result[T, string] {.inline.} =
   decodeSsz(bytes, T)

--- a/fluffy/network/state/state_endpoints.nim
+++ b/fluffy/network/state/state_endpoints.nim
@@ -76,7 +76,7 @@ proc getNextNodeHash(
 
 proc getAccountProof(
     n: StateNetwork, stateRoot: KeccakHash, address: EthAddress
-): Future[Opt[TrieProof]] {.async: (raises: [CancelledError]).} =
+): Future[Result[Opt[TrieProof], string]] {.async: (raises: [CancelledError]).} =
   let nibbles = address.toPath().unpackNibbles()
 
   var
@@ -85,13 +85,12 @@ proc getAccountProof(
     proof = TrieProof.empty()
 
   while nibblesIdx < nibbles.len():
-    let
-      accountTrieNode = (await n.getAccountTrieNode(key)).valueOr:
-        warn "Failed to get account trie node when building account proof"
-        return Opt.none(TrieProof)
-      trieNode = accountTrieNode.node
+    let accountTrieNode = (await n.getAccountTrieNode(key)).valueOr:
+      return err("Failed to get account trie node when building account proof")
 
-    let added = proof.add(trieNode)
+    let
+      trieNode = accountTrieNode.node
+      added = proof.add(trieNode)
     doAssert(added)
 
     let (nextPath, nextNodeHash) = trieNode.getNextNodeHash(nibbles, nibblesIdx).valueOr:
@@ -99,14 +98,16 @@ proc getAccountProof(
 
     key = AccountTrieNodeKey.init(nextPath, nextNodeHash)
 
+  # For now we don't return partial proofs or proofs for non-existing keys
+  # TODO: implement proofs for non-existing keys when needed for eth_getProof RPC
   if nibblesIdx < nibbles.len():
-    Opt.none(TrieProof)
+    ok(Opt.none(TrieProof))
   else:
-    Opt.some(proof)
+    ok(Opt.some(proof))
 
 proc getStorageProof(
     n: StateNetwork, storageRoot: KeccakHash, address: EthAddress, storageKey: UInt256
-): Future[Opt[TrieProof]] {.async: (raises: [CancelledError]).} =
+): Future[Result[Opt[TrieProof], string]] {.async: (raises: [CancelledError]).} =
   let nibbles = storageKey.toPath().unpackNibbles()
 
   var
@@ -116,13 +117,12 @@ proc getStorageProof(
     proof = TrieProof.empty()
 
   while nibblesIdx < nibbles.len():
-    let
-      contractTrieNode = (await n.getContractTrieNode(key)).valueOr:
-        warn "Failed to get contract trie node when building account proof"
-        return Opt.none(TrieProof)
-      trieNode = contractTrieNode.node
+    let contractTrieNode = (await n.getContractTrieNode(key)).valueOr:
+      return err("Failed to get contract trie node when building account proof")
 
-    let added = proof.add(trieNode)
+    let
+      trieNode = contractTrieNode.node
+      added = proof.add(trieNode)
     doAssert(added)
 
     let (nextPath, nextNodeHash) = trieNode.getNextNodeHash(nibbles, nibblesIdx).valueOr:
@@ -130,18 +130,24 @@ proc getStorageProof(
 
     key = ContractTrieNodeKey.init(addressHash, nextPath, nextNodeHash)
 
+  # For now we don't return partial proofs or proofs for non-existing keys
+  # TODO: implement proofs for non-existing keys when needed for eth_getProof RPC
   if nibblesIdx < nibbles.len():
-    Opt.none(TrieProof)
+    ok(Opt.none(TrieProof))
   else:
-    Opt.some(proof)
+    ok(Opt.some(proof))
 
 proc getAccount(
     n: StateNetwork, stateRoot: KeccakHash, address: EthAddress
 ): Future[Opt[Account]] {.async: (raises: [CancelledError]).} =
   let
-    accountProof = (await n.getAccountProof(stateRoot, address)).valueOr:
-      warn "Failed to get account proof"
+    maybeAccountProof = (await n.getAccountProof(stateRoot, address)).valueOr:
+      warn "Failed to get account proof", error = error
       return Opt.none(Account)
+    accountProof = maybeAccountProof.valueOr:
+      warn "Account doesn't exist, returning default account"
+      # return an empty account if the account doesn't exist
+      return Opt.some(newAccount())
     account = accountProof.toAccount().valueOr:
       error "Failed to get account from accountProof"
       return Opt.none(Account)
@@ -170,9 +176,13 @@ proc getStorageAtByStateRoot*(
   let
     account = (await n.getAccount(stateRoot, address)).valueOr:
       return Opt.none(UInt256)
-    storageProof = (await n.getStorageProof(account.storageRoot, address, slotKey)).valueOr:
-      warn "Failed to get storage proof"
+    maybeStorageProof = (await n.getStorageProof(account.storageRoot, address, slotKey)).valueOr:
+      warn "Failed to get storage proof", error = error
       return Opt.none(UInt256)
+    storageProof = maybeStorageProof.valueOr:
+      warn "Slot doesn't exist, returning default storage value"
+      # return zero if the slot doesn't exist
+      return Opt.some(0.u256)
     slotValue = storageProof.toSlot().valueOr:
       error "Failed to get slot from storageProof"
       return Opt.none(UInt256)
@@ -182,14 +192,19 @@ proc getStorageAtByStateRoot*(
 proc getCodeByStateRoot*(
     n: StateNetwork, stateRoot: KeccakHash, address: EthAddress
 ): Future[Opt[Bytecode]] {.async: (raises: [CancelledError]).} =
-  let
-    account = (await n.getAccount(stateRoot, address)).valueOr:
-      return Opt.none(Bytecode)
-    contractCodeKey = ContractCodeKey.init(keccakHash(address), account.codeHash)
-
-  let contractCodeRetrieval = (await n.getContractCode(contractCodeKey)).valueOr:
-    warn "Failed to get contract code"
+  let account = (await n.getAccount(stateRoot, address)).valueOr:
     return Opt.none(Bytecode)
+
+  if account.codeHash == EMPTY_CODE_HASH:
+    warn "Code doesn't exist, returning default code value"
+    # return empty bytecode if the code doesn't exist
+    return Opt.some(Bytecode.empty())
+
+  let
+    contractCodeKey = ContractCodeKey.init(keccakHash(address), account.codeHash)
+    contractCodeRetrieval = (await n.getContractCode(contractCodeKey)).valueOr:
+      warn "Failed to get contract code"
+      return Opt.none(Bytecode)
 
   Opt.some(contractCodeRetrieval.code)
 

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -367,7 +367,7 @@ proc installEthApiHandlers*(
       let
         blockNumber = quantityTag.number.uint64.u256
         blockHash = (await historyNetwork.getBlockHashByNumber(blockNumber)).valueOr:
-          raise newException(ValueError, error)
+          raise newException(ValueError, "Unable to get block hash")
 
         balance = (await stateNetwork.get().getBalance(blockHash, data.EthAddress)).valueOr:
           raise newException(ValueError, "Unable to get balance")
@@ -392,7 +392,7 @@ proc installEthApiHandlers*(
       let
         blockNumber = quantityTag.number.uint64.u256
         blockHash = (await historyNetwork.getBlockHashByNumber(blockNumber)).valueOr:
-          raise newException(ValueError, error)
+          raise newException(ValueError, "Unable to get block hash")
 
         nonce = (
           await stateNetwork.get().getTransactionCount(blockHash, data.EthAddress)
@@ -419,7 +419,7 @@ proc installEthApiHandlers*(
       let
         blockNumber = quantityTag.number.uint64.u256
         blockHash = (await historyNetwork.getBlockHashByNumber(blockNumber)).valueOr:
-          raise newException(ValueError, error)
+          raise newException(ValueError, "Unable to get block hash")
 
         slotValue = (
           await stateNetwork.get().getStorageAt(blockHash, data.EthAddress, slot)
@@ -445,7 +445,7 @@ proc installEthApiHandlers*(
       let
         blockNumber = quantityTag.number.uint64.u256
         blockHash = (await historyNetwork.getBlockHashByNumber(blockNumber)).valueOr:
-          raise newException(ValueError, error)
+          raise newException(ValueError, "Unable to get block hash")
 
         bytecode = (await stateNetwork.get().getCode(blockHash, data.EthAddress)).valueOr:
           raise newException(ValueError, "Unable to get code")

--- a/fluffy/tools/portal_bridge/state_bridge/offers_builder.nim
+++ b/fluffy/tools/portal_bridge/state_bridge/offers_builder.nim
@@ -71,7 +71,7 @@ proc buildContractCodeOffer(
 ) =
   let
     #bytecode = Bytelist.init(code) # This fails to compile for some reason
-    bytecode = List[byte, MAX_BYTECODE_LEN](code)
+    bytecode = Bytecode(code)
     offerKey = ContractCodeKey.init(addressHash, keccakHash(code))
     offerValue = ContractCodeOffer.init(bytecode, accountProof, builder.blockHash)
 


### PR DESCRIPTION
The PR contains the following changes:
- Fluffy state endpoints eth_getBalance, eth_getTransactionCount, eth_getCode, eth_getStorageAt updated to return default values when account, code or storage doesn't exist.
- The endpoints still return an error code when looking up an account, storage or code value fails for any reason.
- Minor refactor to state content helper functions.