### PR TITLE
simplify VertexRef

### DIFF
--- a/nimbus/db/aristo/aristo_blobify.nim
+++ b/nimbus/db/aristo/aristo_blobify.nim
@@ -200,8 +200,8 @@ proc blobifyTo*(vtx: VertexRef; data: var Blob): Result[void,AristoError] =
 
     let
       pSegm =
-        if vtx.ePfx.len > 0:
-          vtx.ePfx.toHexPrefix(isleaf = false)
+        if vtx.pfx.len > 0:
+          vtx.pfx.toHexPrefix(isleaf = false)
         else:
           default(HexPrefixBuf)
       psLen = pSegm.len.byte
@@ -214,7 +214,7 @@ proc blobifyTo*(vtx: VertexRef; data: var Blob): Result[void,AristoError] =
 
   of Leaf:
     let
-      pSegm = vtx.lPfx.toHexPrefix(isleaf = true)
+      pSegm = vtx.pfx.toHexPrefix(isleaf = true)
       psLen = pSegm.len.byte
     if psLen == 0 or 33 < psLen:
       return err(BlobifyLeafPathOverflow)
@@ -325,7 +325,7 @@ proc deblobify*(
       # End `while`
     VertexRef(
       vType: Branch,
-      ePfx:  pathSegment,
+      pfx:   pathSegment,
       bVid:  vtxList)
 
   of 3: # `Leaf` vertex
@@ -341,7 +341,7 @@ proc deblobify*(
       return err(DeblobLeafGotExtPrefix)
     let vtx = VertexRef(
       vType: Leaf,
-      lPfx:  pathSegment)
+      pfx:  pathSegment)
 
     ? record.toOpenArray(0, pLen - 1).deblobify(vtx.lData)
     vtx

--- a/nimbus/db/aristo/aristo_compute.nim
+++ b/nimbus/db/aristo/aristo_compute.nim
@@ -68,7 +68,7 @@ proc computeKeyImpl(
   case vtx.vType:
   of Leaf:
     writer.startList(2)
-    writer.append(vtx.lPfx.toHexPrefix(isLeaf = true).data())
+    writer.append(vtx.pfx.toHexPrefix(isLeaf = true).data())
 
     case vtx.lData.pType
     of AccountData:
@@ -106,12 +106,12 @@ proc computeKeyImpl(
         else:
           w.append(VOID_HASH_KEY)
       w.append EmptyBlob
-    if vtx.ePfx.len > 0: # Extension node
+    if vtx.pfx.len > 0: # Extension node
       var bwriter = initRlpWriter()
       writeBranch(bwriter)
 
       writer.startList(2)
-      writer.append(vtx.ePfx.toHexPrefix(isleaf = false).data())
+      writer.append(vtx.pfx.toHexPrefix(isleaf = false).data())
       writer.append(bwriter.finish().digestTo(HashKey))
     else:
       writeBranch(writer)

--- a/nimbus/db/aristo/aristo_debug.nim
+++ b/nimbus/db/aristo/aristo_debug.nim
@@ -209,9 +209,9 @@ proc ppVtx(nd: VertexRef, db: AristoDbRef, rvid: RootedVertexID): string =
       result = ["ł(", "þ("][nd.vType.ord]
     case nd.vType:
     of Leaf:
-      result &= nd.lPfx.ppPathPfx & "," & nd.lData.ppPayload(db)
+      result &= nd.pfx.ppPathPfx & "," & nd.lData.ppPayload(db)
     of Branch:
-      result &= nd.ePfx.ppPathPfx & ":"
+      result &= nd.pfx.ppPathPfx & ":"
       for n in 0..15:
         if nd.bVid[n].isValid:
           result &= nd.bVid[n].ppVid
@@ -229,33 +229,33 @@ proc ppNode(
     result = "ø"
   else:
     if not rvid.isValid:
-      result = ["L(", "B("][nd.vType.ord]
+      result = ["L(", "B("][nd.vtx.vType.ord]
     elif db.layersGetKey(rvid).isOk:
-      result = ["l(", "b("][nd.vType.ord]
+      result = ["l(", "b("][nd.vtx.vType.ord]
     else:
-      result = ["ł(", "þ("][nd.vType.ord]
-    case nd.vType:
+      result = ["ł(", "þ("][nd.vtx.vType.ord]
+    case nd.vtx.vType:
     of Leaf:
-      result &= nd.lPfx.ppPathPfx & ","
-      if nd.lData.pType == AccountData:
-        result &= "(" & nd.lData.account.ppAriAccount() & ","
-        if nd.lData.stoID.isValid:
-          let tag = db.ppKeyOk(nd.key[0],(rvid.root,nd.lData.stoID.vid))
-          result &= nd.lData.stoID.ppVid & tag
+      result &= nd.vtx.pfx.ppPathPfx & ","
+      if nd.vtx.lData.pType == AccountData:
+        result &= "(" & nd.vtx.lData.account.ppAriAccount() & ","
+        if nd.vtx.lData.stoID.isValid:
+          let tag = db.ppKeyOk(nd.key[0],(rvid.root,nd.vtx.lData.stoID.vid))
+          result &= nd.vtx.lData.stoID.ppVid & tag
         else:
-          result &= nd.lData.stoID.ppVid
+          result &= nd.vtx.lData.stoID.ppVid
           if nd.key[0].isValid:
             result &= nd.key[0].ppKey(db)
         result &= ")"
       else:
-        result &= nd.lData.ppPayload(db)
+        result &= nd.vtx.lData.ppPayload(db)
     of Branch:
-      let keyOnly = nd.bVid.toSeq.filterIt(it.isValid).len == 0
-      result &= nd.ePfx.ppPathPfx & ":"
+      let keyOnly = nd.vtx.bVid.toSeq.filterIt(it.isValid).len == 0
+      result &= nd.vtx.pfx.ppPathPfx & ":"
       for n in 0..15:
-        if nd.bVid[n].isValid:
-          let tag = db.ppKeyOk(nd.key[n],(rvid.root,nd.bVid[n]))
-          result &= nd.bVid[n].ppVid & tag
+        if nd.vtx.bVid[n].isValid:
+          let tag = db.ppKeyOk(nd.key[n],(rvid.root,nd.vtx.bVid[n]))
+          result &= nd.vtx.bVid[n].ppVid & tag
         elif keyOnly and nd.key[n].isValid:
           result &= nd.key[n].ppKey(db)
         if n < 15:

--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -97,12 +97,12 @@ proc deleteImpl(
         of Leaf:
           VertexRef(
             vType: Leaf,
-            lPfx:  br.vtx.ePfx & NibblesBuf.nibble(nbl.byte) & nxt.lPfx,
+            pfx:  br.vtx.pfx & NibblesBuf.nibble(nbl.byte) & nxt.pfx,
             lData: nxt.lData)
         of Branch:
           VertexRef(
             vType: Branch,
-            ePfx:  br.vtx.ePfx & NibblesBuf.nibble(nbl.byte) & nxt.ePfx,
+            pfx:  br.vtx.pfx & NibblesBuf.nibble(nbl.byte) & nxt.pfx,
             bVid: nxt.bVid)
 
       # Put the new vertex at the id of the obsolete branch

--- a/nimbus/db/aristo/aristo_delete/delete_subtree.nim
+++ b/nimbus/db/aristo/aristo_delete/delete_subtree.nim
@@ -58,10 +58,10 @@ proc delStoTreeNow(
       if vtx.bVid[i].isValid:
         ? db.delStoTreeNow(
           (rvid.root, vtx.bVid[i]), accPath,
-          stoPath & vtx.ePfx & NibblesBuf.nibble(byte i))
+          stoPath & vtx.pfx & NibblesBuf.nibble(byte i))
 
   of Leaf:
-    let stoPath = Hash256(data: (stoPath & vtx.lPfx).getBytes())
+    let stoPath = Hash256(data: (stoPath & vtx.pfx).getBytes())
     db.layersPutStoLeaf(mixUp(accPath, stoPath), nil)
 
   db.disposeOfVtx(rvid)

--- a/nimbus/db/aristo/aristo_hike.nim
+++ b/nimbus/db/aristo/aristo_hike.nim
@@ -47,9 +47,9 @@ func getNibblesImpl(hike: Hike; start = 0; maxLen = high(int)): NibblesBuf =
     let leg = hike.legs[n]
     case leg.wp.vtx.vType:
     of Branch:
-      result = result & leg.wp.vtx.ePfx & NibblesBuf.nibble(leg.nibble.byte)
+      result = result & leg.wp.vtx.pfx & NibblesBuf.nibble(leg.nibble.byte)
     of Leaf:
-      result = result & leg.wp.vtx.lPfx
+      result = result & leg.wp.vtx.pfx
 
 # ------------------------------------------------------------------------------
 # Public functions
@@ -89,24 +89,24 @@ proc step*(
   case vtx.vType:
   of Leaf:
     # This must be the last vertex, so there cannot be any `tail` left.
-    if path.len != path.sharedPrefixLen(vtx.lPfx):
+    if path.len != path.sharedPrefixLen(vtx.pfx):
       return err(HikeLeafUnexpected)
 
     ok (vtx, NibblesBuf(), VertexID(0))
 
   of Branch:
     # There must be some more data (aka `tail`) after a `Branch` vertex.
-    if path.len <= vtx.ePfx.len:
+    if path.len <= vtx.pfx.len:
       return err(HikeBranchTailEmpty)
 
     let
-      nibble = path[vtx.ePfx.len].int8
+      nibble = path[vtx.pfx.len].int8
       nextVid = vtx.bVid[nibble]
 
     if not nextVid.isValid:
       return err(HikeBranchMissingEdge)
 
-    ok (vtx, path.slice(vtx.ePfx.len + 1), nextVid)
+    ok (vtx, path.slice(vtx.pfx.len + 1), nextVid)
 
 
 iterator stepUp*(
@@ -162,7 +162,7 @@ proc hikeUp*(
       break
 
     of Branch:
-      hike.legs.add Leg(wp: wp, nibble: int8 hike.tail[vtx.ePfx.len])
+      hike.legs.add Leg(wp: wp, nibble: int8 hike.tail[vtx.pfx.len])
 
     hike.tail = path
     vid = next

--- a/nimbus/db/aristo/aristo_part/part_chain_rlp.nim
+++ b/nimbus/db/aristo/aristo_part/part_chain_rlp.nim
@@ -48,14 +48,14 @@ proc chainRlpNodes*(
   # Follow up child node
   case vtx.vType:
   of Leaf:
-    if path != vtx.lPfx:
+    if path != vtx.pfx:
       err(PartChnLeafPathMismatch)
     else:
       ok()
 
   of Branch:
-    let nChewOff = sharedPrefixLen(vtx.ePfx, path)
-    if nChewOff != vtx.ePfx.len:
+    let nChewOff = sharedPrefixLen(vtx.pfx, path)
+    if nChewOff != vtx.pfx.len:
       err(PartChnExtPfxMismatch)
     elif path.len == nChewOff:
       err(PartChnBranchPathExhausted)

--- a/nimbus/db/aristo/aristo_part/part_debug.nim
+++ b/nimbus/db/aristo/aristo_part/part_debug.nim
@@ -41,7 +41,7 @@ proc pp*(n: PrfNode; ps: PartStateRef): string =
   elif n.prfType == isError:
     "(" & $n.error & ")"
   elif n.prfType == isExtension:
-    "X(" & n.ePfx.pp & "," & n.key[0].pp(ps.db) & ")"
+    "X(" & n.vtx.pfx.pp & "," & n.key[0].pp(ps.db) & ")"
   else:
     "(" & NodeRef(n).pp(ps.db) & ")"
 
@@ -93,7 +93,7 @@ proc pp*(t: Table[VertexID,HashKey]; ps: PartStateRef; indent = 4): string =
          .mapIt((it,t.getOrDefault it))
          .mapIt("(" & it[0].pp & "," & it[1].pp(ps.db) & ")")
          .join("," & indent.toPfx(1)) & "}"
-      
+
 proc pp*(q: seq[HashKey]; ps: PartStateRef): string =
   "(" & q.mapIt(it.pp ps.db).join("->") & ")[#" & $q.len & "]"
 

--- a/nimbus/db/aristo/aristo_serialise.nim
+++ b/nimbus/db/aristo/aristo_serialise.nim
@@ -70,7 +70,7 @@ proc to*(node: NodeRef; T: type seq[Blob]): T =
   ## `<rlp-encoded-node>` type entries. Only in case of a combined extension
   ## and branch vertex argument, there will be a double item list result.
   ##
-  case node.vType:
+  case node.vtx.vType:
   of Branch:
     # Do branch node
     var wr = initRlpWriter()
@@ -80,13 +80,13 @@ proc to*(node: NodeRef; T: type seq[Blob]): T =
     wr.append EmptyBlob
     let brData = wr.finish()
 
-    if 0 < node.ePfx.len:
+    if 0 < node.vtx.pfx.len:
       # Prefix branch by embedded extension node
       let brHash = brData.digestTo(HashKey)
 
       var wrx = initRlpWriter()
       wrx.startList(2)
-      wrx.append node.ePfx.toHexPrefix(isleaf = false).data()
+      wrx.append node.vtx.pfx.toHexPrefix(isleaf = false).data()
       wrx.append brHash
 
       result.add wrx.finish()
@@ -104,8 +104,8 @@ proc to*(node: NodeRef; T: type seq[Blob]): T =
 
     var wr = initRlpWriter()
     wr.startList(2)
-    wr.append node.lPfx.toHexPrefix(isleaf = true).data()
-    wr.append node.lData.serialise(getKey0).value
+    wr.append node.vtx.pfx.toHexPrefix(isleaf = true).data()
+    wr.append node.vtx.lData.serialise(getKey0).value
 
     result.add (wr.finish())
 
@@ -114,7 +114,7 @@ proc digestTo*(node: NodeRef; T: type HashKey): T =
   ## that a `Dummy` node is encoded as as a `Leaf`.
   ##
   var wr = initRlpWriter()
-  case node.vType:
+  case node.vtx.vType:
   of Branch:
     # Do branch node
     wr.startList(17)
@@ -123,11 +123,11 @@ proc digestTo*(node: NodeRef; T: type HashKey): T =
     wr.append EmptyBlob
 
     # Do for embedded extension node
-    if 0 < node.ePfx.len:
+    if 0 < node.vtx.pfx.len:
       let brHash = wr.finish().digestTo(HashKey)
       wr = initRlpWriter()
       wr.startList(2)
-      wr.append node.ePfx.toHexPrefix(isleaf = false).data()
+      wr.append node.vtx.pfx.toHexPrefix(isleaf = false).data()
       wr.append brHash
 
   of Leaf:
@@ -138,8 +138,8 @@ proc digestTo*(node: NodeRef; T: type HashKey): T =
       ok(node.key[0]) # always succeeds
 
     wr.startList(2)
-    wr.append node.lPfx.toHexPrefix(isleaf = true).data()
-    wr.append node.lData.serialise(getKey0).value
+    wr.append node.vtx.pfx.toHexPrefix(isleaf = true).data()
+    wr.append node.vtx.lData.serialise(getKey0).value
 
   wr.finish().digestTo(HashKey)
 

--- a/nimbus/db/aristo/aristo_utils.nim
+++ b/nimbus/db/aristo/aristo_utils.nim
@@ -56,7 +56,7 @@ proc toNode*(
 
   case vtx.vType:
   of Leaf:
-    let node = NodeRef(vType: Leaf, lPfx: vtx.lPfx, lData: vtx.lData)
+    let node = NodeRef(vtx: vtx.dup())
     # Need to resolve storage root for account leaf
     if vtx.lData.pType == AccountData:
       let stoID = vtx.lData.stoID
@@ -68,7 +68,7 @@ proc toNode*(
     return ok node
 
   of Branch:
-    let node = NodeRef(vType: Branch, bVid: vtx.bVid, ePfx: vtx.ePfx)
+    let node = NodeRef(vtx: vtx.dup())
     var missing: seq[VertexID]
     for n in 0 .. 15:
       let vid = vtx.bVid[n]
@@ -100,15 +100,15 @@ iterator subVids*(vtx: VertexRef): VertexID =
 
 iterator subVidKeys*(node: NodeRef): (VertexID,HashKey) =
   ## Simolar to `subVids()` but for nodes
-  case node.vType:
+  case node.vtx.vType:
   of Leaf:
-    if node.lData.pType == AccountData:
-      let stoID = node.lData.stoID
+    if node.vtx.lData.pType == AccountData:
+      let stoID = node.vtx.lData.stoID
       if stoID.isValid:
         yield (stoID.vid, node.key[0])
   of Branch:
     for n in 0 .. 15:
-      let vid = node.bVid[n]
+      let vid = node.vtx.bVid[n]
       if vid.isValid:
         yield (vid,node.key[n])
 

--- a/tests/test_aristo/test_blobify.nim
+++ b/tests/test_aristo/test_blobify.nim
@@ -43,7 +43,7 @@ suite "Aristo blobify":
 
       extension = VertexRef(
         vType: Branch,
-        ePfx: NibblesBuf.nibble(2),
+        pfx: NibblesBuf.nibble(2),
         bVid: [
           VertexID(0),
           VertexID(0),


### PR DESCRIPTION
* move pfx out of variant which avoids pointless field type panic checks and copies on access
* make `VertexRef` a non-inheritable object which reduces its memory footprint and simplifies its use - it's also unclear from a semantic point of view why inheritance makes sense for storing keys