### PR TITLE
Update Fluffy state JSON-RPC endpoints to use history header by block number lookup

### DIFF
--- a/fluffy/network/state/state_endpoints.nim
+++ b/fluffy/network/state/state_endpoints.nim
@@ -266,50 +266,56 @@ proc getProofsByStateRoot*(
 
 # Used by: eth_getBalance,
 proc getBalance*(
-    n: StateNetwork, blockHash: BlockHash, address: EthAddress
+    n: StateNetwork, blockNumOrHash: uint64 | BlockHash, address: EthAddress
 ): Future[Opt[UInt256]] {.async: (raises: [CancelledError]).} =
-  let stateRoot = (await n.getStateRootByBlockHash(blockHash)).valueOr:
-    warn "Failed to get state root by block hash"
+  let stateRoot = (await n.getStateRootByBlockNumOrHash(blockNumOrHash)).valueOr:
+    warn "Failed to get state root by block number or hash", blockNumOrHash
     return Opt.none(UInt256)
 
   await n.getBalanceByStateRoot(stateRoot, address)
 
 # Used by: eth_getTransactionCount
 proc getTransactionCount*(
-    n: StateNetwork, blockHash: BlockHash, address: EthAddress
+    n: StateNetwork, blockNumOrHash: uint64 | BlockHash, address: EthAddress
 ): Future[Opt[AccountNonce]] {.async: (raises: [CancelledError]).} =
-  let stateRoot = (await n.getStateRootByBlockHash(blockHash)).valueOr:
-    warn "Failed to get state root by block hash"
+  let stateRoot = (await n.getStateRootByBlockNumOrHash(blockNumOrHash)).valueOr:
+    warn "Failed to get state root by block number or hash", blockNumOrHash
     return Opt.none(AccountNonce)
 
   await n.getTransactionCountByStateRoot(stateRoot, address)
 
 # Used by: eth_getStorageAt
 proc getStorageAt*(
-    n: StateNetwork, blockHash: BlockHash, address: EthAddress, slotKey: UInt256
+    n: StateNetwork,
+    blockNumOrHash: uint64 | BlockHash,
+    address: EthAddress,
+    slotKey: UInt256,
 ): Future[Opt[UInt256]] {.async: (raises: [CancelledError]).} =
-  let stateRoot = (await n.getStateRootByBlockHash(blockHash)).valueOr:
-    warn "Failed to get state root by block hash"
+  let stateRoot = (await n.getStateRootByBlockNumOrHash(blockNumOrHash)).valueOr:
+    warn "Failed to get state root by block number or hash", blockNumOrHash
     return Opt.none(UInt256)
 
   await n.getStorageAtByStateRoot(stateRoot, address, slotKey)
 
 # Used by: eth_getCode
 proc getCode*(
-    n: StateNetwork, blockHash: BlockHash, address: EthAddress
+    n: StateNetwork, blockNumOrHash: uint64 | BlockHash, address: EthAddress
 ): Future[Opt[Bytecode]] {.async: (raises: [CancelledError]).} =
-  let stateRoot = (await n.getStateRootByBlockHash(blockHash)).valueOr:
-    warn "Failed to get state root by block hash"
+  let stateRoot = (await n.getStateRootByBlockNumOrHash(blockNumOrHash)).valueOr:
+    warn "Failed to get state root by block number or hash", blockNumOrHash
     return Opt.none(Bytecode)
 
   await n.getCodeByStateRoot(stateRoot, address)
 
 # Used by: eth_getProof
 proc getProofs*(
-    n: StateNetwork, blockHash: BlockHash, address: EthAddress, slotKeys: seq[UInt256]
+    n: StateNetwork,
+    blockNumOrHash: uint64 | BlockHash,
+    address: EthAddress,
+    slotKeys: seq[UInt256],
 ): Future[Opt[Proofs]] {.async: (raises: [CancelledError]).} =
-  let stateRoot = (await n.getStateRootByBlockHash(blockHash)).valueOr:
-    warn "Failed to get state root by block hash"
+  let stateRoot = (await n.getStateRootByBlockNumOrHash(blockNumOrHash)).valueOr:
+    warn "Failed to get state root by block number or hash", blockNumOrHash
     return Opt.none(Proofs)
 
   await n.getProofsByStateRoot(stateRoot, address, slotKeys)

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -130,15 +130,15 @@ proc getContractCode*(
 ): Future[Opt[ContractCodeRetrieval]] {.async: (raw: true, raises: [CancelledError]).} =
   n.getContent(key, ContractCodeRetrieval)
 
-proc getStateRootByBlockHash*(
-    n: StateNetwork, hash: BlockHash
+proc getStateRootByBlockNumOrHash*(
+    n: StateNetwork, blockNumOrHash: uint64 | BlockHash
 ): Future[Opt[KeccakHash]] {.async: (raises: [CancelledError]).} =
   if n.historyNetwork.isNone():
     warn "History network is not available"
     return Opt.none(KeccakHash)
 
-  let header = (await n.historyNetwork.get().getVerifiedBlockHeader(hash)).valueOr:
-    warn "Failed to get block header by hash", hash
+  let header = (await n.historyNetwork.get().getVerifiedBlockHeader(blockNumOrHash)).valueOr:
+    warn "Failed to get block header from history", blockNumOrHash
     return Opt.none(KeccakHash)
 
   Opt.some(header.stateRoot)
@@ -156,7 +156,7 @@ proc processOffer*(
 
   let res =
     if n.validateStateIsCanonical:
-      let stateRoot = (await n.getStateRootByBlockHash(contentValue.blockHash)).valueOr:
+      let stateRoot = (await n.getStateRootByBlockNumOrHash(contentValue.blockHash)).valueOr:
         return err("Failed to get state root by block hash")
       validateOffer(Opt.some(stateRoot), contentKey, contentValue)
     else:

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -364,10 +364,7 @@ proc installEthApiHandlers*(
 
     let
       blockNumber = quantityTag.number.uint64
-      blockHash = (await historyNetwork.getBlockHashByNumber(blockNumber)).valueOr:
-        raise newException(ValueError, "Unable to get block hash")
-
-      balance = (await sn.getBalance(blockHash, data.EthAddress)).valueOr:
+      balance = (await sn.getBalance(blockNumber, data.EthAddress)).valueOr:
         raise newException(ValueError, "Unable to get balance")
 
     return balance
@@ -390,10 +387,7 @@ proc installEthApiHandlers*(
 
     let
       blockNumber = quantityTag.number.uint64
-      blockHash = (await historyNetwork.getBlockHashByNumber(blockNumber)).valueOr:
-        raise newException(ValueError, "Unable to get block hash")
-
-      nonce = (await sn.getTransactionCount(blockHash, data.EthAddress)).valueOr:
+      nonce = (await sn.getTransactionCount(blockNumber, data.EthAddress)).valueOr:
         raise newException(ValueError, "Unable to get transaction count")
     return nonce.Quantity
 
@@ -416,10 +410,7 @@ proc installEthApiHandlers*(
 
     let
       blockNumber = quantityTag.number.uint64
-      blockHash = (await historyNetwork.getBlockHashByNumber(blockNumber)).valueOr:
-        raise newException(ValueError, "Unable to get block hash")
-
-      slotValue = (await sn.getStorageAt(blockHash, data.EthAddress, slot)).valueOr:
+      slotValue = (await sn.getStorageAt(blockNumber, data.EthAddress, slot)).valueOr:
         raise newException(ValueError, "Unable to get storage slot")
     return FixedBytes[32](slotValue.toBytesBE())
 
@@ -441,10 +432,7 @@ proc installEthApiHandlers*(
 
     let
       blockNumber = quantityTag.number.uint64
-      blockHash = (await historyNetwork.getBlockHashByNumber(blockNumber)).valueOr:
-        raise newException(ValueError, "Unable to get block hash")
-
-      bytecode = (await sn.getCode(blockHash, data.EthAddress)).valueOr:
+      bytecode = (await sn.getCode(blockNumber, data.EthAddress)).valueOr:
         raise newException(ValueError, "Unable to get code")
     return bytecode.asSeq()
 
@@ -469,9 +457,7 @@ proc installEthApiHandlers*(
 
     let
       blockNumber = quantityTag.number.uint64
-      blockHash = (await historyNetwork.getBlockHashByNumber(blockNumber)).valueOr:
-        raise newException(ValueError, "Unable to get block hash")
-      proofs = (await sn.getProofs(blockHash, data.EthAddress, slots)).valueOr:
+      proofs = (await sn.getProofs(blockNumber, data.EthAddress, slots)).valueOr:
         raise newException(ValueError, "Unable to get proofs")
 
     var storageProof = newSeqOfCap[StorageProof](slots.len)

--- a/fluffy/tests/state_network_tests/state_test_helpers.nim
+++ b/fluffy/tests/state_network_tests/state_test_helpers.nim
@@ -141,8 +141,8 @@ proc stop*(sn: StateNode) {.async.} =
 proc containsId*(sn: StateNode, contentId: ContentId): bool {.inline.} =
   return sn.stateNetwork.contentDB.get(contentId).isSome()
 
-proc mockBlockHashToStateRoot*(
-    sn: StateNode, blockHash: BlockHash, stateRoot: KeccakHash
+proc mockStateRootLookup*(
+    sn: StateNode, blockNumOrHash: uint64 | BlockHash, stateRoot: KeccakHash
 ) =
   let
     blockHeader = BlockHeader(stateRoot: stateRoot)
@@ -150,7 +150,7 @@ proc mockBlockHashToStateRoot*(
     blockHeaderWithProof = BlockHeaderWithProof(
       header: ByteList[2048].init(headerRlp), proof: BlockHeaderProof.init()
     )
-    contentKeyBytes = blockHeaderContentKey(blockHash).encode()
+    contentKeyBytes = blockHeaderContentKey(blockNumOrHash).encode()
     contentId = history_content.toContentId(contentKeyBytes)
 
   sn.portalProtocol().storeContent(

--- a/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
@@ -58,8 +58,8 @@ procSuite "State Endpoints":
         contentValue = AccountTrieNodeOffer.decode(contentValueBytes).get()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
-      stateNode2.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
+      stateNode2.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       # offer the leaf node
       let rootKeyBytes = await stateNode1.portalProtocol.recursiveGossipOffer(
@@ -181,8 +181,8 @@ procSuite "State Endpoints":
         contentValue = AccountTrieNodeOffer.decode(contentValueBytes).get()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
-      stateNode2.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
+      stateNode2.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       # offer the leaf node
       let rootKeyBytes = await stateNode1.portalProtocol.recursiveGossipOffer(
@@ -209,8 +209,8 @@ procSuite "State Endpoints":
         contentValue = ContractTrieNodeOffer.decode(contentValueBytes).get()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
-      stateNode2.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
+      stateNode2.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       # offer the leaf node
       let storageRootKeyBytes = await stateNode1.portalProtocol.recursiveGossipOffer(
@@ -262,8 +262,8 @@ procSuite "State Endpoints":
         contentValue = ContractCodeOffer.decode(contentValueBytes).get()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
-      stateNode2.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
+      stateNode2.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       await stateNode1.portalProtocol.gossipOffer(
         Opt.none(NodeId),

--- a/fluffy/tests/state_network_tests/test_state_gossip_gossipoffer_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_gossip_gossipoffer_vectors.nim
@@ -61,8 +61,8 @@ procSuite "State Gossip - Gossip Offer":
         parentContentValueBytes = parentTestData.content_value_offer.hexToSeqByte()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
-      stateNode2.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
+      stateNode2.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       check not stateNode2.containsId(contentId)
 
@@ -134,8 +134,8 @@ procSuite "State Gossip - Gossip Offer":
         parentContentValueBytes = parentTestData.content_value_offer.hexToSeqByte()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
-      stateNode2.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
+      stateNode2.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       check not stateNode2.containsId(contentId)
 
@@ -198,8 +198,8 @@ procSuite "State Gossip - Gossip Offer":
         contentValue = ContractCodeOffer.decode(contentValueBytes).get()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
-      stateNode2.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
+      stateNode2.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       check not stateNode2.containsId(contentId)
 

--- a/fluffy/tests/state_network_tests/test_state_network_offercontent_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_network_offercontent_vectors.nim
@@ -62,7 +62,7 @@ procSuite "State Network - Offer Content":
       let badStateRoot = KeccakHash.fromBytes(
         "0xBAD7b80af0c28bc1489513346d2706885be90abb07f23ca28e50482adb392d61".hexToSeqByte()
       )
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, badStateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, badStateRoot)
       check (
         await stateNode1.stateNetwork.processOffer(
           Opt.none(NodeId),
@@ -74,7 +74,7 @@ procSuite "State Network - Offer Content":
       ).isErr()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       check not stateNode1.containsId(contentId)
 
@@ -131,7 +131,7 @@ procSuite "State Network - Offer Content":
       let badStateRoot = KeccakHash.fromBytes(
         "0xBAD7b80af0c28bc1489513346d2706885be90abb07f23ca28e50482adb392d61".hexToSeqByte()
       )
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, badStateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, badStateRoot)
       check (
         await stateNode1.stateNetwork.processOffer(
           Opt.none(NodeId),
@@ -143,7 +143,7 @@ procSuite "State Network - Offer Content":
       ).isErr()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       check not stateNode1.containsId(contentId)
 
@@ -201,7 +201,7 @@ procSuite "State Network - Offer Content":
       let badStateRoot = KeccakHash.fromBytes(
         "0xBAD7b80af0c28bc1489513346d2706885be90abb07f23ca28e50482adb392d61".hexToSeqByte()
       )
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, badStateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, badStateRoot)
       check (
         await stateNode1.stateNetwork.processOffer(
           Opt.none(NodeId),
@@ -213,7 +213,7 @@ procSuite "State Network - Offer Content":
       ).isErr()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       check not stateNode1.containsId(contentId)
 
@@ -265,8 +265,8 @@ procSuite "State Network - Offer Content":
         (await stateNode1.portalProtocol().ping(stateNode2.localNode())).isOk()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
-      stateNode2.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
+      stateNode2.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       check not stateNode2.containsId(contentId)
 
@@ -315,8 +315,8 @@ procSuite "State Network - Offer Content":
         (await stateNode1.portalProtocol().ping(stateNode2.localNode())).isOk()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
-      stateNode2.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
+      stateNode2.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       check not stateNode2.containsId(contentId)
 
@@ -366,8 +366,8 @@ procSuite "State Network - Offer Content":
         (await stateNode1.portalProtocol().ping(stateNode2.localNode())).isOk()
 
       # set valid state root
-      stateNode1.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
-      stateNode2.mockBlockHashToStateRoot(contentValue.blockHash, stateRoot)
+      stateNode1.mockStateRootLookup(contentValue.blockHash, stateRoot)
+      stateNode2.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       check not stateNode2.containsId(contentId)
 


### PR DESCRIPTION
This PR updates the Fluffy state JSON-RPC APIs to directly lookup the state by blockNumber and skip the blockNumber to blockHash look up. This reduces the number of history network content look ups required in the worst case when the content doesn't exist in the local database.