### PR TITLE
Remove usage of aliases for Hash32 such as BlockHash

### DIFF
--- a/fluffy/common/common_types.nim
+++ b/fluffy/common/common_types.nim
@@ -17,7 +17,6 @@ type
 
   ContentId* = UInt256
   ContentKeyByteList* = ByteList[2048] # The encoded content key
-  BlockHash* = Hash32
 
 func fromSszBytes*(T: type Hash32, data: openArray[byte]): T {.raises: [SszError].} =
   if data.len != sizeof(result):

--- a/fluffy/eth_data/history_data_json_store.nim
+++ b/fluffy/eth_data/history_data_json_store.nim
@@ -38,11 +38,11 @@ type
 
   BlockDataTable* = Table[string, BlockData]
 
-iterator blockHashes*(blockData: BlockDataTable): BlockHash =
+iterator blockHashes*(blockData: BlockDataTable): Hash32 =
   for k, v in blockData:
-    var blockHash: BlockHash
+    var blockHash: Hash32
     try:
-      blockHash.data = hexToByteArray[sizeof(BlockHash)](k)
+      blockHash.data = hexToByteArray[sizeof(Hash32)](k)
     except ValueError as e:
       error "Invalid hex for block hash", error = e.msg, number = v.number
       continue
@@ -54,9 +54,9 @@ func readBlockData*(
 ): Result[seq[(ContentKey, seq[byte])], string] =
   var res: seq[(ContentKey, seq[byte])]
 
-  var blockHash: BlockHash
+  var blockHash: Hash32
   try:
-    blockHash.data = hexToByteArray[sizeof(BlockHash)](hash)
+    blockHash.data = hexToByteArray[sizeof(Hash32)](hash)
   except ValueError as e:
     return err("Invalid hex for blockhash, number " & $blockData.number & ": " & e.msg)
 
@@ -127,9 +127,9 @@ func readBlockHeader*(blockData: BlockData): Result[Header, string] =
 func readHeaderData*(
     hash: string, blockData: BlockData, verify = false
 ): Result[(ContentKey, seq[byte]), string] =
-  var blockHash: BlockHash
+  var blockHash: Hash32
   try:
-    blockHash.data = hexToByteArray[sizeof(BlockHash)](hash)
+    blockHash.data = hexToByteArray[sizeof(Hash32)](hash)
   except ValueError as e:
     return err("Invalid hex for blockhash, number " & $blockData.number & ": " & e.msg)
 

--- a/fluffy/network/history/content/content_deprecated.nim
+++ b/fluffy/network/history/content/content_deprecated.nim
@@ -28,7 +28,7 @@ type
     epochRecordDeprecated = 0x03
 
   BlockKey = object
-    blockHash: BlockHash
+    blockHash: Hash32
 
   EpochRecordKeyDeprecated = object
     epochHash: Digest

--- a/fluffy/network/history/content/content_keys.nim
+++ b/fluffy/network/history/content/content_keys.nim
@@ -33,7 +33,7 @@ type
     blockNumber = 0x03
 
   BlockKey* = object
-    blockHash*: BlockHash
+    blockHash*: Hash32
 
   BlockNumberKey* = object
     blockNumber*: uint64
@@ -49,19 +49,19 @@ type
     of blockNumber:
       blockNumberKey*: BlockNumberKey
 
-func blockHeaderContentKey*(id: BlockHash | uint64): ContentKey =
-  when id is BlockHash:
+func blockHeaderContentKey*(id: Hash32 | uint64): ContentKey =
+  when id is Hash32:
     ContentKey(contentType: blockHeader, blockHeaderKey: BlockKey(blockHash: id))
   else:
     ContentKey(
       contentType: blockNumber, blockNumberKey: BlockNumberKey(blockNumber: id)
     )
 
-func blockBodyContentKey*(hash: BlockHash): ContentKey =
-  ContentKey(contentType: blockBody, blockBodyKey: BlockKey(blockHash: hash))
+func blockBodyContentKey*(blockHash: Hash32): ContentKey =
+  ContentKey(contentType: blockBody, blockBodyKey: BlockKey(blockHash: blockHash))
 
-func receiptsContentKey*(hash: BlockHash): ContentKey =
-  ContentKey(contentType: receipts, receiptsKey: BlockKey(blockHash: hash))
+func receiptsContentKey*(blockHash: Hash32): ContentKey =
+  ContentKey(contentType: receipts, receiptsKey: BlockKey(blockHash: blockHash))
 
 func encode*(contentKey: ContentKey): ContentKeyByteList =
   ContentKeyByteList.init(SSZ.encode(contentKey))

--- a/fluffy/network/history/validation/historical_hashes_accumulator.nim
+++ b/fluffy/network/history/validation/historical_hashes_accumulator.nim
@@ -47,7 +47,7 @@ const
 
 type
   HeaderRecord* = object
-    blockHash*: BlockHash
+    blockHash*: Hash32
     totalDifficulty*: UInt256
 
   EpochRecord* = List[HeaderRecord, EPOCH_SIZE]

--- a/fluffy/network/state/content/content_keys.nim
+++ b/fluffy/network/state/content/content_keys.nim
@@ -21,10 +21,6 @@ import
 export ssz_serialization, common_types, hash, results
 
 type
-  NodeHash* = Hash32
-  CodeHash* = Hash32
-  AddressHash* = Hash32
-
   ContentType* = enum
     # Note: Need to add this unused value as a case object with an enum without
     # a 0 valueis not allowed: "low(contentType) must be 0 for discriminant".
@@ -40,16 +36,16 @@ type
 
   AccountTrieNodeKey* = object
     path*: Nibbles
-    nodeHash*: NodeHash
+    nodeHash*: Hash32
 
   ContractTrieNodeKey* = object
-    addressHash*: AddressHash
+    addressHash*: Hash32
     path*: Nibbles
-    nodeHash*: NodeHash
+    nodeHash*: Hash32
 
   ContractCodeKey* = object
-    addressHash*: AddressHash
-    codeHash*: CodeHash
+    addressHash*: Hash32
+    codeHash*: Hash32
 
   ContentKey* = object
     case contentType*: ContentType
@@ -64,21 +60,16 @@ type
 
   ContentKeyType* = AccountTrieNodeKey | ContractTrieNodeKey | ContractCodeKey
 
-func init*(
-    T: type AccountTrieNodeKey, path: Nibbles, nodeHash: NodeHash
-): T {.inline.} =
+func init*(T: type AccountTrieNodeKey, path: Nibbles, nodeHash: Hash32): T {.inline.} =
   T(path: path, nodeHash: nodeHash)
 
 func init*(
-    T: type ContractTrieNodeKey,
-    addressHash: AddressHash,
-    path: Nibbles,
-    nodeHash: NodeHash,
+    T: type ContractTrieNodeKey, addressHash: Hash32, path: Nibbles, nodeHash: Hash32
 ): T {.inline.} =
   T(addressHash: addressHash, path: path, nodeHash: nodeHash)
 
 func init*(
-    T: type ContractCodeKey, addressHash: AddressHash, codeHash: CodeHash
+    T: type ContractCodeKey, addressHash: Hash32, codeHash: Hash32
 ): T {.inline.} =
   T(addressHash: addressHash, codeHash: codeHash)
 

--- a/fluffy/network/state/content/content_values.nim
+++ b/fluffy/network/state/content/content_values.nim
@@ -26,7 +26,7 @@ type
 
   AccountTrieNodeOffer* = object
     proof*: TrieProof
-    blockHash*: BlockHash
+    blockHash*: Hash32
 
   AccountTrieNodeRetrieval* = object
     node*: TrieNode
@@ -34,7 +34,7 @@ type
   ContractTrieNodeOffer* = object
     storageProof*: TrieProof
     accountProof*: TrieProof
-    blockHash*: BlockHash
+    blockHash*: Hash32
 
   ContractTrieNodeRetrieval* = object
     node*: TrieNode
@@ -42,7 +42,7 @@ type
   ContractCodeOffer* = object
     code*: Bytecode
     accountProof*: TrieProof
-    blockHash*: BlockHash
+    blockHash*: Hash32
 
   ContractCodeRetrieval* = object
     code*: Bytecode
@@ -53,7 +53,7 @@ type
   ContentValueType* = ContentOfferType | ContentRetrievalType
 
 func init*(
-    T: type AccountTrieNodeOffer, proof: TrieProof, blockHash: BlockHash
+    T: type AccountTrieNodeOffer, proof: TrieProof, blockHash: Hash32
 ): T {.inline.} =
   T(proof: proof, blockHash: blockHash)
 
@@ -64,7 +64,7 @@ func init*(
     T: type ContractTrieNodeOffer,
     storageProof: TrieProof,
     accountProof: TrieProof,
-    blockHash: BlockHash,
+    blockHash: Hash32,
 ): T {.inline.} =
   T(storageProof: storageProof, accountProof: accountProof, blockHash: blockHash)
 
@@ -75,7 +75,7 @@ func init*(
     T: type ContractCodeOffer,
     code: Bytecode,
     accountProof: TrieProof,
-    blockHash: BlockHash,
+    blockHash: Hash32,
 ): T {.inline.} =
   T(code: code, accountProof: accountProof, blockHash: blockHash)
 

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -130,7 +130,7 @@ proc getContractCode*(
   n.getContent(key, ContractCodeRetrieval)
 
 proc getStateRootByBlockNumOrHash*(
-    n: StateNetwork, blockNumOrHash: uint64 | BlockHash
+    n: StateNetwork, blockNumOrHash: uint64 | Hash32
 ): Future[Opt[Hash32]] {.async: (raises: [CancelledError]).} =
   if n.historyNetwork.isNone():
     warn "History network is not available"

--- a/fluffy/rpc/portal_rpc_client.nim
+++ b/fluffy/rpc/portal_rpc_client.nim
@@ -91,7 +91,7 @@ proc historyGetContent(
   ok(content)
 
 proc historyGetBlockHeader*(
-    client: PortalRpcClient, blockHash: BlockHash, validateContent = true
+    client: PortalRpcClient, blockHash: Hash32, validateContent = true
 ): Future[Result[Header, PortalRpcError]] {.async: (raises: []).} =
   ## Fetches the block header for the given hash from the Portal History Network.
   ## The data is first looked up in the node's local database before trying to
@@ -116,7 +116,7 @@ proc historyGetBlockHeader*(
     decodeRlp(headerBytes, Header).valueOrErr(InvalidContentValue)
 
 proc historyGetBlockBody*(
-    client: PortalRpcClient, blockHash: BlockHash, validateContent = true
+    client: PortalRpcClient, blockHash: Hash32, validateContent = true
 ): Future[Result[BlockBody, PortalRpcError]] {.async: (raises: []).} =
   ## Fetches the block body for the given block hash from the Portal History
   ## Network. The data is first looked up in the node's local database before
@@ -136,7 +136,7 @@ proc historyGetBlockBody*(
     decodeBlockBodyBytes(content.toBytes()).valueOrErr(InvalidContentValue)
 
 proc historyGetReceipts*(
-    client: PortalRpcClient, blockHash: BlockHash, validateContent = true
+    client: PortalRpcClient, blockHash: Hash32, validateContent = true
 ): Future[Result[seq[Receipt], PortalRpcError]] {.async: (raises: []).} =
   ## Fetches the receipts for the given block hash from the Portal History
   ## Network. The data is first looked up in the node's local database before

--- a/fluffy/tests/history_network_tests/test_history_content_keys.nim
+++ b/fluffy/tests/history_network_tests/test_history_content_keys.nim
@@ -21,7 +21,7 @@ import
 suite "History Content Keys":
   test "BlockHeader":
     # Input
-    const blockHash = BlockHash.fromHex(
+    const blockHash = Hash32.fromHex(
       "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
     )
 
@@ -53,7 +53,7 @@ suite "History Content Keys":
 
   test "BlockBody":
     # Input
-    const blockHash = BlockHash.fromHex(
+    const blockHash = Hash32.fromHex(
       "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
     )
 
@@ -85,7 +85,7 @@ suite "History Content Keys":
 
   test "Receipts":
     # Input
-    const blockHash = BlockHash.fromHex(
+    const blockHash = Hash32.fromHex(
       "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
     )
 

--- a/fluffy/tests/history_network_tests/test_history_content_validation.nim
+++ b/fluffy/tests/history_network_tests/test_history_content_validation.nim
@@ -39,7 +39,7 @@ suite "History Content Values Validation":
     blockBodyBytes = blockData.body.hexToSeqByte()
     receiptsBytes = blockData.receipts.hexToSeqByte()
 
-    blockHash = BlockHash.fromHex(blockHashStr)
+    blockHash = Hash32.fromHex(blockHashStr)
 
     blockHeader =
       decodeRlp(blockHeaderBytes, Header).expect("Valid header should decode")

--- a/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
+++ b/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
@@ -59,7 +59,7 @@ proc stop(hn: HistoryNode) {.async.} =
 proc containsId(hn: HistoryNode, contentId: ContentId): bool =
   return hn.historyNetwork.contentDB.get(contentId).isSome()
 
-proc store*(hn: HistoryNode, blockHash: BlockHash, blockHeader: Header) =
+proc store*(hn: HistoryNode, blockHash: Hash32, blockHeader: Header) =
   let
     headerRlp = rlp.encode(blockHeader)
     blockHeaderWithProof = BlockHeaderWithProof(
@@ -72,14 +72,14 @@ proc store*(hn: HistoryNode, blockHash: BlockHash, blockHeader: Header) =
     contentKeyBytes, contentId, SSZ.encode(blockHeaderWithProof)
   )
 
-proc store*(hn: HistoryNode, blockHash: BlockHash, blockBody: BlockBody) =
+proc store*(hn: HistoryNode, blockHash: Hash32, blockBody: BlockBody) =
   let
     contentKeyBytes = blockBodyContentKey(blockHash).encode()
     contentId = history_content.toContentId(contentKeyBytes)
 
   hn.portalProtocol().storeContent(contentKeyBytes, contentId, blockBody.encode())
 
-proc store*(hn: HistoryNode, blockHash: BlockHash, receipts: seq[Receipt]) =
+proc store*(hn: HistoryNode, blockHash: Hash32, receipts: seq[Receipt]) =
   let
     contentKeyBytes = receiptsContentKey(blockHash).encode()
     contentId = history_content.toContentId(contentKeyBytes)

--- a/fluffy/tests/state_network_tests/state_test_helpers.nim
+++ b/fluffy/tests/state_network_tests/state_test_helpers.nim
@@ -145,7 +145,7 @@ proc containsId*(sn: StateNode, contentId: ContentId): bool {.inline.} =
   return sn.stateNetwork.contentDB.get(contentId).isSome()
 
 proc mockStateRootLookup*(
-    sn: StateNode, blockNumOrHash: uint64 | BlockHash, stateRoot: Hash32
+    sn: StateNode, blockNumOrHash: uint64 | Hash32, stateRoot: Hash32
 ) =
   let
     blockHeader = Header(stateRoot: stateRoot)

--- a/fluffy/tests/state_network_tests/test_state_content_keys_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_content_keys_vectors.nim
@@ -29,7 +29,7 @@ suite "State Content Keys":
         raiseAssert "Cannot read test vector: " & error
 
       packedNibbles = packNibbles(testCase.path)
-      nodeHash = NodeHash.fromHex(testCase.node_hash)
+      nodeHash = Hash32.fromHex(testCase.node_hash)
       contentKey = AccountTrieNodeKey.init(packedNibbles, nodeHash).toContentKey()
       encoded = contentKey.encode()
 
@@ -60,7 +60,7 @@ suite "State Content Keys":
 
       packedNibbles = packNibbles(testCase.path)
       addressHash = Address.fromHex(testCase.address).data.keccak256()
-      nodeHash = NodeHash.fromHex(testCase.node_hash)
+      nodeHash = Hash32.fromHex(testCase.node_hash)
       contentKey =
         ContractTrieNodeKey.init(addressHash, packedNibbles, nodeHash).toContentKey()
       encoded = contentKey.encode()
@@ -92,7 +92,7 @@ suite "State Content Keys":
         raiseAssert "Cannot read test vector: " & error
 
       addressHash = Address.fromHex(testCase.address).data.keccak256()
-      codeHash = CodeHash.fromHex(testCase.code_hash)
+      codeHash = Hash32.fromHex(testCase.code_hash)
       contentKey = ContractCodeKey.init(addressHash, codeHash).toContentKey()
       encoded = contentKey.encode()
 

--- a/fluffy/tests/state_network_tests/test_state_content_values_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_content_values_vectors.nim
@@ -27,7 +27,7 @@ suite "State Content Values":
       testCase = YamlAccountTrieNodeWithProof.loadFromYaml(file).valueOr:
         raiseAssert "Cannot read test vector: " & error
 
-      blockHash = BlockHash.fromHex(testCase.block_hash)
+      blockHash = Hash32.fromHex(testCase.block_hash)
       proof =
         TrieProof.init(testCase.proof.map((hex) => TrieNode.init(hex.hexToSeqByte())))
       accountTrieNodeOffer = AccountTrieNodeOffer.init(proof, blockHash)
@@ -75,7 +75,7 @@ suite "State Content Values":
       testCase = YamlContractStorageTrieNodeWithProof.loadFromYaml(file).valueOr:
         raiseAssert "Cannot read test vector: " & error
 
-      blockHash = BlockHash.fromHex(testCase.block_hash)
+      blockHash = Hash32.fromHex(testCase.block_hash)
       storageProof = TrieProof.init(
         testCase.storage_proof.map((hex) => TrieNode.init(hex.hexToSeqByte()))
       )
@@ -133,7 +133,7 @@ suite "State Content Values":
         raiseAssert "Cannot read test vector: " & error
 
       code = Bytecode.init(testCase.bytecode.hexToSeqByte())
-      blockHash = BlockHash.fromHex(testCase.block_hash)
+      blockHash = Hash32.fromHex(testCase.block_hash)
       accountProof = TrieProof.init(
         testCase.account_proof.map((hex) => TrieNode.init(hex.hexToSeqByte()))
       )

--- a/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
+++ b/fluffy/tools/beacon_lc_bridge/beacon_lc_bridge.nim
@@ -96,7 +96,7 @@ proc calculateWithdrawalsRoot(items: openArray[WithdrawalV1]): Hash32 {.raises: 
 
 proc asPortalBlockData*(
     payload: ExecutionPayloadV1
-): (common_types.BlockHash, BlockHeaderWithProof, PortalBlockBodyLegacy) =
+): (Hash32, BlockHeaderWithProof, PortalBlockBodyLegacy) =
   let
     txRoot = calculateTransactionData(payload.transactions)
 

--- a/fluffy/tools/portal_bridge/portal_bridge_history.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_history.nim
@@ -139,9 +139,7 @@ proc getBlockReceipts(
 ## Portal JSON-RPC API helper calls for pushing block and receipts
 
 proc gossipBlockHeader(
-    client: RpcClient,
-    id: common_types.BlockHash | uint64,
-    headerWithProof: BlockHeaderWithProof,
+    client: RpcClient, id: Hash32 | uint64, headerWithProof: BlockHeaderWithProof
 ): Future[Result[void, string]] {.async: (raises: []).} =
   let
     contentKey = blockHeaderContentKey(id)
@@ -160,7 +158,7 @@ proc gossipBlockHeader(
 
 proc gossipBlockBody(
     client: RpcClient,
-    hash: common_types.BlockHash,
+    hash: Hash32,
     body: PortalBlockBodyLegacy | PortalBlockBodyShanghai,
 ): Future[Result[void, string]] {.async: (raises: []).} =
   let
@@ -179,7 +177,7 @@ proc gossipBlockBody(
   return ok()
 
 proc gossipReceipts(
-    client: RpcClient, hash: common_types.BlockHash, receipts: PortalReceipts
+    client: RpcClient, hash: Hash32, receipts: PortalReceipts
 ): Future[Result[void, string]] {.async: (raises: []).} =
   let
     contentKey = receiptsContentKey(hash)

--- a/fluffy/tools/portal_bridge/state_bridge/offers_builder.nim
+++ b/fluffy/tools/portal_bridge/state_bridge/offers_builder.nim
@@ -15,19 +15,19 @@ import
 
 type OffersBuilder* = object
   worldState: WorldStateRef
-  blockHash: BlockHash
+  blockHash: Hash32
   accountTrieOffers: seq[AccountTrieOfferWithKey]
   contractTrieOffers: seq[ContractTrieOfferWithKey]
   contractCodeOffers: seq[ContractCodeOfferWithKey]
 
-proc init*(T: type OffersBuilder, worldState: WorldStateRef, blockHash: BlockHash): T =
+proc init*(T: type OffersBuilder, worldState: WorldStateRef, blockHash: Hash32): T =
   T(worldState: worldState, blockHash: blockHash)
 
 proc toTrieProof(proof: seq[seq[byte]]): TrieProof =
   TrieProof.init(proof.map((node) => TrieNode.init(node)))
 
 proc buildAccountTrieNodeOffer(
-    builder: var OffersBuilder, addressHash: content_keys.AddressHash, proof: TrieProof
+    builder: var OffersBuilder, addressHash: Hash32, proof: TrieProof
 ) =
   try:
     let
@@ -43,7 +43,7 @@ proc buildAccountTrieNodeOffer(
 
 proc buildContractTrieNodeOffer(
     builder: var OffersBuilder,
-    addressHash: content_keys.AddressHash,
+    addressHash: Hash32,
     slotHash: SlotKeyHash,
     storageProof: TrieProof,
     accountProof: TrieProof,
@@ -64,7 +64,7 @@ proc buildContractTrieNodeOffer(
 
 proc buildContractCodeOffer(
     builder: var OffersBuilder,
-    addressHash: content_keys.AddressHash,
+    addressHash: Hash32,
     code: seq[byte],
     accountProof: TrieProof,
 ) =


### PR DESCRIPTION
These create only confusion as if they are actual different types and it is within their usage already clear what they are about because of the name of the variable or the function.

They are also nowhere aliased like this in any of the Portal specification.