### PR TITLE
small cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,11 +191,6 @@ ifneq ($(ENABLE_EVMC), 0)
   T8N_PARAMS := -d:chronicles_enabled=off
 endif
 
-# disabled by default, enable with ENABLE_VMLOWMEM=1
-ifneq ($(if $(ENABLE_VMLOWMEM),$(ENABLE_VMLOWMEM),0),0)
-  NIM_PARAMS += -d:lowmem:1
-endif
-
 # eth protocol settings, rules from "nimbus/sync/protocol/eth/variables.mk"
 NIM_PARAMS := $(NIM_PARAMS) $(NIM_ETH_PARAMS)
 

--- a/README.md
+++ b/README.md
@@ -211,11 +211,6 @@ available.)
  * ENABLE_EVMC=1<br>
    Enable mostly EVMC compliant wrapper around the native Nim VM
 
- * ENABLE_VMLOWMEM=1<br>
-   Enable low-memory version of the native Nim VM. This version is not
-   optimised and coded in a way so that low memory compilers can handle it
-   (observed on 32 bit windows 7.)
-
 For these variables, using &lt;variable&gt;=0 is ignored and &lt;variable&gt;=2
 has the same effect as &lt;variable&gt;=1 (ditto for other numbers.)
 

--- a/fluffy/nim.cfg
+++ b/fluffy/nim.cfg
@@ -16,5 +16,4 @@
 
 --styleCheck:usages
 --styleCheck:error
---hint[ConvFromXtoItselfNotNeeded]:off
 --hint[Processing]:off

--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -154,7 +154,7 @@ proc initializeDb(com: CommonRef) =
     finalized =
       try:
         com.db.finalizedHeader()
-      except BlockNotFound as exc:
+      except BlockNotFound:
         debug "No finalized block stored in database, reverting to base"
         base
     head =

--- a/nimbus/db/aristo/aristo_part.nim
+++ b/nimbus/db/aristo/aristo_part.nim
@@ -117,7 +117,7 @@ proc partUntwigGeneric*(
   try:
     let nibbles = NibblesBuf.fromBytes path
     return chain.trackRlpNodes(root.to(HashKey), nibbles, start=true)
-  except RlpError as e:
+  except RlpError:
     return err(PartTrkRlpError)
 
 proc partUntwigPath*(

--- a/nimbus/db/aristo/aristo_part/part_helpers.nim
+++ b/nimbus/db/aristo/aristo_part/part_helpers.nim
@@ -124,7 +124,7 @@ func toNodesTab*(
     # Decode blob `w`
     let nd = block:
       try: rlp.decode(w, PrfNode)
-      except RlpError as e:
+      except RlpError:
         return err(PartRlpNodeException)
 
     case nd.prfType:
@@ -142,7 +142,7 @@ func toNodesTab*(
         var pyl: PrfPayload
         try:
           pyl = rlp.decode(nd.lData.rawBlob, PrfPayload)
-        except RlpError as e:
+        except RlpError:
           pyl = PrfPayload(prfType: isError, error: PartRlpPayloadException)
 
         case pyl.prfType:

--- a/nimbus/evm/interpreter_dispatch.nim
+++ b/nimbus/evm/interpreter_dispatch.nim
@@ -10,11 +10,6 @@
 
 {.push raises: [].}
 
-const
-  # help with low memory when compiling selectVM() function
-  lowmem {.intdefine.}: int = 0
-  lowMemoryCompileTime {.used.} = lowmem > 0
-
 import
   std/[macros, strformat],
   pkg/[chronicles, chronos, stew/byteutils],
@@ -29,14 +24,6 @@ logScope:
 # ------------------------------------------------------------------------------
 # Private functions
 # ------------------------------------------------------------------------------
-
-const
-  supportedOS = defined(windows) or defined(linux) or defined(macosx)
-  optimizationCondition = not lowMemoryCompileTime and defined(release) and supportedOS
-
-when optimizationCondition:
-  # this is a top level pragma since nim 1.6.16
-  {.optimization: speed.}
 
 proc runVM(
     c: VmCpt,

--- a/nimbus/evm/interpreter_dispatch.nim
+++ b/nimbus/evm/interpreter_dispatch.nim
@@ -8,6 +8,8 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
+{.push raises: [].}
+
 const
   # help with low memory when compiling selectVM() function
   lowmem {.intdefine.}: int = 0
@@ -19,9 +21,7 @@ import
   ".."/[constants, db/ledger],
   "."/[code_stream, computation, evm_errors],
   "."/[message, precompiles, state, types],
-  ./interpreter/[op_dispatcher, gas_costs]
-
-{.push raises: [].}
+  ./interpreter/op_dispatcher
 
 logScope:
   topics = "vm opcode"

--- a/nimbus/rpc/server_api.nim
+++ b/nimbus/rpc/server_api.nim
@@ -60,7 +60,7 @@ proc ledgerFromTag(api: ServerAPIRef, blockTag: BlockTag): Result[LedgerRef, str
     # TODO: Replay state?
     err("Block state not ready")
 
-proc blockFromTag(api: ServerAPIRef, blockTag: BlockTag): Result[EthBlock, string] =
+func blockFromTag(api: ServerAPIRef, blockTag: BlockTag): Result[EthBlock, string] =
   if blockTag.kind == bidAlias:
     let tag = blockTag.alias.toLowerAscii
     case tag
@@ -71,12 +71,7 @@ proc blockFromTag(api: ServerAPIRef, blockTag: BlockTag): Result[EthBlock, strin
     let blockNum = common.BlockNumber blockTag.number
     return api.chain.blockByNumber(blockNum)
 
-proc blockFromTag(api: ServerAPIRef, blockTag: Opt[BlockTag]): Result[EthBlock, string] =
-  let blockId = blockTag.get(defaultTag)
-  api.blockFromTag(blockId)
-
 proc setupServerAPI*(api: ServerAPIRef, server: RpcServer) =
-
   server.rpc("eth_getBalance") do(data: Web3Address, blockTag: BlockTag) -> UInt256:
     ## Returns the balance of the account of given address.
     let

--- a/nimbus/tracer.nim
+++ b/nimbus/tracer.nim
@@ -63,8 +63,7 @@ proc init(
     T: type CaptCtxRef;
     com: CommonRef;
     root: common.Hash256;
-      ): T
-      {.raises: [CatchableError].} =
+      ): T =
   let ctx = block:
     let rc = com.db.ctx.newCtxByKey(root)
     if rc.isErr:

--- a/nimbus_verified_proxy/nim.cfg
+++ b/nimbus_verified_proxy/nim.cfg
@@ -19,5 +19,4 @@
 
 --styleCheck:usages
 --styleCheck:error
---hint[ConvFromXtoItselfNotNeeded]:off
 --hint[Processing]:off

--- a/premix/persist.nim
+++ b/premix/persist.nim
@@ -17,25 +17,13 @@ import
   ../nimbus/core/chain,
   ../nimbus/common,
   ../nimbus/db/opts,
-  ../nimbus/db/[core_db/persistent, storage_types],
+  ../nimbus/db/core_db/persistent,
   configuration  # must be late (compilation annoyance)
 
 when defined(graphql):
   import graphql_downloader
 else:
   import downloader
-
-# `lmdb` is not used, anymore
-#
-# const
-#   manualCommit = nimbus_db_backend == "lmdb"
-#
-# template persistToDb(db: ChainDB, body: untyped) =
-#   when manualCommit:
-#     if not db.txBegin(): doAssert(false)
-#   body
-#   when manualCommit:
-#     if not db.txCommit(): doAssert(false)
 
 template persistToDb(db: CoreDbRef, body: untyped) =
   block: body

--- a/tests/test_aristo/test_merge_proof.nim
+++ b/tests/test_aristo/test_merge_proof.nim
@@ -125,10 +125,6 @@ proc testMergeProofAndKvpList*(
       # Update root
       rootKey = w.root
 
-    let
-      db = ps.db
-      testId = idPfx & "#" & $w.id & "." & $n
-
     if 0 < w.proof.len:
       let rc = ps.partPut(w.proof, ForceGenericPayload)
       xCheckRc rc.error == 0


### PR DESCRIPTION
Mostly targeting some specific compile warnings/hints, e.g., regarding unused variables, imports, and impossible-to-throw exceptions.

Regarding the removal of the lowmem compilation tuning,
https://github.com/status-im/nimbus-eth1/blob/0a8986bc77e816e47b442bb78aec6b2df565ea9d/config.nims#L133
already implies this unconditionally. It was was/is misleading to have this build time tunable which does nothing on top of the already-existing `config.nims`