### PR TITLE
Fluffy state portal rpc validation

### DIFF
--- a/fluffy/network/state/state_validation.nim
+++ b/fluffy/network/state/state_validation.nim
@@ -45,7 +45,6 @@ proc validateTrieProof*(
   if proof.len() == 0:
     return err("proof is empty")
 
-  # TODO: Remove this once the hive tests support passing in state roots from the history network
   if expectedRootHash.isSome():
     if not proof[0].hashEquals(expectedRootHash.get()):
       return err("hash of proof root node doesn't match the expected root hash")

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -1590,12 +1590,15 @@ proc storeContent*(
     contentKey: ContentKeyByteList,
     contentId: ContentId,
     content: seq[byte],
-) =
+): bool {.discardable.} =
   # Always re-check that the key is still in the node range to make sure only
   # content in range is stored.
   if p.inRange(contentId):
     doAssert(p.dbPut != nil)
     p.dbPut(contentKey, contentId, content)
+    true
+  else:
+    false
 
 proc seedTable*(p: PortalProtocol) =
   ## Seed the table with specifically provided Portal bootstrap nodes. These are

--- a/fluffy/rpc/rpc_portal_beacon_api.nim
+++ b/fluffy/rpc/rpc_portal_beacon_api.nim
@@ -115,13 +115,10 @@ proc installPortalBeaconApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
     let
       key = ContentKeyByteList.init(hexToSeqByte(contentKey))
       contentValueBytes = hexToSeqByte(contentValue)
-      contentId = p.toContentId(key)
+      contentId = p.toContentId(key).valueOr:
+        raise invalidKeyErr()
 
-    if contentId.isSome():
-      p.storeContent(key, contentId.get(), contentValueBytes)
-      return true
-    else:
-      raise invalidKeyErr()
+    p.storeContent(key, contentId, contentValueBytes)
 
   rpcServer.rpc("portal_beaconLocalContent") do(contentKey: string) -> string:
     let

--- a/fluffy/rpc/rpc_portal_history_api.nim
+++ b/fluffy/rpc/rpc_portal_history_api.nim
@@ -115,13 +115,10 @@ proc installPortalHistoryApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
     let
       key = ContentKeyByteList.init(hexToSeqByte(contentKey))
       contentValueBytes = hexToSeqByte(contentValue)
-      contentId = p.toContentId(key)
+      contentId = p.toContentId(key).valueOr:
+        raise invalidKeyErr()
 
-    if contentId.isSome():
-      p.storeContent(key, contentId.get(), contentValueBytes)
-      return true
-    else:
-      raise invalidKeyErr()
+    p.storeContent(key, contentId, contentValueBytes)
 
   rpcServer.rpc("portal_historyLocalContent") do(contentKey: string) -> string:
     let

--- a/fluffy/rpc/rpc_portal_state_api.nim
+++ b/fluffy/rpc/rpc_portal_state_api.nim
@@ -144,11 +144,13 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
 
   rpcServer.rpc("portal_stateLocalContent") do(contentKey: string) -> string:
     let
-      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
-      contentId = p.toContentId(key).valueOr:
+      keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      key = ContentKey.decode(keyBytes).valueOr:
+        raise invalidKeyErr()
+      contentId = p.toContentId(keyBytes).valueOr:
         raise invalidKeyErr()
 
-      contentResult = p.dbGet(key, contentId).valueOr:
+      contentResult = p.dbGet(keyBytes, contentId).valueOr:
         raise contentNotFoundErr()
 
     return contentResult.to0xHex()


### PR DESCRIPTION
I've added additional validations to `portal_stateLocalContent` and `portal_stateStore`. In stateStore we now return the status of the storeContent so that if the data is stored in the db we return true and otherwise return false. The same is applied to beacon and history stateStore.

