### PR TITLE
Remove EpochRecord getContent

### DIFF
--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -391,20 +391,6 @@ proc getContent(
   else:
     Opt.some(res.get())
 
-proc getContent(
-    n: HistoryNetwork,
-    T: type EpochRecord,
-    contentKey: ContentKeyByteList,
-    contentId: ContentId,
-): Opt[T] =
-  let localContent = n.portalProtocol.getLocalContent(contentKey, contentId).valueOr:
-    return Opt.none(T)
-
-  try:
-    Opt.some(SSZ.decode(localContent, T))
-  except SerializationError:
-    raiseAssert("Stored data should always be serialized correctly")
-
 ## Public API to get the history network specific types, either from database
 ## or through a lookup on the Portal Network
 

--- a/fluffy/tools/portal_bridge/portal_bridge_history.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_history.nim
@@ -15,7 +15,7 @@ import
   results,
   stew/byteutils,
   eth/common/keys,
-  eth/common/[base, headers_rlp, blocks_rlp],
+  eth/common/[base, headers_rlp, blocks_rlp, receipts],
   eth/p2p/discoveryv5/random2,
   ../../../nimbus/beacon/web3_eth_conv,
   ../../../hive_integration/nodocker/engine/engine_client,
@@ -79,9 +79,9 @@ func asReceipt(receiptObject: ReceiptObject): Result[Receipt, string] =
   var logs: seq[Log]
   if receiptObject.logs.len > 0:
     for log in receiptObject.logs:
-      var topics: seq[Topic]
+      var topics: seq[receipts.Topic]
       for topic in log.topics:
-        topics.add(Topic(topic))
+        topics.add(topic)
 
       logs.add(Log(address: log.address, data: log.data, topics: topics))
 


### PR DESCRIPTION
EpochRecord type is removed from the network.

And avoid a deprecation warning in portal_bridge.