### PR TITLE
speed up key computation

### DIFF
--- a/nimbus/db/aristo/aristo_api.nim
+++ b/nimbus/db/aristo/aristo_api.nim
@@ -1036,9 +1036,9 @@ func init*(
 
   else:
     beDup.getVtxFn =
-      proc(a: RootedVertexID): auto =
+      proc(a: RootedVertexID, flags: set[GetVtxFlag]): auto =
         AristoApiProfBeGetVtxFn.profileRunner:
-          result = be.getVtxFn(a)
+          result = be.getVtxFn(a, flags)
     data.list[AristoApiProfBeGetVtxFn.ord].masked = true
 
     beDup.getKeyFn =

--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -71,7 +71,7 @@ proc deleteImpl(
 
   # Unlink child vertex from structural table
   br.vtx.bVid[hike.legs[^2].nibble] = VertexID(0)
-  db.layersUpdateVtx((hike.root, br.vid), br.vtx)
+  db.layersPutVtx((hike.root, br.vid), br.vtx)
 
   # Clear all Merkle hash keys up to the root key
   for n in 0 .. hike.legs.len - 2:
@@ -111,7 +111,7 @@ proc deleteImpl(
           bVid: nxt.bVid)
 
     # Put the new vertex at the id of the obsolete branch
-    db.layersUpdateVtx((hike.root, br.vid), vtx)
+    db.layersPutVtx((hike.root, br.vid), vtx)
 
     if vtx.vType == Leaf:
       ok(vtx)

--- a/nimbus/db/aristo/aristo_delete.nim
+++ b/nimbus/db/aristo/aristo_delete.nim
@@ -71,7 +71,7 @@ proc deleteImpl(
 
   # Unlink child vertex from structural table
   br.vtx.bVid[hike.legs[^2].nibble] = VertexID(0)
-  db.layersPutVtx((hike.root, br.vid), br.vtx)
+  db.layersUpdateVtx((hike.root, br.vid), br.vtx)
 
   # Clear all Merkle hash keys up to the root key
   for n in 0 .. hike.legs.len - 2:
@@ -111,7 +111,7 @@ proc deleteImpl(
           bVid: nxt.bVid)
 
     # Put the new vertex at the id of the obsolete branch
-    db.layersPutVtx((hike.root, br.vid), vtx)
+    db.layersUpdateVtx((hike.root, br.vid), vtx)
 
     if vtx.vType == Leaf:
       ok(vtx)

--- a/nimbus/db/aristo/aristo_desc/desc_backend.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_backend.nim
@@ -20,7 +20,7 @@ import
 
 type
   GetVtxFn* =
-    proc(rvid: RootedVertexID): Result[VertexRef,AristoError] {.gcsafe, raises: [].}
+    proc(rvid: RootedVertexID, flags: set[GetVtxFlag]): Result[VertexRef,AristoError] {.gcsafe, raises: [].}
       ## Generic backend database retrieval function for a single structural
       ## `Aristo DB` data record.
 

--- a/nimbus/db/aristo/aristo_desc/desc_structural.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_structural.nim
@@ -130,6 +130,11 @@ type
 
     txUid*: uint                           ## Transaction identifier if positive
 
+  GetVtxFlag* = enum
+    PeekCache
+      ## Peek into, but don't update cache - useful on work loads that are
+      ## unfriendly to caches
+
 # ------------------------------------------------------------------------------
 # Public helpers (misc)
 # ------------------------------------------------------------------------------

--- a/nimbus/db/aristo/aristo_init/memory_db.nim
+++ b/nimbus/db/aristo/aristo_init/memory_db.nim
@@ -86,7 +86,7 @@ proc endSession(hdl: PutHdlRef; db: MemBackendRef): MemPutHdlRef =
 
 proc getVtxFn(db: MemBackendRef): GetVtxFn =
   result =
-    proc(rvid: RootedVertexID): Result[VertexRef,AristoError] =
+    proc(rvid: RootedVertexID, flags: set[GetVtxFlag]): Result[VertexRef,AristoError] =
       # Fetch serialised data record
       let data = db.mdb.sTab.getOrDefault(rvid, EmptyBlob)
       if 0 < data.len:

--- a/nimbus/db/aristo/aristo_init/rocks_db.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db.nim
@@ -75,10 +75,10 @@ proc endSession(hdl: PutHdlRef; db: RdbBackendRef): RdbPutHdlRef =
 
 proc getVtxFn(db: RdbBackendRef): GetVtxFn =
   result =
-    proc(rvid: RootedVertexID): Result[VertexRef,AristoError] =
+    proc(rvid: RootedVertexID, flags: set[GetVtxFlag]): Result[VertexRef,AristoError] =
 
       # Fetch serialised data record
-      let vtx = db.rdb.getVtx(rvid).valueOr:
+      let vtx = db.rdb.getVtx(rvid, flags).valueOr:
         when extraTraceMessages:
           trace logTxt "getVtxFn() failed", rvid, error=error[0], info=error[1]
         return err(error[0])

--- a/scripts/make_states.sh
+++ b/scripts/make_states.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Create a set of states, each advanced by 100k blocks
+# Create a set of states, each advanced by 1M blocks
 
 set -e
 
@@ -18,18 +18,23 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 DATE="$(date -u +%Y%m%d_%H%M)"
 REV=$(git rev-parse --short=8 HEAD)
 DATA_DIR="$1/${DATE}-${REV}"
+ERA_DIR="$2"
+ERA1_DIR="$3"
+STATS_DIR="$4"
+
+shift 4
 
 mkdir -p "$DATA_DIR"
-[ "$5" ] && cp -ar "$5"/* "$DATA_DIR"
+[ -d "$1" ] && { cp -ar "$1"/* "$DATA_DIR" ; shift ; }
 
 while true;
 do
   "$SCRIPT_DIR/../build/nimbus" import \
     --data-dir:"${DATA_DIR}" \
-    --era1-dir:"$2" \
-    --era-dir:"$3" \
-    --debug-csv-stats:"$4/stats-${DATE}-${REV}.csv" \
-    --max-blocks:1000000
-  cp -ar "$1/${DATE}-${REV}" "$1/${DATE}-${REV}"-$(printf "%04d" $counter)
+    --era1-dir:"${ERA_DIR}" \
+    --era-dir:"${ERA1_DIR}" \
+    --debug-csv-stats:"${STATS_DIR}/stats-${DATE}-${REV}.csv" \
+    --max-blocks:1000000 "$@"
+  cp -ar "${DATA_DIR}" "${DATA_DIR}-$(printf "%04d" $counter)"
   counter=$((counter+1))
 done


### PR DESCRIPTION
* batch database key writes during `computeKey` calls
* log progress when there are many keys to update
* avoid evicting the vertex cache when traversing the trie for key computation purposes
* avoid storing trivial leaf hashes that directly can be loaded from the vertex