### PR TITLE
drop support for generic data in coredb

### DIFF
--- a/nimbus/db/aristo/aristo_api.nim
+++ b/nimbus/db/aristo/aristo_api.nim
@@ -57,27 +57,6 @@ type
       ## this leaf entry referres to a storage tree, this one will be deleted
       ## as well.
 
-  AristoApiDeleteGenericDataFn* =
-    proc(db: AristoDbRef;
-         root: VertexID;
-         path: openArray[byte];
-        ): Result[bool,AristoError]
-        {.noRaise.}
-      ## Delete the leaf data entry addressed by the argument `path`.  The MPT
-      ## sub-tree the leaf data entry is subsumed under is passed as argument
-      ## `root` which must be greater than `VertexID(1)` and smaller than
-      ## `LEAST_FREE_VID`.
-      ##
-      ## The return value is `true` if the argument `path` deleted was the last
-      ## one and the tree does not exist anymore.
-
-  AristoApiDeleteGenericTreeFn* =
-    proc(db: AristoDbRef;
-         root: VertexID;
-        ): Result[void,AristoError]
-        {.noRaise.}
-      ## Variant of `deleteGenericData()` for purging the whole MPT sub-tree.
-
   AristoApiDeleteStorageDataFn* =
     proc(db: AristoDbRef;
          accPath: Hash32;
@@ -120,24 +99,6 @@ type
         ): Result[Hash32,AristoError]
         {.noRaise.}
       ## Fetch the Merkle hash of the account root. Force update if the
-      ## argument `updateOK` is set `true`.
-
-  AristoApiFetchGenericDataFn* =
-    proc(db: AristoDbRef;
-         root: VertexID;
-         path: openArray[byte];
-        ): Result[seq[byte],AristoError]
-        {.noRaise.}
-      ## For a generic sub-tree starting at `root`, fetch the data record
-      ## indexed by `path`.
-
-  AristoApiFetchGenericStateFn* =
-    proc(db: AristoDbRef;
-         root: VertexID;
-         updateOk: bool;
-        ): Result[Hash32,AristoError]
-        {.noRaise.}
-      ## Fetch the Merkle hash of the argument `root`. Force update if the
       ## argument `updateOK` is set `true`.
 
   AristoApiFetchStorageDataFn* =
@@ -245,15 +206,6 @@ type
       ## For an account record indexed by `accPath` query whether this record
       ## exists on the database.
 
-  AristoApiHasPathGenericFn* =
-    proc(db: AristoDbRef;
-         root: VertexID;
-         path: openArray[byte];
-        ): Result[bool,AristoError]
-        {.noRaise.}
-      ## For a generic sub-tree starting at `root` and indexed by `path`,
-      ## mquery whether this record exists on the database.
-
   AristoApiHasPathStorageFn* =
     proc(db: AristoDbRef;
          accPath: Hash32;
@@ -306,16 +258,6 @@ type
       ## not on the database already or the value differend from `accRec`, and
       ## `false` otherwise.
 
-  AristoApiMergeGenericDataFn* =
-    proc(db: AristoDbRef;
-         root: VertexID;
-         path: openArray[byte];
-         data: openArray[byte];
-        ): Result[bool,AristoError]
-        {.noRaise.}
-      ## Variant of `mergeXXX()` for generic sub-trees, i.e. for arguments
-      ## `root` greater than `VertexID(1)` and smaller than `LEAST_FREE_VID`.
-
   AristoApiMergeStorageDataFn* =
     proc(db: AristoDbRef;
          accPath: Hash32;
@@ -338,17 +280,6 @@ type
       ## a partial path will be returned follwed by a `false` value.
       ##
       ## Errors will only be returned for invalid paths.
-
-  AristoApiPartGenericTwig* =
-    proc(db: AristoDbRef;
-         root: VertexID;
-         path: openArray[byte];
-        ): Result[(seq[seq[byte]],bool), AristoError]
-        {.noRaise.}
-      ## Variant of `partAccountTwig()`.
-      ##
-      ## Note: This function provides a functionality comparable to the
-      ## `getBranch()` function from `hexary.nim`
 
   AristoApiPartStorageTwig* =
     proc(db: AristoDbRef;
@@ -488,8 +419,6 @@ type
     commit*: AristoApiCommitFn
 
     deleteAccountRecord*: AristoApiDeleteAccountRecordFn
-    deleteGenericData*: AristoApiDeleteGenericDataFn
-    deleteGenericTree*: AristoApiDeleteGenericTreeFn
     deleteStorageData*: AristoApiDeleteStorageDataFn
     deleteStorageTree*: AristoApiDeleteStorageTreeFn
 
@@ -497,8 +426,6 @@ type
 
     fetchAccountRecord*: AristoApiFetchAccountRecordFn
     fetchAccountStateRoot*: AristoApiFetchAccountStateRootFn
-    fetchGenericData*: AristoApiFetchGenericDataFn
-    fetchGenericState*: AristoApiFetchGenericStateFn
     fetchStorageData*: AristoApiFetchStorageDataFn
     fetchStorageRoot*: AristoApiFetchStorageRootFn
 
@@ -507,7 +434,6 @@ type
     forget*: AristoApiForgetFn
     forkTx*: AristoApiForkTxFn
     hasPathAccount*: AristoApiHasPathAccountFn
-    hasPathGeneric*: AristoApiHasPathGenericFn
     hasPathStorage*: AristoApiHasPathStorageFn
     hasStorageData*: AristoApiHasStorageDataFn
 
@@ -516,11 +442,9 @@ type
     nForked*: AristoApiNForkedFn
 
     mergeAccountRecord*: AristoApiMergeAccountRecordFn
-    mergeGenericData*: AristoApiMergeGenericDataFn
     mergeStorageData*: AristoApiMergeStorageDataFn
 
     partAccountTwig*: AristoApiPartAccountTwig
-    partGenericTwig*: AristoApiPartGenericTwig
     partStorageTwig*: AristoApiPartStorageTwig
     partUntwigGeneric*: AristoApiPartUntwigGeneric
     partUntwigGenericOk*: AristoApiPartUntwigGenericOk
@@ -542,8 +466,6 @@ type
     AristoApiProfCommitFn               = "commit"
 
     AristoApiProfDeleteAccountRecordFn  = "deleteAccountRecord"
-    AristoApiProfDeleteGenericDataFn    = "deleteGnericData"
-    AristoApiProfDeleteGenericTreeFn    = "deleteGnericTree"
     AristoApiProfDeleteStorageDataFn    = "deleteStorageData"
     AristoApiProfDeleteStorageTreeFn    = "deleteStorageTree"
 
@@ -551,8 +473,6 @@ type
 
     AristoApiProfFetchAccountRecordFn   = "fetchAccountRecord"
     AristoApiProfFetchAccountStateRootFn = "fetchAccountStateRoot"
-    AristoApiProfFetchGenericDataFn     = "fetchGenericData"
-    AristoApiProfFetchGenericStateFn    = "fetchGenericState"
     AristoApiProfFetchStorageDataFn     = "fetchStorageData"
     AristoApiProfFetchStorageRootFn     = "fetchStorageRoot"
 
@@ -562,7 +482,6 @@ type
     AristoApiProfForkTxFn               = "forkTx"
 
     AristoApiProfHasPathAccountFn       = "hasPathAccount"
-    AristoApiProfHasPathGenericFn       = "hasPathGeneric"
     AristoApiProfHasPathStorageFn       = "hasPathStorage"
     AristoApiProfHasStorageDataFn       = "hasStorageData"
 
@@ -571,14 +490,10 @@ type
     AristoApiProfNForkedFn              = "nForked"
 
     AristoApiProfMergeAccountRecordFn   = "mergeAccountRecord"
-    AristoApiProfMergeGenericDataFn     = "mergeGenericData"
     AristoApiProfMergeStorageDataFn     = "mergeStorageData"
 
     AristoApiProfPartAccountTwigFn      = "partAccountTwig"
-    AristoApiProfPartGenericTwigFn      = "partGenericTwig"
     AristoApiProfPartStorageTwigFn      = "partStorageTwig"
-    AristoApiProfPartUntwigGenericFn    = "partUntwigGeneric"
-    AristoApiProfPartUntwigGenericOkFn  = "partUntwigGenericOk"
     AristoApiProfPartUntwigPathFn       = "partUntwigPath"
     AristoApiProfPartUntwigPathOkFn     = "partUntwigPathOk"
 
@@ -614,8 +529,6 @@ when AutoValidateApiHooks:
     doAssert not api.commit.isNil
 
     doAssert not api.deleteAccountRecord.isNil
-    doAssert not api.deleteGenericData.isNil
-    doAssert not api.deleteGenericTree.isNil
     doAssert not api.deleteStorageData.isNil
     doAssert not api.deleteStorageTree.isNil
 
@@ -623,8 +536,6 @@ when AutoValidateApiHooks:
 
     doAssert not api.fetchAccountRecord.isNil
     doAssert not api.fetchAccountStateRoot.isNil
-    doAssert not api.fetchGenericData.isNil
-    doAssert not api.fetchGenericState.isNil
     doAssert not api.fetchStorageData.isNil
     doAssert not api.fetchStorageRoot.isNil
 
@@ -634,7 +545,6 @@ when AutoValidateApiHooks:
     doAssert not api.forkTx.isNil
 
     doAssert not api.hasPathAccount.isNil
-    doAssert not api.hasPathGeneric.isNil
     doAssert not api.hasPathStorage.isNil
     doAssert not api.hasStorageData.isNil
 
@@ -643,11 +553,9 @@ when AutoValidateApiHooks:
     doAssert not api.nForked.isNil
 
     doAssert not api.mergeAccountRecord.isNil
-    doAssert not api.mergeGenericData.isNil
     doAssert not api.mergeStorageData.isNil
 
     doAssert not api.partAccountTwig.isNil
-    doAssert not api.partGenericTwig.isNil
     doAssert not api.partStorageTwig.isNil
     doAssert not api.partUntwigGeneric.isNil
     doAssert not api.partUntwigGenericOk.isNil
@@ -690,8 +598,6 @@ func init*(api: var AristoApiObj) =
   api.commit = commit
 
   api.deleteAccountRecord = deleteAccountRecord
-  api.deleteGenericData = deleteGenericData
-  api.deleteGenericTree = deleteGenericTree
   api.deleteStorageData = deleteStorageData
   api.deleteStorageTree = deleteStorageTree
 
@@ -699,8 +605,6 @@ func init*(api: var AristoApiObj) =
 
   api.fetchAccountRecord = fetchAccountRecord
   api.fetchAccountStateRoot = fetchAccountStateRoot
-  api.fetchGenericData = fetchGenericData
-  api.fetchGenericState = fetchGenericState
   api.fetchStorageData = fetchStorageData
   api.fetchStorageRoot = fetchStorageRoot
 
@@ -710,7 +614,6 @@ func init*(api: var AristoApiObj) =
   api.forkTx = forkTx
 
   api.hasPathAccount = hasPathAccount
-  api.hasPathGeneric = hasPathGeneric
   api.hasPathStorage = hasPathStorage
   api.hasStorageData = hasStorageData
 
@@ -719,14 +622,10 @@ func init*(api: var AristoApiObj) =
   api.nForked = nForked
 
   api.mergeAccountRecord = mergeAccountRecord
-  api.mergeGenericData = mergeGenericData
   api.mergeStorageData = mergeStorageData
 
   api.partAccountTwig = partAccountTwig
-  api.partGenericTwig = partGenericTwig
   api.partStorageTwig = partStorageTwig
-  api.partUntwigGeneric = partUntwigGeneric
-  api.partUntwigGenericOk = partUntwigGenericOk
   api.partUntwigPath = partUntwigPath
   api.partUntwigPathOk = partUntwigPathOk
 
@@ -749,16 +648,12 @@ func dup*(api: AristoApiRef): AristoApiRef =
     commit:               api.commit,
 
     deleteAccountRecord:  api.deleteAccountRecord,
-    deleteGenericData:    api.deleteGenericData,
-    deleteGenericTree:    api.deleteGenericTree,
     deleteStorageData:    api.deleteStorageData,
     deleteStorageTree:    api.deleteStorageTree,
 
     fetchLastSavedState:  api.fetchLastSavedState,
     fetchAccountRecord:   api.fetchAccountRecord,
     fetchAccountStateRoot: api.fetchAccountStateRoot,
-    fetchGenericData:     api.fetchGenericData,
-    fetchGenericState:    api.fetchGenericState,
     fetchStorageData:     api.fetchStorageData,
     fetchStorageRoot:     api.fetchStorageRoot,
 
@@ -768,7 +663,6 @@ func dup*(api: AristoApiRef): AristoApiRef =
     forkTx:               api.forkTx,
 
     hasPathAccount:       api.hasPathAccount,
-    hasPathGeneric:       api.hasPathGeneric,
     hasPathStorage:       api.hasPathStorage,
     hasStorageData:       api.hasStorageData,
 
@@ -777,14 +671,10 @@ func dup*(api: AristoApiRef): AristoApiRef =
     nForked:              api.nForked,
 
     mergeAccountRecord:   api.mergeAccountRecord,
-    mergeGenericData:     api.mergeGenericData,
     mergeStorageData:     api.mergeStorageData,
 
     partAccountTwig:      api.partAccountTwig,
-    partGenericTwig:      api.partGenericTwig,
     partStorageTwig:      api.partStorageTwig,
-    partUntwigGeneric:    api.partUntwigGeneric,
-    partUntwigGenericOk:  api.partUntwigGenericOk,
     partUntwigPath:       api.partUntwigPath,
     partUntwigPathOk:     api.partUntwigPathOk,
 
@@ -835,16 +725,6 @@ func init*(
       AristoApiProfDeleteAccountRecordFn.profileRunner:
         result = api.deleteAccountRecord(a, b)
 
-  profApi.deleteGenericData =
-    proc(a: AristoDbRef; b: VertexID; c: openArray[byte]): auto =
-      AristoApiProfDeleteGenericDataFn.profileRunner:
-        result = api.deleteGenericData(a, b, c)
-
-  profApi.deleteGenericTree =
-    proc(a: AristoDbRef; b: VertexID): auto =
-      AristoApiProfDeleteGenericTreeFn.profileRunner:
-        result = api.deleteGenericTree(a, b)
-
   profApi.deleteStorageData =
     proc(a: AristoDbRef; b: Hash32, c: Hash32): auto =
       AristoApiProfDeleteStorageDataFn.profileRunner:
@@ -869,16 +749,6 @@ func init*(
     proc(a: AristoDbRef; b: bool): auto =
       AristoApiProfFetchAccountStateRootFn.profileRunner:
         result = api.fetchAccountStateRoot(a, b)
-
-  profApi.fetchGenericData =
-    proc(a: AristoDbRef; b: VertexID; c: openArray[byte]): auto =
-      AristoApiProfFetchGenericDataFn.profileRunner:
-        result = api.fetchGenericData(a, b, c)
-
-  profApi.fetchGenericState =
-    proc(a: AristoDbRef; b: VertexID; c: bool): auto =
-      AristoApiProfFetchGenericStateFn.profileRunner:
-        result = api.fetchGenericState(a, b, c)
 
   profApi.fetchStorageData =
     proc(a: AristoDbRef; b, stoPath: Hash32): auto =
@@ -915,11 +785,6 @@ func init*(
       AristoApiProfHasPathAccountFn.profileRunner:
         result = api.hasPathAccount(a, b)
 
-  profApi.hasPathGeneric =
-    proc(a: AristoDbRef; b: VertexID; c: openArray[byte]): auto =
-      AristoApiProfHasPathGenericFn.profileRunner:
-        result = api.hasPathGeneric(a, b, c)
-
   profApi.hasPathStorage =
     proc(a: AristoDbRef; b, c: Hash32): auto =
       AristoApiProfHasPathStorageFn.profileRunner:
@@ -950,11 +815,6 @@ func init*(
       AristoApiProfMergeAccountRecordFn.profileRunner:
         result = api.mergeAccountRecord(a, b, c)
 
-  profApi.mergeGenericData =
-    proc(a: AristoDbRef; b: VertexID, c, d: openArray[byte]): auto =
-      AristoApiProfMergeGenericDataFn.profileRunner:
-        result = api.mergeGenericData(a, b, c, d)
-
   profApi.mergeStorageData =
     proc(a: AristoDbRef; b, c: Hash32, d: Uint256): auto =
       AristoApiProfMergeStorageDataFn.profileRunner:
@@ -965,25 +825,10 @@ func init*(
       AristoApiProfPartAccountTwigFn.profileRunner:
         result = api.partAccountTwig(a, b)
 
-  profApi.partGenericTwig =
-    proc(a: AristoDbRef; b: VertexID; c: openArray[byte]): auto =
-      AristoApiProfPartGenericTwigFn.profileRunner:
-        result = api.partGenericTwig(a, b, c)
-
   profApi.partStorageTwig =
     proc(a: AristoDbRef; b: Hash32; c: Hash32): auto =
       AristoApiProfPartStorageTwigFn.profileRunner:
         result = api.partStorageTwig(a, b, c)
-
-  profApi.partUntwigGeneric =
-    proc(a: openArray[seq[byte]]; b: Hash32; c: openArray[byte]): auto =
-      AristoApiProfPartUntwigGenericFn.profileRunner:
-        result = api.partUntwigGeneric(a, b, c)
-
-  profApi.partUntwigGenericOk =
-    proc(a: openArray[seq[byte]]; b:Hash32; c:openArray[byte]; d:Opt[seq[byte]]): auto =
-      AristoApiProfPartUntwigGenericOkFn.profileRunner:
-        result = api.partUntwigGenericOk(a, b, c, d)
 
   profApi.partUntwigPath =
     proc(a: openArray[seq[byte]]; b, c: Hash32): auto =

--- a/nimbus/db/core_db/base.nim
+++ b/nimbus/db/core_db/base.nim
@@ -26,7 +26,6 @@ export
   CoreDbErrorCode,
   CoreDbError,
   CoreDbKvtRef,
-  CoreDbMptRef,
   CoreDbPersistentTypes,
   CoreDbRef,
   CoreDbTxRef,
@@ -208,7 +207,7 @@ proc stateBlockNumber*(db: CoreDbRef): BlockNumber =
   db.ifTrackNewApi: debug logTxt, api, elapsed, result
 
 proc verify*(
-    db: CoreDbRef | CoreDbMptRef | CoreDbAccRef;
+    db: CoreDbRef | CoreDbAccRef;
     proof: openArray[seq[byte]];
     root: Hash32;
     path: openArray[byte];
@@ -239,7 +238,7 @@ proc verify*(
   mpt.ifTrackNewApi: debug logTxt, api, elapsed, result
 
 proc verifyOk*(
-    db: CoreDbRef | CoreDbMptRef | CoreDbAccRef;
+    db: CoreDbRef | CoreDbAccRef;
     proof: openArray[seq[byte]];
     root: Hash32;
     path: openArray[byte];
@@ -263,7 +262,7 @@ proc verifyOk*(
   mpt.ifTrackNewApi: debug logTxt, api, elapsed, result
 
 proc verify*(
-    db: CoreDbRef | CoreDbMptRef | CoreDbAccRef;
+    db: CoreDbRef | CoreDbAccRef;
     proof: openArray[seq[byte]];
     root: Hash32;
     path: Hash32;
@@ -284,7 +283,7 @@ proc verify*(
   mpt.ifTrackNewApi: debug logTxt, api, elapsed, result
 
 proc verifyOk*(
-    db: CoreDbRef | CoreDbMptRef | CoreDbAccRef;
+    db: CoreDbRef | CoreDbAccRef;
     proof: openArray[seq[byte]];
     root: Hash32;
     path: Hash32;
@@ -409,130 +408,6 @@ proc hasKey*(kvt: CoreDbKvtRef; key: openArray[byte]): bool =
   kvt.setTrackNewApi KvtHasKeyFn
   result = kvt.call(hasKeyRc, kvt.kvt, key).valueOr: false
   kvt.ifTrackNewApi: debug logTxt, api, elapsed, key=key.toStr, result
-
-# ------------------------------------------------------------------------------
-# Public functions for generic columns
-# ------------------------------------------------------------------------------
-
-proc getGeneric*(
-    ctx: CoreDbCtxRef;
-    clearData = false;
-      ): CoreDbMptRef =
-  ## Get a generic MPT, viewed as column
-  ##
-  ctx.setTrackNewApi CtxGetGenericFn
-  result = CoreDbMptRef(ctx)
-  if clearData:
-    result.call(deleteGenericTree, ctx.mpt, CoreDbVidGeneric).isOkOr:
-      raiseAssert $api & ": " & $error
-  ctx.ifTrackNewApi: debug logTxt, api, clearData, elapsed
-
-# ----------- generic MPT ---------------
-
-proc proof*(
-    mpt: CoreDbMptRef;
-    key: openArray[byte];
-      ): CoreDbRc[(seq[seq[byte]],bool)] =
-  ## On the generic MPT, collect the nodes along the `key` interpreted as
-  ## path. Return these path nodes as a chain of rlp-encoded blobs followed
-  ## by a bool value which is `true` if the `key` path exists in the database,
-  ## and `false` otherwise. In the latter case, the chain of rlp-encoded blobs
-  ## are the nodes proving that the `key` path does not exist.
-  ##
-  mpt.setTrackNewApi MptProofFn
-  result = block:
-    let rc = mpt.call(partGenericTwig, mpt.mpt, CoreDbVidGeneric, key)
-    if rc.isOk:
-      ok(rc.value)
-    else:
-      err(rc.error.toError($api, ProofCreate))
-  mpt.ifTrackNewApi: debug logTxt, api, elapsed, result
-
-proc fetch*(mpt: CoreDbMptRef; key: openArray[byte]): CoreDbRc[seq[byte]] =
-  ## Fetch data from the argument `mpt`. The function always returns a
-  ## non-empty `seq[byte]` or an error code.
-  ##
-  mpt.setTrackNewApi MptFetchFn
-  result = block:
-    let rc = mpt.call(fetchGenericData, mpt.mpt, CoreDbVidGeneric, key)
-    if rc.isOk:
-      ok(rc.value)
-    elif rc.error == FetchPathNotFound:
-      err(rc.error.toError($api, MptNotFound))
-    else:
-      err(rc.error.toError $api)
-  mpt.ifTrackNewApi: debug logTxt, api, elapsed, key=key.toStr, result
-
-proc fetchOrEmpty*(mpt: CoreDbMptRef; key: openArray[byte]): CoreDbRc[seq[byte]] =
-  ## This function returns an empty `seq[byte]` if the argument `key` is not found
-  ## on the database.
-  ##
-  mpt.setTrackNewApi MptFetchOrEmptyFn
-  result = block:
-    let rc = mpt.call(fetchGenericData, mpt.mpt, CoreDbVidGeneric, key)
-    if rc.isOk:
-      ok(rc.value)
-    elif rc.error == FetchPathNotFound:
-      CoreDbRc[seq[byte]].ok(EmptyBlob)
-    else:
-      err(rc.error.toError $api)
-  mpt.ifTrackNewApi: debug logTxt, api, elapsed, key=key.toStr, result
-
-proc delete*(mpt: CoreDbMptRef; key: openArray[byte]): CoreDbRc[void] =
-  mpt.setTrackNewApi MptDeleteFn
-  result = block:
-    let rc = mpt.call(deleteGenericData, mpt.mpt,CoreDbVidGeneric, key)
-    if rc.isOk:
-      ok()
-    elif rc.error == DelPathNotFound:
-      err(rc.error.toError($api, MptNotFound))
-    else:
-      err(rc.error.toError $api)
-  mpt.ifTrackNewApi: debug logTxt, api, elapsed, key=key.toStr, result
-
-proc merge*(
-    mpt: CoreDbMptRef;
-    key: openArray[byte];
-    val: openArray[byte];
-      ): CoreDbRc[void] =
-  mpt.setTrackNewApi MptMergeFn
-  result = block:
-    let rc = mpt.call(mergeGenericData, mpt.mpt,CoreDbVidGeneric, key, val)
-    if rc.isOk:
-      ok()
-    else:
-      err(rc.error.toError $api)
-  mpt.ifTrackNewApi:
-    debug logTxt, api, elapsed, key=key.toStr, val=val.toLenStr, result
-
-proc hasPath*(mpt: CoreDbMptRef; key: openArray[byte]): CoreDbRc[bool] =
-  ## This function would be named `contains()` if it returned `bool` rather
-  ## than a `Result[]`.
-  ##
-  mpt.setTrackNewApi MptHasPathFn
-  result = block:
-    let rc = mpt.call(hasPathGeneric, mpt.mpt, CoreDbVidGeneric, key)
-    if rc.isOk:
-      ok(rc.value)
-    else:
-      err(rc.error.toError $api)
-  mpt.ifTrackNewApi: debug logTxt, api, elapsed, key=key.toStr, result
-
-proc state*(mpt: CoreDbMptRef; updateOk = false): CoreDbRc[Hash32] =
-  ## This function retrieves the Merkle state hash of the argument
-  ## database column (if acvailable.)
-  ##
-  ## If the argument `updateOk` is set `true`, the Merkle hashes of the
-  ## database will be updated first (if needed, at all).
-  ##
-  mpt.setTrackNewApi MptStateFn
-  result = block:
-    let rc = mpt.call(fetchGenericState, mpt.mpt, CoreDbVidGeneric, updateOk)
-    if rc.isOk:
-      ok(rc.value)
-    else:
-      err(rc.error.toError $api)
-  mpt.ifTrackNewApi: debug logTxt, api, elapsed, updateOK, result
 
 # ------------------------------------------------------------------------------
 # Public methods for accounts

--- a/nimbus/db/core_db/base/api_tracking.nim
+++ b/nimbus/db/core_db/base/api_tracking.nim
@@ -23,7 +23,7 @@ type
     ## Needed for local `$` as it would be ambiguous for `Duration`
 
   CoreDbApiTrackRef* =
-    CoreDbRef | CoreDbKvtRef | CoreDbCtxRef | CoreDbMptRef | CoreDbAccRef |
+    CoreDbRef | CoreDbKvtRef | CoreDbCtxRef | CoreDbAccRef |
     CoreDbTxRef
 
   CoreDbFnInx* = enum
@@ -78,16 +78,6 @@ type
     KvtLenFn            = "len"
     KvtPairsIt          = "pairs"
     KvtPutFn            = "put"
-
-    MptDeleteFn         = "mpt/delete"
-    MptFetchFn          = "mpt/fetch"
-    MptFetchOrEmptyFn   = "mpt/fetchOrEmpty"
-    MptForgetFn         = "mpt/forget"
-    MptHasPathFn        = "mpt/hasPath"
-    MptMergeFn          = "mpt/merge"
-    MptProofFn          = "mpt/proof"
-    MptPairsIt          = "mpt/pairs"
-    MptStateFn          = "mpt/state"
 
     TxCommitFn          = "commit"
     TxDisposeFn         = "dispose"
@@ -152,7 +142,6 @@ func toStr(rc: CoreDbRc[CoreDbRef]): string = rc.toStr "db"
 func toStr(rc: CoreDbRc[CoreDbKvtRef]): string = rc.toStr "kvt"
 func toStr(rc: CoreDbRc[CoreDbTxRef]): string = rc.toStr "tx"
 func toStr(rc: CoreDbRc[CoreDbCtxRef]): string = rc.toStr "ctx"
-func toStr(rc: CoreDbRc[CoreDbMptRef]): string = rc.toStr "mpt"
 func toStr(rc: CoreDbRc[CoreDbAccRef]): string = rc.toStr "acc"
 
 # ------------------------------------------------------------------------------

--- a/nimbus/db/core_db/base/base_desc.nim
+++ b/nimbus/db/core_db/base/base_desc.nim
@@ -26,9 +26,6 @@ const
   CoreDbPersistentTypes* = {AristoDbRocks}
     ## List of persistent DB types (currently only a single one)
 
-  CoreDbVidGeneric* = VertexID(2)
-    ## Generic `MPT` root vertex ID for calculating Merkle hashes
-
 type
   CoreDbProfListRef* = AristoDbProfListRef
     ## Borrowed from `aristo_profile`, only used in profiling mode
@@ -82,7 +79,7 @@ type
       tracerHook*: RootRef        ## Debugging/tracing
 
   CoreDbCtxRef* = ref object
-    ## Shared context for `CoreDbMptRef`, `CoreDbAccRef`, `CoreDbKvtRef`
+    ## Shared context for `CoreDbAccRef`, `CoreDbKvtRef`
     parent*: CoreDbRef
     mpt*: AristoDbRef           ## `Aristo` database
     kvt*: KvtDbRef              ## `KVT` key-value table
@@ -92,9 +89,6 @@ type
 
   CoreDbAccRef* = distinct CoreDbCtxRef
     ## Similar to `CoreDbKvtRef`, only dealing with `Aristo` accounts
-
-  CoreDbMptRef* = distinct CoreDbCtxRef
-    ## Generic MPT
 
   CoreDbTxRef* = ref object
     ## Transaction descriptor

--- a/nimbus/db/core_db/base/base_helpers.nim
+++ b/nimbus/db/core_db/base/base_helpers.nim
@@ -40,7 +40,7 @@ proc bless*(db: CoreDbRef; ctx: CoreDbCtxRef): CoreDbCtxRef =
     ctx.validate
   ctx
 
-proc bless*(ctx: CoreDbCtxRef; dsc: CoreDbMptRef | CoreDbTxRef): auto =
+proc bless*(ctx: CoreDbCtxRef; dsc: CoreDbTxRef): auto =
   dsc.ctx = ctx
   when CoreDbAutoValidateDescriptors:
     dsc.validate
@@ -80,7 +80,7 @@ func toError*(e: KvtError; s: string; error = Unspecified): CoreDbError =
 # Public Aristo helpers
 # ------------------------------------------------------------------------------
 
-template mpt*(dsc: CoreDbAccRef | CoreDbMptRef): AristoDbRef =
+template mpt*(dsc: CoreDbAccRef): AristoDbRef =
   CoreDbCtxRef(dsc).mpt
 
 template mpt*(tx: CoreDbTxRef): AristoDbRef =
@@ -98,7 +98,7 @@ template call*(api: AristoApiRef; fn: untyped; args: varArgs[untyped]): untyped 
     fn(args)
 
 template call*(
-    acc: CoreDbAccRef | CoreDbMptRef;
+    acc: CoreDbAccRef;
     fn: untyped;
     args: varArgs[untyped];
       ): untyped =


### PR DESCRIPTION
All actual access to CoreDB is typed (account or storage) - it's unlikely ethereum will grow another trie structure in the near future.