### PR TITLE
Implementation of EIP-7742 for Prague

### DIFF
--- a/hive_integration/nodocker/engine/cancun/customizer.nim
+++ b/hive_integration/nodocker/engine/cancun/customizer.nim
@@ -337,7 +337,7 @@ func getTimestamp*(cust: CustomPayloadData, basePayload: ExecutionPayload): uint
 # blockHash is calculated automatically.
 proc customizePayload*(cust: CustomPayloadData, data: ExecutableData): ExecutableData {.gcsafe.} =
   let requestsHash = calcRequestsHash(data.executionRequests)
-  var customHeader = blockHeader(data.basePayload, data.beaconRoot, requestsHash)
+  var customHeader = blockHeader(data.basePayload, data.beaconRoot, requestsHash, data.targetBlobsPerBlock)
   if cust.transactions.isSome:
     customHeader.transactionsRoot = calcTxRoot(cust.transactions.get)
 

--- a/hive_integration/nodocker/engine/cancun/helpers.nim
+++ b/hive_integration/nodocker/engine/cancun/helpers.nim
@@ -46,7 +46,7 @@ func getMinExcessBlobGasForBlobGasPrice(data_gas_price: uint64): uint64 =
 
   while current_data_gas_price < data_gas_price:
     current_excess_data_gas += GAS_PER_BLOB.uint64
-    current_data_gas_price = getBlobBaseFee(current_excess_data_gas).truncate(uint64)
+    current_data_gas_price = getBlobBaseFee(current_excess_data_gas, Opt.none(uint64)).truncate(uint64)
 
   return current_excess_data_gas
 

--- a/hive_integration/nodocker/engine/cancun/step_newpayloads.nim
+++ b/hive_integration/nodocker/engine/cancun/step_newpayloads.nim
@@ -73,7 +73,7 @@ proc verifyPayload(step: NewPayloads,
       excessBlobGas: Opt.some(parentExcessBlobGas),
       blobGasUsed: Opt.some(parentBlobGasUsed)
     )
-    expectedExcessBlobGas = calcExcessBlobGas(parent)
+    expectedExcessBlobGas = calcExcessBlobGas(parent, Opt.none(uint64))
 
   if com.isCancunOrLater(payload.timestamp.EthTime):
     if payload.excessBlobGas.isNone:
@@ -96,7 +96,7 @@ proc verifyPayload(step: NewPayloads,
 
     var
       totalBlobCount = 0
-      expectedBlobGasPrice = getBlobBaseFee(expectedExcessBlobGas)
+      expectedBlobGasPrice = getBlobBaseFee(expectedExcessBlobGas, Opt.none(uint64))
 
     for tx in blobTxsInPayload:
       let blobCount = tx.versionedHashes.len

--- a/hive_integration/nodocker/engine/clmock.nim
+++ b/hive_integration/nodocker/engine/clmock.nim
@@ -90,9 +90,6 @@ type
     onSafeBlockChange *        : proc(): bool {.gcsafe.}
     onFinalizedBlockChange*    : proc(): bool {.gcsafe.}
 
-
-
-
 func latestExecutableData*(cl: CLMocker): ExecutableData =
   ExecutableData(
     basePayload: cl.latestPayloadBuilt,
@@ -100,6 +97,7 @@ func latestExecutableData*(cl: CLMocker): ExecutableData =
     attr       : cl.latestPayloadAttributes,
     versionedHashes: Opt.some(collectBlobHashes(cl.latestPayloadBuilt.transactions)),
     executionRequests: cl.latestExecutionRequests,
+    targetBlobsPerBlock: cl.latestPayloadAttributes.targetBlobsPerBlock,
   )
 
 func latestPayloadNumber*(h: Table[uint64, ExecutionPayload]): uint64 =
@@ -344,8 +342,10 @@ proc getNextPayload(cl: CLMocker): bool =
   cl.latestExecutionRequests = x.executionRequests
 
   let parentBeaconBlockRoot = cl.latestPayloadAttributes.parentBeaconBlockRoot
+  let targetBlobsPerBlock = cl.latestPayloadAttributes.targetBlobsPerBlock
   let requestsHash = calcRequestsHash(x.executionRequests)
-  let header = blockHeader(cl.latestPayloadBuilt, parentBeaconBlockRoot, requestsHash)
+  let header = blockHeader(cl.latestPayloadBuilt, parentBeaconBlockRoot, requestsHash, targetBlobsPerBlock)
+
   let blockHash = header.blockHash
   if blockHash != cl.latestPayloadBuilt.blockHash:
     error "CLMocker: getNextPayload blockHash mismatch",

--- a/hive_integration/nodocker/engine/engine/invalid_ancestor.nim
+++ b/hive_integration/nodocker/engine/engine/invalid_ancestor.nim
@@ -194,7 +194,7 @@ method getName(cs: InvalidMissingAncestorReOrgSyncTest): string =
 
 func blockHeader(ex: ExecutableData): Header =
   let requestsHash = calcRequestsHash(ex.executionRequests)
-  blockHeader(ex.basePayload, ex.beaconRoot, requestsHash)
+  blockHeader(ex.basePayload, ex.beaconRoot, requestsHash, ex.targetBlobsPerBlock)
 
 func blockBody(ex: ExecutableData): BlockBody =
   blockBody(ex.basePayload)

--- a/hive_integration/nodocker/engine/engine/suggested_fee_recipient.nim
+++ b/hive_integration/nodocker/engine/engine/suggested_fee_recipient.nim
@@ -12,7 +12,8 @@ import
   chronicles,
   eth/common/eth_types_rlp,
   ./engine_spec,
-  ../../../../nimbus/transaction
+  ../../../../nimbus/transaction,
+  web3/conversions
 
 type
   SuggestedFeeRecipientTest* = ref object of EngineSpec

--- a/hive_integration/nodocker/engine/engine_client.nim
+++ b/hive_integration/nodocker/engine/engine_client.nim
@@ -69,6 +69,13 @@ proc forkchoiceUpdatedV3*(client: RpcClient,
   wrapTrySimpleRes:
     client.engine_forkchoiceUpdatedV3(update, payloadAttributes)
 
+proc forkchoiceUpdatedV4*(client: RpcClient,
+      update: ForkchoiceStateV1,
+      payloadAttributes = Opt.none(PayloadAttributes)):
+        Result[ForkchoiceUpdatedResponse, string] =
+  wrapTrySimpleRes:
+    client.engine_forkchoiceUpdatedV4(update, payloadAttributes)
+
 proc forkchoiceUpdated*(client: RpcClient,
                         version: Version,
                         update: ForkchoiceStateV1,
@@ -78,7 +85,7 @@ proc forkchoiceUpdated*(client: RpcClient,
   of Version.V1: return client.forkchoiceUpdatedV1(update, attr.V1)
   of Version.V2: return client.forkchoiceUpdatedV2(update, attr)
   of Version.V3: return client.forkchoiceUpdatedV3(update, attr)
-  of Version.V4: discard
+  of Version.V4: return client.forkchoiceUpdatedV4(update, attr)
 
 proc getPayloadV1*(client: RpcClient, payloadId: Bytes8): Result[ExecutionPayloadV1, string] =
   wrapTrySimpleRes:
@@ -163,11 +170,12 @@ proc newPayloadV4*(client: RpcClient,
       payload: ExecutionPayloadV3,
       versionedHashes: seq[VersionedHash],
       parentBeaconBlockRoot: Hash32,
-      executionRequests: array[3, seq[byte]]):
+      executionRequests: array[3, seq[byte]],
+      targetBlobsPerBlock: Quantity):
         Result[PayloadStatusV1, string] =
   wrapTrySimpleRes:
     client.engine_newPayloadV4(payload, versionedHashes,
-      parentBeaconBlockRoot, executionRequests)
+      parentBeaconBlockRoot, executionRequests, targetBlobsPerBlock)
 
 proc newPayloadV1*(client: RpcClient,
       payload: ExecutionPayload):
@@ -194,11 +202,12 @@ proc newPayloadV4*(client: RpcClient,
       payload: ExecutionPayload,
       versionedHashes: Opt[seq[VersionedHash]],
       parentBeaconBlockRoot: Opt[Hash32],
-      executionRequests: Opt[array[3, seq[byte]]]):
-        Result[PayloadStatusV1, string] =
+      executionRequests: Opt[array[3, seq[byte]]],
+      targetBlobsPerBlock: Opt[Quantity]
+      ): Result[PayloadStatusV1, string] =
   wrapTrySimpleRes:
     client.engine_newPayloadV4(payload, versionedHashes,
-      parentBeaconBlockRoot, executionRequests)
+      parentBeaconBlockRoot, executionRequests, targetBlobsPerBlock)
 
 proc newPayload*(client: RpcClient,
                  version: Version,
@@ -214,7 +223,8 @@ proc newPayload*(client: RpcClient,
     return client.newPayloadV4(payload.basePayload,
       payload.versionedHashes,
       payload.beaconRoot,
-      payload.executionRequests)
+      payload.executionRequests,
+      payload.targetBlobsPerBlock)
 
 proc exchangeCapabilities*(client: RpcClient,
       methods: seq[string]):

--- a/hive_integration/nodocker/engine/engine_client.nim
+++ b/hive_integration/nodocker/engine/engine_client.nim
@@ -280,7 +280,7 @@ proc toBlockHeader*(bc: BlockObject): Header =
     excessBlobGas  : maybeU64(bc.excessBlobGas),
     parentBeaconBlockRoot: bc.parentBeaconBlockRoot,
     requestsHash   : bc.requestsHash,
-    targetBlobsPerBlock: bc.targetBlobsPerBlock,
+    targetBlobsPerBlock: maybeU64(bc.targetBlobsPerBlock),
   )
 
 func vHashes(x: Opt[seq[Hash32]]): seq[VersionedHash] =

--- a/hive_integration/nodocker/engine/engine_client.nim
+++ b/hive_integration/nodocker/engine/engine_client.nim
@@ -280,6 +280,7 @@ proc toBlockHeader*(bc: BlockObject): Header =
     excessBlobGas  : maybeU64(bc.excessBlobGas),
     parentBeaconBlockRoot: bc.parentBeaconBlockRoot,
     requestsHash   : bc.requestsHash,
+    targetBlobsPerBlock: bc.targetBlobsPerBlock,
   )
 
 func vHashes(x: Opt[seq[Hash32]]): seq[VersionedHash] =

--- a/hive_integration/nodocker/engine/types.nim
+++ b/hive_integration/nodocker/engine/types.nim
@@ -61,6 +61,7 @@ type
     beaconRoot*  : Opt[Hash32]
     versionedHashes*: Opt[seq[Hash32]]
     executionRequests*: Opt[array[3, seq[byte]]]
+    targetBlobsPerBlock*: Opt[Quantity]
 
 const
   DefaultTimeout* = 60 # seconds
@@ -347,4 +348,3 @@ func toExecutableData*(payload: ExecutionPayload, attr: PayloadAttributes): Exec
     beaconRoot: attr.parentBeaconBlockRoot,
     versionedHashes: Opt.some(collectBlobHashes(payload.transactions)),
   )
-  

--- a/hive_integration/nodocker/pyspec/pyspec_sim.nim
+++ b/hive_integration/nodocker/pyspec/pyspec_sim.nim
@@ -141,6 +141,7 @@ proc runTest(node: JsonNode, network: string): TestStatus =
       # failed
       break
 
+    # TODO: version based on timestamp
     latestVersion = payload.payload.version
 
     let res = env.rpcClient.newPayload(latestVersion, payload.payload)

--- a/nimbus/beacon/api_handler/api_utils.nim
+++ b/nimbus/beacon/api_handler/api_utils.nim
@@ -43,6 +43,10 @@ proc computePayloadId*(blockHash: common.Hash32,
       ctx.update(wd)
   if params.parentBeaconBlockRoot.isSome:
     ctx.update(distinctBase params.parentBeaconBlockRoot.get)
+  if params.targetBlobsPerBlock.isSome:
+    ctx.update(toBytesBE distinctBase params.targetBlobsPerBlock.get)
+  if params.maxBlobsPerBlock.isSome:
+    ctx.update(toBytesBE distinctBase params.maxBlobsPerBlock.get)
   ctx.finish dest.data
   ctx.clear()
   (distinctBase result)[0..7] = dest.data[0..7]

--- a/nimbus/beacon/beacon_engine.nim
+++ b/nimbus/beacon/beacon_engine.nim
@@ -141,8 +141,8 @@ func get*(ben: BeaconEngineRef, id: Bytes8,
 # Public functions
 # ------------------------------------------------------------------------------
 proc generateExecutionBundle*(ben: BeaconEngineRef,
-                      attrs: PayloadAttributes):
-                         Result[ExecutionBundle, string] =
+                              attrs: PayloadAttributes):
+                                Result[ExecutionBundle, string] =
   wrapException:
     let
       xp  = ben.txPool
@@ -155,6 +155,16 @@ proc generateExecutionBundle*(ben: BeaconEngineRef,
 
     if attrs.parentBeaconBlockRoot.isSome:
       pos.parentBeaconBlockRoot = attrs.parentBeaconBlockRoot.get
+
+    if attrs.targetBlobsPerBlock.isSome:
+      pos.targetBlobsPerBlock = uint64(attrs.targetBlobsPerBlock.get)
+    else:
+      pos.targetBlobsPerBlock = 0'u64
+
+    if attrs.maxBlobsPerBlock.isSome:
+      pos.maxBlobsPerBlock = uint64(attrs.maxBlobsPerBlock.get)
+    else:
+      pos.maxBlobsPerBlock = 0'u64
 
     pos.setWithdrawals(attrs)
 

--- a/nimbus/beacon/payload_conv.nim
+++ b/nimbus/beacon/payload_conv.nim
@@ -86,7 +86,8 @@ func executionPayloadV1V2*(blk: Block): ExecutionPayloadV1OrV2 =
 
 func blockHeader*(p: ExecutionPayload,
                   parentBeaconBlockRoot: Opt[Hash32],
-                  requestsHash: Opt[Hash32]):
+                  requestsHash: Opt[Hash32],
+                  targetBlobsPerBlock: Opt[Quantity]):
                     Header =
   Header(
     parentHash     : p.parentHash,
@@ -110,6 +111,7 @@ func blockHeader*(p: ExecutionPayload,
     excessBlobGas  : u64(p.excessBlobGas),
     parentBeaconBlockRoot: parentBeaconBlockRoot,
     requestsHash   : requestsHash,
+    targetBlobsPerBlock: u64(targetBlobsPerBlock),
   )
 
 func blockBody*(p: ExecutionPayload):
@@ -122,10 +124,11 @@ func blockBody*(p: ExecutionPayload):
 
 func ethBlock*(p: ExecutionPayload,
                parentBeaconBlockRoot: Opt[Hash32],
-               requestsHash: Opt[Hash32]):
+               requestsHash: Opt[Hash32],
+               targetBlobsPerBlock: Opt[Quantity]):
                  Block {.gcsafe, raises:[RlpError].} =
   Block(
-    header      : blockHeader(p, parentBeaconBlockRoot, requestsHash),
+    header      : blockHeader(p, parentBeaconBlockRoot, requestsHash, targetBlobsPerBlock),
     uncles      : @[],
     transactions: ethTxs p.transactions,
     withdrawals : ethWithdrawals p.withdrawals,

--- a/nimbus/beacon/payload_queue.nim
+++ b/nimbus/beacon/payload_queue.nim
@@ -36,7 +36,6 @@ type
     blockValue*: UInt256
     blobsBundle*: Opt[BlobsBundleV1]
     executionRequests*: Opt[array[3, seq[byte]]]
-    targetBlobsPerBlock*: Opt[Quantity]
 
   PayloadItem = object
     id: Bytes8

--- a/nimbus/beacon/web3_eth_conv.nim
+++ b/nimbus/beacon/web3_eth_conv.nim
@@ -35,7 +35,7 @@ type
 # Pretty printers
 # ------------------------------------------------------------------------------
 
-proc `$`*(x: Opt[common.Hash32]): string =
+proc `$`*(x: Opt[Hash32]): string =
   if x.isNone: "none"
   else: x.get().data.toHex
 

--- a/nimbus/core/casper.nim
+++ b/nimbus/core/casper.nim
@@ -7,7 +7,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 import
-  eth/common/blocks 
+  eth/common/blocks
 
 type
   CasperRef* = ref object
@@ -16,6 +16,8 @@ type
     prevRandao  : Bytes32
     withdrawals : seq[Withdrawal] ## EIP-4895
     beaconRoot  : Hash32 ## EIP-4788
+    targetBlobsPerBlock*: uint64
+    maxBlobsPerBlock*: uint64
 
 # ------------------------------------------------------------------------------
 # Getters
@@ -36,6 +38,12 @@ proc withdrawals*(ctx: CasperRef): seq[Withdrawal] =
 func parentBeaconBlockRoot*(ctx: CasperRef): Hash32 =
   ctx.beaconRoot
 
+func targetBlobsPerBlock*(ctx: CasperRef): uint64 =
+  ctx.targetBlobsPerBlock
+
+func maxBlobsPerBlock*(ctx: CasperRef): uint64 =
+  ctx.maxBlobsPerBlock
+
 # ------------------------------------------------------------------------------
 # Setters
 # ------------------------------------------------------------------------------
@@ -54,3 +62,9 @@ proc `withdrawals=`*(ctx: CasperRef, val: sink seq[Withdrawal]) =
 
 proc `parentBeaconBlockRoot=`*(ctx: CasperRef, val: Hash32) =
   ctx.beaconRoot = val
+
+proc `targetBlobsPerBlock=`*(ctx: CasperRef, val: uint64) =
+  ctx.targetBlobsPerBlock = val
+
+proc `maxBlobsPerBlock=`*(ctx: CasperRef, val: uint64) =
+  ctx.maxBlobsPerBlock = val

--- a/nimbus/core/tx_pool/tx_tasks/tx_classify.nim
+++ b/nimbus/core/tx_pool/tx_tasks/tx_classify.nim
@@ -112,11 +112,12 @@ proc txFeesCovered(xp: TxPoolRef; item: TxItemRef): bool =
   if item.tx.txType >= TxEip4844:
     let
       excessBlobGas = xp.excessBlobGas
-      blobGasPrice = getBlobBaseFee(excessBlobGas)
+      blobGasPrice = getBlobBaseFee(excessBlobGas, xp.targetBlobsPerBlock)
     if item.tx.maxFeePerBlobGas < blobGasPrice:
       debug "invalid tx: maxFeePerBlobGas smaller than blobGasPrice",
         maxFeePerBlobGas=item.tx.maxFeePerBlobGas,
-        blobGasPrice=blobGasPrice
+        blobGasPrice=blobGasPrice,
+        targetBlobsPerBlock=xp.targetBlobsPerBlock
       return false
   true
 

--- a/nimbus/core/validate.nim
+++ b/nimbus/core/validate.nim
@@ -276,6 +276,7 @@ proc validateTransaction*(
     maxLimit: GasInt;          ## gasLimit from block header
     baseFee:  UInt256;         ## baseFee from block header
     excessBlobGas: uint64;     ## excessBlobGas from parent block header
+    targetBlobsCount: Opt[uint64];
     fork:     EVMFork): Result[void, string] =
 
   ? validateTxBasic(tx, fork)
@@ -332,7 +333,7 @@ proc validateTransaction*(
 
   if tx.txType >= TxEip4844:
     # ensure that the user was willing to at least pay the current data gasprice
-    let blobGasPrice = getBlobBaseFee(excessBlobGas)
+    let blobGasPrice = getBlobBaseFee(excessBlobGas, targetBlobsCount)
     if tx.maxFeePerBlobGas < blobGasPrice:
       return err("invalid tx: maxFeePerBlobGas smaller than blobGasPrice. " &
         &"maxFeePerBlobGas={tx.maxFeePerBlobGas}, blobGasPrice={blobGasPrice}")

--- a/nimbus/evm/state.nim
+++ b/nimbus/evm/state.nim
@@ -56,6 +56,7 @@ func blockCtx(com: CommonRef, header: Header):
     coinbase     : header.coinbase,
     excessBlobGas: header.excessBlobGas.get(0'u64),
     parentHash   : header.parentHash,
+    targetBlobsPerBlock: header.targetBlobsPerBlock,
   )
 
 # --------------

--- a/nimbus/evm/types.nim
+++ b/nimbus/evm/types.nim
@@ -47,6 +47,7 @@ type
     coinbase*         : Address
     excessBlobGas*    : uint64
     parentHash*       : Hash32
+    targetBlobsPerBlock*  : Opt[uint64]
 
   TxContext* = object
     origin*         : Address

--- a/nimbus/rpc/engine_api.nim
+++ b/nimbus/rpc/engine_api.nim
@@ -60,9 +60,10 @@ proc setupEngineAPI*(engine: BeaconEngineRef, server: RpcServer) =
   server.rpc("engine_newPayloadV4") do(payload: ExecutionPayload,
                                        expectedBlobVersionedHashes: Opt[seq[Hash32]],
                                        parentBeaconBlockRoot: Opt[Hash32],
-                                       executionRequests: Opt[array[3, seq[byte]]]) -> PayloadStatusV1:
+                                       executionRequests: Opt[array[3, seq[byte]]],
+                                       targetBlobsPerBlock: Opt[Quantity]) -> PayloadStatusV1:
     return engine.newPayload(Version.V4, payload,
-      expectedBlobVersionedHashes, parentBeaconBlockRoot, executionRequests)
+      expectedBlobVersionedHashes, parentBeaconBlockRoot, executionRequests, targetBlobsPerBlock)
 
   server.rpc("engine_getPayloadV1") do(payloadId: Bytes8) -> ExecutionPayloadV1:
     return engine.getPayload(Version.V1, payloadId).executionPayload.V1
@@ -91,6 +92,10 @@ proc setupEngineAPI*(engine: BeaconEngineRef, server: RpcServer) =
   server.rpc("engine_forkchoiceUpdatedV3") do(update: ForkchoiceStateV1,
                     attrs: Opt[PayloadAttributes]) -> ForkchoiceUpdatedResponse:
     return engine.forkchoiceUpdated(Version.V3, update, attrs)
+
+  server.rpc("engine_forkchoiceUpdatedV4") do(update: ForkchoiceStateV1,
+                    attrs: Opt[PayloadAttributes]) -> ForkchoiceUpdatedResponse:
+    return engine.forkchoiceUpdated(Version.V4, update, attrs)
 
   server.rpc("engine_getPayloadBodiesByHashV1") do(hashes: seq[Hash32]) ->
                                                seq[Opt[ExecutionPayloadBodyV1]]:

--- a/nimbus/rpc/oracle.nim
+++ b/nimbus/rpc/oracle.nim
@@ -99,9 +99,9 @@ func calcBaseFee(com: CommonRef, bc: BlockContent): UInt256 =
 proc processBlock(oracle: Oracle, bc: BlockContent, percentiles: openArray[float64]): ProcessedFees =
   result = ProcessedFees(
     baseFee: bc.header.baseFeePerGas.get(0.u256),
-    blobBaseFee: getBlobBaseFee(bc.header.excessBlobGas.get(0'u64)),
+    blobBaseFee: getBlobBaseFee(bc.header.excessBlobGas.get(0'u64), bc.header.targetBlobsPerBlock),
     nextBaseFee: calcBaseFee(oracle.com, bc),
-    nextBlobBaseFee: getBlobBaseFee(calcExcessBlobGas(bc.header)),
+    nextBlobBaseFee: getBlobBaseFee(calcExcessBlobGas(bc.header, Opt.none(uint64)), Opt.none(uint64)),
     gasUsedRatio: float64(bc.header.gasUsed) / float64(bc.header.gasLimit),
     blobGasUsedRatio: float64(bc.header.blobGasUsed.get(0'u64)) / float64(MAX_BLOB_GAS_PER_BLOCK)
   )

--- a/nimbus/rpc/rpc_utils.nim
+++ b/nimbus/rpc/rpc_utils.nim
@@ -212,6 +212,7 @@ proc populateBlockObject*(blockHash: eth_types.Hash32,
   result.blobGasUsed = w3Qty(header.blobGasUsed)
   result.excessBlobGas = w3Qty(header.excessBlobGas)
   result.requestsHash = header.requestsHash
+  result.targetBlobsPerBlock = header.targetBlobsPerBlock
 
 proc populateReceipt*(receipt: Receipt, gasUsed: GasInt, tx: Transaction,
                       txIndex: uint64, header: Header): ReceiptObject =

--- a/nimbus/rpc/rpc_utils.nim
+++ b/nimbus/rpc/rpc_utils.nim
@@ -212,7 +212,7 @@ proc populateBlockObject*(blockHash: eth_types.Hash32,
   result.blobGasUsed = w3Qty(header.blobGasUsed)
   result.excessBlobGas = w3Qty(header.excessBlobGas)
   result.requestsHash = header.requestsHash
-  result.targetBlobsPerBlock = header.targetBlobsPerBlock
+  result.targetBlobsPerBlock = w3Qty(header.targetBlobsPerBlock)
 
 proc populateReceipt*(receipt: Receipt, gasUsed: GasInt, tx: Transaction,
                       txIndex: uint64, header: Header): ReceiptObject =

--- a/nimbus/rpc/rpc_utils.nim
+++ b/nimbus/rpc/rpc_utils.nim
@@ -270,7 +270,7 @@ proc populateReceipt*(receipt: Receipt, gasUsed: GasInt, tx: Transaction,
 
   if tx.txType == TxEip4844:
     res.blobGasUsed = Opt.some(Quantity(tx.versionedHashes.len.uint64 * GAS_PER_BLOB.uint64))
-    res.blobGasPrice = Opt.some(getBlobBaseFee(header.excessBlobGas.get(0'u64)))
+    res.blobGasPrice = Opt.some(getBlobBaseFee(header.excessBlobGas.get(0'u64), header.targetBlobsPerBlock))
 
   return res
 

--- a/nimbus/rpc/server_api.nim
+++ b/nimbus/rpc/server_api.nim
@@ -659,7 +659,7 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, ctx: EthContext) =
     if header.excessBlobGas.isNone:
       raise newException(ValueError, "excessBlobGas missing from latest header")
     let blobBaseFee =
-      getBlobBaseFee(header.excessBlobGas.get) * header.blobGasUsed.get.u256
+      getBlobBaseFee(header.excessBlobGas.get, header.targetBlobsPerBlock) * header.blobGasUsed.get.u256
     if blobBaseFee > high(uint64).u256:
       raise newException(ValueError, "blobBaseFee is bigger than uint64.max")
     return w3Qty blobBaseFee.truncate(uint64)

--- a/nimbus/transaction/call_common.nim
+++ b/nimbus/transaction/call_common.nim
@@ -82,7 +82,7 @@ proc setupHost(call: CallParams): TransactionHost =
     origin         : call.origin.get(call.sender),
     gasPrice       : call.gasPrice,
     versionedHashes: call.versionedHashes,
-    blobBaseFee    : getBlobBaseFee(vmState.blockCtx.excessBlobGas),
+    blobBaseFee    : getBlobBaseFee(vmState.blockCtx.excessBlobGas, vmState.blockCtx.targetBlobsPerBlock),
   )
 
   var intrinsicGas: GasInt = 0
@@ -193,7 +193,7 @@ proc prepareToRunComputation(host: TransactionHost, call: CallParams) =
       # EIP-4844
       if fork >= FkCancun:
         let blobFee = calcDataFee(call.versionedHashes.len,
-          vmState.blockCtx.excessBlobGas)
+          vmState.blockCtx.excessBlobGas, vmState.blockCtx.targetBlobsPerBlock)
         db.subBalance(call.sender, blobFee)
 
 proc calculateAndPossiblyRefundGas(host: TransactionHost, call: CallParams): GasInt =

--- a/nimbus_verified_proxy/nimbus_verified_proxy.nim
+++ b/nimbus_verified_proxy/nimbus_verified_proxy.nim
@@ -146,6 +146,7 @@ proc run*(
                 executionPayload(payload.asEngineExecutionPayload()),
                 parentBeaconBlockRoot = Opt.none(Hash32),
                 requestsHash = Opt.none(Hash32),
+                targetBlobsPerBlock = Opt.none(Quantity)
               )
               blockCache.add(populateBlockObject(blk.header.rlpHash, blk, 0.u256, true))
             except RlpError as exc:

--- a/nimbus_verified_proxy/nimbus_verified_proxy.nim
+++ b/nimbus_verified_proxy/nimbus_verified_proxy.nim
@@ -146,7 +146,7 @@ proc run*(
                 executionPayload(payload.asEngineExecutionPayload()),
                 parentBeaconBlockRoot = Opt.none(Hash32),
                 requestsHash = Opt.none(Hash32),
-                targetBlobsPerBlock = Opt.none(Quantity)
+                targetBlobsPerBlock = Opt.none(Quantity),
               )
               blockCache.add(populateBlockObject(blk.header.rlpHash, blk, 0.u256, true))
             except RlpError as exc:

--- a/tests/engine_api/newPayloadV4_invalid_blockhash.json
+++ b/tests/engine_api/newPayloadV4_invalid_blockhash.json
@@ -2,7 +2,7 @@
     "payload": {
       "baseFeePerGas": "0x7",
       "blobGasUsed": "0x40000",
-      "blockHash": "0x187307d7dc9beb87af2a1d8340e9f17a3bbe4738963daeaf6d8e13b27b2d6a7f",
+      "blockHash": "0x9f410c54a21b1ca10bf812e81fba9e84eaef9ae457de97322c5eb381140a2fe3",
       "blockNumber": "0x94b2",
       "excessBlobGas": "0x0",
       "extraData": "0xd883010e0c846765746888676f312e32332e32856c696e7578",
@@ -38,5 +38,6 @@
       "0x",
       "0x",
       "0x"
-    ]
+    ],
+    "targetBlobsPerBlock": "0x1"
 }

--- a/tools/t8n/t8n_debug.nim
+++ b/tools/t8n/t8n_debug.nim
@@ -71,6 +71,7 @@ type
     parentBlobGasUsed*: Opt[Quantity]
     parentExcessBlobGas*: Opt[Quantity]
     parentBeaconBlockRoot*: Opt[Hash32]
+    currentTargetBlobsPerBlock*: Opt[Quantity]
 
   BCTInput* = object
     alloc: JsonString
@@ -140,6 +141,7 @@ proc toBctEnv(parentBlock, currentBlock: Block, hashes: BCTHashes): BCTEnv =
   result.parentExcessBlobGas = w3Qty(parent.excessBlobGas)
   result.withdrawals         = w3Withdrawals(currentBlock.withdrawals)
   result.blockHashes         = hashes
+  result.currentTargetBlobsPerBlock = w3Qty(current.targetBlobsPerBlock)
 
 func toInput(prevAlloc: JsonString,
              prevBlock, currBlock: Block,

--- a/tools/t8n/types.nim
+++ b/tools/t8n/types.nim
@@ -53,6 +53,7 @@ type
     parentExcessBlobGas*: Opt[uint64]
     parentBeaconBlockRoot*: Opt[Hash32]
     depositContractAddress*: Opt[Address]
+    currentTargetBlobsPerBlock*: Opt[uint64]
 
   TxObject* = object
     `type`*: Opt[uint64]


### PR DESCRIPTION
TODOs:
- [x] How `maximumBlobCount` should be used in block creation?
- [x] Where `targetBlobCount` come from when converting to `Header`. From `ExecutionPayloadV4` or from `engine_newPayloadV4`'s param?
- [x] What about `engine_getPayloadV4`? should the response return `ExecutionPayloadV4` or additional `targetBlobCount` field?
- [x] Difference between EIP-7742 spec `targetBlobCount` of block header, and consensus spec `targetBlobsPerBlock` of `PayloadAttributesV4`
- [ ] emvstate: add targetBlobsPerBlock
- [ ] Upgrade on nimbus-eth2 side

fix #2753