### PR TITLE
fix missed cache opportunity

### DIFF
--- a/nimbus/db/aristo/aristo_fetch.nim
+++ b/nimbus/db/aristo/aristo_fetch.nim
@@ -62,12 +62,12 @@ proc retrieveAccountLeaf(
   if (let leafVtx = db.layersGetAccLeaf(accPath); leafVtx.isSome()):
     if not leafVtx[].isValid():
       return err(FetchPathNotFound)
-    return ok leafVtx
+    return ok leafVtx[]
 
   if (let leafVtx = db.accLeaves.get(accPath); leafVtx.isSome()):
     if not leafVtx[].isValid():
       return err(FetchPathNotFound)
-    return ok leafVtx
+    return ok leafVtx[]
 
   # Updated payloads are stored in the layers so if we didn't find them there,
   # it must have been in the database


### PR DESCRIPTION
The storage leaf cache was being circumvented when actually fetching leaves and was instead only being filled with items :/

Also avoids an expensive copy when fetching account data (broadly, variant objects are comparatively expensive to copy and fetching accounts is a hotspot)