### PR TITLE
Allow Portal beacon LC sync to start from a stored LC bootstrap

### DIFF
--- a/fluffy/portal_node.nim
+++ b/fluffy/portal_node.nim
@@ -108,7 +108,7 @@ proc new*(
         loadAccumulator()
 
     beaconNetwork =
-      if PortalSubnetwork.beacon in subnetworks and config.trustedBlockRoot.isSome():
+      if PortalSubnetwork.beacon in subnetworks:
         let
           beaconDb = BeaconDb.new(networkData, config.dataDir / "db" / "beacon_db")
           beaconNetwork = BeaconNetwork.new(
@@ -166,7 +166,6 @@ proc new*(
 
         beaconLightClient.onFinalizedHeader = onFinalizedHeader
         beaconLightClient.onOptimisticHeader = onOptimisticHeader
-        beaconLightClient.trustedBlockRoot = config.trustedBlockRoot
 
         # TODO:
         # Quite dirty. Use register validate callbacks instead. Or, revisit

--- a/fluffy/tests/beacon_network_tests/beacon_test_helpers.nim
+++ b/fluffy/tests/beacon_network_tests/beacon_test_helpers.nim
@@ -18,19 +18,17 @@ type BeaconNode* = ref object
   beaconNetwork*: BeaconNetwork
 
 proc newLCNode*(
-    rng: ref HmacDrbgContext, port: int, networkData: NetworkInitData
+    rng: ref HmacDrbgContext,
+    port: int,
+    networkData: NetworkInitData,
+    trustedBlockRoot: Opt[Digest] = Opt.none(Digest),
 ): BeaconNode =
   let
     node = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(port))
     db = BeaconDb.new(networkData, "", inMemory = true)
     streamManager = StreamManager.new(node)
     network = BeaconNetwork.new(
-      PortalNetwork.none,
-      node,
-      db,
-      streamManager,
-      networkData.forks,
-      Opt.none(Eth2Digest),
+      PortalNetwork.none, node, db, streamManager, networkData.forks, trustedBlockRoot
     )
 
   return BeaconNode(discoveryProtocol: node, beaconNetwork: network)


### PR DESCRIPTION
Portal beacon LC sync can be started now from a provided trusted block root or, in case it has been running before, from a previously verified and stored LC bootstrap.

This required altering the the beacon db on how the bootstraps are stored.