### PR TITLE
Fix JSON encoding for NodeId, no leading zeroes dropped

### DIFF
--- a/fluffy/rpc/rpc_types.nim
+++ b/fluffy/rpc/rpc_types.nim
@@ -100,13 +100,13 @@ proc readValue*(
     r.raiseUnexpectedValue("Invalid ENR")
 
 proc writeValue*(w: var JsonWriter[JrpcConv], v: NodeId) {.gcsafe, raises: [IOError].} =
-  w.writeValue("0x" & v.toHex())
+  w.writeValue(v.toBytesBE().to0xHex())
 
 proc writeValue*(
     w: var JsonWriter[JrpcConv], v: Opt[NodeId]
 ) {.gcsafe, raises: [IOError].} =
   if v.isSome():
-    w.writeValue("0x" & v.get().toHex())
+    w.writeValue(v.get())
   else:
     w.writeValue("0x")
 
@@ -139,7 +139,8 @@ proc writeValue*(
 ) {.gcsafe, raises: [IOError].} =
   w.beginRecord()
   w.writeField("enrSeq", v.enrSeq)
-  w.writeField("dataRadius", "0x" & v.dataRadius.toHex)
+  # Portal json-rpc specifications allows for dropping leading zeroes.
+  w.writeField("dataRadius", "0x" & v.dataRadius.toHex())
   w.endRecord()
 
 proc readValue*(


### PR DESCRIPTION
Portal JSON-RPC API specifications dictate that the NodeId must be the 32 byte identifier. We had leading zeroes being dropped in our implementation.

This was causing failure in Hive due to more strictness there.

I will probably adapt this in the toString function for NodeId in the future.