### PR TITLE
rpc fixes and enable kurtosis

### DIFF
--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -266,7 +266,7 @@ jobs:
         echo "Test Result:  $test_result"
         echo "$test_status"
 
-        if [ "$test_result" == "success" ]; then
+        if ! [ "$test_result" == "success" ]; then
           echo ""
           echo "Failed Test Task Status:"
           echo "$failed_test_status"

--- a/kurtosis-network-params.yml
+++ b/kurtosis-network-params.yml
@@ -24,8 +24,8 @@ tx_spammer_params:
   tx_spammer_extra_args: ["--accounts=1", "--txcount=1"]
 mev_type: null
 assertoor_params:
-  image: "ethpandaops/assertoor:latest"
-  run_stability_check: true
+  image: "ethpandaops/assertoor:master"
+  run_stability_check: false
   run_block_proposal_check: true
   run_transaction_test: true
   run_blob_transaction_test: false

--- a/nimbus/core/chain/forked_chain.nim
+++ b/nimbus/core/chain/forked_chain.nim
@@ -28,9 +28,9 @@ type
     forkJunction: BlockNumber
     hash: Hash256
 
-  BlockDesc = object
-    blk: EthBlock
-    receipts: seq[Receipt]
+  BlockDesc* = object
+    blk*: EthBlock
+    receipts*: seq[Receipt]
 
   BaseDesc = object
     hash: Hash256
@@ -582,9 +582,6 @@ func txRecords*(c: ForkedChainRef): Table[Hash256, Hash256] =
 
 func memoryBlocks*(c: ForkedChainRef): Table[Hash256, BlockDesc] =
   c.blocks
-
-func receipts*(b: BlockDesc): seq[Receipt] =
-  b.receipts
 
 func blockTransactions*(b: BlockDesc): seq[Transaction] =
   b.blk.transactions

--- a/nimbus/core/chain/forked_chain.nim
+++ b/nimbus/core/chain/forked_chain.nim
@@ -583,9 +583,6 @@ func txRecords*(c: ForkedChainRef, txHash: Hash256): (Hash256, uint64) =
 func memoryBlock*(c: ForkedChainRef, blockHash: Hash256): BlockDesc =
   c.blocks.getOrDefault(blockHash)
 
-func blockTransactions*(b: BlockDesc): seq[Transaction] =
-  b.blk.transactions
-
 proc latestBlock*(c: ForkedChainRef): EthBlock =
   c.blocks.withValue(c.cursorHash, val) do:
     return val.blk

--- a/nimbus/rpc/server_api.nim
+++ b/nimbus/rpc/server_api.nim
@@ -74,12 +74,7 @@ proc blockFromTag(api: ServerAPIRef, blockTag: BlockTag): Result[EthBlock, strin
       return err("Unsupported block tag " & tag)
   else:
     let blockNum = common.BlockNumber blockTag.number
-    let blk = api.chain.blockByNumber(blockNum).valueOr:
-      try:
-        api.chain.db.getEthBlock(blockNum)
-      except BlockNotFound:
-        return err("Block not found, number = " & $blockNum)
-    ok(blk)
+    return api.chain.blockByNumber(blockNum)
 
 proc setupServerAPI*(api: ServerAPIRef, server: RpcServer) =
   server.rpc("eth_getBalance") do(data: Web3Address, blockTag: BlockTag) -> UInt256:

--- a/nimbus/rpc/server_api.nim
+++ b/nimbus/rpc/server_api.nim
@@ -22,6 +22,7 @@ import
   ../transaction/call_evm,
   ../evm/evm_errors,
   ./rpc_types,
+  ./rpc_utils,
   ./filters,
   ./server_api_helpers
 
@@ -258,3 +259,40 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer) =
       res    = rpcCallEvm(args, header, api.com).valueOr:
                  raise newException(ValueError, "rpcCallEvm error: " & $error.code)
     res.output
+
+  server.rpc("eth_getTransactionReceipt") do(data: Web3Hash) -> ReceiptObject:
+    ## Returns the receipt of a transaction by transaction hash.
+    ##
+    ## data: Hash of a transaction.
+    ## Returns ReceiptObject or nil when no receipt was found.
+    var
+      idx = 0'u64
+      prevGasUsed = GasInt(0)
+    
+    let txHash = data.ethHash()
+    if api.chain.txRecords.hasKey(txHash):
+      let blockhash = api.chain.txRecords[txHash]
+      let blkdesc = api.chain.memoryBlocks[blockhash]
+      
+      for i, receipt in blkdesc.receipts:
+        let gasUsed = receipt.cumulativeGasUsed - prevGasUsed
+        prevGasUsed = receipt.cumulativeGasUsed
+        if txHash == blkdesc.blockTransactions[i].rlpHash:
+          return populateReceipt(receipt, gasUsed, blkdesc.blockTransactions[i], uint64(i), blkdesc.blk.header)
+
+    let txDetails = api.chain.db.getTransactionKey(data.ethHash())
+    if txDetails.index < 0:
+      return nil
+
+    let header = api.chain.headerByNumber(txDetails.blockNumber).valueOr:
+      raise newException(ValueError, "Block not found")
+    var tx: Transaction
+    if not api.chain.db.getTransactionByIndex(header.txRoot, uint16(txDetails.index), tx):
+      return nil
+
+    for receipt in api.chain.db.getReceipts(header.receiptsRoot):
+      let gasUsed = receipt.cumulativeGasUsed - prevGasUsed
+      prevGasUsed = receipt.cumulativeGasUsed
+      if idx == txDetails.index:
+        return populateReceipt(receipt, gasUsed, tx, txDetails.index, header)
+      idx.inc

--- a/nimbus/rpc/server_api.nim
+++ b/nimbus/rpc/server_api.nim
@@ -50,12 +50,7 @@ proc headerFromTag(api: ServerAPIRef, blockTag: BlockTag): Result[common.BlockHe
       return err("Unsupported block tag " & tag)
   else:
     let blockNum = common.BlockNumber blockTag.number
-    let blkhdr = api.chain.headerByNumber(blockNum).valueOr:
-      try:
-        api.chain.db.getBlockHeader(blockNum)
-      except BlockNotFound:
-        return err("Block header not found, number = " & $blockNum)
-    ok(blkhdr)
+    return api.chain.headerByNumber(blockNum)
 
 proc headerFromTag(api: ServerAPIRef, blockTag: Opt[BlockTag]): Result[common.BlockHeader, string] =
   let blockId = blockTag.get(defaultTag)

--- a/nimbus/rpc/server_api.nim
+++ b/nimbus/rpc/server_api.nim
@@ -302,3 +302,5 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer) =
 
         if txid == idx:
           return populateReceipt(receipt, gasUsed, blkdesc.blk.transactions[txid], txid, blkdesc.blk.header)
+
+        idx.inc

--- a/run-kurtosis-check.sh
+++ b/run-kurtosis-check.sh
@@ -238,7 +238,7 @@ else
   done
   echo
 
-  if [ -z "$failed_test_id" ]; then
+  if ! [ -z "$failed_test_id" ]; then
     echo "failed_test_status"
     get_tasks_status "$failed_test_id"
     echo ""

--- a/run-kurtosis-check.sh
+++ b/run-kurtosis-check.sh
@@ -238,7 +238,7 @@ else
   done
   echo
 
-  if ! [ -z "$failed_test_id" ]; then
+  if [ -z "$failed_test_id" ]; then
     echo "failed_test_status"
     get_tasks_status "$failed_test_id"
     echo ""


### PR DESCRIPTION
Once the blocks get's persisted to the db, the rpc can't serve it through the `ForkedChainRef`
Resulting in older blocks returning `null`

<img width="601" alt="Screenshot_2024-10-02_at_3 26 09_PM" src="https://github.com/user-attachments/assets/795aaeb8-76fb-4f1d-b3de-e88d521f3a11">

Also fixes #2679 
