### PR TITLE
Rename Fluffy rpc methods to match updated spec

### DIFF
--- a/fluffy/rpc/portal_rpc_client.nim
+++ b/fluffy/rpc/portal_rpc_client.nim
@@ -48,7 +48,7 @@ func toPortalRpcError(e: ref CatchableError): PortalRpcError =
   else:
     raiseAssert(e.msg)
 
-proc historyLocalContent(
+proc portal_historyLocalContent(
     client: PortalRpcClient, contentKey: string
 ): Future[Result[string, PortalRpcError]] {.async: (raises: []).} =
   try:
@@ -57,12 +57,11 @@ proc historyLocalContent(
   except CatchableError as e:
     err(e.toPortalRpcError())
 
-proc historyRecursiveFindContent(
+proc portal_historyGetContent(
     client: PortalRpcClient, contentKey: string
 ): Future[Result[string, PortalRpcError]] {.async: (raises: []).} =
   try:
-    let contentInfo =
-      await RpcClient(client).portal_historyRecursiveFindContent(contentKey)
+    let contentInfo = await RpcClient(client).portal_historyGetContent(contentKey)
     ok(contentInfo.content)
   except CatchableError as e:
     err(e.toPortalRpcError())
@@ -83,9 +82,9 @@ proc historyGetContent(
     client: PortalRpcClient, contentKey: string
 ): Future[Result[string, PortalRpcError]] {.async: (raises: []).} =
   # Look up the content from the local db before trying to get it from the network
-  let content = (await client.historyLocalContent(contentKey)).valueOr:
+  let content = (await client.portal_historyLocalContent(contentKey)).valueOr:
     if error == ContentNotFound:
-      ?await client.historyRecursiveFindContent(contentKey)
+      ?await client.portal_historyGetContent(contentKey)
     else:
       return err(error)
   ok(content)

--- a/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
@@ -25,7 +25,7 @@ createRpcSigsFromNim(RpcClient):
   proc portal_stateFindContent(enr: Record, contentKey: string): JsonNode
   proc portal_stateOffer(enr: Record, contentKey: string, contentValue: string): string
   proc portal_stateRecursiveFindNodes(nodeId: NodeId): seq[Record]
-  proc portal_stateRecursiveFindContent(contentKey: string): ContentInfo
+  proc portal_stateGetContent(contentKey: string): ContentInfo
   proc portal_stateStore(contentKey: string, contentValue: string): bool
   proc portal_stateLocalContent(contentKey: string): string
   proc portal_stateGossip(contentKey: string, contentValue: string): int
@@ -46,7 +46,7 @@ createRpcSigsFromNim(RpcClient):
   ): string
 
   proc portal_historyRecursiveFindNodes(nodeId: NodeId): seq[Record]
-  proc portal_historyRecursiveFindContent(contentKey: string): ContentInfo
+  proc portal_historyGetContent(contentKey: string): ContentInfo
   proc portal_historyStore(contentKey: string, contentValue: string): bool
   proc portal_historyLocalContent(contentKey: string): string
   proc portal_historyGossip(contentKey: string, contentValue: string): int
@@ -64,7 +64,7 @@ createRpcSigsFromNim(RpcClient):
   proc portal_beaconFindContent(enr: Record, contentKey: string): JsonNode
   proc portal_beaconOffer(enr: Record, contentKey: string, contentValue: string): string
   proc portal_beaconRecursiveFindNodes(nodeId: NodeId): seq[Record]
-  proc portal_beaconRecursiveFindContent(contentKey: string): ContentInfo
+  proc portal_beaconGetContent(contentKey: string): ContentInfo
   proc portal_beaconStore(contentKey: string, contentValue: string): bool
   proc portal_beaconLocalContent(contentKey: string): string
   proc portal_beaconGossip(contentKey: string, contentValue: string): int

--- a/fluffy/rpc/rpc_portal_beacon_api.nim
+++ b/fluffy/rpc/rpc_portal_beacon_api.nim
@@ -76,9 +76,7 @@ proc installPortalBeaconApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
 
     SSZ.encode(offerResult).to0xHex()
 
-  rpcServer.rpc("portal_beaconRecursiveFindContent") do(
-    contentKey: string
-  ) -> ContentInfo:
+  rpcServer.rpc("portal_beaconGetContent") do(contentKey: string) -> ContentInfo:
     let
       key = ContentKeyByteList.init(hexToSeqByte(contentKey))
       contentId = p.toContentId(key).valueOr:
@@ -91,7 +89,7 @@ proc installPortalBeaconApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
       content: contentResult.content.to0xHex(), utpTransfer: contentResult.utpTransfer
     )
 
-  rpcServer.rpc("portal_beaconTraceRecursiveFindContent") do(
+  rpcServer.rpc("portal_beaconTraceGetContent") do(
     contentKey: string
   ) -> TraceContentLookupResult:
     let

--- a/fluffy/rpc/rpc_portal_history_api.nim
+++ b/fluffy/rpc/rpc_portal_history_api.nim
@@ -76,9 +76,7 @@ proc installPortalHistoryApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
 
     SSZ.encode(offerResult).to0xHex()
 
-  rpcServer.rpc("portal_historyRecursiveFindContent") do(
-    contentKey: string
-  ) -> ContentInfo:
+  rpcServer.rpc("portal_historyGetContent") do(contentKey: string) -> ContentInfo:
     let
       key = ContentKeyByteList.init(hexToSeqByte(contentKey))
       contentId = p.toContentId(key).valueOr:
@@ -91,7 +89,7 @@ proc installPortalHistoryApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
       content: contentResult.content.to0xHex(), utpTransfer: contentResult.utpTransfer
     )
 
-  rpcServer.rpc("portal_historyTraceRecursiveFindContent") do(
+  rpcServer.rpc("portal_historyTraceGetContent") do(
     contentKey: string
   ) -> TraceContentLookupResult:
     let

--- a/fluffy/rpc/rpc_portal_state_api.nim
+++ b/fluffy/rpc/rpc_portal_state_api.nim
@@ -83,9 +83,7 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
 
     SSZ.encode(offerResult).to0xHex()
 
-  rpcServer.rpc("portal_stateRecursiveFindContent") do(
-    contentKey: string
-  ) -> ContentInfo:
+  rpcServer.rpc("portal_stateGetContent") do(contentKey: string) -> ContentInfo:
     let
       keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
       (key, contentId) = validateGetContentKey(keyBytes).valueOr:
@@ -105,7 +103,7 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
 
     ContentInfo(content: contentValue.to0xHex(), utpTransfer: foundContent.utpTransfer)
 
-  rpcServer.rpc("portal_stateTraceRecursiveFindContent") do(
+  rpcServer.rpc("portal_stateTraceGetContent") do(
     contentKey: string
   ) -> TraceContentLookupResult:
     let

--- a/fluffy/tools/portal_bridge/portal_bridge_history.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_history.nim
@@ -422,7 +422,7 @@ proc runBackfillLoopAuditMode(
         contentHex =
           try:
             (
-              await portalClient.portal_historyRecursiveFindContent(
+              await portalClient.portal_historyGetContent(
                 contentKey.encode.asSeq().toHex()
               )
             ).content
@@ -454,7 +454,7 @@ proc runBackfillLoopAuditMode(
         contentHex =
           try:
             (
-              await portalClient.portal_historyRecursiveFindContent(
+              await portalClient.portal_historyGetContent(
                 contentKey.encode.asSeq().toHex()
               )
             ).content
@@ -482,7 +482,7 @@ proc runBackfillLoopAuditMode(
         contentHex =
           try:
             (
-              await portalClient.portal_historyRecursiveFindContent(
+              await portalClient.portal_historyGetContent(
                 contentKey.encode.asSeq().toHex()
               )
             ).content

--- a/fluffy/tools/portal_bridge/portal_bridge_state.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_state.nim
@@ -329,8 +329,7 @@ proc runBackfillGossipBlockOffersLoop(
       await sleepAsync(100.milliseconds) # wait for the peers to be updated
       for k, _ in offersMap:
         try:
-          let contentInfo =
-            await portalClient.portal_stateRecursiveFindContent(k.to0xHex())
+          let contentInfo = await portalClient.portal_stateGetContent(k.to0xHex())
           if contentInfo.content.len() == 0:
             error "Found empty contentValue", workerId
             retryGossip = true


### PR DESCRIPTION
Rename Fluffy rpc methods to match updated spec (related PR: https://github.com/ethereum/portal-network-specs/pull/344). `portal_*RecursiveFindContent` renamed to `portal_*GetContent`. 