### PR TITLE
Fluffy: Prevent removal of bootstrap nodes in local networks.

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -154,6 +154,7 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
     portalProtocolConfig = PortalProtocolConfig.init(
       config.tableIpLimit, config.bucketIpLimit, config.bitsPerHop, config.radiusConfig,
       config.disablePoke,
+      disableBootstrapRemoval = config.network == PortalNetwork.none # don't remove bootstrap nodes for local networks
     )
 
     portalNodeConfig = PortalNodeConfig(
@@ -166,6 +167,7 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
       portalConfig: portalProtocolConfig,
       dataDir: string config.dataDir,
       storageCapacity: config.storageCapacityMB * 1_000_000,
+
     )
 
     node = PortalNode.new(

--- a/fluffy/network/wire/portal_protocol_config.nim
+++ b/fluffy/network/wire/portal_protocol_config.nim
@@ -40,12 +40,14 @@ type
     bitsPerHop*: int
     radiusConfig*: RadiusConfig
     disablePoke*: bool
+    disableBootstrapRemoval*: bool
 
 const
   defaultRadiusConfig* = RadiusConfig(kind: Dynamic)
   defaultRadiusConfigDesc* = $defaultRadiusConfig.kind
   defaultDisablePoke* = false
   revalidationTimeout* = chronos.seconds(30)
+  disableBootstrapRemoval* = false
 
   defaultPortalProtocolConfig* = PortalProtocolConfig(
     tableIpLimits: DefaultTableIpLimits,
@@ -60,6 +62,7 @@ proc init*(
     bitsPerHop: int,
     radiusConfig: RadiusConfig,
     disablePoke: bool,
+    disableBootstrapRemoval: bool,
 ): T =
   PortalProtocolConfig(
     tableIpLimits:
@@ -67,6 +70,7 @@ proc init*(
     bitsPerHop: bitsPerHop,
     radiusConfig: radiusConfig,
     disablePoke: disablePoke,
+    disableBootstrapRemoval: disableBootstrapRemoval
   )
 
 func fromLogRadius*(T: type UInt256, logRadius: uint16): T =


### PR DESCRIPTION
When network=none we don't connect to mainnet or the testnet so we likely need to use our own bootstrap nodes in this case rather than use the default ones. 

I found that Fluffy would remove its peer nodes from the routing table if any timeout occurs which breaks things in a small local network such as when there are only two nodes running. In this case the nodes would need to be restarted to force them to reconnect to each other.

This change prevents the nodes from being removed if they are defined as bootstrap nodes and network=none.