### PR TITLE
Migrate `keyed_queue` to `minilru`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -237,3 +237,6 @@
 	url = https://github.com/status-im/portal-mainnet.git
 	ignore = untracked
 	branch = master
+[submodule "vendor/nim-minilru"]
+	path = vendor/nim-minilru
+	url = https://github.com/status-im/nim-minilru.git

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -30,7 +30,8 @@ requires "nim >= 1.6.0",
   "ethash",
   "blscurve",
   "evmc",
-  "web3"
+  "web3",
+  "minilru"
 
 binDir = "build"
 

--- a/nimbus/db/aristo/aristo_blobify.nim
+++ b/nimbus/db/aristo/aristo_blobify.nim
@@ -16,7 +16,7 @@ import
   stew/[arrayops, endians2],
   ./aristo_desc
 
-export aristo_desc
+export aristo_desc, results
 
 # Allocation-free version short big-endian encoding that skips the leading
 # zeroes

--- a/nimbus/db/aristo/aristo_constants.nim
+++ b/nimbus/db/aristo/aristo_constants.nim
@@ -12,7 +12,6 @@
 
 import
   std/sets,
-  eth/common,
   ./aristo_desc/desc_identifiers
 
 const

--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -219,7 +219,7 @@ proc deleteStorageData*(
 
   ?db.deleteImpl(stoHike)
 
-  db.layersPutStoLeaf(AccountKey.mixUp(accPath, stoPath), nil)
+  db.layersPutStoLeaf(mixUp(accPath, stoPath), nil)
 
   # Make sure that an account leaf has no dangling sub-trie
   if db.getVtx((stoID.vid, stoID.vid)).isValid:

--- a/nimbus/db/aristo/aristo_delete/delete_subtree.nim
+++ b/nimbus/db/aristo/aristo_delete/delete_subtree.nim
@@ -62,7 +62,7 @@ proc delStoTreeNow(
 
   of Leaf:
     let stoPath = Hash256(data: (stoPath & vtx.lPfx).getBytes())
-    db.layersPutStoLeaf(AccountKey.mixUp(accPath, stoPath), nil)
+    db.layersPutStoLeaf(mixUp(accPath, stoPath), nil)
 
   db.disposeOfVtx(rvid)
 

--- a/nimbus/db/aristo/aristo_delta.nim
+++ b/nimbus/db/aristo/aristo_delta.nim
@@ -104,14 +104,10 @@ proc deltaPersistent*(
 
   # Copy back updated payloads
   for accPath, vtx in db.balancer.accLeaves:
-    let accKey = accPath.to(AccountKey)
-    if not db.accLeaves.lruUpdate(accKey, vtx):
-      discard db.accLeaves.lruAppend(accKey, vtx, ACC_LRU_SIZE)
+    db.accLeaves.put(accPath, vtx)
 
   for mixPath, vtx in db.balancer.stoLeaves:
-    let mixKey = mixPath.to(AccountKey)
-    if not db.stoLeaves.lruUpdate(mixKey, vtx):
-      discard db.stoLeaves.lruAppend(mixKey, vtx, ACC_LRU_SIZE)
+    db.stoLeaves.put(mixPath, vtx)
 
   # Done with balancer, all saved to backend
   db.balancer = LayerRef(nil)

--- a/nimbus/db/aristo/aristo_init/persistent.nim
+++ b/nimbus/db/aristo/aristo_init/persistent.nim
@@ -52,8 +52,11 @@ proc newAristoRdbDbRef(
         return err(rc.error)
       rc.value
   ok((AristoDbRef(
-    top: LayerRef(vTop: vTop),
-    backend: be), oCfs))
+      top: LayerRef(vTop: vTop),
+      backend: be,
+      accLeaves: LruCache[Hash256, VertexRef].init(ACC_LRU_SIZE),
+      stoLeaves: LruCache[Hash256, VertexRef].init(ACC_LRU_SIZE),
+    ), oCfs))
 
 # ------------------------------------------------------------------------------
 # Public database constuctors, destructor

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -18,9 +18,12 @@ import
   std/concurrency/atomics,
   eth/common,
   rocksdb,
-  stew/[endians2, keyed_queue],
+  stew/endians2,
   ../../aristo_desc,
-  ../init_common
+  ../init_common,
+  minilru
+
+export minilru
 
 type
   RdbWriteEventCb* =
@@ -53,9 +56,9 @@ type
     # is less memory and time efficient (the latter one due to internal LRU
     # handling of the longer key.)
     #
-    rdKeyLru*: KeyedQueue[VertexID,HashKey] ## Read cache
+    rdKeyLru*: LruCache[VertexID,HashKey] ## Read cache
     rdKeySize*: int
-    rdVtxLru*: KeyedQueue[VertexID,VertexRef] ## Read cache
+    rdVtxLru*: LruCache[VertexID,VertexRef] ## Read cache
     rdVtxSize*: int
 
     basePath*: string                  ## Database directory

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_init.nim
@@ -26,10 +26,8 @@ import
 # ------------------------------------------------------------------------------
 
 const
-  lruOverhead = 32
-    # Approximate LRU cache overhead per entry - although `keyed_queue` which is
-    # currently used has a much larger overhead, 32 is an easily reachable
-    # number which likely can be reduced in the future
+  lruOverhead = 20
+    # Approximate LRU cache overhead per entry based on minilru sizes
 
 proc dumpCacheStats(keySize, vtxSize: int) =
   block vtx:
@@ -87,6 +85,9 @@ proc initImpl(
     opts.rdbKeyCacheSize div (sizeof(VertexID) + sizeof(HashKey) + lruOverhead)
   rdb.rdVtxSize =
     opts.rdbVtxCacheSize div (sizeof(VertexID) + sizeof(default(VertexRef)[]) + lruOverhead)
+
+  rdb.rdKeyLru = typeof(rdb.rdKeyLru).init(rdb.rdKeySize)
+  rdb.rdVtxLru = typeof(rdb.rdVtxLru).init(rdb.rdVtxSize)
 
   if opts.rdbPrintStats:
     let

--- a/nimbus/db/aristo/aristo_merge.nim
+++ b/nimbus/db/aristo/aristo_merge.nim
@@ -140,7 +140,7 @@ proc mergeStorageData*(
         # Mark account path Merkle keys for update
         resetKeys()
 
-        db.layersPutStoLeaf(AccountKey.mixUp(accPath, stoPath), rc.value)
+        db.layersPutStoLeaf(mixUp(accPath, stoPath), rc.value)
 
         if not stoID.isValid:
           # Make sure that there is an account that refers to that storage trie

--- a/nimbus/db/core_db/backend/aristo_trace.nim
+++ b/nimbus/db/core_db/backend/aristo_trace.nim
@@ -17,6 +17,7 @@
 
 import
   std/[sequtils, tables, typetraits],
+  stew/keyed_queue,
   eth/common,
   results,
   ../../aristo as use_aristo,


### PR DESCRIPTION
Compared to `keyed_queue`, `minilru` uses significantly less memory, in particular for the 32-byte hash keys where `kq` stores several copies of the key redundantly.