### PR TITLE
Fluffy: Fix state validation issue causing portal hive test failure

### DIFF
--- a/fluffy/docs/the_fluffy_book/docs/fluffy-with-portal-hive.md
+++ b/fluffy/docs/the_fluffy_book/docs/fluffy-with-portal-hive.md
@@ -1,4 +1,4 @@
-# Fluffy with Portal-hive
+# Fluffy with Portal hive
 
 Fluffy is one of the Portal clients that is being tested with [hive](https://github.com/ethereum/hive).
 
@@ -39,7 +39,7 @@ create a local development docker image for Fluffy.
 
 To do that follow next steps:
 
-1) Clone and build portal-hive, see above.
+1) Clone and build hive, see above.
 
 2) Build the local development Docker image using the following command:
 ```
@@ -49,7 +49,7 @@ docker build --tag fluffy-dev --file ./fluffy/tools/docker/Dockerfile.portalhive
 3) Modify the `FROM` tag in the portal-hive `Dockerfile` of fluffy at
 `portal-hive/clients/fluffy/Dockerfile` to use the image that was buid in step 2.
 
-4) Run the tests as [usually](fluffy-with-portal-hive.md/#run-the-hive-tests-locally).
+4) Run the tests as [usual](fluffy-with-portal-hive.md/#run-the-hive-tests-locally).
 
 !!! warning
     The `./vendors` dir is dockerignored and cached. If you have to make local

--- a/fluffy/network/state/state_validation.nim
+++ b/fluffy/network/state/state_validation.nim
@@ -196,13 +196,13 @@ func validateRetrieval*(
     raiseAssert("ContentKey contentType: unused")
   of accountTrieNode:
     let retrieval = ?AccountTrieNodeRetrieval.decode(contentBytes)
-    ?validateRetrieval(key.accountTrieNodeKey, retrieval)
+    validateRetrieval(key.accountTrieNodeKey, retrieval)
   of contractTrieNode:
     let retrieval = ?ContractTrieNodeRetrieval.decode(contentBytes)
-    ?validateRetrieval(key.contractTrieNodeKey, retrieval)
+    validateRetrieval(key.contractTrieNodeKey, retrieval)
   of contractCode:
     let retrieval = ?ContractCodeRetrieval.decode(contentBytes)
-    ?validateRetrieval(key.contractCodeKey, retrieval)
+    validateRetrieval(key.contractCodeKey, retrieval)
 
 func validateOfferGetValue*(
     trustedStateRoot: Opt[Hash32], key: ContentKey, contentBytes: seq[byte]


### PR DESCRIPTION
This should fix the recent portal hive state test failures in the findContent and recursiveFindContent rpc endpoints. I tested and verified all the portal state hive tests now pass when running locally after making these changes.