### PR TITLE
use macos-13 builders; macos-12 EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             builder: ubuntu-20.04
           - target:
               os: macos
-            builder: macos-12
+            builder: macos-13
           - target:
               os: windows
             builder: windows-latest


### PR DESCRIPTION
e.g., https://endoflife.date/macos and https://en.wikipedia.org/wiki/MacOS_Monterey