### PR TITLE
avoid some trivial memory allocations

### DIFF
--- a/nimbus/db/aristo/aristo_compute.nim
+++ b/nimbus/db/aristo/aristo_compute.nim
@@ -68,7 +68,7 @@ proc computeKeyImpl(
   case vtx.vType:
   of Leaf:
     writer.startList(2)
-    writer.append(vtx.lPfx.toHexPrefix(isLeaf = true))
+    writer.append(vtx.lPfx.toHexPrefix(isLeaf = true).data())
 
     case vtx.lData.pType
     of AccountData:
@@ -111,7 +111,7 @@ proc computeKeyImpl(
       writeBranch(bwriter)
 
       writer.startList(2)
-      writer.append(vtx.ePfx.toHexPrefix(isleaf = false))
+      writer.append(vtx.ePfx.toHexPrefix(isleaf = false).data())
       writer.append(bwriter.finish().digestTo(HashKey))
     else:
       writeBranch(writer)

--- a/nimbus/db/aristo/aristo_init/memory_db.nim
+++ b/nimbus/db/aristo/aristo_init/memory_db.nim
@@ -133,14 +133,7 @@ proc putVtxFn(db: MemBackendRef): PutVtxFn =
       let hdl = hdl.getSession db
       if hdl.error.isNil:
         if vtx.isValid:
-          let rc = vtx.blobify()
-          if rc.isErr:
-            hdl.error = TypedPutHdlErrRef(
-              pfx:  VtxPfx,
-              vid:  rvid.vid,
-              code: rc.error)
-            return
-          hdl.sTab[rvid] = rc.value
+          hdl.sTab[rvid] = vtx.blobify()
         else:
           hdl.sTab[rvid] = EmptyBlob
 

--- a/nimbus/db/aristo/aristo_init/rocks_db.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db.nim
@@ -312,10 +312,8 @@ iterator walkVtx*(
     be: RdbBackendRef;
       ): tuple[evid: RootedVertexID, vtx: VertexRef] =
   ## Variant of `walk()` iteration over the vertex sub-table.
-  for (rvid, data) in be.rdb.walkVtx:
-    let rc = data.deblobify VertexRef
-    if rc.isOk:
-      yield (rvid, rc.value)
+  for (rvid, vtx) in be.rdb.walkVtx:
+    yield (rvid, vtx)
 
 iterator walkKey*(
     be: RdbBackendRef;

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_put.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_put.nim
@@ -122,12 +122,7 @@ proc putVtx*(
       ): Result[void,(VertexID,AristoError,string)] =
   let dsc = rdb.session
   if vtx.isValid:
-    let rc = vtx.blobify()
-    if rc.isErr:
-      # Caller must `rollback()` which will flush the `rdVtxLru` cache
-      return err((rvid.vid,rc.error,""))
-
-    dsc.put(rvid.blobify().data(), rc.value, rdb.vtxCol.handle()).isOkOr:
+    dsc.put(rvid.blobify().data(), vtx.blobify(), rdb.vtxCol.handle()).isOkOr:
       # Caller must `rollback()` which will flush the `rdVtxLru` cache
       const errSym = RdbBeDriverPutVtxError
       when extraTraceMessages:

--- a/nimbus/db/aristo/aristo_serialise.nim
+++ b/nimbus/db/aristo/aristo_serialise.nim
@@ -86,7 +86,7 @@ proc to*(node: NodeRef; T: type seq[Blob]): T =
 
       var wrx = initRlpWriter()
       wrx.startList(2)
-      wrx.append node.ePfx.toHexPrefix(isleaf = false)
+      wrx.append node.ePfx.toHexPrefix(isleaf = false).data()
       wrx.append brHash
 
       result.add wrx.finish()
@@ -104,7 +104,7 @@ proc to*(node: NodeRef; T: type seq[Blob]): T =
 
     var wr = initRlpWriter()
     wr.startList(2)
-    wr.append node.lPfx.toHexPrefix(isleaf = true)
+    wr.append node.lPfx.toHexPrefix(isleaf = true).data()
     wr.append node.lData.serialise(getKey0).value
 
     result.add (wr.finish())
@@ -127,7 +127,7 @@ proc digestTo*(node: NodeRef; T: type HashKey): T =
       let brHash = wr.finish().digestTo(HashKey)
       wr = initRlpWriter()
       wr.startList(2)
-      wr.append node.ePfx.toHexPrefix(isleaf = false)
+      wr.append node.ePfx.toHexPrefix(isleaf = false).data()
       wr.append brHash
 
   of Leaf:
@@ -138,7 +138,7 @@ proc digestTo*(node: NodeRef; T: type HashKey): T =
       ok(node.key[0]) # always succeeds
 
     wr.startList(2)
-    wr.append node.lPfx.toHexPrefix(isleaf = true)
+    wr.append node.lPfx.toHexPrefix(isleaf = true).data()
     wr.append node.lData.serialise(getKey0).value
 
   wr.finish().digestTo(HashKey)

--- a/tests/test_aristo/test_blobify.nim
+++ b/tests/test_aristo/test_blobify.nim
@@ -65,8 +65,8 @@ suite "Aristo blobify":
       )
 
     check:
-      deblobify(blobify(leafRawData)[], VertexRef)[] == leafRawData
-      deblobify(blobify(leafAccount)[], VertexRef)[] == leafAccount
-      deblobify(blobify(leafStoData)[], VertexRef)[] == leafStoData
-      deblobify(blobify(branch)[], VertexRef)[] == branch
-      deblobify(blobify(extension)[], VertexRef)[] == extension
+      deblobify(blobify(leafRawData), VertexRef)[] == leafRawData
+      deblobify(blobify(leafAccount), VertexRef)[] == leafAccount
+      deblobify(blobify(leafStoData), VertexRef)[] == leafStoData
+      deblobify(blobify(branch), VertexRef)[] == branch
+      deblobify(blobify(extension), VertexRef)[] == extension

--- a/tests/test_aristo/test_portal_proof.nim
+++ b/tests/test_aristo/test_portal_proof.nim
@@ -115,7 +115,7 @@ func asExtension(b: Blob; path: Hash256): Blob =
     var wr = initRlpWriter()
 
     wr.startList(2)
-    wr.append NibblesBuf.fromBytes(@[nibble]).slice(1).toHexPrefix(isleaf=false)
+    wr.append NibblesBuf.fromBytes(@[nibble]).slice(1).toHexPrefix(isleaf=false).data()
     wr.append node.listElem(nibble.int).toBytes
     wr.finish()
 


### PR DESCRIPTION
* pre-allocate `blobify` data and remove redundant error handling (cannot fail on correct data)
* use threadvar for temporary storage when decoding rdb, avoiding closure env
* speed up database walkers by avoiding many temporaries

~5% perf improvement on block import, 100x on database iteration (useful for building analysis tooling)