### PR TITLE
Fix multiple instances running from same dataDir

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -81,6 +81,7 @@ proc run(
   addExitProc(
     proc() =
       discard closeFile(lockFileHandle)
+      discard unlockFile(lockFileHandle, 0'i64, 0'i64)
   )
 
   ## Network configuration


### PR DESCRIPTION
Minimum working fix for #2157 

Tested locally with `./build/fluffy --rpc` on two instances.

* Do we want to write some specific information to the lock file?
* Do we want to implement OS level locks with `io2.lockFile` to prevent other processes from writing to the lock file?