### PR TITLE
Feature: User configurable extraData when assemble a block

### DIFF
--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -15,7 +15,7 @@ import
   ../core/casper,
   ../db/[core_db, ledger, storage_types],
   ../utils/[utils, ec_recover],
-  ".."/[constants, errors],
+  ".."/[constants, errors, version],
   "."/[chain_config, evmforks, genesis, hardforks]
 
 export
@@ -94,6 +94,9 @@ type
 
     pruneHistory: bool
       ## Must not not set for a full node, might go away some time
+
+    extraData: string
+      ## Value of extraData field when building block
 
 # ------------------------------------------------------------------------------
 # Forward declarations
@@ -175,8 +178,7 @@ proc init(com         : CommonRef,
           networkId   : NetworkId,
           config      : ChainConfig,
           genesis     : Genesis,
-          pruneHistory: bool,
-            ) =
+          pruneHistory: bool) =
 
   config.daoCheck()
 
@@ -187,7 +189,8 @@ proc init(com         : CommonRef,
   com.syncProgress= SyncProgress()
   com.syncState   = Waiting
   com.pruneHistory= pruneHistory
-  com.pos = CasperRef.new
+  com.pos         = CasperRef.new
+  com.extraData   = ShortClientId
 
   # com.forkIdCalculator and com.genesisHash are set
   # by setForkId
@@ -420,6 +423,9 @@ func syncHighest*(com: CommonRef): BlockNumber =
 func syncState*(com: CommonRef): SyncState =
   com.syncState
 
+func extraData*(com: CommonRef): string =
+  com.extraData
+
 # ------------------------------------------------------------------------------
 # Setters
 # ------------------------------------------------------------------------------
@@ -457,6 +463,9 @@ func `reqBeaconSyncTarget=`*(com: CommonRef; cb: ReqBeaconSyncTargetCB) =
 func `notifyBadBlock=`*(com: CommonRef; cb: NotifyBadBlockCB) =
   ## Activate or reset a call back handler for bad block notification.
   com.notifyBadBlock = cb
+
+func `extraData=`*(com: CommonRef, val: string) =
+  com.extraData = val
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -84,7 +84,7 @@ const
 
 let
   defaultListenAddress      = getAutoAddress(Port(0)).toIpAddress()
-  defaultListenAddressDesc      = $defaultListenAddress & ", meaning all network interfaces"
+  defaultListenAddressDesc  = $defaultListenAddress & ", meaning all network interfaces"
 
 # `when` around an option doesn't work with confutils; it fails to compile.
 # Workaround that by setting the `ignore` pragma on EVMC-specific options.
@@ -178,6 +178,12 @@ type
       defaultValue: none(string)
       defaultValueDesc: "Baked in trusted setup"
       name: "trusted-setup-file" .}: Option[string]
+
+    extraData* {.
+      desc: "Value of extraData field when assemble a block(max 32 bytes)"
+      defaultValue: ShortClientId
+      defaultValueDesc: $ShortClientId
+      name: "extra-data" .}: string
 
     network {.
       separator: "\pETHEREUM NETWORK OPTIONS:"

--- a/nimbus/core/tx_pool/tx_packer.nim
+++ b/nimbus/core/tx_pool/tx_packer.nim
@@ -315,7 +315,7 @@ proc packerVmExec*(xp: TxPoolRef): Result[TxPacker, string]
 
 func getExtraData(com: CommonRef): seq[byte] =
   if com.extraData.len > 32:
-    @(com.extraData.toBytes[0..<32])
+    com.extraData.toBytes[0..<32]
   else:
     com.extraData.toBytes
 

--- a/nimbus/core/tx_pool/tx_packer.nim
+++ b/nimbus/core/tx_pool/tx_packer.nim
@@ -16,6 +16,7 @@
 
 import
   stew/sorted_set,
+  stew/byteutils,
   ../../db/ledger,
   ../../common/common,
   ../../utils/utils,
@@ -312,6 +313,12 @@ proc packerVmExec*(xp: TxPoolRef): Result[TxPacker, string]
   ok(pst)
   # Block chain will roll back automatically
 
+func getExtraData(com: CommonRef): seq[byte] =
+  if com.extraData.len > 32:
+    @(com.extraData.toBytes[0..<32])
+  else:
+    com.extraData.toBytes
+
 proc assembleHeader*(pst: TxPacker): Header =
   ## Generate a new header, a child of the cached `head`
   let
@@ -331,7 +338,7 @@ proc assembleHeader*(pst: TxPacker): Header =
     gasLimit:      vmState.blockCtx.gasLimit,
     gasUsed:       vmState.cumulativeGasUsed,
     timestamp:     pos.timestamp,
-    extraData:     @[],
+    extraData:     getExtraData(com),
     mixHash:       pos.prevRandao,
     nonce:         default(Bytes8),
     baseFeePerGas: vmState.blockCtx.baseFeePerGas,

--- a/nimbus/nimbus_execution_client.nim
+++ b/nimbus/nimbus_execution_client.nim
@@ -201,10 +201,10 @@ proc run(nimbus: NimbusNode, conf: NimbusConf) =
     params = conf.networkParams)
 
   if conf.extraData.len > 32:
-    warn "ExtraData exceeds 32 bytes limit",
-      extraData=conf.extraData
+    warn "ExtraData exceeds 32 bytes limit, truncate",
+      extraData=conf.extraData,
       len=conf.extraData.len
-    
+
   com.extraData = conf.extraData
 
   defer:

--- a/nimbus/nimbus_execution_client.nim
+++ b/nimbus/nimbus_execution_client.nim
@@ -200,6 +200,8 @@ proc run(nimbus: NimbusNode, conf: NimbusConf) =
     networkId = conf.networkId,
     params = conf.networkParams)
 
+  com.extraData = conf.extraData
+
   defer:
     com.db.finish()
 

--- a/nimbus/nimbus_execution_client.nim
+++ b/nimbus/nimbus_execution_client.nim
@@ -200,6 +200,11 @@ proc run(nimbus: NimbusNode, conf: NimbusConf) =
     networkId = conf.networkId,
     params = conf.networkParams)
 
+  if conf.extraData.len > 32:
+    warn "ExtraData exceeds 32 bytes limit",
+      extraData=conf.extraData
+      len=conf.extraData.len
+    
   com.extraData = conf.extraData
 
   defer:

--- a/nimbus/version.nim
+++ b/nimbus/version.nim
@@ -62,3 +62,6 @@ const
   FullVersionStr* = "v" & NimbusVersion & "-" & GitRevision
 
   ClientId* = &"{NimbusName}/{FullVersionStr}/{hostOS}-{hostCPU}/Nim-{NimVersion}/{VmName}"
+
+  ShortClientId* = NimbusName & "/" & FullVersionStr
+  


### PR DESCRIPTION
As evident from https://holesky.beaconcha.in/block/2657016 when nimbus-eth1 assemble a block, the extraData field is empty. This commit will give user a chance to put his extraData or use default value.