### PR TITLE
Use stateRoot/storageRoot more consistently

### DIFF
--- a/hive_integration/nodocker/pyspec/test_env.nim
+++ b/hive_integration/nodocker/pyspec/test_env.nim
@@ -40,12 +40,12 @@ proc setupELClient*(conf: ChainConfig, node: JsonNode): TestEnv =
     memDB = newCoreDbRef DefaultDbMemory
     genesisHeader = node.genesisHeader
     com = CommonRef.new(memDB, conf)
-    stateDB = LedgerRef.init(memDB, EMPTY_ROOT_HASH)
+    stateDB = LedgerRef.init(memDB)
     chain = newForkedChain(com, genesisHeader)
 
   setupStateDB(node["pre"], stateDB)
   stateDB.persist()
-  doAssert stateDB.rootHash == genesisHeader.stateRoot
+  doAssert stateDB.getStateRoot == genesisHeader.stateRoot
 
   doAssert com.db.persistHeader(genesisHeader,
               com.proofOfStake(genesisHeader))

--- a/nimbus/common/genesis.nim
+++ b/nimbus/common/genesis.nim
@@ -32,7 +32,7 @@ proc toGenesisHeader*(
   ##
   ## The function returns the `Genesis` block header.
   ##
-  let ac = LedgerRef.init(db, EMPTY_ROOT_HASH)
+  let ac = LedgerRef.init(db)
 
   for address, account in g.alloc:
     ac.setNonce(address, account.nonce)
@@ -52,7 +52,7 @@ proc toGenesisHeader*(
     difficulty: g.difficulty,
     mixHash: g.mixHash,
     coinbase: g.coinbase,
-    stateRoot: ac.state(),
+    stateRoot: ac.getStateRoot(),
     parentHash: GENESIS_PARENT_HASH,
     transactionsRoot: EMPTY_ROOT_HASH,
     receiptsRoot: EMPTY_ROOT_HASH,

--- a/nimbus/core/executor/executor_helpers.nim
+++ b/nimbus/core/executor/executor_helpers.nim
@@ -53,7 +53,7 @@ proc makeReceipt*(vmState: BaseVMState; txType: TxType): Receipt =
     rec.status = vmState.status
   else:
     rec.isHash = true
-    rec.hash   = vmState.stateDB.rootHash
+    rec.hash   = vmState.stateDB.getStateRoot()
     # we set the status for the t8n output consistency
     rec.status = vmState.status
 

--- a/nimbus/core/executor/process_block.nim
+++ b/nimbus/core/executor/process_block.nim
@@ -163,13 +163,13 @@ proc procBlkEpilogue(
     consolidationReqs = processDequeueConsolidationRequests(vmState)
 
   if not skipValidation:
-    let stateDB = vmState.stateDB
-    if header.stateRoot != stateDB.rootHash:
+    let stateRoot = vmState.stateDB.getStateRoot()
+    if header.stateRoot != stateRoot:
       # TODO replace logging with better error
       debug "wrong state root in block",
         blockNumber = header.number,
         expected = header.stateRoot,
-        actual = stateDB.rootHash,
+        actual = stateRoot,
         arrivedFrom = vmState.com.db.getCanonicalHead().stateRoot
       return err("stateRoot mismatch")
 

--- a/nimbus/core/tx_pool/tx_packer.nim
+++ b/nimbus/core/tx_pool/tx_packer.nim
@@ -144,8 +144,8 @@ proc runTxCommit(pst: var TxPacker; item: TxItemRef; gasBurned: GasInt)
   pst.blockValue += reward
 
   # Save accounts via persist() is not needed unless the fork is smaller
-  # than `FkByzantium` in which case, the `rootHash()` function is called
-  # by `makeReceipt()`. As the `rootHash()` function asserts unconditionally
+  # than `FkByzantium` in which case, the `getStateRoot()` function is called
+  # by `makeReceipt()`. As the `getStateRoot()` function asserts unconditionally
   # that the account cache has been saved, the `persist()` call is
   # obligatory here.
   if vmState.fork < FkByzantium:
@@ -270,7 +270,7 @@ proc vmExecCommit(pst: var TxPacker): Result[void, string] =
     pst.consolidationReqs = processDequeueConsolidationRequests(vmState)
     pst.depositReqs = ?parseDepositLogs(vmState.allLogs)
 
-  # Finish up, then vmState.stateDB.rootHash may be accessed
+  # Finish up, then vmState.stateDB.stateRoot may be accessed
   stateDB.persist(clearEmptyAccount = vmState.fork >= FkSpurious)
 
   # Update flexi-array, set proper length
@@ -279,7 +279,7 @@ proc vmExecCommit(pst: var TxPacker): Result[void, string] =
 
   pst.receiptsRoot = vmState.receipts.calcReceiptsRoot
   pst.logsBloom = vmState.receipts.createBloom
-  pst.stateRoot = vmState.stateDB.rootHash
+  pst.stateRoot = vmState.stateDB.getStateRoot()
   ok()
 
 # ------------------------------------------------------------------------------

--- a/nimbus/db/aristo/aristo_api.nim
+++ b/nimbus/db/aristo/aristo_api.nim
@@ -114,7 +114,7 @@ type
         {.noRaise.}
       ## Fetch an account record from the database indexed by `accPath`.
 
-  AristoApiFetchAccountStateFn* =
+  AristoApiFetchAccountStateRootFn* =
     proc(db: AristoDbRef;
          updateOk: bool;
         ): Result[Hash32,AristoError]
@@ -149,7 +149,7 @@ type
       ## For a storage tree related to account `accPath`, fetch the data
       ## record from the database indexed by `stoPath`.
 
-  AristoApiFetchStorageStateFn* =
+  AristoApiFetchStorageRootFn* =
     proc(db: AristoDbRef;
          accPath: Hash32;
          updateOk: bool;
@@ -496,11 +496,11 @@ type
     fetchLastSavedState*: AristoApiFetchLastSavedStateFn
 
     fetchAccountRecord*: AristoApiFetchAccountRecordFn
-    fetchAccountState*: AristoApiFetchAccountStateFn
+    fetchAccountStateRoot*: AristoApiFetchAccountStateRootFn
     fetchGenericData*: AristoApiFetchGenericDataFn
     fetchGenericState*: AristoApiFetchGenericStateFn
     fetchStorageData*: AristoApiFetchStorageDataFn
-    fetchStorageState*: AristoApiFetchStorageStateFn
+    fetchStorageRoot*: AristoApiFetchStorageRootFn
 
     findTx*: AristoApiFindTxFn
     finish*: AristoApiFinishFn
@@ -550,11 +550,11 @@ type
     AristoApiProfFetchLastSavedStateFn  = "fetchLastSavedState"
 
     AristoApiProfFetchAccountRecordFn   = "fetchAccountRecord"
-    AristoApiProfFetchAccountStateFn    = "fetchAccountState"
+    AristoApiProfFetchAccountStateRootFn = "fetchAccountStateRoot"
     AristoApiProfFetchGenericDataFn     = "fetchGenericData"
     AristoApiProfFetchGenericStateFn    = "fetchGenericState"
     AristoApiProfFetchStorageDataFn     = "fetchStorageData"
-    AristoApiProfFetchStorageStateFn    = "fetchStorageState"
+    AristoApiProfFetchStorageRootFn     = "fetchStorageRoot"
 
     AristoApiProfFindTxFn               = "findTx"
     AristoApiProfFinishFn               = "finish"
@@ -622,11 +622,11 @@ when AutoValidateApiHooks:
     doAssert not api.fetchLastSavedState.isNil
 
     doAssert not api.fetchAccountRecord.isNil
-    doAssert not api.fetchAccountState.isNil
+    doAssert not api.fetchAccountStateRoot.isNil
     doAssert not api.fetchGenericData.isNil
     doAssert not api.fetchGenericState.isNil
     doAssert not api.fetchStorageData.isNil
-    doAssert not api.fetchStorageState.isNil
+    doAssert not api.fetchStorageRoot.isNil
 
     doAssert not api.findTx.isNil
     doAssert not api.finish.isNil
@@ -698,11 +698,11 @@ func init*(api: var AristoApiObj) =
   api.fetchLastSavedState = fetchLastSavedState
 
   api.fetchAccountRecord = fetchAccountRecord
-  api.fetchAccountState = fetchAccountState
+  api.fetchAccountStateRoot = fetchAccountStateRoot
   api.fetchGenericData = fetchGenericData
   api.fetchGenericState = fetchGenericState
   api.fetchStorageData = fetchStorageData
-  api.fetchStorageState = fetchStorageState
+  api.fetchStorageRoot = fetchStorageRoot
 
   api.findTx = findTx
   api.finish = finish
@@ -756,11 +756,11 @@ func dup*(api: AristoApiRef): AristoApiRef =
 
     fetchLastSavedState:  api.fetchLastSavedState,
     fetchAccountRecord:   api.fetchAccountRecord,
-    fetchAccountState:    api.fetchAccountState,
+    fetchAccountStateRoot: api.fetchAccountStateRoot,
     fetchGenericData:     api.fetchGenericData,
     fetchGenericState:    api.fetchGenericState,
     fetchStorageData:     api.fetchStorageData,
-    fetchStorageState:    api.fetchStorageState,
+    fetchStorageRoot:     api.fetchStorageRoot,
 
     findTx:               api.findTx,
     finish:               api.finish,
@@ -865,10 +865,10 @@ func init*(
       AristoApiProfFetchAccountRecordFn.profileRunner:
         result = api.fetchAccountRecord(a, b)
 
-  profApi.fetchAccountState =
+  profApi.fetchAccountStateRoot =
     proc(a: AristoDbRef; b: bool): auto =
-      AristoApiProfFetchAccountStateFn.profileRunner:
-        result = api.fetchAccountState(a, b)
+      AristoApiProfFetchAccountStateRootFn.profileRunner:
+        result = api.fetchAccountStateRoot(a, b)
 
   profApi.fetchGenericData =
     proc(a: AristoDbRef; b: VertexID; c: openArray[byte]): auto =
@@ -885,10 +885,10 @@ func init*(
       AristoApiProfFetchStorageDataFn.profileRunner:
         result = api.fetchStorageData(a, b, stoPath)
 
-  profApi.fetchStorageState =
+  profApi.fetchStorageRoot =
     proc(a: AristoDbRef; b: Hash32; c: bool): auto =
-      AristoApiProfFetchStorageStateFn.profileRunner:
-        result = api.fetchStorageState(a, b, c)
+      AristoApiProfFetchStorageRootFn.profileRunner:
+        result = api.fetchStorageRoot(a, b, c)
 
   profApi.findTx =
     proc(a: AristoDbRef; b: RootedVertexID; c: HashKey): auto =

--- a/nimbus/db/aristo/aristo_fetch.nim
+++ b/nimbus/db/aristo/aristo_fetch.nim
@@ -244,7 +244,7 @@ proc fetchAccountRecord*(
 
   ok leafVtx.lData.account
 
-proc fetchAccountState*(
+proc fetchAccountStateRoot*(
     db: AristoDbRef;
     updateOk: bool;
       ): Result[Hash32,AristoError] =
@@ -302,7 +302,7 @@ proc fetchStorageData*(
   ##
   db.retrieveStoragePayload(accPath, stoPath)
 
-proc fetchStorageState*(
+proc fetchStorageRoot*(
     db: AristoDbRef;
     accPath: Hash32;
     updateOk: bool;

--- a/nimbus/db/core_db/backend/aristo_trace.nim
+++ b/nimbus/db/core_db/backend/aristo_trace.nim
@@ -261,7 +261,7 @@ proc jLogger(
 func to(w: AristoApiProfNames; T: type TracePfx): T =
   case w:
   of AristoApiProfFetchAccountRecordFn,
-     AristoApiProfFetchAccountStateFn,
+     AristoApiProfFetchAccountStateRootFn,
      AristoApiProfDeleteAccountRecordFn,
      AristoApiProfMergeAccountRecordFn:
     return TrpAccounts
@@ -272,7 +272,7 @@ func to(w: AristoApiProfNames; T: type TracePfx): T =
      AristoApiProfMergeGenericDataFn:
     return TrpGeneric
   of AristoApiProfFetchStorageDataFn,
-     AristoApiProfFetchStorageStateFn,
+     AristoApiProfFetchStorageRootFn,
      AristoApiProfDeleteStorageDataFn,
      AristoApiProfDeleteStorageTreeFn,
      AristoApiProfMergeStorageDataFn:
@@ -490,17 +490,17 @@ proc ariTraceRecorder(tr: TraceRecorderRef) =
         debug logTxt $info, level, accPath, accRec
       ok accRec
 
-  tracerApi.fetchAccountState =
+  tracerApi.fetchAccountStateRoot =
     proc(mpt: AristoDbRef;
          updateOk: bool;
         ): Result[Hash32,AristoError] =
-      const info = AristoApiProfFetchAccountStateFn
+      const info = AristoApiProfFetchAccountStateRootFn
 
       when CoreDbNoisyCaptJournal:
         let level = tr.topLevel()
 
       # Find entry on DB
-      let state = api.fetchAccountState(mpt, updateOk).valueOr:
+      let state = api.fetchAccountStateRoot(mpt, updateOk).valueOr:
         when CoreDbNoisyCaptJournal:
           debug logTxt $info, level, updateOk, error
         tr.jLogger logRecord(info, TrqFind, error)
@@ -546,7 +546,7 @@ proc ariTraceRecorder(tr: TraceRecorderRef) =
         let level = tr.topLevel()
 
       # Find entry on DB
-      let state = api.fetchAccountState(mpt, updateOk).valueOr:
+      let state = api.fetchAccountStateRoot(mpt, updateOk).valueOr:
         when CoreDbNoisyCaptJournal:
           debug logTxt $info, level, root, updateOk, error
         tr.jLogger(root, logRecord(info, TrqFind, error))
@@ -581,18 +581,18 @@ proc ariTraceRecorder(tr: TraceRecorderRef) =
         debug logTxt $info, level, accPath, stoPath, stoData
       ok stoData
 
-  tracerApi.fetchStorageState =
+  tracerApi.fetchStorageRoot =
     proc(mpt: AristoDbRef;
          accPath: Hash32;
          updateOk: bool;
         ): Result[Hash32,AristoError] =
-      const info = AristoApiProfFetchStorageStateFn
+      const info = AristoApiProfFetchStorageRootFn
 
       when CoreDbNoisyCaptJournal:
         let level = tr.topLevel()
 
       # Find entry on DB
-      let state = api.fetchStorageState(mpt, accPath, updateOk).valueOr:
+      let state = api.fetchStorageRoot(mpt, accPath, updateOk).valueOr:
         when CoreDbNoisyCaptJournal:
           debug logTxt $info, level, accPath, updateOk, error
         tr.jLogger(accPath, logRecord(info, TrqFind, error))

--- a/nimbus/db/core_db/base.nim
+++ b/nimbus/db/core_db/base.nim
@@ -655,7 +655,7 @@ proc hasPath*(
   acc.ifTrackNewApi:
     debug logTxt, api, elapsed, accPath=($$accPath), result
 
-proc state*(acc: CoreDbAccRef; updateOk = false): CoreDbRc[Hash32] =
+proc stateRoot*(acc: CoreDbAccRef; updateOk = false): CoreDbRc[Hash32] =
   ## This function retrieves the Merkle state hash of the accounts
   ## column (if available.)
   ##
@@ -664,7 +664,7 @@ proc state*(acc: CoreDbAccRef; updateOk = false): CoreDbRc[Hash32] =
   ##
   acc.setTrackNewApi AccStateFn
   result = block:
-    let rc = acc.call(fetchAccountState, acc.mpt, updateOk)
+    let rc = acc.call(fetchAccountStateRoot, acc.mpt, updateOk)
     if rc.isOk:
       ok(rc.value)
     else:
@@ -786,7 +786,7 @@ proc slotState*(
   ##
   acc.setTrackNewApi AccSlotStateFn
   result = block:
-    let rc = acc.call(fetchStorageState, acc.mpt, accPath, updateOk)
+    let rc = acc.call(fetchStorageRoot, acc.mpt, accPath, updateOk)
     if rc.isOk:
       ok(rc.value)
     else:
@@ -839,7 +839,7 @@ proc recast*(
   ## hash (see `slotState()` above) is currently unavailable.
   ##
   acc.setTrackNewApi AccRecastFn
-  let rc = acc.call(fetchStorageState, acc.mpt, accPath, updateOk)
+  let rc = acc.call(fetchStorageRoot, acc.mpt, accPath, updateOk)
   result = block:
     if rc.isOk:
       ok Account(

--- a/nimbus/db/ledger.nim
+++ b/nimbus/db/ledger.nim
@@ -28,10 +28,8 @@ export AccountsLedgerRef, base, base_config, base_iterators
 # Public constructor
 # ------------------------------------------------------------------------------
 
-proc init*(
-    _: type LedgerRef, db: CoreDbRef, root: Hash32, storeSlotHash: bool = false
-): LedgerRef =
-  LedgerRef(ac: AccountsLedgerRef.init(db, root, storeSlotHash)).bless(db)
+proc init*(_: type LedgerRef, db: CoreDbRef, storeSlotHash: bool = false): LedgerRef =
+  LedgerRef(ac: AccountsLedgerRef.init(db, storeSlotHash)).bless(db)
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/db/ledger/backend/accounts_ledger.nim
+++ b/nimbus/db/ledger/backend/accounts_ledger.nim
@@ -150,8 +150,7 @@ proc resetCoreDbAccount(ac: AccountsLedgerRef, acc: AccountRef) =
   acc.statement.codeHash = emptyEthAccount.codeHash
 
 # The AccountsLedgerRef is modeled after TrieDatabase for it's transaction style
-proc init*(x: typedesc[AccountsLedgerRef], db: CoreDbRef,
-           root: Hash32, storeSlotHash: bool): AccountsLedgerRef =
+proc init*(x: typedesc[AccountsLedgerRef], db: CoreDbRef, storeSlotHash: bool): AccountsLedgerRef =
   new result
   result.ledger = db.ctx.getAccounts()
   result.kvt = db.ctx.getKvt()
@@ -164,14 +163,13 @@ proc init*(x: typedesc[AccountsLedgerRef], db: CoreDbRef,
 proc init*(x: typedesc[AccountsLedgerRef], db: CoreDbRef): AccountsLedgerRef =
   init(x, db, EMPTY_ROOT_HASH)
 
-# Renamed `rootHash()` => `state()`
-proc state*(ac: AccountsLedgerRef): Hash32 =
+proc getStateRoot*(ac: AccountsLedgerRef): Hash32 =
   const info = "state(): "
   # make sure all savepoint already committed
   doAssert(ac.savePoint.parentSavepoint.isNil)
   # make sure all cache already committed
   doAssert(ac.isDirty == false)
-  ac.ledger.state(updateOk=true).valueOr:
+  ac.ledger.stateRoot(updateOk=true).valueOr:
     raiseAssert info & $$error
 
 proc isTopLevelClean*(ac: AccountsLedgerRef): bool =
@@ -897,7 +895,7 @@ proc getStorageProof*(ac: AccountsLedgerRef, address: Address, slots: openArray[
 
   storageProof
 
-proc state*(db: ReadOnlyStateDB): Hash32 {.borrow.}
+proc getStateRoot*(db: ReadOnlyStateDB): Hash32 {.borrow.}
 proc getCodeHash*(db: ReadOnlyStateDB, address: Address): Hash32 = getCodeHash(distinctBase db, address)
 proc getStorageRoot*(db: ReadOnlyStateDB, address: Address): Hash32 = getStorageRoot(distinctBase db, address)
 proc getBalance*(db: ReadOnlyStateDB, address: Address): UInt256 = getBalance(distinctBase db, address)

--- a/nimbus/db/ledger/base.nim
+++ b/nimbus/db/ledger/base.nim
@@ -274,9 +274,9 @@ proc setTransientStorage*(
   ldg.ac.setTransientStorage(eAddr, slot, val)
   ldg.ifTrackApi: debug apiTxt, api, elapsed, eAddr=($$eAddr), slot, val
 
-proc state*(ldg: LedgerRef): Hash32 =
+proc getStateRoot*(ldg: LedgerRef): Hash32 =
   ldg.beginTrackApi LdgStateFn
-  result = ldg.ac.state()
+  result = ldg.ac.getStateRoot()
   ldg.ifTrackApi: debug apiTxt, api, elapsed, result
 
 proc subBalance*(ldg: LedgerRef, eAddr: Address, delta: UInt256) =
@@ -288,9 +288,6 @@ proc getAccessList*(ldg: LedgerRef): AccessList =
   ldg.beginTrackApi LdgGetAccessListFn
   result = ldg.ac.getAccessList()
   ldg.ifTrackApi: debug apiTxt, api, elapsed
-
-proc rootHash*(ldg: LedgerRef): Hash32 =
-  ldg.state()
 
 proc getEthAccount*(ldg: LedgerRef, eAddr: Address): Account =
   ldg.beginTrackApi LdgGetAthAccountFn
@@ -307,7 +304,7 @@ proc getStorageProof*(ldg: LedgerRef, eAddr: Address, slots: openArray[UInt256])
 # Public virtual read-only methods
 # ------------------------------------------------------------------------------
 
-proc rootHash*(db: ReadOnlyStateDB): Hash32 {.borrow.}
+proc getStateRoot*(db: ReadOnlyStateDB): Hash32 {.borrow.}
 proc getCodeHash*(db: ReadOnlyStateDB, address: Address): Hash32 = getCodeHash(distinctBase db, address)
 proc getStorageRoot*(db: ReadOnlyStateDB, address: Address): Hash32 = getStorageRoot(distinctBase db, address)
 proc getBalance*(db: ReadOnlyStateDB, address: Address): UInt256 = getBalance(distinctBase db, address)

--- a/nimbus/db/ledger/base/api_tracking.nim
+++ b/nimbus/db/ledger/base/api_tracking.nim
@@ -61,7 +61,6 @@ type
     LdgPersistFn               = "persist"
     LdgRipemdSpecialFn         = "ripemdSpecial"
     LdgRollbackFn              = "rollback"
-    LdgRootHashFn              = "rootHash"
     LdgSafeDisposeFn           = "safeDispose"
     LdgSelfDestruct6780Fn      = "selfDestruct6780"
     LdgSelfDestructFn          = "selfDestruct"

--- a/nimbus/evm/state.nim
+++ b/nimbus/evm/state.nim
@@ -84,7 +84,7 @@ proc new*(
   ## with the `parent` block header.
   new result
   result.init(
-    ac       = LedgerRef.init(com.db, parent.stateRoot, storeSlotHash),
+    ac       = LedgerRef.init(com.db, storeSlotHash),
     parent   = parent,
     blockCtx = blockCtx,
     com      = com,
@@ -96,12 +96,12 @@ proc reinit*(self:     BaseVMState;     ## Object descriptor
              linear: bool
              ): bool =
   ## Re-initialise state descriptor. The `LedgerRef` database is
-  ## re-initilaise only if its `rootHash` doe not point to `parent.stateRoot`,
+  ## re-initilaise only if its `getStateRoot()` doe not point to `parent.stateRoot`,
   ## already. Accumulated state data are reset. When linear, we assume that
   ## the state recently processed the parent block.
   ##
   ## This function returns `true` unless the `LedgerRef` database could be
-  ## queries about its `rootHash`, i.e. `isTopLevelClean` evaluated `true`. If
+  ## queries about its `getStateRoot()`, i.e. `isTopLevelClean` evaluated `true`. If
   ## this function returns `false`, the function argument `self` is left
   ## untouched.
   if self.stateDB.isTopLevelClean:
@@ -109,8 +109,8 @@ proc reinit*(self:     BaseVMState;     ## Object descriptor
       tracer = self.tracer
       com    = self.com
       db     = com.db
-      ac     = if linear or self.stateDB.rootHash == parent.stateRoot: self.stateDB
-               else: LedgerRef.init(db, parent.stateRoot, self.stateDB.ac.storeSlotHash)
+      ac     = if linear or self.stateDB.getStateRoot() == parent.stateRoot: self.stateDB
+               else: LedgerRef.init(db, self.stateDB.ac.storeSlotHash)
       flags  = self.flags
     self[].reset
     self.init(
@@ -168,7 +168,7 @@ proc init*(
   ## It requires the `header` argument properly initalised so that for PoA
   ## networks, the miner address is retrievable via `ecRecover()`.
   self.init(
-    ac       = LedgerRef.init(com.db, parent.stateRoot, storeSlotHash),
+    ac       = LedgerRef.init(com.db, storeSlotHash),
     parent   = parent,
     blockCtx = com.blockCtx(header),
     com      = com,

--- a/nimbus/graphql/ethapi.nim
+++ b/nimbus/graphql/ethapi.nim
@@ -11,7 +11,7 @@ import
   std/[strutils],
   stew/byteutils, stint,
   results,
-  eth/common/transaction_utils, 
+  eth/common/transaction_utils,
   chronos,
   graphql, graphql/graphql as context,
   graphql/common/types, graphql/httpserver,
@@ -23,7 +23,7 @@ import
   ../core/[tx_pool, tx_pool/tx_item],
   ../common/common,
   web3/eth_api_types
- 
+
 from eth/p2p import EthereumNode
 export httpserver
 
@@ -146,10 +146,11 @@ proc wdNode(ctx: GraphqlContextRef, wd: Withdrawal): Node =
     wd: wd
   )
 
-proc getStateDB(com: CommonRef, header: Header): LedgerRef =
+proc getStateDB(com: CommonRef, header: Header): LedgerRef  {.deprecated: "LedgerRef does not support loading a particular state".} =
   ## Retrieves the account db from canonical head
   ## we don't use accounst_cache here because it's read only operations
-  LedgerRef.init(com.db, header.stateRoot)
+  # TODO the ledger initialized here refers to the base, not the given header!
+  LedgerRef.init(com.db)
 
 proc getBlockByNumber(ctx: GraphqlContextRef, number: Node): RespResult =
   try:

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -77,7 +77,7 @@ proc setupEthRpc*(
   proc getStateDB(header:Header): LedgerRef =
     ## Retrieves the account db from canonical head
     # we don't use accounst_cache here because it's only read operations
-    LedgerRef.init(chainDB, header.stateRoot)
+    LedgerRef.init(chainDB)
 
   proc stateDBFromTag(quantityTag: BlockTag, readOnly = true): LedgerRef
       {.gcsafe, raises: [CatchableError].} =

--- a/nimbus/rpc/server_api.nim
+++ b/nimbus/rpc/server_api.nim
@@ -61,7 +61,7 @@ proc headerFromTag(api: ServerAPIRef, blockTag: Opt[BlockTag]): Result[Header, s
 proc ledgerFromTag(api: ServerAPIRef, blockTag: BlockTag): Result[LedgerRef, string] =
   let header = ?api.headerFromTag(blockTag)
   if api.chain.stateReady(header):
-    ok(LedgerRef.init(api.com.db, header.stateRoot))
+    ok(LedgerRef.init(api.com.db))
   else:
     # TODO: Replay state?
     err("Block state not ready")

--- a/nimbus/utils/debug.nim
+++ b/nimbus/utils/debug.nim
@@ -76,7 +76,7 @@ proc debugAccounts*(vmState: BaseVMState): string =
     accountList.add address
 
   let res = %{
-    "rootHash": %($vmState.readOnlyStateDB.rootHash),
+    "stateRoot": %($vmState.readOnlyStateDB.getStateRoot()),
     "accounts": %dumpAccounts(vmState.stateDB, accountList),
   }
 
@@ -94,7 +94,7 @@ proc debug*(vms: BaseVMState): string =
   result.add "excessBlobGas    : " & $vms.blockCtx.excessBlobGas & "\n"
   result.add "flags            : " & $vms.flags               & "\n"
   result.add "receipts.len     : " & $vms.receipts.len        & "\n"
-  result.add "stateDB.root     : " & $vms.stateDB.rootHash    & "\n"
+  result.add "stateDB.root     : " & $vms.stateDB.getStateRoot() & "\n"
   result.add "cumulativeGasUsed: " & $vms.cumulativeGasUsed   & "\n"
   result.add "tx.origin        : " & $vms.txCtx.origin        & "\n"
   result.add "tx.gasPrice      : " & $vms.txCtx.gasPrice      & "\n"

--- a/nimbus/utils/state_dump.nim
+++ b/nimbus/utils/state_dump.nim
@@ -87,7 +87,7 @@ proc dumpAccounts*(db: LedgerRef): Table[Address, DumpAccount] =
 
 proc dumpState*(db: LedgerRef): StateDump =
   StateDump(
-    root: db.rootHash,
+    root: db.getStateRoot(),
     accounts: dumpAccounts(db)
   )
 

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -59,7 +59,7 @@ proc parseEnv(node: JsonNode): TestEnv =
   result.pre = node["pre"]
 
 proc rootExists(db: CoreDbRef; root: Hash32): bool =
-  let state = db.ctx.getAccounts().state(updateOk=true).valueOr:
+  let state = db.ctx.getAccounts().stateRoot(updateOk=true).valueOr:
     return false
   state == root
 
@@ -67,7 +67,7 @@ proc executeCase(node: JsonNode): bool =
   let
     env     = parseEnv(node)
     memDB   = newCoreDbRef DefaultDbMemory
-    stateDB = LedgerRef.init(memDB, EMPTY_ROOT_HASH)
+    stateDB = LedgerRef.init(memDB)
     config  = getChainConfig(env.network)
     com     = CommonRef.new(memDB, config)
 

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -52,7 +52,7 @@ proc makeBlk(com: CommonRef, number: BlockNumber, parentBlk: Block): Block =
       amount: 1,
     )
 
-  let ledger = LedgerRef.init(com.db, parent.stateRoot)
+  let ledger = LedgerRef.init(com.db)
   for wd in wds:
     ledger.addBalance(wd.address, wd.weiAmount)
 
@@ -69,7 +69,7 @@ proc makeBlk(com: CommonRef, number: BlockNumber, parentBlk: Block): Block =
     difficulty : 0.u256,
     timestamp  : parent.timestamp + 1,
     gasLimit   : parent.gasLimit,
-    stateRoot  : ledger.state,
+    stateRoot  : ledger.getStateRoot(),
     transactionsRoot     : parent.txRoot,
     baseFeePerGas  : parent.baseFeePerGas,
     receiptsRoot   : parent.receiptsRoot,

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -121,7 +121,7 @@ proc testFixtureIndexes(ctx: var TestCtx, testStatusIMPL: var TestStatus) =
   coinbaseStateClearing(vmState, miner)
 
   block post:
-    let obtainedHash = vmState.readOnlyStateDB.rootHash
+    let obtainedHash = vmState.readOnlyStateDB.getStateRoot()
     check obtainedHash == ctx.expectedHash
     let logEntries = vmState.getAndClearLogEntries()
     let actualLogsHash = rlpHash(logEntries)

--- a/tests/test_getproof_json.nim
+++ b/tests/test_getproof_json.nim
@@ -69,7 +69,7 @@ proc setupStateDB(genAccounts: GenesisAlloc, stateDB: LedgerRef): Hash32 =
 
   stateDB.persist()
 
-  stateDB.rootHash
+  stateDB.getStateRoot()
 
 proc checkProofsForExistingLeafs(
     genAccounts: GenesisAlloc,
@@ -129,9 +129,9 @@ proc getProofJsonMain*() =
         let
           accounts = getGenesisAlloc("tests" / "customgenesis" / file)
           coreDb = newCoreDbRef(DefaultDbMemory)
-          accountsCache = LedgerRef.init(coreDb, emptyRlpHash)
+          accountsCache = LedgerRef.init(coreDb)
           stateRootHash = setupStateDB(accounts, accountsCache)
-          accountDb = LedgerRef.init(coreDb, stateRootHash)
+          accountDb = LedgerRef.init(coreDb)
 
         checkProofsForExistingLeafs(accounts, accountDb, stateRootHash)
 
@@ -141,9 +141,9 @@ proc getProofJsonMain*() =
         let
           accounts = getGenesisAlloc("tests" / "customgenesis" / file)
           coreDb = newCoreDbRef(DefaultDbMemory)
-          accountsCache = LedgerRef.init(coreDb, emptyRlpHash)
+          accountsCache = LedgerRef.init(coreDb)
           stateRootHash = setupStateDB(accounts, accountsCache)
-          accountDb = LedgerRef.init(coreDb, stateRootHash)
+          accountDb = LedgerRef.init(coreDb)
 
         checkProofsForMissingLeafs(accounts, accountDb, stateRootHash)
 

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -145,8 +145,8 @@ proc importBlock(env: TestEnv; blk: Block) =
     raiseAssert "persistBlocks() failed at block #" &
       $blk.header.number & " msg: " & error
 
-proc getLedger(com: CommonRef; header: Header): LedgerRef =
-  LedgerRef.init(com.db, header.stateRoot)
+proc getLedger(com: CommonRef): LedgerRef =
+  LedgerRef.init(com.db)
 
 func getRecipient(tx: Transaction): Address =
   tx.to.expect("transaction have no recipient")
@@ -352,7 +352,7 @@ proc runLedgerTransactionTests(noisy = true) =
       for n in env.txi:
         let dbTx = env.xdb.ctx.newTransaction()
         defer: dbTx.dispose()
-        let ledger = env.com.getLedger(head)
+        let ledger = env.com.getLedger()
         env.runTrial2ok(ledger, n)
 
     test &"Run {env.txi.len} three-step trials with rollback":
@@ -360,7 +360,7 @@ proc runLedgerTransactionTests(noisy = true) =
       for n in env.txi:
         let dbTx = env.xdb.ctx.newTransaction()
         defer: dbTx.dispose()
-        let ledger = env.com.getLedger(head)
+        let ledger = env.com.getLedger()
         env.runTrial3(ledger, n, rollback = true)
 
     test &"Run {env.txi.len} three-step trials with extra db frame rollback" &
@@ -369,7 +369,7 @@ proc runLedgerTransactionTests(noisy = true) =
       for n in env.txi:
         let dbTx = env.xdb.ctx.newTransaction()
         defer: dbTx.dispose()
-        let ledger = env.com.getLedger(head)
+        let ledger = env.com.getLedger()
         env.runTrial3Survive(ledger, n, noisy)
 
     test &"Run {env.txi.len} tree-step trials without rollback":
@@ -377,7 +377,7 @@ proc runLedgerTransactionTests(noisy = true) =
       for n in env.txi:
         let dbTx = env.xdb.ctx.newTransaction()
         defer: dbTx.dispose()
-        let ledger = env.com.getLedger(head)
+        let ledger = env.com.getLedger()
         env.runTrial3(ledger, n, rollback = false)
 
     test &"Run {env.txi.len} four-step trials with rollback and db frames":
@@ -385,7 +385,7 @@ proc runLedgerTransactionTests(noisy = true) =
       for n in env.txi:
         let dbTx = env.xdb.ctx.newTransaction()
         defer: dbTx.dispose()
-        let ledger = env.com.getLedger(head)
+        let ledger = env.com.getLedger()
         env.runTrial4(ledger, n, rollback = true)
 
 proc runLedgerBasicOperationsTests() =
@@ -395,10 +395,10 @@ proc runLedgerBasicOperationsTests() =
 
       var
         memDB = newCoreDbRef DefaultDbMemory
-        stateDB {.used.} = LedgerRef.init(memDB, EMPTY_ROOT_HASH)
+        stateDB {.used.} = LedgerRef.init(memDB)
         address {.used.} = address"0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6"
         code {.used.} = hexToSeqByte("0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6")
-        rootHash {.used.} : Hash32
+        stateRoot {.used.} : Hash32
 
     test "accountExists and isDeadAccount":
       check stateDB.accountExists(address) == false
@@ -452,7 +452,7 @@ proc runLedgerBasicOperationsTests() =
       check y.originalStorage.len == 3
 
     test "Ledger various operations":
-      var ac = LedgerRef.init(memDB, EMPTY_ROOT_HASH)
+      var ac = LedgerRef.init(memDB)
       var addr1 = initAddr(1)
 
       check ac.isDeadAccount(addr1) == true
@@ -482,17 +482,17 @@ proc runLedgerBasicOperationsTests() =
       check ac.getCodeSize(addr1) == code.len
 
       ac.persist()
-      rootHash = ac.rootHash
+      stateRoot = ac.getStateRoot()
 
-      var db = LedgerRef.init(memDB, EMPTY_ROOT_HASH)
+      var db = LedgerRef.init(memDB)
       db.setBalance(addr1, 1100.u256)
       db.setNonce(addr1, 2)
       db.setCode(addr1, code)
       db.setStorage(addr1, 1.u256, 10.u256)
-      check rootHash == db.rootHash
+      check stateRoot == db.getStateRoot()
 
       # Ledger readonly operations using previous hash
-      var ac2 = LedgerRef.init(memDB, rootHash)
+      var ac2 = LedgerRef.init(memDB)
       var addr2 = initAddr(2)
 
       check ac2.getCodeHash(addr2) == emptyAcc.codeHash
@@ -509,10 +509,10 @@ proc runLedgerBasicOperationsTests() =
       ac2.persist()
       # readonly operations should not modify
       # state trie at all
-      check ac2.rootHash == rootHash
+      check ac2.getStateRoot() == stateRoot
 
     test "Ledger code retrieval after persist called":
-      var ac = LedgerRef.init(memDB, EMPTY_ROOT_HASH)
+      var ac = LedgerRef.init(memDB)
       var addr2 = initAddr(2)
       ac.setCode(addr2, code)
       ac.persist()
@@ -545,7 +545,7 @@ proc runLedgerBasicOperationsTests() =
       proc accessList(ac: LedgerRef, address, slot: int) {.inline.} =
         ac.accessList(address.initAddr, slot.u256)
 
-      var ac = LedgerRef.init(memDB, EMPTY_ROOT_HASH)
+      var ac = LedgerRef.init(memDB)
 
       ac.accessList(0xaa)
       ac.accessList(0xbb, 0x01)
@@ -587,7 +587,7 @@ proc runLedgerBasicOperationsTests() =
       check ac.verifySlots(0xdd, 0x04)
 
     test "transient storage operations":
-      var ac = LedgerRef.init(memDB, EMPTY_ROOT_HASH)
+      var ac = LedgerRef.init(memDB)
 
       proc tStore(ac: LedgerRef, address, slot, val: int) =
         ac.setTransientStorage(address.initAddr, slot.u256, val.u256)
@@ -654,7 +654,7 @@ proc runLedgerBasicOperationsTests() =
 
     test "ledger contractCollision":
       # use previous hash
-      var ac = LedgerRef.init(memDB, EMPTY_ROOT_HASH)
+      var ac = LedgerRef.init(memDB)
       let addr2 = initAddr(2)
       check ac.contractCollision(addr2) == false
 
@@ -675,7 +675,7 @@ proc runLedgerBasicOperationsTests() =
       check ac.contractCollision(addr4) == true
 
     test "Ledger storage iterator":
-      var ac = LedgerRef.init(memDB, EMPTY_ROOT_HASH, storeSlotHash = true)
+      var ac = LedgerRef.init(memDB, storeSlotHash = true)
       let addr2 = initAddr(2)
       ac.setStorage(addr2, 1.u256, 2.u256)
       ac.setStorage(addr2, 2.u256, 3.u256)

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -170,13 +170,13 @@ proc setupEnv(com: CommonRef, signer, ks2: Address, ctx: EthContext): TestEnv =
     timeStamp   = date.toTime.toUnix.EthTime
     difficulty  = com.calcDifficulty(timeStamp, parent)
 
-  # call persist() before we get the rootHash
+  # call persist() before we get the stateRoot
   vmState.stateDB.persist()
 
   var header = Header(
     parentHash  : parentHash,
     #coinbase*:      Address
-    stateRoot   : vmState.stateDB.rootHash,
+    stateRoot   : vmState.stateDB.getStateRoot(),
     txRoot      : txRoot,
     receiptsRoot : receiptsRoot,
     bloom       : createBloom(vmState.receipts),

--- a/tests/test_txpool2.nim
+++ b/tests/test_txpool2.nim
@@ -180,14 +180,14 @@ proc runTxPoolPosTest() =
       check rr.isOk()
 
     test "validate TxPool prevRandao setter":
-      var sdb = LedgerRef.init(com.db, blk.header.stateRoot)
+      var sdb = LedgerRef.init(com.db)
       let val = sdb.getStorage(recipient, slot)
       let randao = Bytes32(val.toBytesBE)
       check randao == prevRandao
 
     test "feeRecipient rewarded":
       check blk.header.coinbase == feeRecipient
-      var sdb = LedgerRef.init(com.db, blk.header.stateRoot)
+      var sdb = LedgerRef.init(com.db)
       let bal = sdb.getBalance(feeRecipient)
       check not bal.isZero
 
@@ -245,14 +245,14 @@ proc runTxPoolBlobhashTest() =
       check rr.isOk()
 
     test "validate TxPool prevRandao setter":
-      var sdb = LedgerRef.init(com.db, blk.header.stateRoot)
+      var sdb = LedgerRef.init(com.db)
       let val = sdb.getStorage(recipient, slot)
       let randao = Bytes32(val.toBytesBE)
       check randao == prevRandao
 
     test "feeRecipient rewarded":
       check blk.header.coinbase == feeRecipient
-      var sdb = LedgerRef.init(com.db, blk.header.stateRoot)
+      var sdb = LedgerRef.init(com.db)
       let bal = sdb.getBalance(feeRecipient)
       check not bal.isZero
 
@@ -329,7 +329,7 @@ proc runTxHeadDelta(noisy = true) =
       check com.syncCurrent == 10.BlockNumber
       head = com.db.getBlockHeader(com.syncCurrent)
       let
-        sdb = LedgerRef.init(com.db, head.stateRoot)
+        sdb = LedgerRef.init(com.db)
         expected = u256(txPerblock * numBlocks) * amount
         balance = sdb.getBalance(recipient)
       check balance == expected

--- a/tools/common/state_clearing.nim
+++ b/tools/common/state_clearing.nim
@@ -33,7 +33,7 @@ proc coinbaseStateClearing*(vmState: BaseVMState,
     # db.persist is an important step when using `db/ledger`
     # it will affect the account storage's location
     # during the next call to `getComittedStorage`
-    # and the result of rootHash
+    # and the result of getStateRoot
 
     # do not clear cache, we need the cache when constructing
     # post state

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -137,7 +137,7 @@ proc runExecution(ctx: var StateContext, conf: StateConf, pre: JsonNode): StateR
     db.persist(clearEmptyAccount = false) # settle accounts storage
 
   defer:
-    let stateRoot = vmState.readOnlyStateDB.rootHash
+    let stateRoot = vmState.readOnlyStateDB.getStateRoot()
     ctx.verifyResult(vmState, stateRoot)
     result = StateResult(
       name : ctx.name,

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -323,14 +323,14 @@ proc exec(ctx: TransContext,
     consolidationReqs: seq[byte]
 
   if vmState.com.isPragueOrLater(ctx.env.currentTimestamp):
-    # Execute EIP-7002 and EIP-7251 before calculating rootHash
+    # Execute EIP-7002 and EIP-7251 before calculating stateRoot
     withdrawalReqs = processDequeueWithdrawalRequests(vmState)
     consolidationReqs = processDequeueConsolidationRequests(vmState)
 
   let stateDB = vmState.stateDB
   stateDB.postState(result.alloc)
   result.result = ExecutionResult(
-    stateRoot   : stateDB.rootHash,
+    stateRoot   : stateDB.getStateRoot(),
     txRoot      : includedTx.calcTxRoot,
     receiptsRoot: calcReceiptsRoot(vmState.receipts),
     logsHash    : calcLogsHash(vmState.receipts),


### PR DESCRIPTION
* prefer the spec-derived name where possible
* don't pass stateRoot to LedgerRef and friends (it doesn't do anything)
* add deprecation warning in graphql - it needs updating to use forkedchain instead