### PR TITLE
Tune revalidateMax + defaultMaxGossipNodes values in wire protocol

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -115,7 +115,7 @@ const
   ## that will be processed
   refreshInterval = 5.minutes ## Interval of launching a random query to
   ## refresh the routing table.
-  revalidateMax = 10000 ## Revalidation of a peer is done between 0 and this
+  revalidateMax = 4000 ## Revalidation of a peer is done between 0 and this
   ## value in milliseconds
   initialLookups = 1 ## Amount of lookups done when populating the routing table
 
@@ -1500,8 +1500,8 @@ proc neighborhoodGossip*(
   # 1. Select the closest neighbours in the routing table
   # 2. Check if the radius is known for these these nodes and whether they are
   # in range of the content to be offered.
-  # 3. If more than n (= 8) nodes are in range, offer these nodes the content
-  # (max nodes set at 8).
+  # 3. If more than n (= maxGossipNodes) nodes are in range, offer these nodes
+  # the content (maxed out at n).
   # 4. If less than n nodes are in range, do a node lookup, and offer the nodes
   # returned from the lookup the content (max nodes set at 8)
   #

--- a/fluffy/network/wire/portal_protocol_config.nim
+++ b/fluffy/network/wire/portal_protocol_config.nim
@@ -46,7 +46,7 @@ const
   defaultRadiusConfig* = RadiusConfig(kind: Dynamic)
   defaultRadiusConfigDesc* = $defaultRadiusConfig.kind
   defaultDisablePoke* = false
-  defaultMaxGossipNodes = 8
+  defaultMaxGossipNodes = 4
   revalidationTimeout* = chronos.seconds(30)
 
   defaultPortalProtocolConfig* = PortalProtocolConfig(


### PR DESCRIPTION
The revalidateMax value is lowered to have a quicker ramp up of the radiusCache + to keep it healthier.

The defaultMaxGossipNodes value is lowered because with the current value a Nodes lookup is triggered almost always. This value is dependant on the content replication value. This is dependant on the network (and subnetwork) because of the amount of nodes and their radius/storage capacity.


Some metrics to support these values:
Left part: MaxGossipNodes = 4, revalidateMax still at 10k
Right part: MaxGossipNodes = 6, revalidateMax still at 10k
![image](https://github.com/user-attachments/assets/769359e9-e0cf-433d-9dc7-df59c8dc1bc8)


Left part: MaxGossipNodes = 4, revalidateMax at 4k (Settings of this PR)
Right part: MaxGossipNodes = 4, revalidateMax at 6k
![image](https://github.com/user-attachments/assets/a5dbd980-6953-490b-abd7-602bb7971afc)


These current settings does of course mean that more ping/pong request/responses are happening:
![image](https://github.com/user-attachments/assets/9882fdc4-66b7-4184-ada8-14d85338a5ac)

