### PR TITLE
Fix eth/common & web3 related deprecation warnings for fluffy

### DIFF
--- a/fluffy/common/common_types.nim
+++ b/fluffy/common/common_types.nim
@@ -7,9 +7,9 @@
 
 {.push raises: [].}
 
-import results, ssz_serialization, stew/byteutils, eth/rlp, nimcrypto/hash
+import results, ssz_serialization, stew/byteutils, eth/rlp, eth/common/hashes
 
-export hash, ssz_serialization
+export hashes, ssz_serialization
 
 type
   Bytes2* = ByteVector[2]
@@ -17,7 +17,16 @@ type
 
   ContentId* = UInt256
   ContentKeyByteList* = ByteList[2048] # The encoded content key
-  BlockHash* = MDigest[32 * 8] # Bytes32
+  BlockHash* = Hash32
+
+func fromSszBytes*(T: type Hash32, data: openArray[byte]): T {.raises: [SszError].} =
+  if data.len != sizeof(result):
+    raiseIncorrectSize T
+
+  T.copyFrom(data)
+
+template toSszType*(v: Hash32): array[32, byte] =
+  v.data
 
 func `$`*(x: ByteList[2048]): string =
   x.asSeq.to0xHex()

--- a/fluffy/common/common_utils.nim
+++ b/fluffy/common/common_utils.nim
@@ -7,16 +7,7 @@
 
 {.push raises: [].}
 
-import
-  std/[os, strutils],
-  chronicles,
-  eth/common,
-  stew/[io2, arrayops],
-  eth/p2p/discoveryv5/enr
-
-func fromBytes*(T: type KeccakHash, hash: openArray[byte]): T =
-  doAssert(hash.len() == 32)
-  KeccakHash(array[32, byte].initCopyFrom(hash))
+import std/[os, strutils], chronicles, eth/common, stew/io2, eth/p2p/discoveryv5/enr
 
 iterator strippedLines(filename: string): string {.raises: [ref IOError].} =
   for line in lines(filename):

--- a/fluffy/common/common_utils.nim
+++ b/fluffy/common/common_utils.nim
@@ -7,7 +7,7 @@
 
 {.push raises: [].}
 
-import std/[os, strutils], chronicles, eth/common, stew/io2, eth/p2p/discoveryv5/enr
+import std/[os, strutils], chronicles, stew/io2, eth/p2p/discoveryv5/enr
 
 iterator strippedLines(filename: string): string {.raises: [ref IOError].} =
   for line in lines(filename):

--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -13,7 +13,7 @@ import
   confutils,
   confutils/std/net,
   chronicles,
-  eth/keys,
+  eth/common/keys,
   eth/p2p/discoveryv5/[enr, node, routing_table],
   nimcrypto/hash,
   stew/byteutils,

--- a/fluffy/database/era1_db.nim
+++ b/fluffy/database/era1_db.nim
@@ -11,6 +11,7 @@ import
   std/os,
   stew/io2,
   results,
+  eth/common/blocks,
   ../network/history/validation/historical_hashes_accumulator,
   ../eth_data/era1
 
@@ -58,7 +59,7 @@ proc new*(
 ): Era1DB =
   Era1DB(path: path, network: network, accumulator: accumulator)
 
-proc getEthBlock*(db: Era1DB, blockNumber: uint64): Result[EthBlock, string] =
+proc getEthBlock*(db: Era1DB, blockNumber: uint64): Result[Block, string] =
   let f = ?db.getEra1File(blockNumber.era)
 
   f.getEthBlock(blockNumber)

--- a/fluffy/eth_data/history_data_seeding.nim
+++ b/fluffy/eth_data/history_data_seeding.nim
@@ -12,12 +12,12 @@ import
   results,
   chronos,
   chronicles,
-  eth/common/eth_types,
-  eth/rlp,
   ../network/wire/portal_protocol,
   ../network/history/
     [history_content, history_network, validation/historical_hashes_accumulator],
   "."/[era1, history_data_json_store, history_data_ssz_e2s]
+
+from eth/common/eth_types_rlp import rlpHash
 
 export results
 
@@ -140,7 +140,7 @@ proc historyPropagateHeadersWithProof*(
         content = headerWithProof.get()
         contentKey = ContentKey(
           contentType: blockHeader,
-          blockHeaderKey: BlockKey(blockHash: header.blockHash()),
+          blockHeaderKey: BlockKey(blockHash: header.rlpHash()),
         )
         encKey = history_content.encode(contentKey)
         contentId = history_content.toContentId(encKey)
@@ -229,7 +229,7 @@ iterator headersWithProof*(
     let
       contentKey = ContentKey(
         contentType: blockHeader,
-        blockHeaderKey: BlockKey(blockHash: blockHeader.blockHash()),
+        blockHeaderKey: BlockKey(blockHash: blockHeader.rlpHash()),
       ).encode()
 
       headerWithProof = buildHeaderWithProof(blockHeader, epochRecord).valueOr:
@@ -241,7 +241,7 @@ iterator headersWithProof*(
 
 iterator blockContent*(f: Era1File): (ContentKeyByteList, seq[byte]) =
   for (header, body, receipts, _) in f.era1BlockTuples:
-    let blockHash = header.blockHash()
+    let blockHash = header.rlpHash()
 
     block: # block body
       let

--- a/fluffy/eth_data/history_data_ssz_e2s.nim
+++ b/fluffy/eth_data/history_data_ssz_e2s.nim
@@ -11,7 +11,7 @@ import
   stew/[byteutils, io2],
   chronicles,
   results,
-  eth/[rlp, common/eth_types],
+  eth/common/headers_rlp,
   ncli/e2store,
   ../network/history/[history_content, validation/historical_hashes_accumulator]
 
@@ -57,13 +57,13 @@ const
   # first ~1M (?) block headers, after that there is no gain so we don't do it.
   ExecutionBlockHeaderRecord* = [byte 0xFF, 0x00]
 
-proc readBlockHeaders*(file: string): Result[seq[BlockHeader], string] =
+proc readBlockHeaders*(file: string): Result[seq[headers.Header], string] =
   let fh = ?openFile(file, {OpenFlags.Read}).mapErr(toString)
   defer:
     discard closeFile(fh)
 
   var data: seq[byte]
-  var blockHeaders: seq[BlockHeader]
+  var blockHeaders: seq[headers.Header]
   while true:
     let header = readRecord(fh, data).valueOr:
       break
@@ -71,7 +71,7 @@ proc readBlockHeaders*(file: string): Result[seq[BlockHeader], string] =
     if header.typ == ExecutionBlockHeaderRecord:
       let blockHeader =
         try:
-          rlp.decode(data, BlockHeader)
+          rlp.decode(data, headers.Header)
         except RlpError as e:
           return err("Invalid block header in " & file & ": " & e.msg)
 

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -19,7 +19,7 @@ import
   json_rpc/clients/httpclient,
   results,
   stew/[byteutils, io2],
-  eth/keys,
+  eth/common/keys,
   eth/net/nat,
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   ./conf,

--- a/fluffy/network/history/content/content_keys.nim
+++ b/fluffy/network/history/content/content_keys.nim
@@ -9,7 +9,6 @@
 
 import
   nimcrypto/[sha2, hash],
-  stew/byteutils,
   results,
   stint,
   ssz_serialization,
@@ -80,9 +79,6 @@ func toContentId*(contentKey: ContentKeyByteList): ContentId =
 
 func toContentId*(contentKey: ContentKey): ContentId =
   toContentId(encode(contentKey))
-
-func `$`*(x: BlockHash): string =
-  "0x" & x.data.toHex()
 
 func `$`*(x: BlockKey): string =
   "blockHash: " & $x.blockHash

--- a/fluffy/network/state/content/content_keys.nim
+++ b/fluffy/network/state/content/content_keys.nim
@@ -14,16 +14,16 @@ import
   nimcrypto/[hash, sha2, keccak],
   results,
   stint,
-  eth/common/eth_types,
+  eth/common/hashes,
   ssz_serialization,
   ./nibbles
 
 export ssz_serialization, common_types, hash, results
 
 type
-  NodeHash* = KeccakHash
-  CodeHash* = KeccakHash
-  AddressHash* = KeccakHash
+  NodeHash* = Hash32
+  CodeHash* = Hash32
+  AddressHash* = Hash32
 
   ContentType* = enum
     # Note: Need to add this unused value as a case object with an enum without
@@ -63,17 +63,6 @@ type
       contractCodeKey*: ContractCodeKey
 
   ContentKeyType* = AccountTrieNodeKey | ContractTrieNodeKey | ContractCodeKey
-
-func fromSszBytes*(
-    T: type KeccakHash, data: openArray[byte]
-): T {.raises: [SszError].} =
-  if data.len != sizeof(result):
-    raiseIncorrectSize T
-
-  T.copyFrom(data)
-
-template toSszType*(v: KeccakHash): array[32, byte] =
-  v.data
 
 func init*(
     T: type AccountTrieNodeKey, path: Nibbles, nodeHash: NodeHash

--- a/fluffy/network/state/content/content_values.nim
+++ b/fluffy/network/state/content/content_values.nim
@@ -10,7 +10,7 @@
 
 {.push raises: [].}
 
-import results, eth/common/eth_types, ssz_serialization, ../../../common/common_types
+import results, ssz_serialization, ../../../common/common_types
 
 export ssz_serialization, common_types, hash, results
 

--- a/fluffy/network/state/content/nibbles.nim
+++ b/fluffy/network/state/content/nibbles.nim
@@ -10,15 +10,9 @@
 
 {.push raises: [].}
 
-import
-  nimcrypto/hash,
-  results,
-  stint,
-  eth/common/eth_types,
-  ssz_serialization,
-  ../../../common/common_types
+import results, ssz_serialization, ../../../common/common_types
 
-export ssz_serialization, common_types, hash, results
+export ssz_serialization, common_types, results
 
 const
   MAX_PACKED_NIBBLES_LEN = 33

--- a/fluffy/network/state/state_gossip.nim
+++ b/fluffy/network/state/state_gossip.nim
@@ -11,7 +11,7 @@ import
   results,
   chronos,
   chronicles,
-  eth/common,
+  eth/common/hashes,
   ../wire/portal_protocol,
   ./state_content,
   ./state_utils
@@ -71,7 +71,7 @@ func getParent*(offerWithKey: AccountTrieOfferWithKey): AccountTrieOfferWithKey 
     (key, offer) = offerWithKey
     parent = offer.proof.withPath(key.path).getParent()
     parentKey =
-      AccountTrieNodeKey.init(parent.path, keccakHash(parent.proof[^1].asSeq()))
+      AccountTrieNodeKey.init(parent.path, keccak256(parent.proof[^1].asSeq()))
     parentOffer = AccountTrieNodeOffer.init(parent.proof, offer.blockHash)
 
   parentOffer.withKey(parentKey)
@@ -81,7 +81,7 @@ func getParent*(offerWithKey: ContractTrieOfferWithKey): ContractTrieOfferWithKe
     (key, offer) = offerWithKey
     parent = offer.storageProof.withPath(key.path).getParent()
     parentKey = ContractTrieNodeKey.init(
-      key.addressHash, parent.path, keccakHash(parent.proof[^1].asSeq())
+      key.addressHash, parent.path, keccak256(parent.proof[^1].asSeq())
     )
     parentOffer =
       ContractTrieNodeOffer.init(parent.proof, offer.accountProof, offer.blockHash)

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -11,8 +11,6 @@ import
   results,
   chronos,
   chronicles,
-  eth/common/eth_hash,
-  eth/common,
   eth/p2p/discoveryv5/[protocol, enr],
   ../../database/content_db,
   ../history/history_network,
@@ -133,14 +131,14 @@ proc getContractCode*(
 
 proc getStateRootByBlockNumOrHash*(
     n: StateNetwork, blockNumOrHash: uint64 | BlockHash
-): Future[Opt[KeccakHash]] {.async: (raises: [CancelledError]).} =
+): Future[Opt[Hash32]] {.async: (raises: [CancelledError]).} =
   if n.historyNetwork.isNone():
     warn "History network is not available"
-    return Opt.none(KeccakHash)
+    return Opt.none(Hash32)
 
   let header = (await n.historyNetwork.get().getVerifiedBlockHeader(blockNumOrHash)).valueOr:
     warn "Failed to get block header from history", blockNumOrHash
-    return Opt.none(KeccakHash)
+    return Opt.none(Hash32)
 
   Opt.some(header.stateRoot)
 
@@ -162,7 +160,7 @@ proc processOffer*(
       validateOffer(Opt.some(stateRoot), contentKey, contentValue)
     else:
       # Skip state root validation
-      validateOffer(Opt.none(KeccakHash), contentKey, contentValue)
+      validateOffer(Opt.none(Hash32), contentKey, contentValue)
 
   if res.isErr():
     return err("Offered content failed validation: " & res.error())

--- a/fluffy/network/state/state_utils.nim
+++ b/fluffy/network/state/state_utils.nim
@@ -7,9 +7,18 @@
 
 {.push raises: [].}
 
-import results, eth/common, ./state_content
+import
+  results,
+  stew/arrayops,
+  eth/rlp,
+  eth/common/[hashes, addresses, base_rlp, accounts_rlp],
+  ./state_content
 
-export results, common
+export results, hashes, accounts, addresses, rlp
+
+func fromBytes*(T: type Hash32, hash: openArray[byte]): T =
+  doAssert(hash.len() == 32)
+  Hash32(array[32, byte].initCopyFrom(hash))
 
 func decodePrefix*(nodePrefixRlp: Rlp): (byte, bool, Nibbles) {.raises: RlpError.} =
   doAssert(not nodePrefixRlp.isEmpty())
@@ -84,11 +93,11 @@ func removeLeafKeyEndNibbles*(
 
   unpackedNibbles.dropN(leafPrefix.len()).packNibbles()
 
-func toPath*(hash: KeccakHash): Nibbles {.inline.} =
+func toPath*(hash: Hash32): Nibbles {.inline.} =
   Nibbles.init(hash.data, isEven = true)
 
-func toPath*(address: EthAddress): Nibbles {.inline.} =
-  keccakHash(address).toPath()
+func toPath*(address: Address): Nibbles {.inline.} =
+  keccak256(address.data).toPath()
 
 func toPath*(slotKey: UInt256): Nibbles {.inline.} =
-  keccakHash(toBytesBE(slotKey)).toPath()
+  keccak256(toBytesBE(slotKey)).toPath()

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -21,9 +21,9 @@ import
   ssz_serialization,
   metrics,
   faststreams,
+  minilru,
   eth/rlp,
-  eth/p2p/discoveryv5/
-    [protocol, node, enr, routing_table, random2, nodes_verification, lru],
+  eth/p2p/discoveryv5/[protocol, node, enr, routing_table, random2, nodes_verification],
   "."/[portal_stream, portal_protocol_config],
   ./messages
 

--- a/fluffy/rpc/portal_rpc_client.nim
+++ b/fluffy/rpc/portal_rpc_client.nim
@@ -10,15 +10,13 @@ import
   chronos,
   stew/byteutils,
   results,
-  eth/common/eth_types,
+  eth/common/[headers_rlp, blocks_rlp, receipts_rlp],
   json_rpc/rpcclient,
   ../common/common_types,
   ../network/history/[history_content, history_network],
   ./rpc_calls/[rpc_discovery_calls, rpc_portal_calls, rpc_portal_debug_calls]
 
-export
-  rpcclient, rpc_discovery_calls, rpc_portal_calls, rpc_portal_debug_calls, results,
-  eth_types
+export rpcclient, rpc_discovery_calls, rpc_portal_calls, rpc_portal_debug_calls, results
 
 type
   PortalRpcClient* = distinct RpcClient
@@ -94,7 +92,7 @@ proc historyGetContent(
 
 proc historyGetBlockHeader*(
     client: PortalRpcClient, blockHash: BlockHash, validateContent = true
-): Future[Result[BlockHeader, PortalRpcError]] {.async: (raises: []).} =
+): Future[Result[Header, PortalRpcError]] {.async: (raises: []).} =
   ## Fetches the block header for the given hash from the Portal History Network.
   ## The data is first looked up in the node's local database before trying to
   ## fetch it from the network.
@@ -115,7 +113,7 @@ proc historyGetBlockHeader*(
   if validateContent:
     validateBlockHeaderBytes(headerBytes, blockHash).valueOrErr(ContentValidationFailed)
   else:
-    decodeRlp(headerBytes, BlockHeader).valueOrErr(InvalidContentValue)
+    decodeRlp(headerBytes, Header).valueOrErr(InvalidContentValue)
 
 proc historyGetBlockBody*(
     client: PortalRpcClient, blockHash: BlockHash, validateContent = true

--- a/fluffy/rpc/rpc_calls/rpc_eth_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_eth_calls.nim
@@ -20,7 +20,7 @@ export eth_api_types
 createRpcSigsFromNim(RpcClient):
   proc web3_clientVersion(): string
   proc eth_chainId(): Quantity
-  proc eth_getBlockByHash(data: BlockHash, fullTransactions: bool): Opt[BlockObject]
+  proc eth_getBlockByHash(data: Hash32, fullTransactions: bool): Opt[BlockObject]
   proc eth_getBlockByNumber(
     blockId: BlockIdentifier, fullTransactions: bool
   ): Opt[BlockObject]
@@ -29,12 +29,12 @@ createRpcSigsFromNim(RpcClient):
     blockId: BlockIdentifier, quantity: Quantity
   ): BlockObject
 
-  proc eth_getBlockTransactionCountByHash(data: BlockHash): Quantity
-  proc eth_getTransactionReceipt(data: TxHash): Opt[ReceiptObject]
+  proc eth_getBlockTransactionCountByHash(data: Hash32): Quantity
+  proc eth_getTransactionReceipt(data: Hash32): Opt[ReceiptObject]
   proc eth_getLogs(filterOptions: FilterOptions): seq[LogObject]
 
   proc eth_getBlockReceipts(blockId: string): Opt[seq[ReceiptObject]]
-  proc eth_getBlockReceipts(blockId: BlockNumber): Opt[seq[ReceiptObject]]
+  proc eth_getBlockReceipts(blockId: Quantity): Opt[seq[ReceiptObject]]
   proc eth_getBlockReceipts(blockId: RtBlockIdentifier): Opt[seq[ReceiptObject]]
 
   proc eth_getBalance(data: Address, blockId: BlockIdentifier): UInt256

--- a/fluffy/rpc/rpc_debug_api.nim
+++ b/fluffy/rpc/rpc_debug_api.nim
@@ -10,11 +10,7 @@
 import
   json_rpc/rpcserver,
   chronicles,
-  web3/conversions, # sigh, for FixedBytes marshalling
-  web3/eth_api_types,
-  web3/primitives as web3types,
-  eth/common/eth_types,
-  ../common/common_utils,
+  web3/[eth_api_types, conversions],
   ../network/state/state_endpoints
 
 template getOrRaise(stateNetwork: Opt[StateNetwork]): StateNetwork =
@@ -24,104 +20,84 @@ template getOrRaise(stateNetwork: Opt[StateNetwork]): StateNetwork =
 
 proc installDebugApiHandlers*(rpcServer: RpcServer, stateNetwork: Opt[StateNetwork]) =
   rpcServer.rpc("debug_getBalanceByStateRoot") do(
-    data: web3Types.Address, stateRoot: web3types.Hash256
+    address: Address, stateRoot: Hash32
   ) -> UInt256:
     ## Returns the balance of the account of given address.
     ##
-    ## data: address to check for balance.
+    ## address: address to check for balance.
     ## stateRoot: the state root used to search the state trie.
     ## Returns integer of the current balance in wei.
 
     let
       sn = stateNetwork.getOrRaise()
-      balance = (
-        await sn.getBalanceByStateRoot(
-          KeccakHash.fromBytes(stateRoot.bytes()), data.EthAddress
-        )
-      ).valueOr:
+      balance = (await sn.getBalanceByStateRoot(stateRoot, address)).valueOr:
         raise newException(ValueError, "Unable to get balance")
 
     return balance
 
   rpcServer.rpc("debug_getTransactionCountByStateRoot") do(
-    data: web3Types.Address, stateRoot: web3types.Hash256
+    address: Address, stateRoot: Hash32
   ) -> Quantity:
     ## Returns the number of transactions sent from an address.
     ##
-    ## data: address.
+    ## address: address.
     ## stateRoot: the state root used to search the state trie.
     ## Returns integer of the number of transactions send from this address.
 
     let
       sn = stateNetwork.getOrRaise()
-      nonce = (
-        await sn.getTransactionCountByStateRoot(
-          KeccakHash.fromBytes(stateRoot.bytes()), data.EthAddress
-        )
-      ).valueOr:
+      nonce = (await sn.getTransactionCountByStateRoot(stateRoot, address)).valueOr:
         raise newException(ValueError, "Unable to get transaction count")
 
     return nonce.Quantity
 
   rpcServer.rpc("debug_getStorageAtByStateRoot") do(
-    data: web3Types.Address, slot: UInt256, stateRoot: web3types.Hash256
+    address: Address, slot: UInt256, stateRoot: Hash32
   ) -> FixedBytes[32]:
     ## Returns the value from a storage position at a given address.
     ##
-    ## data: address of the storage.
+    ## address: address of the storage.
     ## slot: integer of the position in the storage.
     ## stateRoot: the state root used to search the state trie.
     ## Returns: the value at this storage position.
 
     let
       sn = stateNetwork.getOrRaise()
-      slotValue = (
-        await sn.getStorageAtByStateRoot(
-          KeccakHash.fromBytes(stateRoot.bytes()), data.EthAddress, slot
-        )
-      ).valueOr:
+      slotValue = (await sn.getStorageAtByStateRoot(stateRoot, address, slot)).valueOr:
         raise newException(ValueError, "Unable to get storage slot")
 
     return FixedBytes[32](slotValue.toBytesBE())
 
   rpcServer.rpc("debug_getCodeByStateRoot") do(
-    data: web3Types.Address, stateRoot: web3types.Hash256
+    address: Address, stateRoot: Hash32
   ) -> seq[byte]:
     ## Returns code at a given address.
     ##
-    ## data: address
+    ## address: address
     ## stateRoot: the state root used to search the state trie.
     ## Returns the code from the given address.
 
     let
       sn = stateNetwork.getOrRaise()
-      bytecode = (
-        await sn.getCodeByStateRoot(
-          KeccakHash.fromBytes(stateRoot.bytes()), data.EthAddress
-        )
-      ).valueOr:
+      bytecode = (await sn.getCodeByStateRoot(stateRoot, address)).valueOr:
         raise newException(ValueError, "Unable to get code")
 
     return bytecode.asSeq()
 
   rpcServer.rpc("debug_getProofByStateRoot") do(
-    data: web3Types.Address, slots: seq[UInt256], stateRoot: web3types.Hash256
+    address: Address, slots: seq[UInt256], stateRoot: Hash32
   ) -> ProofResponse:
     ## Returns information about an account and storage slots along with account
     ## and storage proofs which prove the existence of the values in the state.
     ##
-    ## data: address of the account.
+    ## address: address of the account.
     ## slots: integers of the positions in the storage to return.
     ## stateRoot: the state root used to search the state trie.
     ## Returns: the proof response containing the account, account proof and storage proof
 
     let
       sn = stateNetwork.getOrRaise()
-      proofs = (
-        await sn.getProofsByStateRoot(
-          KeccakHash.fromBytes(stateRoot.bytes()), data.EthAddress, slots
-        )
-      ).valueOr:
+      proofs = (await sn.getProofsByStateRoot(stateRoot, address, slots)).valueOr:
         raise newException(ValueError, "Unable to get proofs")
 
     var storageProof = newSeqOfCap[StorageProof](slots.len)
@@ -136,11 +112,11 @@ proc installDebugApiHandlers*(rpcServer: RpcServer, stateNetwork: Opt[StateNetwo
       )
 
     return ProofResponse(
-      address: data,
+      address: address,
       accountProof: seq[RlpEncodedBytes](proofs.accountProof),
       balance: proofs.account.balance,
-      nonce: web3types.Quantity(proofs.account.nonce),
-      codeHash: web3types.Hash256(proofs.account.codeHash.data),
-      storageHash: web3types.Hash256(proofs.account.storageRoot.data),
+      nonce: Quantity(proofs.account.nonce),
+      codeHash: proofs.account.codeHash,
+      storageHash: proofs.account.storageRoot,
       storageProof: storageProof,
     )

--- a/fluffy/tests/history_network_tests/test_block_proof_historical_roots_vectors.nim
+++ b/fluffy/tests/history_network_tests/test_block_proof_historical_roots_vectors.nim
@@ -14,7 +14,6 @@ import
   unittest2,
   yaml,
   beacon_chain/spec/datatypes/bellatrix,
-  ../../common/common_types,
   ../../network_metadata,
   ../../network/history/validation/block_proof_historical_roots,
   ../../eth_data/[yaml_utils, yaml_eth_types]
@@ -32,7 +31,7 @@ suite "History Block Proofs - Historical Roots - Test Vectors":
           testProof = YamlTestProofBellatrix.loadFromYaml(path).valueOr:
             raiseAssert "Cannot read test vector: " & error
 
-          blockHash = BlockHash.fromHex(testProof.execution_block_header)
+          blockHash = Digest.fromHex(testProof.execution_block_header)
           blockProof = BlockProofHistoricalRoots(
             beaconBlockProof:
               array[14, Digest].fromHex(testProof.historical_roots_proof),

--- a/fluffy/tests/history_network_tests/test_block_proof_historical_summaries_vectors.nim
+++ b/fluffy/tests/history_network_tests/test_block_proof_historical_summaries_vectors.nim
@@ -16,7 +16,6 @@ import
   yaml,
   ssz_serialization,
   beacon_chain/spec/datatypes/capella,
-  ../../common/common_types,
   ../../network/history/validation/block_proof_historical_summaries,
   ../../network/beacon/beacon_init_loader,
   ../../eth_data/[yaml_utils, yaml_eth_types]
@@ -61,7 +60,7 @@ suite "History Block Proofs - Historical Summaries - Test Vectors":
           testProof = YamlTestProof.loadFromYaml(path).valueOr:
             raiseAssert "Cannot read test vector: " & error
 
-          blockHash = BlockHash.fromHex(testProof.execution_block_header)
+          blockHash = Digest.fromHex(testProof.execution_block_header)
           blockProof = BlockProofHistoricalSummaries(
             beaconBlockProof:
               array[13, Digest].fromHex(testProof.historical_summaries_proof),

--- a/fluffy/tests/history_network_tests/test_historical_hashes_accumulator.nim
+++ b/fluffy/tests/history_network_tests/test_historical_hashes_accumulator.nim
@@ -12,7 +12,7 @@
 import
   unittest2,
   stint,
-  eth/common/eth_types_rlp,
+  eth/common/headers,
   ../../eth_data/history_data_json_store,
   ../../network/history/[history_content, validation/historical_hashes_accumulator],
   ./test_history_util
@@ -36,12 +36,12 @@ suite "Historical Hashes Accumulator":
         int(amount) - 1,
       ]
 
-    var headers: seq[BlockHeader]
+    var headers: seq[Header]
     for i in 0 ..< amount:
       # Note: These test headers will not be a blockchain, as the parent hashes
       # are not properly filled in. That's fine however for this test, as that
       # is not the way the headers are verified with the accumulator.
-      headers.add(BlockHeader(number: i, difficulty: 1.stuint(256)))
+      headers.add(Header(number: i, difficulty: 1.stuint(256)))
 
     let accumulatorRes = buildAccumulatorData(headers)
     check accumulatorRes.isOk()
@@ -58,7 +58,7 @@ suite "Historical Hashes Accumulator":
     block: # Test invalid headers
       # Post merge block number must fail (> than latest header in accumulator)
       var proof: HistoricalHashesAccumulatorProof
-      let header = BlockHeader(number: mergeBlockNumber)
+      let header = Header(number: mergeBlockNumber)
       check verifyAccumulatorProof(accumulator, header, proof).isErr()
 
       # Test altered block headers by altering the difficulty
@@ -67,7 +67,7 @@ suite "Historical Hashes Accumulator":
         check:
           proof.isOk()
         # Alter the block header so the proof no longer matches
-        let header = BlockHeader(number: i.uint64, difficulty: 2.stuint(256))
+        let header = Header(number: i.uint64, difficulty: 2.stuint(256))
 
         check verifyAccumulatorProof(accumulator, header, proof.get()).isErr()
 
@@ -81,9 +81,9 @@ suite "Historical Hashes Accumulator":
     # Less headers than needed to finish the accumulator
     const amount = mergeBlockNumber - 1
 
-    var headers: seq[BlockHeader]
+    var headers: seq[Header]
     for i in 0 ..< amount:
-      headers.add(BlockHeader(number: i, difficulty: 1.stuint(256)))
+      headers.add(Header(number: i, difficulty: 1.stuint(256)))
 
     let accumulatorRes = buildAccumulator(headers)
 

--- a/fluffy/tests/history_network_tests/test_historical_hashes_accumulator_root.nim
+++ b/fluffy/tests/history_network_tests/test_historical_hashes_accumulator_root.nim
@@ -13,7 +13,7 @@ import
   unittest2,
   stint,
   stew/byteutils,
-  eth/common/eth_types_rlp,
+  eth/common/headers,
   ../../eth_data/history_data_json_store,
   ../../network/history/[history_content, validation/historical_hashes_accumulator]
 
@@ -33,7 +33,7 @@ suite "Historical Hashes Accumulator Root":
     check blockDataRes.isOk()
     let blockData = blockDataRes.get()
 
-    var headers: seq[BlockHeader]
+    var headers: seq[Header]
     # Len of headers from blockdata + genesis header
     headers.setLen(blockData.len() + 1)
 

--- a/fluffy/tests/history_network_tests/test_history_content.nim
+++ b/fluffy/tests/history_network_tests/test_history_content.nim
@@ -12,7 +12,7 @@
 import
   unittest2,
   stew/byteutils,
-  eth/common/eth_types_rlp,
+  eth/common/headers_rlp,
   ../../network_metadata,
   ../../eth_data/[history_data_json_store, history_data_ssz_e2s],
   ../../network/history/
@@ -69,7 +69,7 @@ suite "History Content Values":
 
       let blockHeaderWithProof = contentValue.get()
 
-      let res = decodeRlp(blockHeaderWithProof.header.asSeq(), BlockHeader)
+      let res = decodeRlp(blockHeaderWithProof.header.asSeq(), Header)
       check res.isOk()
       let header = res.get()
 
@@ -104,7 +104,7 @@ suite "History Content Values":
 
         let blockHeaderWithProof = contentValue.get()
 
-        let res = decodeRlp(blockHeaderWithProof.header.asSeq(), BlockHeader)
+        let res = decodeRlp(blockHeaderWithProof.header.asSeq(), Header)
         check res.isOk()
         let header = res.get()
 
@@ -135,7 +135,7 @@ suite "History Content Values":
       headerEncoded = headerContent.content_value.hexToSeqByte()
       headerWithProofRes = decodeSsz(headerEncoded, BlockHeaderWithProof)
     check headerWithProofRes.isOk()
-    let headerRes = decodeRlp(headerWithProofRes.get().header.asSeq(), BlockHeader)
+    let headerRes = decodeRlp(headerWithProofRes.get().header.asSeq(), Header)
     check headerRes.isOk()
     let header = headerRes.get()
 
@@ -201,7 +201,7 @@ suite "History Content Values":
       headerEncoded = headerContent.content_value.hexToSeqByte()
       headerWithProofRes = decodeSsz(headerEncoded, BlockHeaderWithProof)
     check headerWithProofRes.isOk()
-    let headerRes = decodeRlp(headerWithProofRes.get().header.asSeq(), BlockHeader)
+    let headerRes = decodeRlp(headerWithProofRes.get().header.asSeq(), Header)
     check headerRes.isOk()
     let header = headerRes.get()
 

--- a/fluffy/tests/history_network_tests/test_history_content_validation.nim
+++ b/fluffy/tests/history_network_tests/test_history_content_validation.nim
@@ -14,7 +14,7 @@ import
   stint,
   stew/byteutils,
   results,
-  eth/[common/eth_types, rlp],
+  eth/common/headers_rlp,
   ../../common/common_types,
   ../../eth_data/history_data_json_store,
   ../../network/history/history_network
@@ -42,7 +42,7 @@ suite "History Content Values Validation":
     blockHash = BlockHash.fromHex(blockHashStr)
 
     blockHeader =
-      decodeRlp(blockHeaderBytes, BlockHeader).expect("Valid header should decode")
+      decodeRlp(blockHeaderBytes, Header).expect("Valid header should decode")
     blockBody = validateBlockBodyBytes(blockBodyBytes, blockHeader).expect(
         "Should be Valid decoded block body"
       )

--- a/fluffy/tests/rpc_tests/test_discovery_rpc.nim
+++ b/fluffy/tests/rpc_tests/test_discovery_rpc.nim
@@ -14,7 +14,7 @@ import
   json_rpc/clients/httpclient,
   stint,
   eth/p2p/discoveryv5/enr,
-  eth/keys,
+  eth/common/keys,
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   ../../rpc/rpc_discovery_api,
   ../test_helpers

--- a/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
+++ b/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
@@ -14,7 +14,8 @@ import
   json_rpc/clients/httpclient,
   stint,
   eth/p2p/discoveryv5/enr,
-  eth/keys,
+  eth/common/keys,
+  eth/common/[headers_rlp, blocks_rlp, receipts_rlp],
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   ../../network/wire/[portal_protocol, portal_stream, portal_protocol_config],
   ../../network/history/
@@ -22,6 +23,8 @@ import
   ../../database/content_db,
   ../../rpc/[portal_rpc_client, rpc_portal_api],
   ../test_helpers
+
+from eth/common/eth_types_rlp import rlpHash
 
 type HistoryNode = ref object
   discoveryProtocol*: discv5_protocol.Protocol
@@ -56,7 +59,7 @@ proc stop(hn: HistoryNode) {.async.} =
 proc containsId(hn: HistoryNode, contentId: ContentId): bool =
   return hn.historyNetwork.contentDB.get(contentId).isSome()
 
-proc store*(hn: HistoryNode, blockHash: BlockHash, blockHeader: BlockHeader) =
+proc store*(hn: HistoryNode, blockHash: BlockHash, blockHeader: Header) =
   let
     headerRlp = rlp.encode(blockHeader)
     blockHeaderWithProof = BlockHeaderWithProof(
@@ -122,8 +125,8 @@ procSuite "Portal RPC Client":
   asyncTest "Test historyGetBlockHeader with validation":
     let
       tc = await setupTest(rng)
-      blockHeader = BlockHeader(number: 100)
-      blockHash = blockHeader.blockHash()
+      blockHeader = Header(number: 100)
+      blockHash = blockHeader.rlpHash()
 
     # Test content not found
     block:
@@ -145,7 +148,7 @@ procSuite "Portal RPC Client":
 
     # Test content validation failed
     block:
-      tc.historyNode.store(blockHash, BlockHeader()) # bad header
+      tc.historyNode.store(blockHash, Header()) # bad header
 
       let blockHeaderRes =
         await tc.client.historyGetBlockHeader(blockHash, validateContent = true)
@@ -158,8 +161,8 @@ procSuite "Portal RPC Client":
   asyncTest "Test historyGetBlockHeader without validation":
     let
       tc = await setupTest(rng)
-      blockHeader = BlockHeader(number: 200)
-      blockHash = blockHeader.blockHash()
+      blockHeader = Header(number: 200)
+      blockHash = blockHeader.rlpHash()
 
     # Test content not found
     block:
@@ -184,9 +187,9 @@ procSuite "Portal RPC Client":
   asyncTest "Test historyGetBlockBody with validation":
     let
       tc = await setupTest(rng)
-      blockHeader = BlockHeader(number: 300)
+      blockHeader = Header(number: 300)
       blockBody = BlockBody()
-      blockHash = blockHeader.blockHash()
+      blockHash = blockHeader.rlpHash()
 
     # Test content not found
     block:
@@ -212,9 +215,9 @@ procSuite "Portal RPC Client":
   asyncTest "Test historyGetBlockBody without validation":
     let
       tc = await setupTest(rng)
-      blockHeader = BlockHeader(number: 300)
+      blockHeader = Header(number: 300)
       blockBody = BlockBody()
-      blockHash = blockHeader.blockHash()
+      blockHash = blockHeader.rlpHash()
 
     # Test content not found
     block:
@@ -240,9 +243,9 @@ procSuite "Portal RPC Client":
   asyncTest "Test historyGetReceipts with validation":
     let
       tc = await setupTest(rng)
-      blockHeader = BlockHeader(number: 300)
+      blockHeader = Header(number: 300)
       receipts = @[Receipt()]
-      blockHash = blockHeader.blockHash()
+      blockHash = blockHeader.rlpHash()
 
     # Test content not found
     block:
@@ -268,9 +271,9 @@ procSuite "Portal RPC Client":
   asyncTest "Test historyGetReceipts without validation":
     let
       tc = await setupTest(rng)
-      blockHeader = BlockHeader(number: 300)
+      blockHeader = Header(number: 300)
       receipts = @[Receipt()]
-      blockHash = blockHeader.blockHash()
+      blockHash = blockHeader.rlpHash()
 
     # Test content not found
     block:

--- a/fluffy/tests/state_network_tests/test_state_content_keys_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_content_keys_vectors.nim
@@ -8,7 +8,7 @@
 import
   unittest2,
   stew/byteutils,
-  eth/common,
+  eth/common/addresses,
   ../../network/state/state_content,
   ../../eth_data/yaml_utils
 
@@ -59,7 +59,7 @@ suite "State Content Keys":
         raiseAssert "Cannot read test vector: " & error
 
       packedNibbles = packNibbles(testCase.path)
-      addressHash = EthAddress.fromHex(testCase.address).keccakHash()
+      addressHash = Address.fromHex(testCase.address).data.keccak256()
       nodeHash = NodeHash.fromHex(testCase.node_hash)
       contentKey =
         ContractTrieNodeKey.init(addressHash, packedNibbles, nodeHash).toContentKey()
@@ -91,7 +91,7 @@ suite "State Content Keys":
       testCase = YamlContractBytecodeKey.loadFromYaml(file).valueOr:
         raiseAssert "Cannot read test vector: " & error
 
-      addressHash = EthAddress.fromHex(testCase.address).keccakHash()
+      addressHash = Address.fromHex(testCase.address).data.keccak256()
       codeHash = CodeHash.fromHex(testCase.code_hash)
       contentKey = ContractCodeKey.init(addressHash, codeHash).toContentKey()
       encoded = contentKey.encode()

--- a/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
@@ -10,9 +10,7 @@ import
   testutils/unittests,
   chronos,
   stew/byteutils,
-  eth/common,
-  eth/p2p/discoveryv5/protocol as discv5_protocol,
-  eth/p2p/discoveryv5/routing_table,
+  eth/common/[addresses, headers_rlp],
   ../../network/wire/[portal_protocol, portal_stream],
   ../../network/state/
     [state_content, state_network, state_gossip, state_endpoints, state_utils],
@@ -49,8 +47,7 @@ procSuite "State Endpoints":
         continue
 
       let
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         leafData = testData
         contentKeyBytes = leafData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
@@ -76,9 +73,9 @@ procSuite "State Endpoints":
       let
         address =
           if i == 0:
-            EthAddress.fromHex("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+            addresses.Address.fromHex("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
           elif i == 3:
-            EthAddress.fromHex("0x1584a2c066b7a455dbd6ae2807a7334e83c35fa5")
+            addresses.Address.fromHex("0x1584a2c066b7a455dbd6ae2807a7334e83c35fa5")
           else:
             raiseAssert("Invalid test case")
         expectedAccount = contentValue.proof.toAccount().get()
@@ -131,7 +128,8 @@ procSuite "State Endpoints":
       block:
         # test non-existant account
         let
-          badAddress = EthAddress.fromHex("0xbadaaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+          badAddress =
+            addresses.Address.fromHex("0xbadaaa39b223fe8d0a0e5c4f27ead9083c756cc2")
           balanceRes =
             await stateNode2.stateNetwork.getBalance(contentValue.blockHash, badAddress)
           nonceRes = await stateNode2.stateNetwork.getTransactionCount(
@@ -172,8 +170,7 @@ procSuite "State Endpoints":
       # seed the account data
       let
         testData = accountTrieTestCase[0]
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         leafData = testData
         contentKeyBytes = leafData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
@@ -200,8 +197,7 @@ procSuite "State Endpoints":
       # seed the storage data
       let
         testData = contractTrieTestCase[0]
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         leafData = testData
         contentKeyBytes = leafData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
@@ -225,7 +221,8 @@ procSuite "State Endpoints":
       await stateNode2.waitUntilContentAvailable(toContentId(storageRootKeyBytes))
 
       let
-        address = EthAddress.fromHex("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+        address =
+          addresses.Address.fromHex("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
         slot = 2.u256
         badSlot = 3.u256
         expectedSlot = contentValue.storageProof.toSlot().get()
@@ -253,8 +250,7 @@ procSuite "State Endpoints":
         testCase = YamlContractBytecodeKVs.loadFromYaml(bytecodeFile).valueOr:
           raiseAssert "Cannot read test vector: " & error
         testData = testCase[0]
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -277,8 +273,10 @@ procSuite "State Endpoints":
       await stateNode2.waitUntilContentAvailable(contentId)
 
       let
-        address = EthAddress.fromHex("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
-        badAddress = EthAddress.fromHex("0xbadaaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+        address =
+          addresses.Address.fromHex("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+        badAddress =
+          addresses.Address.fromHex("0xbadaaa39b223fe8d0a0e5c4f27ead9083c756cc2")
         expectedCode = contentValue.code
 
         codeRes = await stateNode2.stateNetwork.getCode(contentValue.blockHash, address)

--- a/fluffy/tests/state_network_tests/test_state_gossip_getparent_genesis.nim
+++ b/fluffy/tests/state_network_tests/test_state_gossip_getparent_genesis.nim
@@ -11,7 +11,8 @@ import
   std/os,
   unittest2,
   results,
-  eth/[common, trie, trie/db],
+  eth/[trie, trie/db],
+  eth/common/hashes,
   ../../../nimbus/common/chain_config,
   ../../network/state/[state_content, state_validation, state_gossip, state_utils],
   ./state_test_helpers
@@ -32,9 +33,9 @@ suite "State Gossip getParent - Genesis JSON Files":
         let
           proof = accountState.generateAccountProof(address)
           leafNode = proof[^1]
-          addressHash = keccakHash(address).data
+          addressHash = keccak256(address.data).data
           path = removeLeafKeyEndNibbles(Nibbles.init(addressHash, true), leafNode)
-          key = AccountTrieNodeKey.init(path, keccakHash(leafNode.asSeq()))
+          key = AccountTrieNodeKey.init(path, keccak256(leafNode.asSeq()))
           offer = AccountTrieNodeOffer(proof: proof)
 
         var db = newMemoryDB()
@@ -69,7 +70,7 @@ suite "State Gossip getParent - Genesis JSON Files":
 
       for address, account in accounts:
         let
-          addressHash = address.keccakHash()
+          addressHash = address.data.keccak256()
           accountProof = accountState.generateAccountProof(address)
 
         if account.code.len() > 0:
@@ -79,14 +80,14 @@ suite "State Gossip getParent - Genesis JSON Files":
             let
               storageProof = storageState.generateStorageProof(slotKey)
               leafNode = storageProof[^1]
-              slotKeyHash = keccakHash(toBytesBE(slotKey)).data
+              slotKeyHash = keccak256(toBytesBE(slotKey)).data
               path = removeLeafKeyEndNibbles(
-                Nibbles.init(keccakHash(toBytesBE(slotKey)).data, true), leafNode
+                Nibbles.init(keccak256(toBytesBE(slotKey)).data, true), leafNode
               )
               key = ContractTrieNodeKey(
                 addressHash: addressHash,
                 path: path,
-                nodeHash: keccakHash(leafNode.asSeq()),
+                nodeHash: keccak256(leafNode.asSeq()),
               )
               offer = ContractTrieNodeOffer(
                 storageProof: storageProof, accountProof: accountProof

--- a/fluffy/tests/state_network_tests/test_state_gossip_getparent_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_gossip_getparent_vectors.nim
@@ -10,7 +10,6 @@ import
   results,
   unittest2,
   stew/byteutils,
-  eth/common,
   ../../network/state/[state_content, state_gossip],
   ./state_test_helpers
 

--- a/fluffy/tests/state_network_tests/test_state_gossip_gossipoffer_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_gossip_gossipoffer_vectors.nim
@@ -10,7 +10,7 @@ import
   testutils/unittests,
   chronos,
   stew/byteutils,
-  eth/common,
+  eth/common/headers_rlp,
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   eth/p2p/discoveryv5/routing_table,
   ../../network/wire/[portal_protocol, portal_stream],
@@ -46,8 +46,7 @@ procSuite "State Gossip - Gossip Offer":
 
       let
         parentTestData = testCase[i + 1]
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -119,8 +118,7 @@ procSuite "State Gossip - Gossip Offer":
 
       let
         parentTestData = testCase[i + 1]
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -189,8 +187,7 @@ procSuite "State Gossip - Gossip Offer":
 
     for i, testData in testCase:
       let
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)

--- a/fluffy/tests/state_network_tests/test_state_network_offercontent_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_network_offercontent_vectors.nim
@@ -10,12 +10,11 @@ import
   testutils/unittests,
   chronos,
   stew/byteutils,
-  eth/common,
+  eth/common/[hashes, headers_rlp],
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   eth/p2p/discoveryv5/routing_table,
-  ../../common/common_utils,
   ../../network/wire/[portal_protocol, portal_stream],
-  ../../network/state/[state_content, state_network],
+  ../../network/state/[state_content, state_network, state_utils],
   ../../database/content_db,
   ./state_test_helpers
 
@@ -36,8 +35,7 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -59,7 +57,7 @@ procSuite "State Network - Offer Content":
       ).isErr()
 
       # set bad state root
-      let badStateRoot = KeccakHash.fromBytes(
+      let badStateRoot = Hash32.fromBytes(
         "0xBAD7b80af0c28bc1489513346d2706885be90abb07f23ca28e50482adb392d61".hexToSeqByte()
       )
       stateNode1.mockStateRootLookup(contentValue.blockHash, badStateRoot)
@@ -105,8 +103,7 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -128,7 +125,7 @@ procSuite "State Network - Offer Content":
       ).isErr()
 
       # set bad state root
-      let badStateRoot = KeccakHash.fromBytes(
+      let badStateRoot = Hash32.fromBytes(
         "0xBAD7b80af0c28bc1489513346d2706885be90abb07f23ca28e50482adb392d61".hexToSeqByte()
       )
       stateNode1.mockStateRootLookup(contentValue.blockHash, badStateRoot)
@@ -175,8 +172,7 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -198,7 +194,7 @@ procSuite "State Network - Offer Content":
       ).isErr()
 
       # set bad state root
-      let badStateRoot = KeccakHash.fromBytes(
+      let badStateRoot = Hash32.fromBytes(
         "0xBAD7b80af0c28bc1489513346d2706885be90abb07f23ca28e50482adb392d61".hexToSeqByte()
       )
       stateNode1.mockStateRootLookup(contentValue.blockHash, badStateRoot)
@@ -246,8 +242,7 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -296,8 +291,7 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)
@@ -347,8 +341,7 @@ procSuite "State Network - Offer Content":
 
     for testData in testCase:
       let
-        stateRoot =
-          rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+        stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
         contentKeyBytes = testData.content_key.hexToSeqByte().ContentKeyByteList
         contentKey = ContentKey.decode(contentKeyBytes).get()
         contentId = toContentId(contentKeyBytes)

--- a/fluffy/tests/state_network_tests/test_state_validation_trieproof.nim
+++ b/fluffy/tests/state_network_tests/test_state_validation_trieproof.nim
@@ -14,14 +14,13 @@ import
   stew/byteutils,
   unittest2,
   stint,
-  eth/common/eth_hash,
-  nimcrypto/hash,
+  eth/common/hashes,
   eth/trie/[hexary, db, trie_defs],
   ../../network/state/[state_content, state_validation],
   ./state_test_helpers
 
 proc getKeyBytes(i: int): seq[byte] =
-  let hash = keccakHash(u256(i).toBytesBE())
+  let hash = keccak256(u256(i).toBytesBE())
   return toSeq(hash.data)
 
 suite "State Validation - validateTrieProof":

--- a/fluffy/tests/state_network_tests/test_state_validation_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_validation_vectors.nim
@@ -10,9 +10,8 @@ import
   results,
   unittest2,
   stew/byteutils,
-  eth/common,
-  ../../common/common_utils,
-  ../../network/state/[state_content, state_validation],
+  eth/common/[hashes, headers_rlp],
+  ../../network/state/[state_content, state_validation, state_utils],
   ./state_test_helpers
 
 suite "State Validation - Test Vectors":
@@ -135,8 +134,7 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      let stateRoot =
-        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+      let stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
 
       block:
         let contentKey = ContentKey
@@ -166,7 +164,7 @@ suite "State Validation - Test Vectors":
 
     for i, testData in testCase:
       let
-        stateRoot = KeccakHash.fromBytes(stateRoots[i].hexToSeqByte())
+        stateRoot = Hash32.fromBytes(stateRoots[i].hexToSeqByte())
         contentKey = ContentKey
           .decode(testData.content_key.hexToSeqByte().ContentKeyByteList)
           .get()
@@ -186,8 +184,7 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      let stateRoot =
-        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+      let stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
 
       let contentKey =
         ContentKey.decode(testData.content_key.hexToSeqByte().ContentKeyByteList).get()
@@ -206,8 +203,7 @@ suite "State Validation - Test Vectors":
     for i, testData in testCase:
       if i == 2:
         continue # second test case only has root node
-      let stateRoot =
-        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+      let stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
 
       let contentKey =
         ContentKey.decode(testData.content_key.hexToSeqByte().ContentKeyByteList).get()
@@ -224,8 +220,7 @@ suite "State Validation - Test Vectors":
         "hash of next node doesn't match the expected" in res.error()
 
     for i, testData in testCase:
-      let stateRoot =
-        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+      let stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
 
       let contentKey =
         ContentKey.decode(testData.content_key.hexToSeqByte().ContentKeyByteList).get()
@@ -249,8 +244,7 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      let stateRoot =
-        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+      let stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
 
       block:
         let contentKey = ContentKey
@@ -278,7 +272,7 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      var stateRoot = KeccakHash.fromBytes(stateRoots[i].hexToSeqByte())
+      var stateRoot = Hash32.fromBytes(stateRoots[i].hexToSeqByte())
 
       let contentKey =
         ContentKey.decode(testData.content_key.hexToSeqByte().ContentKeyByteList).get()
@@ -299,8 +293,7 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      let stateRoot =
-        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+      let stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
 
       block:
         let contentKey = ContentKey
@@ -393,8 +386,7 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      let stateRoot =
-        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+      let stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
 
       let contentKey =
         ContentKey.decode(testData.content_key.hexToSeqByte().ContentKeyByteList).get()
@@ -416,7 +408,7 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      var stateRoot = KeccakHash.fromBytes(stateRoots[i].hexToSeqByte())
+      var stateRoot = Hash32.fromBytes(stateRoots[i].hexToSeqByte())
 
       let contentKey =
         ContentKey.decode(testData.content_key.hexToSeqByte().ContentKeyByteList).get()
@@ -437,8 +429,7 @@ suite "State Validation - Test Vectors":
       raiseAssert "Cannot read test vector: " & error
 
     for i, testData in testCase:
-      let stateRoot =
-        rlp.decode(testData.block_header.hexToSeqByte(), BlockHeader).stateRoot
+      let stateRoot = rlp.decode(testData.block_header.hexToSeqByte(), Header).stateRoot
 
       block:
         let contentKey = ContentKey

--- a/fluffy/tests/wire_protocol_tests/test_portal_wire_protocol.nim
+++ b/fluffy/tests/wire_protocol_tests/test_portal_wire_protocol.nim
@@ -12,7 +12,7 @@ import
   chronos,
   testutils/unittests,
   results,
-  eth/keys,
+  eth/common/keys,
   eth/p2p/discoveryv5/routing_table,
   nimcrypto/[hash, sha2],
   eth/p2p/discoveryv5/protocol as discv5_protocol,

--- a/fluffy/tools/blockwalk.nim
+++ b/fluffy/tools/blockwalk.nim
@@ -40,26 +40,20 @@ type BlockWalkConf* = object
   blockHash* {.
     desc: "The block hash from where to start walking the blocks backwards",
     name: "block-hash"
-  .}: BlockHash
+  .}: Hash32
 
-proc parseCmdArg*(T: type BlockHash, p: string): T {.raises: [ValueError].} =
-  var hash: array[32, byte]
-  try:
-    hexToByteArray(p, hash)
-  except ValueError:
-    raise newException(ValueError, "Invalid Hash256")
+proc parseCmdArg*(T: type Hash32, p: string): T {.raises: [ValueError].} =
+  Hash32.fromHex(p)
 
-  return BlockHash(hash)
-
-proc completeCmdArg*(T: type BlockHash, val: string): seq[string] =
+proc completeCmdArg*(T: type Hash32, val: string): seq[string] =
   return @[]
 
-proc walkBlocks(client: RpcClient, startHash: BlockHash) {.async: (raises: []).} =
+proc walkBlocks(client: RpcClient, startHash: Hash32) {.async: (raises: []).} =
   var parentHash = startHash
-  var blockNumber: BlockNumber
+  var blockNumber: Quantity
 
   # Should be 0x0, but block 0 does not exist in the json data file
-  while blockNumber != BlockNumber(0x1):
+  while blockNumber != Quantity(0x1):
     let parentBlockOpt =
       try:
         await client.eth_getBlockByHash(parentHash, false)

--- a/fluffy/tools/fcli_db.nim
+++ b/fluffy/tools/fcli_db.nim
@@ -5,7 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import chronicles, confutils, stint, eth/keys, ../database/content_db, ./benchmark
+import
+  chronicles, confutils, stint, eth/common/keys, ../database/content_db, ./benchmark
 
 when defined(posix):
   import system/ansi_c

--- a/fluffy/tools/portal_bridge/portal_bridge_state.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_state.nim
@@ -16,9 +16,8 @@ import
   stew/byteutils,
   web3/[eth_api, eth_api_types],
   results,
-  eth/common/[eth_types, eth_types_rlp],
+  eth/common/[addresses_rlp, hashes_rlp],
   ../../../nimbus/common/chain_config,
-  ../../common/common_utils,
   ../../rpc/rpc_calls/rpc_trace_calls,
   ../../rpc/portal_rpc_client,
   ../../network/state/[state_content, state_gossip],
@@ -27,11 +26,11 @@ import
 
 type BlockData = object
   blockNumber: uint64
-  blockHash: KeccakHash
+  blockHash: Hash32
   miner: EthAddress
   uncles: seq[tuple[miner: EthAddress, blockNumber: uint64]]
-  parentStateRoot: KeccakHash
-  stateRoot: KeccakHash
+  parentStateRoot: Hash32
+  stateRoot: Hash32
   stateDiffs: seq[TransactionDiff]
 
 type BlockOffersRef = ref object
@@ -122,11 +121,11 @@ proc runBackfillCollectBlockDataLoop(
 
       let blockData = BlockData(
         blockNumber: currentBlockNumber,
-        blockHash: KeccakHash.fromBytes(blockObject.hash.bytes()),
+        blockHash: blockObject.hash,
         miner: blockObject.miner.EthAddress,
         uncles: uncleBlocks.mapIt((it.miner.EthAddress, it.number.uint64)),
-        parentStateRoot: KeccakHash.fromBytes(parentStateRoot.bytes()),
-        stateRoot: KeccakHash.fromBytes(blockObject.stateRoot.bytes()),
+        parentStateRoot: parentStateRoot,
+        stateRoot: blockObject.stateRoot,
         stateDiffs: stateDiffs,
       )
       db.putBlockData(currentBlockNumber, blockData)

--- a/fluffy/tools/portal_bridge/state_bridge/offers_builder.nim
+++ b/fluffy/tools/portal_bridge/state_bridge/offers_builder.nim
@@ -9,7 +9,7 @@
 
 import
   std/[sequtils, sugar],
-  eth/common,
+  eth/common/hashes,
   ../../../network/state/[state_content, state_utils, state_gossip],
   ./world_state
 
@@ -34,7 +34,7 @@ proc buildAccountTrieNodeOffer(
       path = removeLeafKeyEndNibbles(
         Nibbles.init(addressHash.data, isEven = true), proof[^1]
       )
-      offerKey = AccountTrieNodeKey.init(path, keccakHash(proof[^1].asSeq()))
+      offerKey = AccountTrieNodeKey.init(path, keccak256(proof[^1].asSeq()))
       offerValue = AccountTrieNodeOffer.init(proof, builder.blockHash)
 
     builder.accountTrieOffers.add(offerValue.withKey(offerKey))
@@ -53,9 +53,8 @@ proc buildContractTrieNodeOffer(
       path = removeLeafKeyEndNibbles(
         Nibbles.init(slotHash.data, isEven = true), storageProof[^1]
       )
-      offerKey = ContractTrieNodeKey.init(
-        addressHash, path, keccakHash(storageProof[^1].asSeq())
-      )
+      offerKey =
+        ContractTrieNodeKey.init(addressHash, path, keccak256(storageProof[^1].asSeq()))
       offerValue =
         ContractTrieNodeOffer.init(storageProof, accountProof, builder.blockHash)
 
@@ -72,7 +71,7 @@ proc buildContractCodeOffer(
   let
     #bytecode = Bytelist.init(code) # This fails to compile for some reason
     bytecode = Bytecode(code)
-    offerKey = ContractCodeKey.init(addressHash, keccakHash(code))
+    offerKey = ContractCodeKey.init(addressHash, keccak256(code))
     offerValue = ContractCodeOffer.init(bytecode, accountProof, builder.blockHash)
 
   builder.contractCodeOffers.add(offerValue.withKey(offerKey))

--- a/fluffy/tools/portal_bridge/state_bridge/state_diff.nim
+++ b/fluffy/tools/portal_bridge/state_bridge/state_diff.nim
@@ -11,7 +11,7 @@ import
   chronicles,
   stew/byteutils,
   stint,
-  eth/common/[eth_types, eth_types_rlp],
+  eth/common/base,
   ../../../rpc/rpc_calls/rpc_trace_calls,
   ../portal_bridge_common
 
@@ -33,7 +33,7 @@ type
   SlotDiff* = tuple[slotKey: UInt256, slotValueDiff: StateValueDiff[UInt256]]
 
   AccountDiff* = object
-    address*: EthAddress
+    address*: Address
     balanceDiff*: StateValueDiff[UInt256]
     nonceDiff*: StateValueDiff[AccountNonce]
     storageDiff*: seq[SlotDiff]
@@ -88,7 +88,7 @@ proc toTransactionDiff(
       )
 
     let accountDiff = AccountDiff(
-      address: EthAddress.fromHex(addrJson),
+      address: Address.fromHex(addrJson),
       balanceDiff: toStateValueDiff(accJson["balance"], UInt256),
       nonceDiff: toStateValueDiff(accJson["nonce"], AccountNonce),
       storageDiff: storageDiff,

--- a/fluffy/tools/portal_bridge/state_bridge/world_state_helper.nim
+++ b/fluffy/tools/portal_bridge/state_bridge/world_state_helper.nim
@@ -11,7 +11,7 @@ import
   chronicles,
   stint,
   results,
-  eth/common/[eth_types, eth_types_rlp],
+  eth/common/addresses,
   ../../../../nimbus/common/chain_config,
   ./[state_diff, world_state]
 
@@ -71,15 +71,15 @@ proc applyStateDiff*(worldState: WorldStateRef, txDiff: TransactionDiff) =
 
 proc applyBlockRewards*(
     worldState: WorldStateRef,
-    minerData: tuple[miner: EthAddress, blockNumber: uint64],
-    uncleMinersData: openArray[tuple[miner: EthAddress, blockNumber: uint64]],
+    minerData: tuple[miner: Address, blockNumber: uint64],
+    uncleMinersData: openArray[tuple[miner: Address, blockNumber: uint64]],
 ) =
   const baseReward = u256(5) * pow(u256(10), 18)
 
   block:
     # calculate block miner reward
     let
-      minerAddress = EthAddress(minerData.miner)
+      minerAddress = Address(minerData.miner)
       uncleInclusionReward = (baseReward shr 5) * u256(uncleMinersData.len())
 
     var accState = worldState.getAccount(minerAddress)
@@ -89,7 +89,7 @@ proc applyBlockRewards*(
   # calculate uncle miners rewards
   for i, uncleMinerData in uncleMinersData:
     let
-      uncleMinerAddress = EthAddress(uncleMinerData.miner)
+      uncleMinerAddress = Address(uncleMinerData.miner)
       uncleReward =
         (u256(8 + uncleMinerData.blockNumber - minerData.blockNumber) * baseReward) shr 3
     var accState = worldState.getAccount(uncleMinerAddress)
@@ -97,7 +97,7 @@ proc applyBlockRewards*(
     worldState.setAccount(uncleMinerAddress, accState)
 
 const
-  DAORefundContract: EthAddress = address"0xbf4ed7b27f1d666546e30d74d50d173d20bca754"
+  DAORefundContract: Address = address"0xbf4ed7b27f1d666546e30d74d50d173d20bca754"
 
   DAODrainList = [
     address"0xd4fe7bc31cedb7bfb8a345f31e668033056b2728",

--- a/fluffy/tools/portal_bridge/state_bridge/world_state_helper.nim
+++ b/fluffy/tools/portal_bridge/state_bridge/world_state_helper.nim
@@ -15,6 +15,8 @@ import
   ../../../../nimbus/common/chain_config,
   ./[state_diff, world_state]
 
+from ../../../../nimbus/core/dao import DAORefundContract, DAODrainList
+
 export chain_config, state_diff, world_state
 
 proc applyGenesisAccounts*(worldState: WorldStateRef, alloc: GenesisAlloc) =
@@ -78,145 +80,18 @@ proc applyBlockRewards*(
 
   block:
     # calculate block miner reward
-    let
-      minerAddress = Address(minerData.miner)
-      uncleInclusionReward = (baseReward shr 5) * u256(uncleMinersData.len())
-
-    var accState = worldState.getAccount(minerAddress)
+    let uncleInclusionReward = (baseReward shr 5) * u256(uncleMinersData.len())
+    var accState = worldState.getAccount(minerData.miner)
     accState.addBalance(baseReward + uncleInclusionReward)
-    worldState.setAccount(minerAddress, accState)
+    worldState.setAccount(minerData.miner, accState)
 
   # calculate uncle miners rewards
   for i, uncleMinerData in uncleMinersData:
-    let
-      uncleMinerAddress = Address(uncleMinerData.miner)
-      uncleReward =
-        (u256(8 + uncleMinerData.blockNumber - minerData.blockNumber) * baseReward) shr 3
-    var accState = worldState.getAccount(uncleMinerAddress)
+    let uncleReward =
+      (u256(8 + uncleMinerData.blockNumber - minerData.blockNumber) * baseReward) shr 3
+    var accState = worldState.getAccount(uncleMinerData.miner)
     accState.addBalance(uncleReward)
-    worldState.setAccount(uncleMinerAddress, accState)
-
-const
-  DAORefundContract: Address = address"0xbf4ed7b27f1d666546e30d74d50d173d20bca754"
-
-  DAODrainList = [
-    address"0xd4fe7bc31cedb7bfb8a345f31e668033056b2728",
-    address"0xb3fb0e5aba0e20e5c49d252dfd30e102b171a425",
-    address"0x2c19c7f9ae8b751e37aeb2d93a699722395ae18f",
-    address"0xecd135fa4f61a655311e86238c92adcd779555d2",
-    address"0x1975bd06d486162d5dc297798dfc41edd5d160a7",
-    address"0xa3acf3a1e16b1d7c315e23510fdd7847b48234f6",
-    address"0x319f70bab6845585f412ec7724b744fec6095c85",
-    address"0x06706dd3f2c9abf0a21ddcc6941d9b86f0596936",
-    address"0x5c8536898fbb74fc7445814902fd08422eac56d0",
-    address"0x6966ab0d485353095148a2155858910e0965b6f9",
-    address"0x779543a0491a837ca36ce8c635d6154e3c4911a6",
-    address"0x2a5ed960395e2a49b1c758cef4aa15213cfd874c",
-    address"0x5c6e67ccd5849c0d29219c4f95f1a7a93b3f5dc5",
-    address"0x9c50426be05db97f5d64fc54bf89eff947f0a321",
-    address"0x200450f06520bdd6c527622a273333384d870efb",
-    address"0xbe8539bfe837b67d1282b2b1d61c3f723966f049",
-    address"0x6b0c4d41ba9ab8d8cfb5d379c69a612f2ced8ecb",
-    address"0xf1385fb24aad0cd7432824085e42aff90886fef5",
-    address"0xd1ac8b1ef1b69ff51d1d401a476e7e612414f091",
-    address"0x8163e7fb499e90f8544ea62bbf80d21cd26d9efd",
-    address"0x51e0ddd9998364a2eb38588679f0d2c42653e4a6",
-    address"0x627a0a960c079c21c34f7612d5d230e01b4ad4c7",
-    address"0xf0b1aa0eb660754448a7937c022e30aa692fe0c5",
-    address"0x24c4d950dfd4dd1902bbed3508144a54542bba94",
-    address"0x9f27daea7aca0aa0446220b98d028715e3bc803d",
-    address"0xa5dc5acd6a7968a4554d89d65e59b7fd3bff0f90",
-    address"0xd9aef3a1e38a39c16b31d1ace71bca8ef58d315b",
-    address"0x63ed5a272de2f6d968408b4acb9024f4cc208ebf",
-    address"0x6f6704e5a10332af6672e50b3d9754dc460dfa4d",
-    address"0x77ca7b50b6cd7e2f3fa008e24ab793fd56cb15f6",
-    address"0x492ea3bb0f3315521c31f273e565b868fc090f17",
-    address"0x0ff30d6de14a8224aa97b78aea5388d1c51c1f00",
-    address"0x9ea779f907f0b315b364b0cfc39a0fde5b02a416",
-    address"0xceaeb481747ca6c540a000c1f3641f8cef161fa7",
-    address"0xcc34673c6c40e791051898567a1222daf90be287",
-    address"0x579a80d909f346fbfb1189493f521d7f48d52238",
-    address"0xe308bd1ac5fda103967359b2712dd89deffb7973",
-    address"0x4cb31628079fb14e4bc3cd5e30c2f7489b00960c",
-    address"0xac1ecab32727358dba8962a0f3b261731aad9723",
-    address"0x4fd6ace747f06ece9c49699c7cabc62d02211f75",
-    address"0x440c59b325d2997a134c2c7c60a8c61611212bad",
-    address"0x4486a3d68fac6967006d7a517b889fd3f98c102b",
-    address"0x9c15b54878ba618f494b38f0ae7443db6af648ba",
-    address"0x27b137a85656544b1ccb5a0f2e561a5703c6a68f",
-    address"0x21c7fdb9ed8d291d79ffd82eb2c4356ec0d81241",
-    address"0x23b75c2f6791eef49c69684db4c6c1f93bf49a50",
-    address"0x1ca6abd14d30affe533b24d7a21bff4c2d5e1f3b",
-    address"0xb9637156d330c0d605a791f1c31ba5890582fe1c",
-    address"0x6131c42fa982e56929107413a9d526fd99405560",
-    address"0x1591fc0f688c81fbeb17f5426a162a7024d430c2",
-    address"0x542a9515200d14b68e934e9830d91645a980dd7a",
-    address"0xc4bbd073882dd2add2424cf47d35213405b01324",
-    address"0x782495b7b3355efb2833d56ecb34dc22ad7dfcc4",
-    address"0x58b95c9a9d5d26825e70a82b6adb139d3fd829eb",
-    address"0x3ba4d81db016dc2890c81f3acec2454bff5aada5",
-    address"0xb52042c8ca3f8aa246fa79c3feaa3d959347c0ab",
-    address"0xe4ae1efdfc53b73893af49113d8694a057b9c0d1",
-    address"0x3c02a7bc0391e86d91b7d144e61c2c01a25a79c5",
-    address"0x0737a6b837f97f46ebade41b9bc3e1c509c85c53",
-    address"0x97f43a37f595ab5dd318fb46e7a155eae057317a",
-    address"0x52c5317c848ba20c7504cb2c8052abd1fde29d03",
-    address"0x4863226780fe7c0356454236d3b1c8792785748d",
-    address"0x5d2b2e6fcbe3b11d26b525e085ff818dae332479",
-    address"0x5f9f3392e9f62f63b8eac0beb55541fc8627f42c",
-    address"0x057b56736d32b86616a10f619859c6cd6f59092a",
-    address"0x9aa008f65de0b923a2a4f02012ad034a5e2e2192",
-    address"0x304a554a310c7e546dfe434669c62820b7d83490",
-    address"0x914d1b8b43e92723e64fd0a06f5bdb8dd9b10c79",
-    address"0x4deb0033bb26bc534b197e61d19e0733e5679784",
-    address"0x07f5c1e1bc2c93e0402f23341973a0e043f7bf8a",
-    address"0x35a051a0010aba705c9008d7a7eff6fb88f6ea7b",
-    address"0x4fa802324e929786dbda3b8820dc7834e9134a2a",
-    address"0x9da397b9e80755301a3b32173283a91c0ef6c87e",
-    address"0x8d9edb3054ce5c5774a420ac37ebae0ac02343c6",
-    address"0x0101f3be8ebb4bbd39a2e3b9a3639d4259832fd9",
-    address"0x5dc28b15dffed94048d73806ce4b7a4612a1d48f",
-    address"0xbcf899e6c7d9d5a215ab1e3444c86806fa854c76",
-    address"0x12e626b0eebfe86a56d633b9864e389b45dcb260",
-    address"0xa2f1ccba9395d7fcb155bba8bc92db9bafaeade7",
-    address"0xec8e57756626fdc07c63ad2eafbd28d08e7b0ca5",
-    address"0xd164b088bd9108b60d0ca3751da4bceb207b0782",
-    address"0x6231b6d0d5e77fe001c2a460bd9584fee60d409b",
-    address"0x1cba23d343a983e9b5cfd19496b9a9701ada385f",
-    address"0xa82f360a8d3455c5c41366975bde739c37bfeb8a",
-    address"0x9fcd2deaff372a39cc679d5c5e4de7bafb0b1339",
-    address"0x005f5cee7a43331d5a3d3eec71305925a62f34b6",
-    address"0x0e0da70933f4c7849fc0d203f5d1d43b9ae4532d",
-    address"0xd131637d5275fd1a68a3200f4ad25c71a2a9522e",
-    address"0xbc07118b9ac290e4622f5e77a0853539789effbe",
-    address"0x47e7aa56d6bdf3f36be34619660de61275420af8",
-    address"0xacd87e28b0c9d1254e868b81cba4cc20d9a32225",
-    address"0xadf80daec7ba8dcf15392f1ac611fff65d94f880",
-    address"0x5524c55fb03cf21f549444ccbecb664d0acad706",
-    address"0x40b803a9abce16f50f36a77ba41180eb90023925",
-    address"0xfe24cdd8648121a43a7c86d289be4dd2951ed49f",
-    address"0x17802f43a0137c506ba92291391a8a8f207f487d",
-    address"0x253488078a4edf4d6f42f113d1e62836a942cf1a",
-    address"0x86af3e9626fce1957c82e88cbf04ddf3a2ed7915",
-    address"0xb136707642a4ea12fb4bae820f03d2562ebff487",
-    address"0xdbe9b615a3ae8709af8b93336ce9b477e4ac0940",
-    address"0xf14c14075d6c4ed84b86798af0956deef67365b5",
-    address"0xca544e5c4687d109611d0f8f928b53a25af72448",
-    address"0xaeeb8ff27288bdabc0fa5ebb731b6f409507516c",
-    address"0xcbb9d3703e651b0d496cdefb8b92c25aeb2171f7",
-    address"0x6d87578288b6cb5549d5076a207456a1f6a63dc0",
-    address"0xb2c6f0dfbb716ac562e2d85d6cb2f8d5ee87603e",
-    address"0xaccc230e8a6e5be9160b8cdf2864dd2a001c28b6",
-    address"0x2b3455ec7fedf16e646268bf88846bd7a2319bb2",
-    address"0x4613f3bca5c44ea06337a9e439fbc6d42e501d0a",
-    address"0xd343b217de44030afaa275f54d31a9317c7f441e",
-    address"0x84ef4b2357079cd7a7c69fd7a37cd0609a679106",
-    address"0xda2fef9e4a3230988ff17df2165440f37e8b1708",
-    address"0xf4c64518ea10f995918a454158c6b61407ea345c",
-    address"0x7602b46df5390e432ef1c307d4f2c9ff6d65cc97",
-    address"0xbb9bc244d798123fde783fcc1c72d3bb8c189413",
-    address"0x807640a13483f8ac783c557fcdf27be11ea4ac7a",
-  ]
+    worldState.setAccount(uncleMinerData.miner, accState)
 
 # ApplyDAOHardFork modifies the state database according to the DAO hard-fork
 # rules, transferring all balances of a set of DAO accounts to a single refund

--- a/fluffy/tools/portalcli.nim
+++ b/fluffy/tools/portalcli.nim
@@ -17,7 +17,7 @@ import
   stew/byteutils,
   results,
   nimcrypto/[hash, sha2],
-  eth/[keys, net/nat],
+  eth/[common/keys, net/nat],
   eth/p2p/discoveryv5/[enr, node],
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   ../common/common_utils,

--- a/nimbus/core/dao.nim
+++ b/nimbus/core/dao.nim
@@ -8,7 +8,7 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import eth/common, ../db/ledger
+import stint, eth/common/addresses, ../db/ledger
 
 const
   # DAOForkBlockExtra is the block header extra-data field to set for the DAO fork
@@ -21,9 +21,9 @@ const
   DAOForkExtraRange* = 10
 
   # DAORefundContract is the address of the refund contract to send DAO balances to.
-  DAORefundContract: EthAddress = address"0xbf4ed7b27f1d666546e30d74d50d173d20bca754"
+  DAORefundContract*: Address = address"0xbf4ed7b27f1d666546e30d74d50d173d20bca754"
 
-  DAODrainList = [
+  DAODrainList* = [
     address"0xd4fe7bc31cedb7bfb8a345f31e668033056b2728",
     address"0xb3fb0e5aba0e20e5c49d252dfd30e102b171a425",
     address"0x2c19c7f9ae8b751e37aeb2d93a699722395ae18f",


### PR DESCRIPTION
This commit uses the new types in the new eth/common/ structure to remove deprecation warnings.

It is however more than just a mass replace as also all places where eth/common or eth/common/eth_types or eth/common/eth_types_rlp got imported have been revised and adjusted to a better per submodule based import.

There are still a bunch of toMDigest deprecation warnings but that convertor is not needed for fluffy code anymore so in theory it should not be used (bug?). It seems to still get imported via export leaks ffrom imported nimbus code I think.