### PR TITLE
keep macOS CPU targeting consistent with EOL/supported macOS versions

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -90,19 +90,11 @@ if defined(windows):
 if defined(disableMarchNative):
   if defined(i386) or defined(amd64):
     if defined(macosx):
-      # https://support.apple.com/kb/sp803
-      # "macOS Catalina - Technical Specifications": EOL as of 2022-09
-      # https://support.apple.com/kb/sp833
-      # "macOS Big Sur - Technical Specifications" lists current oldest
-      # supported models: MacBook (2015 or later), MacBook Air (2013 or later),
-      # MacBook Pro (Late 2013 or later), Mac mini (2014 or later), iMac (2014
-      # or later), iMac Pro (2017 or later), Mac Pro (2013 or later).
-      #
-      # These all have Haswell or newer CPUs.
-      #
-      # This ensures AVX2, AES-NI, PCLMUL, BMI1, and BMI2 instruction set support.
-      switch("passC", "-march=haswell -mtune=generic")
-      switch("passL", "-march=haswell -mtune=generic")
+      # https://support.apple.com/en-us/102861
+      # "macOS Ventura is compatible with these computers" lists current oldest
+      # supported x86 models, all of which have Kaby Lake or newer CPUs.
+      switch("passC", "-march=skylake -mtune=generic")
+      switch("passL", "-march=skylake -mtune=generic")
     else:
       switch("passC", "-mssse3")
       switch("passL", "-mssse3")


### PR DESCRIPTION
https://en.wikipedia.org/wiki/MacOS_Monterey is EOL