### PR TITLE
Reverse calculate the radius at node restart

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -129,16 +129,12 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
       config.dataDir / config.network.getDbDirectory() / "contentdb_" &
         d.localNode.id.toBytesBE().toOpenArray(0, 8).toHex(),
       storageCapacity = config.storageCapacityMB * 1_000_000,
+      radiusConfig = config.radiusConfig,
+      localId = d.localNode.id,
       manualCheckpoint = true,
     )
 
-    let radius =
-      if config.radiusConfig.kind == Static:
-        UInt256.fromLogRadius(config.radiusConfig.logRadius)
-      else:
-        let oldRadiusApproximation = db.getLargestDistance(d.localNode.id)
-        db.estimateNewRadius(oldRadiusApproximation)
-
+    let radius = db.estimateNewRadius(config.radiusConfig)
     # Note: In the case of dynamical radius this is all an approximation that
     # heavily relies on uniformly distributed content and thus will always
     # have an error margin, either down or up of the requested capacity.

--- a/fluffy/network/beacon/beacon_network.nim
+++ b/fluffy/network/beacon/beacon_network.nim
@@ -196,23 +196,15 @@ proc new*(
 
     stream = streamManager.registerNewStream(contentQueue)
 
-    # Need to adjust the radius to a static max value as for the Beacon chain
-    # network all data must be accepted currently.
-    portalConfigAdjusted = PortalProtocolConfig(
-      tableIpLimits: portalConfig.tableIpLimits,
-      bitsPerHop: portalConfig.bitsPerHop,
-      radiusConfig: RadiusConfig(kind: Static, logRadius: 256),
-      disablePoke: portalConfig.disablePoke,
-    )
-
     portalProtocol = PortalProtocol.new(
       baseProtocol,
       getProtocolId(portalNetwork, PortalSubnetwork.beacon),
       toContentIdHandler,
       createGetHandler(beaconDb),
+      createRadiusHandler(beaconDb),
       stream,
       bootstrapRecords,
-      config = portalConfigAdjusted,
+      config = portalConfig,
     )
 
   portalProtocol.dbPut = createStoreHandler(beaconDb)

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -692,6 +692,7 @@ proc new*(
       getProtocolId(portalNetwork, PortalSubnetwork.history),
       toContentIdHandler,
       createGetHandler(contentDB),
+      createRadiusHandler(contentDB),
       stream,
       bootstrapRecords,
       config = portalConfig,
@@ -752,10 +753,11 @@ proc statusLogLoop(n: HistoryNetwork) {.async: (raises: []).} =
       # radius drop.
       # TODO: Get some float precision calculus?
       let radiusPercentage =
-        n.portalProtocol.dataRadius div (UInt256.high() div u256(100))
+        n.portalProtocol.dataRadius() div (UInt256.high() div u256(100))
 
       info "History network status",
-        radius = radiusPercentage.toString(10) & "%",
+        radiusPercentage = radiusPercentage.toString(10) & "%",
+        radius = n.portalProtocol.dataRadius().toHex(),
         dbSize = $(n.contentDB.size() div 1000) & "kb",
         routingTableNodes = n.portalProtocol.routingTable.len()
 

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -57,6 +57,7 @@ proc new*(
     getProtocolId(portalNetwork, PortalSubnetwork.state),
     toContentIdHandler,
     createGetHandler(contentDB),
+    createRadiusHandler(contentDB),
     s,
     bootstrapRecords,
     config = portalConfig,

--- a/fluffy/network/wire/portal_protocol_config.nim
+++ b/fluffy/network/wire/portal_protocol_config.nim
@@ -73,18 +73,6 @@ func fromLogRadius*(T: type UInt256, logRadius: uint16): T =
   # Get the max value of the logRadius range
   pow((2).stuint(256), logRadius) - 1
 
-func getInitialRadius*(rc: RadiusConfig): UInt256 =
-  case rc.kind
-  of Static:
-    return UInt256.fromLogRadius(rc.logRadius)
-  of Dynamic:
-    # In case of a dynamic radius we start from the maximum value to quickly
-    # gather as much data as possible, and also make sure each data piece in
-    # the database is in our range after a node restart.
-    # Alternative would be to store node the radius in database, and initialize
-    # it from database after a restart
-    return UInt256.high()
-
 ## Confutils parsers
 
 proc parseCmdArg*(T: type RadiusConfig, p: string): T {.raises: [ValueError].} =

--- a/fluffy/portal_node.nim
+++ b/fluffy/portal_node.nim
@@ -79,6 +79,8 @@ proc new*(
       config.dataDir / network.getDbDirectory() / "contentdb_" &
         discovery.localNode.id.toBytesBE().toOpenArray(0, 8).toHex(),
       storageCapacity = config.storageCapacity,
+      radiusConfig = config.portalConfig.radiusConfig,
+      localId = discovery.localNode.id,
     )
     # TODO: Portal works only over mainnet data currently
     networkData = loadNetworkData("mainnet")

--- a/fluffy/tests/state_network_tests/state_test_helpers.nim
+++ b/fluffy/tests/state_network_tests/state_test_helpers.nim
@@ -115,7 +115,9 @@ proc newStateNode*(
 ): StateNode {.raises: [CatchableError].} =
   let
     node = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(port))
-    db = ContentDB.new("", uint32.high, inMemory = true)
+    db = ContentDB.new(
+      "", uint32.high, RadiusConfig(kind: Dynamic), node.localNode.id, inMemory = true
+    )
     sm = StreamManager.new(node)
     hn = HistoryNetwork.new(PortalNetwork.none, node, db, sm, FinishedAccumulator())
     sn =

--- a/fluffy/tests/test_history_network.nim
+++ b/fluffy/tests/test_history_network.nim
@@ -26,7 +26,9 @@ proc newHistoryNode(
 ): HistoryNode =
   let
     node = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(port))
-    db = ContentDB.new("", uint32.high, inMemory = true)
+    db = ContentDB.new(
+      "", uint32.high, RadiusConfig(kind: Dynamic), node.localNode.id, inMemory = true
+    )
     streamManager = StreamManager.new(node)
     historyNetwork =
       HistoryNetwork.new(PortalNetwork.none, node, db, streamManager, accumulator)

--- a/fluffy/tools/fcli_db.nim
+++ b/fluffy/tools/fcli_db.nim
@@ -69,7 +69,13 @@ func generateRandomU256(rng: var HmacDrbgContext): UInt256 =
 proc cmdGenerate(conf: DbConf) =
   let
     rng = newRng()
-    db = ContentDB.new(conf.databaseDir.string, maxDbSize, inMemory = false)
+    db = ContentDB.new(
+      conf.databaseDir.string,
+      maxDbSize,
+      RadiusConfig(kind: Dynamic),
+      u256(0),
+      inMemory = false,
+    )
     bytes = newSeq[byte](conf.contentSize)
 
   for i in 0 ..< conf.contentAmount:
@@ -79,7 +85,13 @@ proc cmdGenerate(conf: DbConf) =
 proc cmdBench(conf: DbConf) =
   let
     rng = newRng()
-    db = ContentDB.new(conf.databaseDir.string, 4_000_000_000'u64, inMemory = false)
+    db = ContentDB.new(
+      conf.databaseDir.string,
+      4_000_000_000'u64,
+      RadiusConfig(kind: Dynamic),
+      u256(0),
+      inMemory = false,
+    )
     bytes = newSeq[byte](conf.contentSize)
 
   var timers: array[Timers, RunningStat]
@@ -126,6 +138,8 @@ proc cmdPrune(conf: DbConf) =
     let db = ContentDB.new(
       conf.databaseDir.string,
       storageCapacity = 1_000_000, # Doesn't matter if only space reclaiming is done
+      RadiusConfig(kind: Dynamic),
+      u256(0),
       manualCheckpoint = true,
     )
 

--- a/fluffy/tools/portalcli.nim
+++ b/fluffy/tools/portalcli.nim
@@ -243,7 +243,9 @@ proc run(config: PortalCliConf) =
   d.open()
 
   let
-    db = ContentDB.new("", config.storageSize, inMemory = true)
+    db = ContentDB.new(
+      "", config.storageSize, defaultRadiusConfig, d.localNode.id, inMemory = true
+    )
     sm = StreamManager.new(d)
     cq = newAsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])](50)
     stream = sm.registerNewStream(cq)
@@ -252,6 +254,7 @@ proc run(config: PortalCliConf) =
       config.protocolId,
       testContentIdHandler,
       createGetHandler(db),
+      createRadiusHandler(db),
       stream,
       bootstrapRecords = bootstrapRecords,
     )


### PR DESCRIPTION
This avoid restarting the node always with a full radius, which causes the node the be bombarded with offers which it later has to delete anyhow.

In order to implement this functionality, several changes were made as the radius needed to move from the Portal wire protocol current location to the contentDB and beaconDB, which is conceptually more correct anyhow.

So radius is now part of the database objects and a handler is used in the portal wire protocol to access its value.

This fixes https://github.com/status-im/nimbus-eth1/issues/2262

Example of these initial big amount of offers due to max radius:
![image](https://github.com/user-attachments/assets/a00bb0f7-812f-4bdb-851a-4dd207ec9944)
