### PR TITLE
Remove RpcProxy from Fluffy and use RpcHttpServer instead.

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -17,7 +17,6 @@ import
   metrics,
   metrics/chronos_httpserver,
   json_rpc/clients/httpclient,
-  json_rpc/rpcproxy,
   results,
   stew/[byteutils, io2],
   eth/keys,
@@ -216,30 +215,29 @@ proc run(config: PortalConf) {.raises: [CatchableError].} =
     # Note: Set maxRequestBodySize to 4MB instead of 1MB as there are blocks
     # that reach that limit (in hex, for gossip method).
     rpcHttpServer.addHttpServer(ta, maxRequestBodySize = 4 * 1_048_576)
-    var rpcHttpServerWithProxy = RpcProxy.new(rpcHttpServer, config.proxyUri)
 
-    rpcHttpServerWithProxy.installDiscoveryApiHandlers(d)
-    rpcHttpServerWithProxy.installWeb3ApiHandlers()
+    rpcHttpServer.installDiscoveryApiHandlers(d)
+    rpcHttpServer.installWeb3ApiHandlers()
     if node.stateNetwork.isSome():
-      rpcHttpServerWithProxy.installPortalApiHandlers(
+      rpcHttpServer.installPortalApiHandlers(
         node.stateNetwork.value.portalProtocol, "state"
       )
     if node.historyNetwork.isSome():
-      rpcHttpServerWithProxy.installEthApiHandlers(
+      rpcHttpServer.installEthApiHandlers(
         node.historyNetwork.value, node.beaconLightClient, node.stateNetwork
       )
-      rpcHttpServerWithProxy.installPortalApiHandlers(
+      rpcHttpServer.installPortalApiHandlers(
         node.historyNetwork.value.portalProtocol, "history"
       )
-      rpcHttpServerWithProxy.installPortalDebugApiHandlers(
+      rpcHttpServer.installPortalDebugApiHandlers(
         node.historyNetwork.value.portalProtocol, "history"
       )
     if node.beaconNetwork.isSome():
-      rpcHttpServerWithProxy.installPortalApiHandlers(
+      rpcHttpServer.installPortalApiHandlers(
         node.beaconNetwork.value.portalProtocol, "beacon"
       )
-    # TODO: Test proxy with remote node over HTTPS
-    waitFor rpcHttpServerWithProxy.start()
+
+    rpcHttpServer.start()
 
   runForever()
 

--- a/fluffy/rpc/rpc_discovery_api.nim
+++ b/fluffy/rpc/rpc_discovery_api.nim
@@ -9,7 +9,7 @@
 
 import
   std/sequtils,
-  json_rpc/[rpcproxy, rpcserver],
+  json_rpc/rpcserver,
   stew/byteutils,
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   ./rpc_types
@@ -23,9 +23,7 @@ type PongResponse* = object
 
 PongResponse.useDefaultSerializationIn JrpcConv
 
-proc installDiscoveryApiHandlers*(
-    rpcServer: RpcServer | RpcProxy, d: discv5_protocol.Protocol
-) =
+proc installDiscoveryApiHandlers*(rpcServer: RpcServer, d: discv5_protocol.Protocol) =
   ## Discovery v5 JSON-RPC API such as defined here:
   ## https://github.com/ethereum/portal-network-specs/tree/master/jsonrpc
 

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -228,7 +228,7 @@ proc installEthApiHandlers*(
   # of tx hash -> block number -> block hash, in order to get the receipt
   # from from the block with that block hash. The Canonical Indices Network
   # would need to be implemented to get this information.
-  # rpcServerWithProxy.rpc("eth_getTransactionReceipt") do(
+  # rpcServer.rpc("eth_getTransactionReceipt") do(
   #     data: EthHashStr) -> Opt[ReceiptObject]:
 
   rpcServer.rpc("eth_getLogs") do(filterOptions: FilterOptions) -> seq[LogObject]:

--- a/fluffy/rpc/rpc_portal_api.nim
+++ b/fluffy/rpc/rpc_portal_api.nim
@@ -9,7 +9,7 @@
 
 import
   std/[sequtils, json],
-  json_rpc/[rpcproxy, rpcserver],
+  json_rpc/rpcserver,
   json_serialization/std/tables,
   stew/byteutils,
   ../network/wire/portal_protocol,
@@ -41,7 +41,7 @@ TraceResponse.useDefaultSerializationIn JrpcConv
 # as the proc becomes generic, where the rpc macro from router.nim can no longer
 # be found, which is why we export rpcserver which should export router.
 proc installPortalApiHandlers*(
-    rpcServer: RpcServer | RpcProxy, p: PortalProtocol, network: static string
+    rpcServer: RpcServer, p: PortalProtocol, network: static string
 ) =
   let
     invalidKeyErr =

--- a/fluffy/rpc/rpc_portal_debug_api.nim
+++ b/fluffy/rpc/rpc_portal_debug_api.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import
-  json_rpc/[rpcproxy, rpcserver],
+  json_rpc/rpcserver,
   stew/byteutils,
   ../network/wire/portal_protocol,
   ../eth_data/history_data_seeding,
@@ -19,7 +19,7 @@ export rpcserver
 # Non-spec-RPCs that are used for testing, debugging and seeding data without a
 # bridge.
 proc installPortalDebugApiHandlers*(
-    rpcServer: RpcServer | RpcProxy, p: PortalProtocol, network: static string
+    rpcServer: RpcServer, p: PortalProtocol, network: static string
 ) =
   ## Portal debug API calls related to storage and seeding from Era1 files.
   rpcServer.rpc("portal_" & network & "GossipHeaders") do(

--- a/fluffy/rpc/rpc_web3_api.nim
+++ b/fluffy/rpc/rpc_web3_api.nim
@@ -7,10 +7,10 @@
 
 {.push raises: [].}
 
-import json_rpc/[rpcproxy, rpcserver], ../version
+import json_rpc/rpcserver, ../version
 
 export rpcserver
 
-proc installWeb3ApiHandlers*(rpcServer: RpcServer | RpcProxy) =
+proc installWeb3ApiHandlers*(rpcServer: RpcServer) =
   rpcServer.rpc("web3_clientVersion") do() -> string:
     return clientVersion

--- a/fluffy/tests/test_discovery_rpc.nim
+++ b/fluffy/tests/test_discovery_rpc.nim
@@ -10,7 +10,7 @@
 import
   chronos,
   testutils/unittests,
-  json_rpc/[rpcproxy, rpcserver],
+  json_rpc/rpcserver,
   json_rpc/clients/httpclient,
   stint,
   eth/p2p/discoveryv5/enr,
@@ -31,13 +31,10 @@ proc setupTest(rng: ref HmacDrbgContext): Future[TestCase] {.async.} =
     ta = initTAddress(localSrvAddress, localSrvPort)
     localDiscoveryNode =
       initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(20302))
-    fakeProxyConfig = getHttpClientConfig("http://127.0.0.1:8546")
     client = newRpcHttpClient()
 
   let rpcHttpServer = RpcHttpServer.new()
   rpcHttpServer.addHttpServer(ta, maxRequestBodySize = 4 * 1_048_576)
-
-  # var rpcHttpServerWithProxy = RpcProxy.new([ta], fakeProxyConfig)
 
   rpcHttpServer.installDiscoveryApiHandlers(localDiscoveryNode)
 


### PR DESCRIPTION
This PR removes the RpcProxy from Fluffy. The ability to proxy requests is now part of the Nimbus Verified Proxy so this feature is no longer required in Fluffy. Additionally adding support for websockets to Fluffy will now be easier because the RpcProxy type did not support websocket but the RpcServer type does.