### PR TITLE
Fluffy: Add validation and local storage of content in remaining state portal rpc methods

### DIFF
--- a/fluffy/network/state/content/content_keys.nim
+++ b/fluffy/network/state/content/content_keys.nim
@@ -96,7 +96,10 @@ func encode*(contentKey: ContentKey): ContentKeyByteList {.inline.} =
 func decode*(
     T: type ContentKey, contentKey: ContentKeyByteList
 ): Result[T, string] {.inline.} =
-  decodeSsz(contentKey.asSeq(), T)
+  let key = ?decodeSsz(contentKey.asSeq(), T)
+  if key.contentType == unused:
+    return err("ContentKey contentType: unused")
+  ok(key)
 
 func toContentId*(contentKey: ContentKeyByteList): ContentId {.inline.} =
   let idHash = sha256.digest(contentKey.asSeq())

--- a/fluffy/network/state/content/content_keys.nim
+++ b/fluffy/network/state/content/content_keys.nim
@@ -99,6 +99,5 @@ func decode*(
   decodeSsz(contentKey.asSeq(), T)
 
 func toContentId*(contentKey: ContentKeyByteList): ContentId {.inline.} =
-  # TODO: Should we try to parse the content key here for invalid ones?
   let idHash = sha256.digest(contentKey.asSeq())
   readUintBE[256](idHash.data)

--- a/fluffy/network/state/state_gossip.nim
+++ b/fluffy/network/state/state_gossip.nim
@@ -93,34 +93,6 @@ proc gossipOffer*(
     srcNodeId: Opt[NodeId],
     keyBytes: ContentKeyByteList,
     offerBytes: seq[byte],
-    key: AccountTrieNodeKey,
-    offer: AccountTrieNodeOffer,
-) {.async: (raises: [CancelledError]).} =
-  let req1Peers = await p.neighborhoodGossip(
-    srcNodeId, ContentKeysList.init(@[keyBytes]), @[offerBytes]
-  )
-  debug "Offered content gossipped successfully with peers", keyBytes, peers = req1Peers
-
-proc gossipOffer*(
-    p: PortalProtocol,
-    srcNodeId: Opt[NodeId],
-    keyBytes: ContentKeyByteList,
-    offerBytes: seq[byte],
-    key: ContractTrieNodeKey,
-    offer: ContractTrieNodeOffer,
-) {.async: (raises: [CancelledError]).} =
-  let req1Peers = await p.neighborhoodGossip(
-    srcNodeId, ContentKeysList.init(@[keyBytes]), @[offerBytes]
-  )
-  debug "Offered content gossipped successfully with peers", keyBytes, peers = req1Peers
-
-proc gossipOffer*(
-    p: PortalProtocol,
-    srcNodeId: Opt[NodeId],
-    keyBytes: ContentKeyByteList,
-    offerBytes: seq[byte],
-    key: ContractCodeKey,
-    offer: ContractCodeOffer,
 ) {.async: (raises: [CancelledError]).} =
   let peers = await p.neighborhoodGossip(
     srcNodeId, ContentKeysList.init(@[keyBytes]), @[offerBytes]
@@ -136,7 +108,7 @@ proc recursiveGossipOffer*(
     key: AccountTrieNodeKey,
     offer: AccountTrieNodeOffer,
 ): Future[ContentKeyByteList] {.async: (raises: [CancelledError]).} =
-  await gossipOffer(p, srcNodeId, keyBytes, offerBytes, key, offer)
+  await gossipOffer(p, srcNodeId, keyBytes, offerBytes)
 
   # root node, recursive gossip is finished
   if key.path.unpackNibbles().len() == 0:
@@ -161,7 +133,7 @@ proc recursiveGossipOffer*(
     key: ContractTrieNodeKey,
     offer: ContractTrieNodeOffer,
 ): Future[ContentKeyByteList] {.async: (raises: [CancelledError]).} =
-  await gossipOffer(p, srcNodeId, keyBytes, offerBytes, key, offer)
+  await gossipOffer(p, srcNodeId, keyBytes, offerBytes)
 
   # root node, recursive gossip is finished
   if key.path.unpackNibbles().len() == 0:

--- a/fluffy/network/state/state_utils.nim
+++ b/fluffy/network/state/state_utils.nim
@@ -16,7 +16,7 @@ import
 
 export results, hashes, accounts, addresses, rlp
 
-func fromBytes*(T: type Hash32, hash: openArray[byte]): T =
+template fromBytes*(T: type Hash32, hash: openArray[byte]): T =
   doAssert(hash.len() == 32)
   Hash32(array[32, byte].initCopyFrom(hash))
 
@@ -69,14 +69,12 @@ func rlpDecodeContractTrieNode*(contractTrieNode: TrieNode): Result[UInt256, str
   except RlpError as e:
     err(e.msg)
 
-func toAccount*(accountProof: TrieProof): Result[Account, string] {.inline.} =
+template toAccount*(accountProof: TrieProof): Result[Account, string] =
   doAssert(accountProof.len() > 0)
-
   rlpDecodeAccountTrieNode(accountProof[^1])
 
-func toSlot*(storageProof: TrieProof): Result[UInt256, string] {.inline.} =
+template toSlot*(storageProof: TrieProof): Result[UInt256, string] =
   doAssert(storageProof.len() > 0)
-
   rlpDecodeContractTrieNode(storageProof[^1])
 
 func removeLeafKeyEndNibbles*(
@@ -93,11 +91,11 @@ func removeLeafKeyEndNibbles*(
 
   unpackedNibbles.dropN(leafPrefix.len()).packNibbles()
 
-func toPath*(hash: Hash32): Nibbles {.inline.} =
+template toPath*(hash: Hash32): Nibbles =
   Nibbles.init(hash.data, isEven = true)
 
-func toPath*(address: Address): Nibbles {.inline.} =
+template toPath*(address: Address): Nibbles =
   keccak256(address.data).toPath()
 
-func toPath*(slotKey: UInt256): Nibbles {.inline.} =
+template toPath*(slotKey: UInt256): Nibbles =
   keccak256(toBytesBE(slotKey)).toPath()

--- a/fluffy/network/state/state_validation.nim
+++ b/fluffy/network/state/state_validation.nim
@@ -185,10 +185,7 @@ func validateOffer*(
 func validateGetContentKey*(
     keyBytes: ContentKeyByteList
 ): Result[(ContentKey, ContentId), string] =
-  let key = ContentKey.decode(keyBytes).valueOr:
-    return err("Unable to decode content key")
-  if key.contentType == unused:
-    return err("ContentKey contentType: unused")
+  let key = ?ContentKey.decode(keyBytes)
   ok((key, toContentId(keyBytes)))
 
 func validateRetrieval*(

--- a/fluffy/network/state/state_validation.nim
+++ b/fluffy/network/state/state_validation.nim
@@ -13,10 +13,10 @@ export results, state_content, hashes
 
 from eth/common/eth_types_rlp import rlpHash
 
-proc hashEquals(value: TrieNode | Bytecode, expectedHash: Hash32): bool {.inline.} =
+template hashEquals(value: TrieNode | Bytecode, expectedHash: Hash32): bool =
   keccak256(value.asSeq()) == expectedHash
 
-proc isValidNextNode(
+func isValidNextNode(
     thisNodeRlp: Rlp, rlpIdx: int, nextNode: TrieNode
 ): bool {.raises: RlpError.} =
   let hashOrShortRlp = thisNodeRlp.listElem(rlpIdx)
@@ -36,7 +36,7 @@ proc isValidNextNode(
   nextNode.hashEquals(nextHash)
 
 # TODO: Refactor this function to improve maintainability
-proc validateTrieProof*(
+func validateTrieProof*(
     expectedRootHash: Opt[Hash32],
     path: Nibbles,
     proof: TrieProof,
@@ -117,7 +117,7 @@ proc validateTrieProof*(
   else:
     ok()
 
-proc validateRetrieval*(
+func validateRetrieval*(
     key: AccountTrieNodeKey, value: AccountTrieNodeRetrieval
 ): Result[void, string] =
   if value.node.hashEquals(key.nodeHash):
@@ -125,7 +125,7 @@ proc validateRetrieval*(
   else:
     err("hash of account trie node doesn't match the expected node hash")
 
-proc validateRetrieval*(
+func validateRetrieval*(
     key: ContractTrieNodeKey, value: ContractTrieNodeRetrieval
 ): Result[void, string] =
   if value.node.hashEquals(key.nodeHash):
@@ -133,7 +133,7 @@ proc validateRetrieval*(
   else:
     err("hash of contract trie node doesn't match the expected node hash")
 
-proc validateRetrieval*(
+func validateRetrieval*(
     key: ContractCodeKey, value: ContractCodeRetrieval
 ): Result[void, string] =
   if value.code.hashEquals(key.codeHash):
@@ -141,14 +141,14 @@ proc validateRetrieval*(
   else:
     err("hash of bytecode doesn't match the expected code hash")
 
-proc validateOffer*(
+func validateOffer*(
     trustedStateRoot: Opt[Hash32], key: AccountTrieNodeKey, offer: AccountTrieNodeOffer
 ): Result[void, string] =
   ?validateTrieProof(trustedStateRoot, key.path, offer.proof)
 
   validateRetrieval(key, offer.toRetrievalValue())
 
-proc validateOffer*(
+func validateOffer*(
     trustedStateRoot: Opt[Hash32],
     key: ContractTrieNodeKey,
     offer: ContractTrieNodeOffer,
@@ -166,7 +166,7 @@ proc validateOffer*(
 
   validateRetrieval(key, offer.toRetrievalValue())
 
-proc validateOffer*(
+func validateOffer*(
     trustedStateRoot: Opt[Hash32], key: ContractCodeKey, offer: ContractCodeOffer
 ): Result[void, string] =
   ?validateTrieProof(
@@ -181,3 +181,36 @@ proc validateOffer*(
     return err("hash of bytecode doesn't match the code hash in the account proof")
 
   validateRetrieval(key, offer.toRetrievalValue())
+
+func validateGetContentKey*(
+    keyBytes: ContentKeyByteList
+): Result[(ContentKey, ContentId), string] =
+  let key = ContentKey.decode(keyBytes).valueOr:
+    return err("Unable to decode content key")
+  if key.contentType == unused:
+    return err("ContentKey contentType: unused")
+  ok((key, toContentId(keyBytes)))
+
+func validateOfferGetValue*(
+    trustedStateRoot: Opt[Hash32], key: ContentKey, contentBytes: seq[byte]
+): Result[seq[byte], string] =
+  let value =
+    case key.contentType
+    of unused:
+      raiseAssert("ContentKey contentType: unused")
+    of accountTrieNode:
+      let offer = ?AccountTrieNodeOffer.decode(contentBytes)
+      ?validateOffer(trustedStateRoot, key.accountTrieNodeKey, offer)
+      offer.toRetrievalValue.encode()
+    of contractTrieNode:
+      let offer = ?ContractTrieNodeOffer.decode(contentBytes)
+      ?validateOffer(trustedStateRoot, key.contractTrieNodeKey, offer)
+      offer.toRetrievalValue.encode()
+    of contractCode:
+      let offer = ?ContractCodeOffer.decode(contentBytes)
+      ?validateOffer(trustedStateRoot, key.contractCodeKey, offer)
+      offer.toRetrievalValue.encode()
+
+  ok(value)
+
+# TODO: validate retrival value

--- a/fluffy/network/state/state_validation.nim
+++ b/fluffy/network/state/state_validation.nim
@@ -191,6 +191,22 @@ func validateGetContentKey*(
     return err("ContentKey contentType: unused")
   ok((key, toContentId(keyBytes)))
 
+func validateRetrieval*(
+    key: ContentKey, contentBytes: seq[byte]
+): Result[void, string] =
+  case key.contentType
+  of unused:
+    raiseAssert("ContentKey contentType: unused")
+  of accountTrieNode:
+    let retrieval = ?AccountTrieNodeRetrieval.decode(contentBytes)
+    ?validateRetrieval(key.accountTrieNodeKey, retrieval)
+  of contractTrieNode:
+    let retrieval = ?ContractTrieNodeRetrieval.decode(contentBytes)
+    ?validateRetrieval(key.contractTrieNodeKey, retrieval)
+  of contractCode:
+    let retrieval = ?ContractCodeRetrieval.decode(contentBytes)
+    ?validateRetrieval(key.contractCodeKey, retrieval)
+
 func validateOfferGetValue*(
     trustedStateRoot: Opt[Hash32], key: ContentKey, contentBytes: seq[byte]
 ): Result[seq[byte], string] =
@@ -212,5 +228,3 @@ func validateOfferGetValue*(
       offer.toRetrievalValue.encode()
 
   ok(value)
-
-# TODO: validate retrival value

--- a/fluffy/rpc/rpc_portal_state_api.nim
+++ b/fluffy/rpc/rpc_portal_state_api.nim
@@ -36,41 +36,55 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
   ) -> JsonString:
     let
       node = toNodeWithAddress(enr)
-      foundContentResult =
-        await p.findContent(node, ContentKeyByteList.init(hexToSeqByte(contentKey)))
+      keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      (key, contentId) = validateGetContentKey(keyBytes).valueOr:
+        raise invalidKeyErr()
+      foundContent = (await p.findContent(node, keyBytes)).valueOr:
+        raise newException(ValueError, $error)
 
-    if foundContentResult.isErr():
-      raise newException(ValueError, $foundContentResult.error)
-    else:
-      let foundContent = foundContentResult.get()
-      case foundContent.kind
-      of Content:
-        let res = ContentInfo(
-          content: foundContent.content.to0xHex(), utpTransfer: foundContent.utpTransfer
-        )
-        return JrpcConv.encode(res).JsonString
-      of Nodes:
-        let enrs = foundContent.nodes.map(
-          proc(n: Node): Record =
-            n.record
-        )
-        let jsonEnrs = JrpcConv.encode(enrs)
-        return ("{\"enrs\":" & jsonEnrs & "}").JsonString
+    case foundContent.kind
+    of Content:
+      let contentValue = foundContent.content
+      validateRetrieval(key, contentValue).isOkOr:
+        raise invalidValueErr()
+      p.storeContent(keyBytes, contentId, contentValue)
+
+      let res = ContentInfo(
+        content: contentValue.to0xHex(), utpTransfer: foundContent.utpTransfer
+      )
+      JrpcConv.encode(res).JsonString
+    of Nodes:
+      let enrs = foundContent.nodes.map(
+        proc(n: Node): Record =
+          n.record
+      )
+      let jsonEnrs = JrpcConv.encode(enrs)
+      ("{\"enrs\":" & jsonEnrs & "}").JsonString
 
   rpcServer.rpc("portal_stateOffer") do(
     enr: Record, contentItems: seq[ContentItem]
   ) -> string:
     let node = toNodeWithAddress(enr)
 
-    var contentItemsToOffer: seq[ContentKV]
+    var
+      contentItemsToStore: seq[(ContentKeyByteList, ContentId, seq[byte])]
+      contentItemsToOffer: seq[ContentKV]
+
     for contentItem in contentItems:
       let
-        contentKey = hexToSeqByte(contentItem[0])
-        contentValue = hexToSeqByte(contentItem[1])
-        contentKV = ContentKV(
-          contentKey: ContentKeyByteList.init(contentKey), content: contentValue
-        )
+        keyBytes = ContentKeyByteList.init(hexToSeqByte(contentItem[0]))
+        (key, contentId) = validateGetContentKey(keyBytes).valueOr:
+          raise invalidKeyErr()
+        contentBytes = hexToSeqByte(contentItem[1])
+        contentValue = validateOfferGetValue(Opt.none(Hash32), key, contentBytes).valueOr:
+          raise invalidValueErr()
+        contentKV = ContentKV(contentKey: keyBytes, content: contentBytes)
+
+      contentItemsToStore.add((keyBytes, contentId, contentValue))
       contentItemsToOffer.add(contentKV)
+
+    for (keyBytes, contentId, contentValue) in contentItemsToStore:
+      p.storeContent(keyBytes, contentId, contentValue)
 
     let offerResult = (await p.offer(node, contentItemsToOffer)).valueOr:
       raise newException(ValueError, $error)
@@ -81,34 +95,39 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
     contentKey: string
   ) -> ContentInfo:
     let
-      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
-      contentId = p.toContentId(key).valueOr:
+      keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      (key, contentId) = validateGetContentKey(keyBytes).valueOr:
         raise invalidKeyErr()
-
-      contentResult = (await p.contentLookup(key, contentId)).valueOr:
+      foundContent = (await p.contentLookup(keyBytes, contentId)).valueOr:
         raise contentNotFoundErr()
+      contentValue = foundContent.content
 
-    return ContentInfo(
-      content: contentResult.content.to0xHex(), utpTransfer: contentResult.utpTransfer
-    )
+    validateRetrieval(key, contentValue).isOkOr:
+      raise invalidValueErr()
+    p.storeContent(keyBytes, contentId, contentValue)
+
+    ContentInfo(content: contentValue.to0xHex(), utpTransfer: foundContent.utpTransfer)
 
   rpcServer.rpc("portal_stateTraceRecursiveFindContent") do(
     contentKey: string
   ) -> TraceContentLookupResult:
     let
-      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
-      contentId = p.toContentId(key).valueOr:
+      keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      (key, contentId) = validateGetContentKey(keyBytes).valueOr:
         raise invalidKeyErr()
-
-      res = await p.traceContentLookup(key, contentId)
+      res = await p.traceContentLookup(keyBytes, contentId)
 
     # TODO: Might want to restructure the lookup result here. Potentially doing
     # the json conversion in this module.
-    if res.content.isSome():
-      return res
-    else:
+    let contentValue = res.content.valueOr:
       let data = Opt.some(JrpcConv.encode(res.trace).JsonString)
       raise contentNotFoundErrWithTrace(data)
+
+    validateRetrieval(key, contentValue).isOkOr:
+      raise invalidValueErr()
+    p.storeContent(keyBytes, contentId, contentValue)
+
+    res
 
   rpcServer.rpc("portal_stateStore") do(contentKey: string, content: string) -> bool:
     let
@@ -130,14 +149,19 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
       contentResult = p.dbGet(keyBytes, contentId).valueOr:
         raise contentNotFoundErr()
 
-    return contentResult.to0xHex()
+    contentResult.to0xHex()
 
   rpcServer.rpc("portal_stateGossip") do(contentKey: string, content: string) -> int:
     let
-      keyBytes = hexToSeqByte(contentKey)
+      keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      (key, contentId) = validateGetContentKey(keyBytes).valueOr:
+        raise invalidKeyErr()
       contentBytes = hexToSeqByte(content)
-      contentKeys = ContentKeysList(@[ContentKeyByteList.init(keyBytes)])
-      numberOfPeers =
-        await p.neighborhoodGossip(Opt.none(NodeId), contentKeys, @[contentBytes])
+      contentValue = validateOfferGetValue(Opt.none(Hash32), key, contentBytes).valueOr:
+        raise invalidValueErr()
 
-    return numberOfPeers
+    p.storeContent(keyBytes, contentId, contentValue)
+
+    await p.neighborhoodGossip(
+      Opt.none(NodeId), ContentKeysList(@[keyBytes]), @[contentBytes]
+    )

--- a/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
@@ -262,11 +262,7 @@ procSuite "State Endpoints":
       stateNode2.mockStateRootLookup(contentValue.blockHash, stateRoot)
 
       await stateNode1.portalProtocol.gossipOffer(
-        Opt.none(NodeId),
-        contentKeyBytes,
-        contentValueBytes,
-        contentKey.contractCodeKey,
-        contentValue,
+        Opt.none(NodeId), contentKeyBytes, contentValueBytes
       )
 
       # wait for gossip to complete

--- a/fluffy/tests/state_network_tests/test_state_gossip_gossipoffer_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_gossip_gossipoffer_vectors.nim
@@ -66,11 +66,7 @@ procSuite "State Gossip - Gossip Offer":
       check not stateNode2.containsId(contentId)
 
       await stateNode1.portalProtocol.gossipOffer(
-        Opt.none(NodeId),
-        contentKeyBytes,
-        contentValueBytes,
-        contentKey.accountTrieNodeKey,
-        contentValue,
+        Opt.none(NodeId), contentKeyBytes, contentValueBytes
       )
 
       # wait for offer to be processed by state node 2
@@ -138,11 +134,7 @@ procSuite "State Gossip - Gossip Offer":
       check not stateNode2.containsId(contentId)
 
       await stateNode1.portalProtocol.gossipOffer(
-        Opt.none(NodeId),
-        contentKeyBytes,
-        contentValueBytes,
-        contentKey.contractTrieNodeKey,
-        contentValue,
+        Opt.none(NodeId), contentKeyBytes, contentValueBytes
       )
 
       # wait for offer to be processed by state node 2
@@ -201,11 +193,7 @@ procSuite "State Gossip - Gossip Offer":
       check not stateNode2.containsId(contentId)
 
       await stateNode1.portalProtocol.gossipOffer(
-        Opt.none(NodeId),
-        contentKeyBytes,
-        contentValueBytes,
-        contentKey.contractCodeKey,
-        contentValue,
+        Opt.none(NodeId), contentKeyBytes, contentValueBytes
       )
 
       # wait for offer to be processed by state node 2


### PR DESCRIPTION
Changes in this PR:
- Refactor and cleanup some state network code.
- Added new validation functions which are used by the state portal rpc methods.
- Added validation of content keys to all state rpc methods.
- Updated stateFindContent, stateGossip and stateOffer to validate and store content locally before sending or returning.
- Updated stateRecursiveFindContent and stateTraceRecursiveFindContent to first lookup content in the local db, if it doesn't exist then do the recursive lookup, then validate and store fetched content locally before returning.