### PR TITLE
leaf cache fixes

### DIFF
--- a/nimbus/db/aristo/aristo_debug.nim
+++ b/nimbus/db/aristo/aristo_debug.nim
@@ -17,7 +17,7 @@ import
   stew/[byteutils, interval_set],
   ./aristo_desc/desc_backend,
   ./aristo_init/[memory_db, memory_only, rocks_db],
-  "."/[aristo_desc, aristo_get, aristo_hike, aristo_layers,
+  "."/[aristo_desc, aristo_get, aristo_layers,
        aristo_serialise, aristo_utils]
 
 # ------------------------------------------------------------------------------

--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -19,8 +19,7 @@ import
   eth/common,
   results,
   ./aristo_delete/[delete_helpers, delete_subtree],
-  "."/[aristo_desc, aristo_fetch, aristo_get, aristo_hike, aristo_layers,
-       aristo_utils]
+  "."/[aristo_desc, aristo_fetch, aristo_get, aristo_hike, aristo_layers]
 
 # ------------------------------------------------------------------------------
 # Private heplers
@@ -46,69 +45,80 @@ proc branchStillNeeded(vtx: VertexRef): Result[int,void] =
 proc deleteImpl(
     db: AristoDbRef;                   # Database, top layer
     hike: Hike;                        # Fully expanded path
-      ): Result[void,AristoError] =
-  ## Implementation of *delete* functionality.
+      ): Result[VertexRef,AristoError] =
+  ## Removes the last node in the hike and returns the updated leaf in case
+  ## a branch collapsed
 
   # Remove leaf entry
-  let lf =  hike.legs[^1].wp
+  let lf = hike.legs[^1].wp
   if lf.vtx.vType != Leaf:
     return err(DelLeafExpexted)
 
   db.disposeOfVtx((hike.root, lf.vid))
 
-  if 1 < hike.legs.len:
-    # Get current `Branch` vertex `br`
-    let br = block:
-      var wp = hike.legs[^2].wp
-      wp.vtx = wp.vtx.dup # make sure that layers are not impliciteley modified
-      wp
-    if br.vtx.vType != Branch:
-      return err(DelBranchExpexted)
+  if hike.legs.len == 1:
+    # This was the last node in the trie, meaning we don't have any branches or
+    # leaves to update
+    return ok(nil)
 
-    # Unlink child vertex from structural table
-    br.vtx.bVid[hike.legs[^2].nibble] = VertexID(0)
-    db.layersPutVtx((hike.root, br.vid), br.vtx)
+  # Get current `Branch` vertex `br`
+  let br = block:
+    var wp = hike.legs[^2].wp
+    wp.vtx = wp.vtx.dup # make sure that layers are not impliciteley modified
+    wp
+  if br.vtx.vType != Branch:
+    return err(DelBranchExpexted)
 
-    # Clear all Merkle hash keys up to the root key
-    for n in 0 .. hike.legs.len - 2:
-      let vid = hike.legs[n].wp.vid
-      db.layersResKey((hike.root, vid))
+  # Unlink child vertex from structural table
+  br.vtx.bVid[hike.legs[^2].nibble] = VertexID(0)
+  db.layersPutVtx((hike.root, br.vid), br.vtx)
 
-    let nbl = block:
-      let rc = br.vtx.branchStillNeeded()
-      if rc.isErr:
-        return err(DelBranchWithoutRefs)
-      rc.value
+  # Clear all Merkle hash keys up to the root key
+  for n in 0 .. hike.legs.len - 2:
+    let vid = hike.legs[n].wp.vid
+    db.layersResKey((hike.root, vid))
 
-    if 0 <= nbl:
-      # Branch has only one entry - convert it to a leaf or join with parent
+  let nbl = block:
+    let rc = br.vtx.branchStillNeeded()
+    if rc.isErr:
+      return err(DelBranchWithoutRefs)
+    rc.value
 
-      # Get child vertex (there must be one after a `Branch` node)
-      let
-        vid = br.vtx.bVid[nbl]
-        nxt = db.getVtx (hike.root, vid)
-      if not nxt.isValid:
-        return err(DelVidStaleVtx)
+  if 0 <= nbl:
+    # Branch has only one entry - convert it to a leaf or join with parent
 
-      db.disposeOfVtx((hike.root, vid))
+    # Get child vertex (there must be one after a `Branch` node)
+    let
+      vid = br.vtx.bVid[nbl]
+      nxt = db.getVtx (hike.root, vid)
+    if not nxt.isValid:
+      return err(DelVidStaleVtx)
 
-      let vtx =
-        case nxt.vType
-        of Leaf:
-          VertexRef(
-            vType: Leaf,
-            pfx:  br.vtx.pfx & NibblesBuf.nibble(nbl.byte) & nxt.pfx,
-            lData: nxt.lData)
-        of Branch:
-          VertexRef(
-            vType: Branch,
-            pfx:  br.vtx.pfx & NibblesBuf.nibble(nbl.byte) & nxt.pfx,
-            bVid: nxt.bVid)
+    db.disposeOfVtx((hike.root, vid))
 
-      # Put the new vertex at the id of the obsolete branch
-      db.layersPutVtx((hike.root, br.vid), vtx)
+    let vtx =
+      case nxt.vType
+      of Leaf:
+        VertexRef(
+          vType: Leaf,
+          pfx:  br.vtx.pfx & NibblesBuf.nibble(nbl.byte) & nxt.pfx,
+          lData: nxt.lData)
 
-  ok()
+      of Branch:
+        VertexRef(
+          vType: Branch,
+          pfx:  br.vtx.pfx & NibblesBuf.nibble(nbl.byte) & nxt.pfx,
+          bVid: nxt.bVid)
+
+    # Put the new vertex at the id of the obsolete branch
+    db.layersPutVtx((hike.root, br.vid), vtx)
+
+    if vtx.vType == Leaf:
+      ok(vtx)
+    else:
+      ok(nil)
+  else:
+    ok(nil)
 
 # ------------------------------------------------------------------------------
 # Public functions
@@ -121,23 +131,28 @@ proc deleteAccountRecord*(
   ## Delete the account leaf entry addressed by the argument `path`. If this
   ## leaf entry referres to a storage tree, this one will be deleted as well.
   ##
+  var accHike: Hike
+  db.fetchAccountHike(accPath, accHike).isOkOr:
+    if error == FetchAccInaccessible:
+      return err(DelPathNotFound)
+    return err(error)
   let
-    hike = accPath.hikeUp(VertexID(1), db).valueOr:
-      if error[1] in HikeAcceptableStopsNotFound:
-        return err(DelPathNotFound)
-      return err(error[1])
-    stoID = hike.legs[^1].wp.vtx.lData.stoID
+    stoID = accHike.legs[^1].wp.vtx.lData.stoID
 
   # Delete storage tree if present
   if stoID.isValid:
     ? db.delStoTreeImpl((stoID.vid, stoID.vid), accPath)
 
-  ?db.deleteImpl(hike)
+  let otherLeaf = ?db.deleteImpl(accHike)
 
   db.layersPutAccLeaf(accPath, nil)
 
-  ok()
+  if otherLeaf.isValid:
+    db.layersPutAccLeaf(
+      Hash256(data: getBytes(NibblesBuf.fromBytes(accPath.data).replaceSuffix(otherLeaf.pfx))),
+      otherLeaf)
 
+  ok()
 
 proc deleteGenericData*(
     db: AristoDbRef;
@@ -160,12 +175,13 @@ proc deleteGenericData*(
   elif LEAST_FREE_VID <= root.distinctBase:
     return err(DelStoRootNotAccepted)
 
-  let hike = path.hikeUp(root, db).valueOr:
+  var hike: Hike
+  path.hikeUp(root, db, Opt.none(VertexRef), hike).isOkOr:
     if error[1] in HikeAcceptableStopsNotFound:
       return err(DelPathNotFound)
     return err(error[1])
 
-  ?db.deleteImpl(hike)
+  discard ?db.deleteImpl(hike)
 
   ok(not db.getVtx((root, root)).isValid)
 
@@ -185,7 +201,6 @@ proc deleteGenericTree*(
 
   db.delSubTreeImpl root
 
-
 proc deleteStorageData*(
     db: AristoDbRef;
     accPath: Hash256;          # Implies storage data tree
@@ -198,31 +213,48 @@ proc deleteStorageData*(
   ## not refer to a storage tree anymore. In the latter case only the function
   ## will return `true`.
   ##
+
   let
-    accHike = db.fetchAccountHike(accPath).valueOr:
-      if error == FetchAccInaccessible:
-        return err(DelStoAccMissing)
-      return err(error)
+    mixPath = mixUp(accPath, stoPath)
+    stoLeaf = db.cachedStoLeaf(mixPath)
+
+  if stoLeaf == Opt.some(nil):
+    return err(DelPathNotFound)
+
+  var accHike: Hike
+  db.fetchAccountHike(accPath, accHike).isOkOr:
+    if error == FetchAccInaccessible:
+      return err(DelStoAccMissing)
+    return err(error)
+
+  let
     wpAcc = accHike.legs[^1].wp
     stoID = wpAcc.vtx.lData.stoID
 
   if not stoID.isValid:
     return err(DelStoRootMissing)
 
-  let stoHike = stoPath.hikeUp(stoID.vid, db).valueOr:
+  let stoNibbles = NibblesBuf.fromBytes(stoPath.data)
+  var stoHike: Hike
+  stoNibbles.hikeUp(stoID.vid, db, stoLeaf, stoHike).isOkOr:
     if error[1] in HikeAcceptableStopsNotFound:
       return err(DelPathNotFound)
     return err(error[1])
 
   # Mark account path Merkle keys for update
-  db.updateAccountForHasher accHike
+  db.layersResKeys accHike
 
-  ?db.deleteImpl(stoHike)
+  let otherLeaf = ?db.deleteImpl(stoHike)
+  db.layersPutStoLeaf(mixPath, nil)
 
-  db.layersPutStoLeaf(mixUp(accPath, stoPath), nil)
+  if otherLeaf.isValid:
+    let leafMixPath = mixUp(
+      accPath,
+      Hash256(data: getBytes(stoNibbles.replaceSuffix(otherLeaf.pfx))))
+    db.layersPutStoLeaf(leafMixPath, otherLeaf)
 
-  # Make sure that an account leaf has no dangling sub-trie
-  if db.getVtx((stoID.vid, stoID.vid)).isValid:
+  # If there was only one item (that got deleted), update the account as well
+  if stoHike.legs.len > 1:
     return ok(false)
 
   # De-register the deleted storage tree from the account record
@@ -239,11 +271,13 @@ proc deleteStorageTree*(
   ## Variant of `deleteStorageData()` for purging the whole storage tree
   ## associated to the account argument `accPath`.
   ##
+  var accHike: Hike
+  db.fetchAccountHike(accPath, accHike).isOkOr:
+    if error == FetchAccInaccessible:
+      return err(DelStoAccMissing)
+    return err(error)
+
   let
-    accHike = db.fetchAccountHike(accPath).valueOr:
-      if error == FetchAccInaccessible:
-        return err(DelStoAccMissing)
-      return err(error)
     wpAcc = accHike.legs[^1].wp
     stoID = wpAcc.vtx.lData.stoID
 
@@ -251,7 +285,7 @@ proc deleteStorageTree*(
     return err(DelStoRootMissing)
 
   # Mark account path Merkle keys for update
-  db.updateAccountForHasher accHike
+  db.layersResKeys accHike
 
   ? db.delStoTreeImpl((stoID.vid, stoID.vid), accPath)
 

--- a/nimbus/db/aristo/aristo_desc.nim
+++ b/nimbus/db/aristo/aristo_desc.nim
@@ -87,6 +87,17 @@ type
     # Debugging data below, might go away in future
     xMap*: Table[HashKey,RootedVertexID] ## For pretty printing/debugging
 
+  Leg* = object
+    ## For constructing a `VertexPath`
+    wp*: VidVtxPair                ## Vertex ID and data ref
+    nibble*: int8                  ## Next vertex selector for `Branch` (if any)
+
+  Hike* = object
+    ## Trie traversal path
+    root*: VertexID                ## Handy for some fringe cases
+    legs*: ArrayBuf[NibblesBuf.high + 1, Leg] ## Chain of vertices and IDs
+    tail*: NibblesBuf              ## Portion of non completed path
+
 # ------------------------------------------------------------------------------
 # Public helpers
 # ------------------------------------------------------------------------------

--- a/nimbus/db/aristo/aristo_desc/desc_error.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_error.nim
@@ -127,8 +127,7 @@ type
     MergeHikeFailed # Ooops, internal error
     MergeAccRootNotAccepted
     MergeStoRootNotAccepted
-    MergeLeafPathCachedAlready
-    MergeLeafPathOnBackendAlready
+    MergeNoAction
     MergeRootVidMissing
     MergeStoAccMissing
 

--- a/nimbus/db/aristo/aristo_desc/desc_nibbles.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_nibbles.nim
@@ -77,6 +77,13 @@ func slice*(r: NibblesBuf, ibegin: int, iend = -1): NibblesBuf {.noinit.} =
   doAssert ibegin >= 0 and e <= result.bytes.len * 2
   result.iend = e.int8
 
+func replaceSuffix*(r: NibblesBuf, suffix: NibblesBuf): NibblesBuf =
+  for i in 0..<r.len - suffix.len:
+    result[i] = r[i]
+  for i in 0..<suffix.len:
+    result[i + r.len - suffix.len] = suffix[i]
+  result.iend = min(64, r.len + suffix.len).int8
+
 template writeFirstByte(nibbleCountExpr) {.dirty.} =
   let nibbleCount = nibbleCountExpr
   var oddnessFlag = (nibbleCount and 1) != 0

--- a/nimbus/db/aristo/aristo_layers.nim
+++ b/nimbus/db/aristo/aristo_layers.nim
@@ -146,6 +146,11 @@ func layersResKey*(db: AristoDbRef; rvid: RootedVertexID) =
   ## equivalent of a delete function.
   db.layersPutKey(rvid, VOID_HASH_KEY)
 
+func layersResKeys*(db: AristoDbRef; hike: Hike) =
+  ## Reset all cached keys along the given hike
+  for i in 1..hike.legs.len:
+    db.layersResKey((hike.root, hike.legs[^i].wp.vid))
+
 proc layersUpdateVtx*(
     db: AristoDbRef;                   # Database, top layer
     rvid: RootedVertexID;
@@ -154,7 +159,6 @@ proc layersUpdateVtx*(
   ## Update a vertex at `rvid` and reset its associated key entry
   db.layersPutVtx(rvid, vtx)
   db.layersResKey(rvid)
-
 
 func layersPutAccLeaf*(db: AristoDbRef; accPath: Hash256; leafVtx: VertexRef) =
   db.top.accLeaves[accPath] = leafVtx

--- a/nimbus/db/aristo/aristo_utils.nim
+++ b/nimbus/db/aristo/aristo_utils.nim
@@ -16,7 +16,7 @@
 import
   eth/common,
   results,
-  "."/[aristo_constants, aristo_desc, aristo_get, aristo_hike, aristo_layers]
+  "."/[aristo_constants, aristo_desc, aristo_get, aristo_layers]
 
 # ------------------------------------------------------------------------------
 # Public functions, converters
@@ -111,18 +111,6 @@ iterator subVidKeys*(node: NodeRef): (VertexID,HashKey) =
       let vid = node.vtx.bVid[n]
       if vid.isValid:
         yield (vid,node.key[n])
-
-# ---------------------
-
-proc updateAccountForHasher*(
-    db: AristoDbRef;                   # Database
-    hike: Hike;                        # Return value from `retrieveStorageID()`
-      ) =
-  ## The argument `hike` is used to mark/reset the keys along the implied
-  ## vertex path for being re-calculated.
-  ##
-  for w in hike.legs:
-    db.layersResKey((hike.root, w.wp.vid))
 
 # ------------------------------------------------------------------------------
 # End

--- a/tests/test_aristo/test_portal_proof.nim
+++ b/tests/test_aristo/test_portal_proof.nim
@@ -150,10 +150,11 @@ proc testCreatePortalProof(node: JsonNode, testStatusIMPL: var TestStatus) =
   for a in addresses:
     let
       path = a.keccakHash
-      rc = path.hikeUp(VertexID(1), ps.db)
+    var hike: Hike
+    let rc = path.hikeUp(VertexID(1), ps.db, Opt.none(VertexRef), hike)
     sample[path] = ProofData(
       error: (if rc.isErr: rc.error[1] else: AristoError(0)),
-      hike: rc.to(Hike)) # keep `hike` for potential debugging
+      hike: hike) # keep `hike` for potential debugging
 
   # Verify that there is somehing to do, at all
   check 0 < sample.values.toSeq.filterIt(it.error == AristoError 0).len

--- a/tests/test_aristo/test_tx.nim
+++ b/tests/test_aristo/test_tx.nim
@@ -94,8 +94,8 @@ proc randomisedLeafs(
        ): Result[seq[(LeafTie,RootedVertexID)],(VertexID,AristoError)] =
   var lvp: seq[(LeafTie,RootedVertexID)]
   for lty in ltys:
-    let hike = lty.hikeUp(db).valueOr:
-      return err((error[0],error[1]))
+    var hike: Hike
+    ?lty.hikeUp(db, Opt.none(VertexRef), hike)
     lvp.add (lty,(hike.root, hike.legs[^1].wp.vid))
 
   var lvp2 = lvp.sorted(


### PR DESCRIPTION
* Add missing leaf cache update when a leaf turns to a branch with two leaves (on merge) and vice versa (on delete) - this could lead to stale leaves being returned from the cache causing validation failures - it didn't happen because the leaf caches were not being used efficiently :)
* Replace `seq` with `ArrayBuf` in `Hike` allowing it to become allocation-free - this PR also works around an inefficiency in nim in returning large types via a `var` parameter
* Use the leaf cache instead of `getVtxRc` to fetch recent leaves - this makes the vertex cache more efficient at caching branches because fewer leaf requests pass through it.