### PR TITLE
Fluffy State Bridge: State building fixes

### DIFF
--- a/fluffy/tools/portal_bridge/state_bridge/database.nim
+++ b/fluffy/tools/portal_bridge/state_bridge/database.nim
@@ -122,6 +122,9 @@ proc del(
 ): bool {.gcsafe, raises: [].} =
   if dbBackend.contains(key):
     doAssert dbBackend.tx.delete(key, dbBackend.cfHandle).isOk()
+
+    if not dbBackend.updatedCache.isNil():
+      dbBackend.updatedCache.del(key)
     true
   else:
     false

--- a/fluffy/tools/portal_bridge/state_bridge/world_state_helper.nim
+++ b/fluffy/tools/portal_bridge/state_bridge/world_state_helper.nim
@@ -52,15 +52,9 @@ proc applyStateDiff*(worldState: WorldStateRef, txDiff: TransactionDiff) =
 
     if nonceDiff.kind == create or nonceDiff.kind == update:
       accState.setNonce(nonceDiff.after)
-    elif nonceDiff.kind == delete:
-      doAssert deleteAccount == true
 
-    if codeDiff.kind == create and codeDiff.after.len() > 0:
+    if codeDiff.kind == create or codeDiff.kind == update:
       accState.setCode(codeDiff.after)
-    elif codeDiff.kind == update:
-      accState.setCode(codeDiff.after)
-    elif codeDiff.kind == delete:
-      doAssert deleteAccount == true
 
     for (slotKey, slotValueDiff) in storageDiff:
       if slotValueDiff.kind == create or slotValueDiff.kind == update:


### PR DESCRIPTION
This PR fixes the following issues:
- Fixed bug where within a single block a contract was created, deleted and then recreated with empty code. We now allow creating contract with empty code.
- Updated cache values are now deleted when keys are deleted from the database such as when an account is deleted and therefore the code is deleted. The updated cache should also be deleted in this case.