### PR TITLE
use defined constant ZERO_HASH256 instead of runtime default(Hash256)

### DIFF
--- a/nimbus/common/genesis.nim
+++ b/nimbus/common/genesis.nim
@@ -137,7 +137,7 @@ proc toGenesisHeader*(
   if fork >= Cancun:
     result.blobGasUsed           = Opt.some g.blobGasUsed.get(0'u64)
     result.excessBlobGas         = Opt.some g.excessBlobGas.get(0'u64)
-    result.parentBeaconBlockRoot = Opt.some g.parentBeaconBlockRoot.get(default(Hash256))
+    result.parentBeaconBlockRoot = Opt.some g.parentBeaconBlockRoot.get(ZERO_HASH256)
 
 proc toGenesisHeader*(
     genesis: Genesis;

--- a/nimbus/core/chain/persist_blocks.nim
+++ b/nimbus/core/chain/persist_blocks.nim
@@ -222,7 +222,7 @@ proc insertBlockWithoutSetHead*(c: ChainRef, blk: EthBlock): Result[void, string
   ok()
 
 proc setCanonical*(c: ChainRef, header: BlockHeader): Result[void, string] =
-  if header.parentHash == default(Hash256):
+  if header.parentHash == ZERO_HASH256:
     if not c.db.setHead(header):
       return err("setHead failed")
     return ok()

--- a/nimbus/db/core_db/core_apps.nim
+++ b/nimbus/db/core_db/core_apps.nim
@@ -209,7 +209,7 @@ proc setAsCanonicalChainHead(
   # TODO This code handles reorgs - this should be moved elsewhere because we'll
   #      be handling reorgs mainly in-memory
   if header.number == 0 or
-      db.getCanonicalHeaderHash().valueOr(default(Hash256)) != header.parentHash:
+      db.getCanonicalHeaderHash().valueOr(ZERO_HASH256) != header.parentHash:
     var newCanonicalHeaders = sequtils.toSeq(db.findNewAncestors(header))
     reverse(newCanonicalHeaders)
     for h in newCanonicalHeaders:
@@ -255,7 +255,7 @@ proc markCanonicalChain(
     return false
 
   # it is a genesis block, done
-  if currHeader.parentHash == default(Hash256):
+  if currHeader.parentHash == ZERO_HASH256:
     return true
 
   # mark ancestor blocks as canonical too
@@ -268,9 +268,9 @@ proc markCanonicalChain(
       rlp.decode(data, Hash256)
     except RlpError as exc:
       warn info, key, error=exc.msg
-      default(Hash256)
+      ZERO_HASH256
 
-  while currHash != default(Hash256):
+  while currHash != ZERO_HASH256:
     let key = blockNumberToHashKey(currHeader.number)
     let data = kvt.getOrEmpty(key.toOpenArray).valueOr:
       warn info, key, error=($$error)
@@ -287,7 +287,7 @@ proc markCanonicalChain(
       # forking point, done
       break
 
-    if currHeader.parentHash == default(Hash256):
+    if currHeader.parentHash == ZERO_HASH256:
       break
 
     currHash = currHeader.parentHash
@@ -391,7 +391,7 @@ proc getBlockHash*(
     raise newException(BlockNotFound, "No block hash for number " & $n)
 
 proc getHeadBlockHash*(db: CoreDbRef): Hash256 =
-  db.getHash(canonicalHeadHashKey()).valueOr(default(Hash256))
+  db.getHash(canonicalHeadHashKey()).valueOr(ZERO_HASH256)
 
 proc getBlockHeader*(
     db: CoreDbRef;
@@ -904,7 +904,7 @@ proc persistUncles*(db: CoreDbRef, uncles: openArray[BlockHeader]): Hash256 =
 
 
 proc safeHeaderHash*(db: CoreDbRef): Hash256 =
-  db.getHash(safeHashKey()).valueOr(default(Hash256))
+  db.getHash(safeHashKey()).valueOr(ZERO_HASH256)
 
 proc safeHeaderHash*(db: CoreDbRef, headerHash: Hash256) =
   let safeHashKey = safeHashKey()
@@ -915,7 +915,7 @@ proc safeHeaderHash*(db: CoreDbRef, headerHash: Hash256) =
 proc finalizedHeaderHash*(
     db: CoreDbRef;
       ): Hash256 =
-  db.getHash(finalizedHashKey()).valueOr(default(Hash256))
+  db.getHash(finalizedHashKey()).valueOr(ZERO_HASH256)
 
 proc finalizedHeaderHash*(db: CoreDbRef, headerHash: Hash256) =
   let finalizedHashKey = finalizedHashKey()

--- a/nimbus/evm/computation.nim
+++ b/nimbus/evm/computation.nim
@@ -146,18 +146,18 @@ proc getBlockHash*(c: Computation, number: BlockNumber): Hash256 =
       blockNumber = BlockNumber c.host.getTxContext().block_number
       ancestorDepth  = blockNumber - number - 1
     if ancestorDepth >= constants.MAX_PREV_HEADER_DEPTH:
-      return default(Hash256)
+      return ZERO_HASH256
     if number >= blockNumber:
-      return default(Hash256)
+      return ZERO_HASH256
     c.host.getBlockHash(number)
   else:
     let
       blockNumber = c.vmState.blockNumber
       ancestorDepth = blockNumber - number - 1
     if ancestorDepth >= constants.MAX_PREV_HEADER_DEPTH:
-      return default(Hash256)
+      return ZERO_HASH256
     if number >= blockNumber:
-      return default(Hash256)
+      return ZERO_HASH256
     c.vmState.getAncestorHash(number)
 
 template accountExists*(c: Computation, address: EthAddress): bool =
@@ -194,7 +194,7 @@ template getCodeHash*(c: Computation, address: EthAddress): Hash256 =
     let
       db = c.vmState.readOnlyStateDB
     if not db.accountExists(address) or db.isEmptyAccount(address):
-      default(Hash256)
+      ZERO_HASH256
     else:
       db.getCodeHash(address)
 

--- a/nimbus/evm/state.nim
+++ b/nimbus/evm/state.nim
@@ -259,9 +259,9 @@ method getAncestorHash*(
     if db.getBlockHash(blockNumber, blockHash):
       blockHash
     else:
-      default(Hash256)
+      ZERO_HASH256
   except RlpError:
-    default(Hash256)
+    ZERO_HASH256
 
 proc readOnlyStateDB*(vmState: BaseVMState): ReadOnlyStateDB {.inline.} =
   ReadOnlyStateDB(vmState.stateDB)

--- a/nimbus/sync/beacon/skeleton_algo.nim
+++ b/nimbus/sync/beacon/skeleton_algo.nim
@@ -411,7 +411,7 @@ proc processNewHead*(sk: SkeletonRef, head: BlockHeader,
                  newHead=number
                # set the lastchain to genesis for comparison in
                # following conditions
-               segment(0, 0, zeroBlockHash)
+               segment(0, 0, ZERO_HASH256)
              else:
                sk.last
 

--- a/nimbus/sync/beacon/skeleton_utils.nim
+++ b/nimbus/sync/beacon/skeleton_utils.nim
@@ -19,7 +19,6 @@ logScope:
 const
   # How often to log sync status (in ms)
   STATUS_LOG_INTERVAL* = initDuration(microseconds = 8000)
-  zeroBlockHash* = default(Hash256)
 
 # ------------------------------------------------------------------------------
 # Misc helpers
@@ -30,7 +29,7 @@ func u64*(h: BlockHeader): uint64 =
 
 func blockHash*(x: Opt[BlockHeader]): Hash256 =
   if x.isSome: x.get.blockHash
-  else: zeroBlockHash
+  else: ZERO_HASH256
 
 func numberStr*(x: Opt[BlockHeader]): string =
   if x.isSome: $(x.get.u64)

--- a/tests/test_beacon/test_1_initsync.nim
+++ b/tests/test_beacon/test_1_initsync.nim
@@ -185,7 +185,7 @@ proc test1*() =
           skel.putHeader(header)
 
         for x in z.oldState:
-          skel.push(x.head, x.tail, default(Hash256))
+          skel.push(x.head, x.tail, ZERO_HASH256)
 
         let r = skel.initSync(z.head).valueOr:
           debugEcho "initSync: ", error

--- a/tests/test_engine_api.nim
+++ b/tests/test_engine_api.nim
@@ -9,10 +9,8 @@
 # according to those terms.
 
 import
-  std/[base64, times, strutils],
+  std/times,
   eth/common,
-  nimcrypto/[hmac],
-  stew/byteutils,
   json_rpc/rpcclient,
   json_rpc/rpcserver,
   web3/engine_api,

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -48,11 +48,11 @@ proc toBytes(x: string): seq[byte] =
 
 method getAncestorHash*(vmState: BaseVMState; blockNumber: BlockNumber): Hash256 =
   if blockNumber >= vmState.blockNumber:
-    return default(Hash256)
+    return ZERO_HASH256
   elif blockNumber < 0:
-    return default(Hash256)
+    return ZERO_HASH256
   elif blockNumber < vmState.blockNumber - 256:
-    return default(Hash256)
+    return ZERO_HASH256
   else:
     return keccakHash(toBytes($blockNumber))
 

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -93,7 +93,7 @@ proc envToHeader(env: EnvStruct): BlockHeader =
   BlockHeader(
     coinbase   : env.currentCoinbase,
     difficulty : env.currentDifficulty.get(0.u256),
-    mixHash    : env.currentRandom.get(default(Hash256)),
+    mixHash    : env.currentRandom.get(ZERO_HASH256),
     number     : env.currentNumber,
     gasLimit   : env.currentGasLimit,
     timestamp  : env.currentTimestamp,
@@ -129,7 +129,7 @@ proc toTxReceipt(rec: Receipt,
   let contractAddress = genAddress(tx, sender)
   TxReceipt(
     txType: tx.txType,
-    root: if rec.isHash: rec.hash else: default(Hash256),
+    root: if rec.isHash: rec.hash else: ZERO_HASH256,
     status: rec.status,
     cumulativeGasUsed: rec.cumulativeGasUsed,
     logsBloom: rec.logsBloom,
@@ -137,7 +137,7 @@ proc toTxReceipt(rec: Receipt,
     transactionHash: rlpHash(tx),
     contractAddress: contractAddress,
     gasUsed: gasUsed,
-    blockHash: default(Hash256),
+    blockHash: ZERO_HASH256,
     transactionIndex: txIndex
   )
 
@@ -241,7 +241,7 @@ proc exec(ctx: var TransContext,
       prevNumber = ctx.env.currentNumber - 1
       prevHash = ctx.env.blockHashes.getOrDefault(prevNumber)
 
-    if prevHash == static(default(Hash256)):
+    if prevHash == ZERO_HASH256:
       raise newError(ErrorConfig, "previous block hash not found for block number: " & $prevNumber)
 
     vmState.processParentBlockHash(prevHash).isOkOr:
@@ -397,7 +397,7 @@ proc setupAlloc(stateDB: LedgerRef, alloc: GenesisAlloc) =
 method getAncestorHash(vmState: TestVMState; blockNumber: BlockNumber): Hash256 =
   # we can't raise exception here, it'll mess with EVM exception handler.
   # so, store the exception for later using `hashError`
-  var h = default(Hash256)
+  var h = ZERO_HASH256
   if vmState.blockHashes.len == 0:
     vmState.hashError = "getAncestorHash(" &
       $blockNumber & ") invoked, no blockhashes provided"
@@ -465,7 +465,7 @@ proc transitionAction*(ctx: var TransContext, conf: T8NConf) =
         let n = json.parseFile(conf.inputTxs)
         ctx.parseTxs(n)
 
-    let uncleHash = if ctx.env.parentUncleHash == default(Hash256):
+    let uncleHash = if ctx.env.parentUncleHash == ZERO_HASH256:
                       EMPTY_UNCLE_HASH
                     else:
                       ctx.env.parentUncleHash


### PR DESCRIPTION
Intentionally mechanical, except for fixing some `UnusedImport` warnings.

Example codegen changes:

```c
typedef struct tyObject_MDigest__PxXZtpQQu8z5HdYvFSeEAA
    tyObject_MDigest__PxXZtpQQu8z5HdYvFSeEAA;
typedef NU8 tyArray__vEOa9c5qaE9ajWxR5R4zwfQg[32];
struct tyObject_MDigest__PxXZtpQQu8z5HdYvFSeEAA {
  NIM_ALIGN(16) tyArray__vEOa9c5qaE9ajWxR5R4zwfQg data;
};

/* ... */

    tyObject_MDigest__PxXZtpQQu8z5HdYvFSeEAA T5_;
    /* ... */
    switch (sX60gensym222_.oResultPrivate) {
    case NIM_TRUE: {
      if (!(((2 & ((NU8)1 << ((NU)((sX60gensym222_.oResultPrivate)) & 7U))) !=
             0))) {
        raiseFieldError2(
            ((NimStringDesc *)&TM__T9abr9cTL4Q10EHO3W9aP0oNg_2),
            reprDiscriminant(((NI)(sX60gensym222_.oResultPrivate)) +
                                 (NI)IL64(0),
                             (&NTIbool__VaVACK0bpYmqIQ0mKcHfQQ_)));
      }
      T5_ = sX60gensym222_._oResultPrivate_2.vResultPrivate;
    } break;
    case NIM_FALSE: {
      nimZeroMem((void *)(&T5_),
                 sizeof(tyObject_MDigest__PxXZtpQQu8z5HdYvFSeEAA));
    } break;
```
becomes
```c
extern NIM_CONST tyObject_MDigest__PxXZtpQQu8z5HdYvFSeEAA
    ZERO_HASH256__constants_u270;

/* ... */

    switch (sX60gensym222_.oResultPrivate) {
    case NIM_TRUE: {
      if (!(((2 & ((NU8)1 << ((NU)((sX60gensym222_.oResultPrivate)) & 7U))) !=
             0))) {
        raiseFieldError2(
            ((NimStringDesc *)&TM__T9abr9cTL4Q10EHO3W9aP0oNg_2),
            reprDiscriminant(((NI)(sX60gensym222_.oResultPrivate)) +
                                 (NI)IL64(0),
                             (&NTIbool__VaVACK0bpYmqIQ0mKcHfQQ_)));
      }
      T5_ = sX60gensym222_._oResultPrivate_2.vResultPrivate;
    } break;
    case NIM_FALSE: {
      T5_ = ZERO_HASH256__constants_u270;
    } break;
    default: {
    } break;
```