### PR TITLE
Fluffy: Create separate portal rpc handlers for each sub-network

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -26,8 +26,9 @@ import
   ./network_metadata,
   ./common/common_utils,
   ./rpc/[
-    rpc_eth_api, rpc_debug_api, rpc_discovery_api, rpc_portal_history_api,
-    rpc_portal_beacon_api, rpc_portal_state_api, rpc_portal_debug_history_api,
+    rpc_eth_api, rpc_debug_api, rpc_discovery_api, rpc_portal_common_api,
+    rpc_portal_history_api, rpc_portal_beacon_api, rpc_portal_state_api,
+    rpc_portal_debug_history_api,
   ],
   ./database/content_db,
   ./portal_node,
@@ -257,14 +258,23 @@ proc run(
         rpcServer.installDebugApiHandlers(node.stateNetwork)
       of RpcFlag.portal:
         if node.historyNetwork.isSome():
+          rpcServer.installPortalCommonApiHandlers(
+            node.historyNetwork.value.portalProtocol, "history"
+          )
           rpcServer.installPortalHistoryApiHandlers(
             node.historyNetwork.value.portalProtocol
           )
         if node.beaconNetwork.isSome():
+          rpcServer.installPortalCommonApiHandlers(
+            node.beaconNetwork.value.portalProtocol, "beacon"
+          )
           rpcServer.installPortalBeaconApiHandlers(
             node.beaconNetwork.value.portalProtocol
           )
         if node.stateNetwork.isSome():
+          rpcServer.installPortalCommonApiHandlers(
+            node.stateNetwork.value.portalProtocol, "state"
+          )
           rpcServer.installPortalStateApiHandlers(
             node.stateNetwork.value.portalProtocol
           )

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -259,21 +259,21 @@ proc run(
       of RpcFlag.portal:
         if node.historyNetwork.isSome():
           rpcServer.installPortalCommonApiHandlers(
-            node.historyNetwork.value.portalProtocol, "history"
+            node.historyNetwork.value.portalProtocol, PortalSubnetwork.history
           )
           rpcServer.installPortalHistoryApiHandlers(
             node.historyNetwork.value.portalProtocol
           )
         if node.beaconNetwork.isSome():
           rpcServer.installPortalCommonApiHandlers(
-            node.beaconNetwork.value.portalProtocol, "beacon"
+            node.beaconNetwork.value.portalProtocol, PortalSubnetwork.beacon
           )
           rpcServer.installPortalBeaconApiHandlers(
             node.beaconNetwork.value.portalProtocol
           )
         if node.stateNetwork.isSome():
           rpcServer.installPortalCommonApiHandlers(
-            node.stateNetwork.value.portalProtocol, "state"
+            node.stateNetwork.value.portalProtocol, PortalSubnetwork.state
           )
           rpcServer.installPortalStateApiHandlers(
             node.stateNetwork.value.portalProtocol

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -25,11 +25,10 @@ import
   ./conf,
   ./network_metadata,
   ./common/common_utils,
-  ./rpc/
-    [
-      rpc_eth_api, rpc_debug_api, rpc_discovery_api, rpc_portal_api,
-      rpc_portal_debug_api,
-    ],
+  ./rpc/[
+    rpc_eth_api, rpc_debug_api, rpc_discovery_api, rpc_portal_history_api,
+    rpc_portal_beacon_api, rpc_portal_state_api, rpc_portal_debug_history_api,
+  ],
   ./database/content_db,
   ./portal_node,
   ./version,
@@ -258,21 +257,21 @@ proc run(
         rpcServer.installDebugApiHandlers(node.stateNetwork)
       of RpcFlag.portal:
         if node.historyNetwork.isSome():
-          rpcServer.installPortalApiHandlers(
-            node.historyNetwork.value.portalProtocol, "history"
+          rpcServer.installPortalHistoryApiHandlers(
+            node.historyNetwork.value.portalProtocol
           )
         if node.beaconNetwork.isSome():
-          rpcServer.installPortalApiHandlers(
-            node.beaconNetwork.value.portalProtocol, "beacon"
+          rpcServer.installPortalBeaconApiHandlers(
+            node.beaconNetwork.value.portalProtocol
           )
         if node.stateNetwork.isSome():
-          rpcServer.installPortalApiHandlers(
-            node.stateNetwork.value.portalProtocol, "state"
+          rpcServer.installPortalStateApiHandlers(
+            node.stateNetwork.value.portalProtocol
           )
       of RpcFlag.portal_debug:
         if node.historyNetwork.isSome():
-          rpcServer.installPortalDebugApiHandlers(
-            node.historyNetwork.value.portalProtocol, "history"
+          rpcServer.installPortalDebugHistoryApiHandlers(
+            node.historyNetwork.value.portalProtocol
           )
       of RpcFlag.discovery:
         rpcServer.installDiscoveryApiHandlers(d)

--- a/fluffy/rpc/rpc_portal_beacon_api.nim
+++ b/fluffy/rpc/rpc_portal_beacon_api.nim
@@ -51,87 +51,6 @@ proc installPortalBeaconApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
     invalidValueErr =
       (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content value")
 
-  rpcServer.rpc("portal_beaconNodeInfo") do() -> NodeInfo:
-    return p.routingTable.getNodeInfo()
-
-  rpcServer.rpc("portal_beaconRoutingTableInfo") do() -> RoutingTableInfo:
-    return getRoutingTableInfo(p.routingTable)
-
-  rpcServer.rpc("portal_beaconAddEnr") do(enr: Record) -> bool:
-    let node = Node.fromRecord(enr)
-    let addResult = p.addNode(node)
-    if addResult == Added:
-      p.routingTable.setJustSeen(node)
-    return addResult == Added
-
-  rpcServer.rpc("portal_beaconAddEnrs") do(enrs: seq[Record]) -> bool:
-    # Note: unspecified RPC, but useful for our local testnet test
-    for enr in enrs:
-      let node = Node.fromRecord(enr)
-      if p.addNode(node) == Added:
-        p.routingTable.setJustSeen(node)
-
-    return true
-
-  rpcServer.rpc("portal_beaconGetEnr") do(nodeId: NodeId) -> Record:
-    if p.localNode.id == nodeId:
-      return p.localNode.record
-
-    let node = p.getNode(nodeId)
-    if node.isSome():
-      return node.get().record
-    else:
-      raise newException(ValueError, "Record not in local routing table.")
-
-  rpcServer.rpc("portal_beaconDeleteEnr") do(nodeId: NodeId) -> bool:
-    # TODO: Adjust `removeNode` to accept NodeId as param and to return bool.
-    let node = p.getNode(nodeId)
-    if node.isSome():
-      p.routingTable.removeNode(node.get())
-      return true
-    else:
-      return false
-
-  rpcServer.rpc("portal_beaconLookupEnr") do(nodeId: NodeId) -> Record:
-    let lookup = await p.resolve(nodeId)
-    if lookup.isSome():
-      return lookup.get().record
-    else:
-      raise newException(ValueError, "Record not found in DHT lookup.")
-
-  rpcServer.rpc("portal_beaconPing") do(enr: Record) -> PingResult:
-    let
-      node = toNodeWithAddress(enr)
-      pong = await p.ping(node)
-
-    if pong.isErr():
-      raise newException(ValueError, $pong.error)
-    else:
-      let
-        p = pong.get()
-        # Note: the SSZ.decode cannot fail here as it has already been verified
-        # in the ping call.
-        decodedPayload =
-          try:
-            SSZ.decode(p.customPayload.asSeq(), CustomPayload)
-          except MalformedSszError, SszSizeMismatchError:
-            raiseAssert("Already verified")
-      return (p.enrSeq, decodedPayload.dataRadius)
-
-  rpcServer.rpc("portal_beaconFindNodes") do(
-    enr: Record, distances: seq[uint16]
-  ) -> seq[Record]:
-    let
-      node = toNodeWithAddress(enr)
-      nodes = await p.findNodes(node, distances)
-    if nodes.isErr():
-      raise newException(ValueError, $nodes.error)
-    else:
-      return nodes.get().map(
-          proc(n: Node): Record =
-            n.record
-        )
-
   rpcServer.rpc("portal_beaconFindContent") do(
     enr: Record, contentKey: string
   ) -> JsonString:
@@ -172,13 +91,6 @@ proc installPortalBeaconApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
       return SSZ.encode(res.get()).to0xHex()
     else:
       raise newException(ValueError, $res.error)
-
-  rpcServer.rpc("portal_beaconRecursiveFindNodes") do(nodeId: NodeId) -> seq[Record]:
-    let discovered = await p.lookup(nodeId)
-    return discovered.map(
-      proc(n: Node): Record =
-        n.record
-    )
 
   rpcServer.rpc("portal_beaconRecursiveFindContent") do(
     contentKey: string

--- a/fluffy/rpc/rpc_portal_beacon_api.nim
+++ b/fluffy/rpc/rpc_portal_beacon_api.nim
@@ -1,0 +1,270 @@
+# fluffy
+# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import
+  std/[sequtils, json],
+  json_rpc/rpcserver,
+  json_serialization/std/tables,
+  stew/byteutils,
+  ../network/wire/portal_protocol,
+  ../network/state/state_content,
+  ./rpc_types
+
+{.warning[UnusedImport]: off.}
+import json_rpc/errors
+
+export rpcserver, tables
+
+# Portal Network JSON-RPC impelentation as per specification:
+# https://github.com/ethereum/portal-network-specs/tree/master/jsonrpc
+
+const
+  ContentNotFoundError = (code: -39001, msg: "Content not found")
+  ContentNotFoundErrorWithTrace = (code: -39002, msg: "Content not found")
+
+type ContentInfo = object
+  content: string
+  utpTransfer: bool
+
+ContentInfo.useDefaultSerializationIn JrpcConv
+TraceContentLookupResult.useDefaultSerializationIn JrpcConv
+TraceObject.useDefaultSerializationIn JrpcConv
+NodeMetadata.useDefaultSerializationIn JrpcConv
+TraceResponse.useDefaultSerializationIn JrpcConv
+
+# Note:
+# Using a string for the network parameter will give an error in the rpc macro:
+# Error: Invalid node kind nnkInfix for macros.`$`
+# Using a static string works but some sandwich problem seems to be happening,
+# as the proc becomes generic, where the rpc macro from router.nim can no longer
+# be found, which is why we export rpcserver which should export router.
+proc installPortalBeaconApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
+  let
+    invalidKeyErr =
+      (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content key")
+    invalidValueErr =
+      (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content value")
+
+  rpcServer.rpc("portal_beaconNodeInfo") do() -> NodeInfo:
+    return p.routingTable.getNodeInfo()
+
+  rpcServer.rpc("portal_beaconRoutingTableInfo") do() -> RoutingTableInfo:
+    return getRoutingTableInfo(p.routingTable)
+
+  rpcServer.rpc("portal_beaconAddEnr") do(enr: Record) -> bool:
+    let node = Node.fromRecord(enr)
+    let addResult = p.addNode(node)
+    if addResult == Added:
+      p.routingTable.setJustSeen(node)
+    return addResult == Added
+
+  rpcServer.rpc("portal_beaconAddEnrs") do(enrs: seq[Record]) -> bool:
+    # Note: unspecified RPC, but useful for our local testnet test
+    for enr in enrs:
+      let node = Node.fromRecord(enr)
+      if p.addNode(node) == Added:
+        p.routingTable.setJustSeen(node)
+
+    return true
+
+  rpcServer.rpc("portal_beaconGetEnr") do(nodeId: NodeId) -> Record:
+    if p.localNode.id == nodeId:
+      return p.localNode.record
+
+    let node = p.getNode(nodeId)
+    if node.isSome():
+      return node.get().record
+    else:
+      raise newException(ValueError, "Record not in local routing table.")
+
+  rpcServer.rpc("portal_beaconDeleteEnr") do(nodeId: NodeId) -> bool:
+    # TODO: Adjust `removeNode` to accept NodeId as param and to return bool.
+    let node = p.getNode(nodeId)
+    if node.isSome():
+      p.routingTable.removeNode(node.get())
+      return true
+    else:
+      return false
+
+  rpcServer.rpc("portal_beaconLookupEnr") do(nodeId: NodeId) -> Record:
+    let lookup = await p.resolve(nodeId)
+    if lookup.isSome():
+      return lookup.get().record
+    else:
+      raise newException(ValueError, "Record not found in DHT lookup.")
+
+  rpcServer.rpc("portal_beaconPing") do(enr: Record) -> PingResult:
+    let
+      node = toNodeWithAddress(enr)
+      pong = await p.ping(node)
+
+    if pong.isErr():
+      raise newException(ValueError, $pong.error)
+    else:
+      let
+        p = pong.get()
+        # Note: the SSZ.decode cannot fail here as it has already been verified
+        # in the ping call.
+        decodedPayload =
+          try:
+            SSZ.decode(p.customPayload.asSeq(), CustomPayload)
+          except MalformedSszError, SszSizeMismatchError:
+            raiseAssert("Already verified")
+      return (p.enrSeq, decodedPayload.dataRadius)
+
+  rpcServer.rpc("portal_beaconFindNodes") do(
+    enr: Record, distances: seq[uint16]
+  ) -> seq[Record]:
+    let
+      node = toNodeWithAddress(enr)
+      nodes = await p.findNodes(node, distances)
+    if nodes.isErr():
+      raise newException(ValueError, $nodes.error)
+    else:
+      return nodes.get().map(
+          proc(n: Node): Record =
+            n.record
+        )
+
+  rpcServer.rpc("portal_beaconFindContent") do(
+    enr: Record, contentKey: string
+  ) -> JsonString:
+    let
+      node = toNodeWithAddress(enr)
+      foundContentResult =
+        await p.findContent(node, ContentKeyByteList.init(hexToSeqByte(contentKey)))
+
+    if foundContentResult.isErr():
+      raise newException(ValueError, $foundContentResult.error)
+    else:
+      let foundContent = foundContentResult.get()
+      case foundContent.kind
+      of Content:
+        let res = ContentInfo(
+          content: foundContent.content.to0xHex(), utpTransfer: foundContent.utpTransfer
+        )
+        return JrpcConv.encode(res).JsonString
+      of Nodes:
+        let enrs = foundContent.nodes.map(
+          proc(n: Node): Record =
+            n.record
+        )
+        let jsonEnrs = JrpcConv.encode(enrs)
+        return ("{\"enrs\":" & jsonEnrs & "}").JsonString
+
+  rpcServer.rpc("portal_beaconOffer") do(
+    enr: Record, contentKey: string, contentValue: string
+  ) -> string:
+    let
+      node = toNodeWithAddress(enr)
+      key = hexToSeqByte(contentKey)
+      content = hexToSeqByte(contentValue)
+      contentKV = ContentKV(contentKey: ContentKeyByteList.init(key), content: content)
+      res = await p.offer(node, @[contentKV])
+
+    if res.isOk():
+      return SSZ.encode(res.get()).to0xHex()
+    else:
+      raise newException(ValueError, $res.error)
+
+  rpcServer.rpc("portal_beaconRecursiveFindNodes") do(nodeId: NodeId) -> seq[Record]:
+    let discovered = await p.lookup(nodeId)
+    return discovered.map(
+      proc(n: Node): Record =
+        n.record
+    )
+
+  rpcServer.rpc("portal_beaconRecursiveFindContent") do(
+    contentKey: string
+  ) -> ContentInfo:
+    let
+      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentId = p.toContentId(key).valueOr:
+        raise (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content key")
+
+      contentResult = (await p.contentLookup(key, contentId)).valueOr:
+        raise (ref ApplicationError)(
+          code: ContentNotFoundError.code, msg: ContentNotFoundError.msg
+        )
+
+    return ContentInfo(
+      content: contentResult.content.to0xHex(), utpTransfer: contentResult.utpTransfer
+    )
+
+  rpcServer.rpc("portal_beaconTraceRecursiveFindContent") do(
+    contentKey: string
+  ) -> TraceContentLookupResult:
+    let
+      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentId = p.toContentId(key).valueOr:
+        raise (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content key")
+
+      res = await p.traceContentLookup(key, contentId)
+
+    # TODO: Might want to restructure the lookup result here. Potentially doing
+    # the json conversion in this module.
+    if res.content.isSome():
+      return res
+    else:
+      let data = Opt.some(JrpcConv.encode(res.trace).JsonString)
+      raise (ref ApplicationError)(
+        code: ContentNotFoundErrorWithTrace.code,
+        msg: ContentNotFoundErrorWithTrace.msg,
+        data: data,
+      )
+
+  rpcServer.rpc("portal_beaconStore") do(
+    contentKey: string, contentValue: string
+  ) -> bool:
+    let
+      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentValueBytes = hexToSeqByte(contentValue)
+      contentId = p.toContentId(key)
+
+    if contentId.isSome():
+      p.storeContent(key, contentId.get(), contentValueBytes)
+      return true
+    else:
+      raise invalidKeyErr
+
+  rpcServer.rpc("portal_beaconLocalContent") do(contentKey: string) -> string:
+    let
+      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentId = p.toContentId(key).valueOr:
+        raise (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content key")
+
+      contentResult = p.dbGet(key, contentId).valueOr:
+        raise (ref ApplicationError)(
+          code: ContentNotFoundError.code, msg: ContentNotFoundError.msg
+        )
+
+    return contentResult.to0xHex()
+
+  rpcServer.rpc("portal_beaconGossip") do(
+    contentKey: string, contentValue: string
+  ) -> int:
+    let
+      key = hexToSeqByte(contentKey)
+      content = hexToSeqByte(contentValue)
+      contentKeys = ContentKeysList(@[ContentKeyByteList.init(key)])
+      numberOfPeers =
+        await p.neighborhoodGossip(Opt.none(NodeId), contentKeys, @[content])
+
+    return numberOfPeers
+
+  rpcServer.rpc("portal_beaconRandomGossip") do(
+    contentKey: string, contentValue: string
+  ) -> int:
+    let
+      key = hexToSeqByte(contentKey)
+      content = hexToSeqByte(contentValue)
+      contentKeys = ContentKeysList(@[ContentKeyByteList.init(key)])
+      numberOfPeers = await p.randomGossip(Opt.none(NodeId), contentKeys, @[content])
+
+    return numberOfPeers

--- a/fluffy/rpc/rpc_portal_common_api.nim
+++ b/fluffy/rpc/rpc_portal_common_api.nim
@@ -1,0 +1,144 @@
+# fluffy
+# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import
+  std/[sequtils, json],
+  json_rpc/rpcserver,
+  json_serialization/std/tables,
+  stew/byteutils,
+  ../network/wire/portal_protocol,
+  ../network/state/state_content,
+  ./rpc_types
+
+{.warning[UnusedImport]: off.}
+import json_rpc/errors
+
+export rpcserver, tables
+
+# Portal Network JSON-RPC impelentation as per specification:
+# https://github.com/ethereum/portal-network-specs/tree/master/jsonrpc
+
+const
+  ContentNotFoundError = (code: -39001, msg: "Content not found")
+  ContentNotFoundErrorWithTrace = (code: -39002, msg: "Content not found")
+
+type ContentInfo = object
+  content: string
+  utpTransfer: bool
+
+ContentInfo.useDefaultSerializationIn JrpcConv
+TraceContentLookupResult.useDefaultSerializationIn JrpcConv
+TraceObject.useDefaultSerializationIn JrpcConv
+NodeMetadata.useDefaultSerializationIn JrpcConv
+TraceResponse.useDefaultSerializationIn JrpcConv
+
+# Note:
+# Using a string for the network parameter will give an error in the rpc macro:
+# Error: Invalid node kind nnkInfix for macros.`$`
+# Using a static string works but some sandwich problem seems to be happening,
+# as the proc becomes generic, where the rpc macro from router.nim can no longer
+# be found, which is why we export rpcserver which should export router.
+proc installPortalCommonApiHandlers*(
+    rpcServer: RpcServer, p: PortalProtocol, network: static string
+) =
+  let
+    invalidKeyErr =
+      (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content key")
+    invalidValueErr =
+      (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content value")
+
+  rpcServer.rpc("portal_" & network & "NodeInfo") do() -> NodeInfo:
+    return p.routingTable.getNodeInfo()
+
+  rpcServer.rpc("portal_" & network & "RoutingTableInfo") do() -> RoutingTableInfo:
+    return getRoutingTableInfo(p.routingTable)
+
+  rpcServer.rpc("portal_" & network & "AddEnr") do(enr: Record) -> bool:
+    let node = Node.fromRecord(enr)
+    let addResult = p.addNode(node)
+    if addResult == Added:
+      p.routingTable.setJustSeen(node)
+    return addResult == Added
+
+  rpcServer.rpc("portal_" & network & "AddEnrs") do(enrs: seq[Record]) -> bool:
+    # Note: unspecified RPC, but useful for our local testnet test
+    for enr in enrs:
+      let node = Node.fromRecord(enr)
+      if p.addNode(node) == Added:
+        p.routingTable.setJustSeen(node)
+
+    return true
+
+  rpcServer.rpc("portal_" & network & "GetEnr") do(nodeId: NodeId) -> Record:
+    if p.localNode.id == nodeId:
+      return p.localNode.record
+
+    let node = p.getNode(nodeId)
+    if node.isSome():
+      return node.get().record
+    else:
+      raise newException(ValueError, "Record not in local routing table.")
+
+  rpcServer.rpc("portal_" & network & "DeleteEnr") do(nodeId: NodeId) -> bool:
+    # TODO: Adjust `removeNode` to accept NodeId as param and to return bool.
+    let node = p.getNode(nodeId)
+    if node.isSome():
+      p.routingTable.removeNode(node.get())
+      return true
+    else:
+      return false
+
+  rpcServer.rpc("portal_" & network & "LookupEnr") do(nodeId: NodeId) -> Record:
+    let lookup = await p.resolve(nodeId)
+    if lookup.isSome():
+      return lookup.get().record
+    else:
+      raise newException(ValueError, "Record not found in DHT lookup.")
+
+  rpcServer.rpc("portal_" & network & "Ping") do(enr: Record) -> PingResult:
+    let
+      node = toNodeWithAddress(enr)
+      pong = await p.ping(node)
+
+    if pong.isErr():
+      raise newException(ValueError, $pong.error)
+    else:
+      let
+        p = pong.get()
+        # Note: the SSZ.decode cannot fail here as it has already been verified
+        # in the ping call.
+        decodedPayload =
+          try:
+            SSZ.decode(p.customPayload.asSeq(), CustomPayload)
+          except MalformedSszError, SszSizeMismatchError:
+            raiseAssert("Already verified")
+      return (p.enrSeq, decodedPayload.dataRadius)
+
+  rpcServer.rpc("portal_" & network & "FindNodes") do(
+    enr: Record, distances: seq[uint16]
+  ) -> seq[Record]:
+    let
+      node = toNodeWithAddress(enr)
+      nodes = await p.findNodes(node, distances)
+    if nodes.isErr():
+      raise newException(ValueError, $nodes.error)
+    else:
+      return nodes.get().map(
+          proc(n: Node): Record =
+            n.record
+        )
+
+  rpcServer.rpc("portal_" & network & "RecursiveFindNodes") do(
+    nodeId: NodeId
+  ) -> seq[Record]:
+    let discovered = await p.lookup(nodeId)
+    return discovered.map(
+      proc(n: Node): Record =
+        n.record
+    )

--- a/fluffy/rpc/rpc_portal_common_api.nim
+++ b/fluffy/rpc/rpc_portal_common_api.nim
@@ -12,14 +12,14 @@ import
   json_rpc/rpcserver,
   json_serialization/std/tables,
   stew/byteutils,
-  ../network/wire/portal_protocol,
+  ../network/wire/[portal_protocol, portal_protocol_config],
   ../network/state/state_content,
   ./rpc_types
 
 {.warning[UnusedImport]: off.}
 import json_rpc/errors
 
-export rpcserver, tables
+export rpcserver, tables, portal_protocol_config
 
 # Portal Network JSON-RPC impelentation as per specification:
 # https://github.com/ethereum/portal-network-specs/tree/master/jsonrpc
@@ -28,9 +28,10 @@ const
   ContentNotFoundError = (code: -39001, msg: "Content not found")
   ContentNotFoundErrorWithTrace = (code: -39002, msg: "Content not found")
 
+
 type ContentInfo = object
-  content: string
-  utpTransfer: bool
+    content: string
+    utpTransfer: bool
 
 ContentInfo.useDefaultSerializationIn JrpcConv
 TraceContentLookupResult.useDefaultSerializationIn JrpcConv
@@ -45,28 +46,30 @@ TraceResponse.useDefaultSerializationIn JrpcConv
 # as the proc becomes generic, where the rpc macro from router.nim can no longer
 # be found, which is why we export rpcserver which should export router.
 proc installPortalCommonApiHandlers*(
-    rpcServer: RpcServer, p: PortalProtocol, network: static string
+    rpcServer: RpcServer, p: PortalProtocol, network: static PortalSubnetwork
 ) =
+  const networkStr = network.symbolName()
+
   let
     invalidKeyErr =
       (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content key")
     invalidValueErr =
       (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content value")
 
-  rpcServer.rpc("portal_" & network & "NodeInfo") do() -> NodeInfo:
+  rpcServer.rpc("portal_" & networkStr & "NodeInfo") do() -> NodeInfo:
     return p.routingTable.getNodeInfo()
 
-  rpcServer.rpc("portal_" & network & "RoutingTableInfo") do() -> RoutingTableInfo:
+  rpcServer.rpc("portal_" & networkStr & "RoutingTableInfo") do() -> RoutingTableInfo:
     return getRoutingTableInfo(p.routingTable)
 
-  rpcServer.rpc("portal_" & network & "AddEnr") do(enr: Record) -> bool:
+  rpcServer.rpc("portal_" & networkStr & "AddEnr") do(enr: Record) -> bool:
     let node = Node.fromRecord(enr)
     let addResult = p.addNode(node)
     if addResult == Added:
       p.routingTable.setJustSeen(node)
     return addResult == Added
 
-  rpcServer.rpc("portal_" & network & "AddEnrs") do(enrs: seq[Record]) -> bool:
+  rpcServer.rpc("portal_" & networkStr & "AddEnrs") do(enrs: seq[Record]) -> bool:
     # Note: unspecified RPC, but useful for our local testnet test
     for enr in enrs:
       let node = Node.fromRecord(enr)
@@ -75,7 +78,7 @@ proc installPortalCommonApiHandlers*(
 
     return true
 
-  rpcServer.rpc("portal_" & network & "GetEnr") do(nodeId: NodeId) -> Record:
+  rpcServer.rpc("portal_" & networkStr & "GetEnr") do(nodeId: NodeId) -> Record:
     if p.localNode.id == nodeId:
       return p.localNode.record
 
@@ -85,7 +88,7 @@ proc installPortalCommonApiHandlers*(
     else:
       raise newException(ValueError, "Record not in local routing table.")
 
-  rpcServer.rpc("portal_" & network & "DeleteEnr") do(nodeId: NodeId) -> bool:
+  rpcServer.rpc("portal_" & networkStr & "DeleteEnr") do(nodeId: NodeId) -> bool:
     # TODO: Adjust `removeNode` to accept NodeId as param and to return bool.
     let node = p.getNode(nodeId)
     if node.isSome():
@@ -94,14 +97,14 @@ proc installPortalCommonApiHandlers*(
     else:
       return false
 
-  rpcServer.rpc("portal_" & network & "LookupEnr") do(nodeId: NodeId) -> Record:
+  rpcServer.rpc("portal_" & networkStr & "LookupEnr") do(nodeId: NodeId) -> Record:
     let lookup = await p.resolve(nodeId)
     if lookup.isSome():
       return lookup.get().record
     else:
       raise newException(ValueError, "Record not found in DHT lookup.")
 
-  rpcServer.rpc("portal_" & network & "Ping") do(enr: Record) -> PingResult:
+  rpcServer.rpc("portal_" & networkStr & "Ping") do(enr: Record) -> PingResult:
     let
       node = toNodeWithAddress(enr)
       pong = await p.ping(node)
@@ -120,7 +123,7 @@ proc installPortalCommonApiHandlers*(
             raiseAssert("Already verified")
       return (p.enrSeq, decodedPayload.dataRadius)
 
-  rpcServer.rpc("portal_" & network & "FindNodes") do(
+  rpcServer.rpc("portal_" & networkStr & "FindNodes") do(
     enr: Record, distances: seq[uint16]
   ) -> seq[Record]:
     let
@@ -134,7 +137,7 @@ proc installPortalCommonApiHandlers*(
             n.record
         )
 
-  rpcServer.rpc("portal_" & network & "RecursiveFindNodes") do(
+  rpcServer.rpc("portal_" & networkStr & "RecursiveFindNodes") do(
     nodeId: NodeId
   ) -> seq[Record]:
     let discovered = await p.lookup(nodeId)

--- a/fluffy/rpc/rpc_portal_debug_history_api.nim
+++ b/fluffy/rpc/rpc_portal_debug_history_api.nim
@@ -9,20 +9,19 @@
 
 import
   json_rpc/rpcserver,
-  stew/byteutils,
   ../network/wire/portal_protocol,
   ../eth_data/history_data_seeding,
   ../database/content_db
 
 export rpcserver
 
+# TODO: perhaps these endpoints should be named differently staring with "portal_debug_"?
+
 # Non-spec-RPCs that are used for testing, debugging and seeding data without a
 # bridge.
-proc installPortalDebugApiHandlers*(
-    rpcServer: RpcServer, p: PortalProtocol, network: static string
-) =
+proc installPortalDebugHistoryApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
   ## Portal debug API calls related to storage and seeding from Era1 files.
-  rpcServer.rpc("portal_" & network & "GossipHeaders") do(
+  rpcServer.rpc("portal_historyGossipHeaders") do(
     era1File: string, epochRecordFile: Opt[string]
   ) -> bool:
     let res = await p.historyGossipHeadersWithProof(era1File, epochRecordFile)
@@ -31,7 +30,7 @@ proc installPortalDebugApiHandlers*(
     else:
       raise newException(ValueError, $res.error)
 
-  rpcServer.rpc("portal_" & network & "GossipBlockContent") do(era1File: string) -> bool:
+  rpcServer.rpc("portal_historyGossipBlockContent") do(era1File: string) -> bool:
     let res = await p.historyGossipBlockContent(era1File)
     if res.isOk():
       return true
@@ -40,28 +39,28 @@ proc installPortalDebugApiHandlers*(
 
   ## Portal debug API calls related to storage and seeding
   ## TODO: To be removed/replaced with the Era1 versions where applicable.
-  rpcServer.rpc("portal_" & network & "_storeContent") do(dataFile: string) -> bool:
+  rpcServer.rpc("portal_history_storeContent") do(dataFile: string) -> bool:
     let res = p.historyStore(dataFile)
     if res.isOk():
       return true
     else:
       raise newException(ValueError, $res.error)
 
-  rpcServer.rpc("portal_" & network & "_propagate") do(dataFile: string) -> bool:
+  rpcServer.rpc("portal_history_propagate") do(dataFile: string) -> bool:
     let res = await p.historyPropagate(dataFile)
     if res.isOk():
       return true
     else:
       raise newException(ValueError, $res.error)
 
-  rpcServer.rpc("portal_" & network & "_propagateHeaders") do(dataDir: string) -> bool:
+  rpcServer.rpc("portal_history_propagateHeaders") do(dataDir: string) -> bool:
     let res = await p.historyPropagateHeadersWithProof(dataDir)
     if res.isOk():
       return true
     else:
       raise newException(ValueError, $res.error)
 
-  rpcServer.rpc("portal_" & network & "_propagateHeaders") do(
+  rpcServer.rpc("portal_history_propagateHeaders") do(
     epochHeadersFile: string, epochRecordFile: string
   ) -> bool:
     let res =
@@ -71,7 +70,7 @@ proc installPortalDebugApiHandlers*(
     else:
       raise newException(ValueError, $res.error)
 
-  rpcServer.rpc("portal_" & network & "_propagateBlock") do(
+  rpcServer.rpc("portal_history_propagateBlock") do(
     dataFile: string, blockHash: string
   ) -> bool:
     let res = await p.historyPropagateBlock(dataFile, blockHash)

--- a/fluffy/rpc/rpc_portal_history_api.nim
+++ b/fluffy/rpc/rpc_portal_history_api.nim
@@ -1,0 +1,270 @@
+# fluffy
+# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import
+  std/[sequtils, json],
+  json_rpc/rpcserver,
+  json_serialization/std/tables,
+  stew/byteutils,
+  ../network/wire/portal_protocol,
+  ../network/state/state_content,
+  ./rpc_types
+
+{.warning[UnusedImport]: off.}
+import json_rpc/errors
+
+export rpcserver, tables
+
+# Portal Network JSON-RPC impelentation as per specification:
+# https://github.com/ethereum/portal-network-specs/tree/master/jsonrpc
+
+const
+  ContentNotFoundError = (code: -39001, msg: "Content not found")
+  ContentNotFoundErrorWithTrace = (code: -39002, msg: "Content not found")
+
+type ContentInfo = object
+  content: string
+  utpTransfer: bool
+
+ContentInfo.useDefaultSerializationIn JrpcConv
+TraceContentLookupResult.useDefaultSerializationIn JrpcConv
+TraceObject.useDefaultSerializationIn JrpcConv
+NodeMetadata.useDefaultSerializationIn JrpcConv
+TraceResponse.useDefaultSerializationIn JrpcConv
+
+# Note:
+# Using a string for the network parameter will give an error in the rpc macro:
+# Error: Invalid node kind nnkInfix for macros.`$`
+# Using a static string works but some sandwich problem seems to be happening,
+# as the proc becomes generic, where the rpc macro from router.nim can no longer
+# be found, which is why we export rpcserver which should export router.
+proc installPortalHistoryApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
+  let
+    invalidKeyErr =
+      (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content key")
+    invalidValueErr =
+      (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content value")
+
+  rpcServer.rpc("portal_historyNodeInfo") do() -> NodeInfo:
+    return p.routingTable.getNodeInfo()
+
+  rpcServer.rpc("portal_historyRoutingTableInfo") do() -> RoutingTableInfo:
+    return getRoutingTableInfo(p.routingTable)
+
+  rpcServer.rpc("portal_historyAddEnr") do(enr: Record) -> bool:
+    let node = Node.fromRecord(enr)
+    let addResult = p.addNode(node)
+    if addResult == Added:
+      p.routingTable.setJustSeen(node)
+    return addResult == Added
+
+  rpcServer.rpc("portal_historyAddEnrs") do(enrs: seq[Record]) -> bool:
+    # Note: unspecified RPC, but useful for our local testnet test
+    for enr in enrs:
+      let node = Node.fromRecord(enr)
+      if p.addNode(node) == Added:
+        p.routingTable.setJustSeen(node)
+
+    return true
+
+  rpcServer.rpc("portal_historyGetEnr") do(nodeId: NodeId) -> Record:
+    if p.localNode.id == nodeId:
+      return p.localNode.record
+
+    let node = p.getNode(nodeId)
+    if node.isSome():
+      return node.get().record
+    else:
+      raise newException(ValueError, "Record not in local routing table.")
+
+  rpcServer.rpc("portal_historyDeleteEnr") do(nodeId: NodeId) -> bool:
+    # TODO: Adjust `removeNode` to accept NodeId as param and to return bool.
+    let node = p.getNode(nodeId)
+    if node.isSome():
+      p.routingTable.removeNode(node.get())
+      return true
+    else:
+      return false
+
+  rpcServer.rpc("portal_historyLookupEnr") do(nodeId: NodeId) -> Record:
+    let lookup = await p.resolve(nodeId)
+    if lookup.isSome():
+      return lookup.get().record
+    else:
+      raise newException(ValueError, "Record not found in DHT lookup.")
+
+  rpcServer.rpc("portal_historyPing") do(enr: Record) -> PingResult:
+    let
+      node = toNodeWithAddress(enr)
+      pong = await p.ping(node)
+
+    if pong.isErr():
+      raise newException(ValueError, $pong.error)
+    else:
+      let
+        p = pong.get()
+        # Note: the SSZ.decode cannot fail here as it has already been verified
+        # in the ping call.
+        decodedPayload =
+          try:
+            SSZ.decode(p.customPayload.asSeq(), CustomPayload)
+          except MalformedSszError, SszSizeMismatchError:
+            raiseAssert("Already verified")
+      return (p.enrSeq, decodedPayload.dataRadius)
+
+  rpcServer.rpc("portal_historyFindNodes") do(
+    enr: Record, distances: seq[uint16]
+  ) -> seq[Record]:
+    let
+      node = toNodeWithAddress(enr)
+      nodes = await p.findNodes(node, distances)
+    if nodes.isErr():
+      raise newException(ValueError, $nodes.error)
+    else:
+      return nodes.get().map(
+          proc(n: Node): Record =
+            n.record
+        )
+
+  rpcServer.rpc("portal_historyFindContent") do(
+    enr: Record, contentKey: string
+  ) -> JsonString:
+    let
+      node = toNodeWithAddress(enr)
+      foundContentResult =
+        await p.findContent(node, ContentKeyByteList.init(hexToSeqByte(contentKey)))
+
+    if foundContentResult.isErr():
+      raise newException(ValueError, $foundContentResult.error)
+    else:
+      let foundContent = foundContentResult.get()
+      case foundContent.kind
+      of Content:
+        let res = ContentInfo(
+          content: foundContent.content.to0xHex(), utpTransfer: foundContent.utpTransfer
+        )
+        return JrpcConv.encode(res).JsonString
+      of Nodes:
+        let enrs = foundContent.nodes.map(
+          proc(n: Node): Record =
+            n.record
+        )
+        let jsonEnrs = JrpcConv.encode(enrs)
+        return ("{\"enrs\":" & jsonEnrs & "}").JsonString
+
+  rpcServer.rpc("portal_historyOffer") do(
+    enr: Record, contentKey: string, contentValue: string
+  ) -> string:
+    let
+      node = toNodeWithAddress(enr)
+      key = hexToSeqByte(contentKey)
+      content = hexToSeqByte(contentValue)
+      contentKV = ContentKV(contentKey: ContentKeyByteList.init(key), content: content)
+      res = await p.offer(node, @[contentKV])
+
+    if res.isOk():
+      return SSZ.encode(res.get()).to0xHex()
+    else:
+      raise newException(ValueError, $res.error)
+
+  rpcServer.rpc("portal_historyRecursiveFindNodes") do(nodeId: NodeId) -> seq[Record]:
+    let discovered = await p.lookup(nodeId)
+    return discovered.map(
+      proc(n: Node): Record =
+        n.record
+    )
+
+  rpcServer.rpc("portal_historyRecursiveFindContent") do(
+    contentKey: string
+  ) -> ContentInfo:
+    let
+      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentId = p.toContentId(key).valueOr:
+        raise (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content key")
+
+      contentResult = (await p.contentLookup(key, contentId)).valueOr:
+        raise (ref ApplicationError)(
+          code: ContentNotFoundError.code, msg: ContentNotFoundError.msg
+        )
+
+    return ContentInfo(
+      content: contentResult.content.to0xHex(), utpTransfer: contentResult.utpTransfer
+    )
+
+  rpcServer.rpc("portal_historyTraceRecursiveFindContent") do(
+    contentKey: string
+  ) -> TraceContentLookupResult:
+    let
+      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentId = p.toContentId(key).valueOr:
+        raise (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content key")
+
+      res = await p.traceContentLookup(key, contentId)
+
+    # TODO: Might want to restructure the lookup result here. Potentially doing
+    # the json conversion in this module.
+    if res.content.isSome():
+      return res
+    else:
+      let data = Opt.some(JrpcConv.encode(res.trace).JsonString)
+      raise (ref ApplicationError)(
+        code: ContentNotFoundErrorWithTrace.code,
+        msg: ContentNotFoundErrorWithTrace.msg,
+        data: data,
+      )
+
+  rpcServer.rpc("portal_historyStore") do(
+    contentKey: string, contentValue: string
+  ) -> bool:
+    let
+      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentValueBytes = hexToSeqByte(contentValue)
+      contentId = p.toContentId(key)
+
+    if contentId.isSome():
+      p.storeContent(key, contentId.get(), contentValueBytes)
+      return true
+    else:
+      raise invalidKeyErr
+
+  rpcServer.rpc("portal_historyLocalContent") do(contentKey: string) -> string:
+    let
+      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentId = p.toContentId(key).valueOr:
+        raise (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content key")
+
+      contentResult = p.dbGet(key, contentId).valueOr:
+        raise (ref ApplicationError)(
+          code: ContentNotFoundError.code, msg: ContentNotFoundError.msg
+        )
+
+    return contentResult.to0xHex()
+
+  rpcServer.rpc("portal_historyGossip") do(
+    contentKey: string, contentValue: string
+  ) -> int:
+    let
+      key = hexToSeqByte(contentKey)
+      content = hexToSeqByte(contentValue)
+      contentKeys = ContentKeysList(@[ContentKeyByteList.init(key)])
+      numberOfPeers =
+        await p.neighborhoodGossip(Opt.none(NodeId), contentKeys, @[content])
+
+    return numberOfPeers
+
+  rpcServer.rpc("portal_historyRandomGossip") do(
+    contentKey: string, contentValue: string
+  ) -> int:
+    let
+      key = hexToSeqByte(contentKey)
+      content = hexToSeqByte(contentValue)
+      contentKeys = ContentKeysList(@[ContentKeyByteList.init(key)])
+      numberOfPeers = await p.randomGossip(Opt.none(NodeId), contentKeys, @[content])
+
+    return numberOfPeers

--- a/fluffy/rpc/rpc_portal_history_api.nim
+++ b/fluffy/rpc/rpc_portal_history_api.nim
@@ -257,14 +257,3 @@ proc installPortalHistoryApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
         await p.neighborhoodGossip(Opt.none(NodeId), contentKeys, @[content])
 
     return numberOfPeers
-
-  rpcServer.rpc("portal_historyRandomGossip") do(
-    contentKey: string, contentValue: string
-  ) -> int:
-    let
-      key = hexToSeqByte(contentKey)
-      content = hexToSeqByte(contentValue)
-      contentKeys = ContentKeysList(@[ContentKeyByteList.init(key)])
-      numberOfPeers = await p.randomGossip(Opt.none(NodeId), contentKeys, @[content])
-
-    return numberOfPeers

--- a/fluffy/rpc/rpc_portal_state_api.nim
+++ b/fluffy/rpc/rpc_portal_state_api.nim
@@ -51,87 +51,6 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
     invalidValueErr =
       (ref errors.InvalidRequest)(code: -32602, msg: "Invalid content value")
 
-  rpcServer.rpc("portal_stateNodeInfo") do() -> NodeInfo:
-    return p.routingTable.getNodeInfo()
-
-  rpcServer.rpc("portal_stateRoutingTableInfo") do() -> RoutingTableInfo:
-    return getRoutingTableInfo(p.routingTable)
-
-  rpcServer.rpc("portal_stateAddEnr") do(enr: Record) -> bool:
-    let node = Node.fromRecord(enr)
-    let addResult = p.addNode(node)
-    if addResult == Added:
-      p.routingTable.setJustSeen(node)
-    return addResult == Added
-
-  rpcServer.rpc("portal_stateAddEnrs") do(enrs: seq[Record]) -> bool:
-    # Note: unspecified RPC, but useful for our local testnet test
-    for enr in enrs:
-      let node = Node.fromRecord(enr)
-      if p.addNode(node) == Added:
-        p.routingTable.setJustSeen(node)
-
-    return true
-
-  rpcServer.rpc("portal_stateGetEnr") do(nodeId: NodeId) -> Record:
-    if p.localNode.id == nodeId:
-      return p.localNode.record
-
-    let node = p.getNode(nodeId)
-    if node.isSome():
-      return node.get().record
-    else:
-      raise newException(ValueError, "Record not in local routing table.")
-
-  rpcServer.rpc("portal_stateDeleteEnr") do(nodeId: NodeId) -> bool:
-    # TODO: Adjust `removeNode` to accept NodeId as param and to return bool.
-    let node = p.getNode(nodeId)
-    if node.isSome():
-      p.routingTable.removeNode(node.get())
-      return true
-    else:
-      return false
-
-  rpcServer.rpc("portal_stateLookupEnr") do(nodeId: NodeId) -> Record:
-    let lookup = await p.resolve(nodeId)
-    if lookup.isSome():
-      return lookup.get().record
-    else:
-      raise newException(ValueError, "Record not found in DHT lookup.")
-
-  rpcServer.rpc("portal_statePing") do(enr: Record) -> PingResult:
-    let
-      node = toNodeWithAddress(enr)
-      pong = await p.ping(node)
-
-    if pong.isErr():
-      raise newException(ValueError, $pong.error)
-    else:
-      let
-        p = pong.get()
-        # Note: the SSZ.decode cannot fail here as it has already been verified
-        # in the ping call.
-        decodedPayload =
-          try:
-            SSZ.decode(p.customPayload.asSeq(), CustomPayload)
-          except MalformedSszError, SszSizeMismatchError:
-            raiseAssert("Already verified")
-      return (p.enrSeq, decodedPayload.dataRadius)
-
-  rpcServer.rpc("portal_stateFindNodes") do(
-    enr: Record, distances: seq[uint16]
-  ) -> seq[Record]:
-    let
-      node = toNodeWithAddress(enr)
-      nodes = await p.findNodes(node, distances)
-    if nodes.isErr():
-      raise newException(ValueError, $nodes.error)
-    else:
-      return nodes.get().map(
-          proc(n: Node): Record =
-            n.record
-        )
-
   rpcServer.rpc("portal_stateFindContent") do(
     enr: Record, contentKey: string
   ) -> JsonString:
@@ -172,13 +91,6 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
       return SSZ.encode(res.get()).to0xHex()
     else:
       raise newException(ValueError, $res.error)
-
-  rpcServer.rpc("portal_stateRecursiveFindNodes") do(nodeId: NodeId) -> seq[Record]:
-    let discovered = await p.lookup(nodeId)
-    return discovered.map(
-      proc(n: Node): Record =
-        n.record
-    )
 
   rpcServer.rpc("portal_stateRecursiveFindContent") do(
     contentKey: string

--- a/fluffy/rpc/rpc_portal_state_api.nim
+++ b/fluffy/rpc/rpc_portal_state_api.nim
@@ -275,14 +275,3 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
         await p.neighborhoodGossip(Opt.none(NodeId), contentKeys, @[content])
 
     return numberOfPeers
-
-  rpcServer.rpc("portal_stateRandomGossip") do(
-    contentKey: string, contentValue: string
-  ) -> int:
-    let
-      key = hexToSeqByte(contentKey)
-      content = hexToSeqByte(contentValue)
-      contentKeys = ContentKeysList(@[ContentKeyByteList.init(key)])
-      numberOfPeers = await p.randomGossip(Opt.none(NodeId), contentKeys, @[content])
-
-    return numberOfPeers

--- a/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
+++ b/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
@@ -21,7 +21,7 @@ import
   ../../network/history/
     [history_network, history_content, validation/historical_hashes_accumulator],
   ../../database/content_db,
-  ../../rpc/[portal_rpc_client, rpc_portal_api],
+  ../../rpc/[portal_rpc_client, rpc_portal_history_api],
   ../test_helpers
 
 from eth/common/eth_types_rlp import rlpHash
@@ -101,8 +101,8 @@ proc setupTest(rng: ref HmacDrbgContext): Future[TestCase] {.async.} =
 
   let rpcHttpServer = RpcHttpServer.new()
   rpcHttpServer.addHttpServer(ta, maxRequestBodySize = 4 * 1_048_576)
-  rpcHttpServer.installPortalApiHandlers(
-    historyNode.historyNetwork.portalProtocol, "history"
+  rpcHttpServer.installPortalHistoryApiHandlers(
+    historyNode.historyNetwork.portalProtocol
   )
   rpcHttpServer.start()
 


### PR DESCRIPTION
This PR creates a separate rpc handler for each portal sub-network. 

I've removed the 'network' string parameter and basically copied the code into separate files and renamed a few files and procs. The validation that was added to state store no longer requires the `network == 'state'` check and that code is removed from history and beacon handlers. 

There now is a bit of code duplication which is to be expected and I'm thinking that we can refactor this out in future PRs when we add the network specific validation. Perhaps the duplicated code can go into functions in another file that is shared where it makes sense. 
