### PR TITLE
use non-deprecated engine API method for Hive JWT tests

### DIFF
--- a/nrpc/nrpc.nim
+++ b/nrpc/nrpc.nim
@@ -134,7 +134,7 @@ proc syncToEngineApi(conf: NRpcConf) {.async.} =
       try:
         await rpcClient.exchangeCapabilities(
           @[
-            "engine_exchangeTransitionConfigurationV1", "engine_forkchoiceUpdatedV1",
+            "engine_forkchoiceUpdatedV1",
             "engine_getPayloadBodiesByHash", "engine_getPayloadBodiesByRangeV1",
             "engine_getPayloadV1", "engine_newPayloadV1",
           ]


### PR DESCRIPTION
- https://github.com/status-im/nim-web3/pull/132
for context/motivation.

It's not strictly necessary, because it doesn't use the `nim-web3` definitions anyway, but it's better regardless.