### PR TITLE
serve state in rpc

### DIFF
--- a/nimbus/rpc/server_api.nim
+++ b/nimbus/rpc/server_api.nim
@@ -99,11 +99,10 @@ proc headerFromTag(api: ServerAPIRef, blockTag: Opt[BlockTag]): Result[Header, s
 
 proc ledgerFromTag(api: ServerAPIRef, blockTag: BlockTag): Result[LedgerRef, string] =
   let header = ?api.headerFromTag(blockTag)
-  if api.chain.stateReady(header):
-    ok(LedgerRef.init(api.com.db))
-  else:
-    # TODO: Replay state?
-    err("Block state not ready")
+  if not api.chain.stateReady(header):
+    api.chain.replaySegment(header.blockHash)
+  
+  ok(LedgerRef.init(api.com.db))
 
 proc blockFromTag(api: ServerAPIRef, blockTag: BlockTag): Result[Block, string] =
   if blockTag.kind == bidAlias:

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -420,5 +420,21 @@ proc forkedChainMain*() =
       check chain.headerByNumber(5).expect("OK").number == 5
       check chain.headerByNumber(5).expect("OK").blockHash == blk5.blockHash
 
+    test "Import after Replay Segment":
+      let com = env.newCom()
+      var chain = newForkedChain(com, com.genesisHeader, baseDistance = 3)
+
+      check chain.importBlock(blk1).isOk
+      check chain.importBlock(blk2).isOk
+      check chain.importBlock(blk3).isOk
+      check chain.importBlock(blk4).isOk
+      check chain.importBlock(blk5).isOk
+
+      chain.replaySegment(blk2.header.blockHash)
+      chain.replaySegment(blk5.header.blockHash)
+
+      check chain.importBlock(blk6).isOk
+      check chain.importBlock(blk7).isOk
+
 when isMainModule:
   forkedChainMain()


### PR DESCRIPTION
fixes #2700 

Initial concern was after the replay is done, for a rpc call which fetches data state data like account balance from old blocks. It would hinder the block import process of the forked chain. 
That comes with a cleanup solution, which can be implemented with something like `withLedger` template, which will do a cleanup process after the ledger is used.

But the simple approach is better for now since it works, without introducing the complexity of something like `withLedger`