### PR TITLE
rm --protocol CLI flag

### DIFF
--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -117,11 +117,6 @@ type
     noCommand
     `import`
 
-  ProtocolFlag* {.pure.} = enum
-    ## Protocol flags
-    Eth                           ## enable eth subprotocol
-    #Snap                          ## enable snap sub-protocol
-
   RpcFlag* {.pure.} = enum
     ## RPC flags
     Eth                           ## enable eth_ set of RPC API
@@ -365,14 +360,6 @@ type
       defaultValue: NimbusIdent
       defaultValueDesc: $NimbusIdent
       name: "agent-string" .}: string
-
-    protocols {.
-      desc: "Enable specific set of server protocols (available: Eth, " &
-            " None.) This will not affect the sync mode"
-            # " Snap, None.) This will not affect the sync mode"
-      defaultValue: @[]
-      defaultValueDesc: $ProtocolFlag.Eth
-      name: "protocols" .}: seq[string]
 
     beaconChunkSize* {.
       hidden
@@ -670,23 +657,6 @@ proc getNetworkId(conf: NimbusConf): Option[NetworkId] =
     except CatchableError:
       error "Failed to parse network name or id", network
       quit QuitFailure
-
-proc getProtocolFlags*(conf: NimbusConf): set[ProtocolFlag] =
-  if conf.protocols.len == 0:
-    return {ProtocolFlag.Eth}
-
-  var noneOk = false
-  for item in repeatingList(conf.protocols):
-    case item.toLowerAscii()
-    of "eth": result.incl ProtocolFlag.Eth
-    # of "snap": result.incl ProtocolFlag.Snap
-    of "none": noneOk = true
-    else:
-      error "Unknown protocol", name=item
-      quit QuitFailure
-  if noneOk and 0 < result.len:
-    error "Setting none contradicts wire protocols", names = $result
-    quit QuitFailure
 
 proc getRpcFlags(api: openArray[string]): set[RpcFlag] =
   if api.len == 0:

--- a/tests/test_configuration.nim
+++ b/tests/test_configuration.nim
@@ -128,15 +128,6 @@ proc configurationMain*() =
       let cx = cc.getWsFlags()
       check { RpcFlag.Eth, RpcFlag.Debug } == cx
 
-    test "protocols":
-      let conf = makeTestConfig()
-      let flags = conf.getProtocolFlags()
-      check ProtocolFlag.Eth in flags
-
-      let bb = makeConfig(@["--protocols:eth"])
-      let bx = bb.getProtocolFlags()
-      check ProtocolFlag.Eth in bx
-
     test "bootstrap-node and bootstrap-file":
       let conf = makeTestConfig()
       let bootnodes = conf.getBootNodes()


### PR DESCRIPTION
Without `snap`, the only options are `Eth` being present or absent, which controls two things:
- the RPC having the basic `eth_` methods; and
- Nimbus being intialized with a txpool or not.

For the former, that means
https://github.com/status-im/nimbus-eth1/blob/ba1cbed14fea101e1faea37ea5d312fa2c7c81fb/nimbus/rpc/common.nim#L34-L74
and it doesn't seem worth having this option to have a JSON-RPC server which can do some SHA3 hashing on demand. If one wants to disable the RPC servers entirely, there are already options for that.

For the latter the txpool doesn't really do anything unless requested specifically, so it also seems dubiously worthwhile.