### PR TITLE
Engine API: Route more wiring from CoreDb to ForkedChain

### DIFF
--- a/nimbus/beacon/api_handler/api_forkchoice.nim
+++ b/nimbus/beacon/api_handler/api_forkchoice.nim
@@ -177,7 +177,7 @@ proc forkchoiceUpdated*(ben: BeaconEngineRef,
     db.safeHeaderHash(safeBlockHash)
 
   chain.forkChoice(blockHash, finalizedBlockHash).isOkOr:
-    return invalidFCU(error, com, header)
+    return invalidFCU(error, chain, header)
 
   # If payload generation was requested, create a new block to be potentially
   # sealed by the beacon client. The payload will be requested later, and we

--- a/nimbus/beacon/api_handler/api_utils.nim
+++ b/nimbus/beacon/api_handler/api_utils.nim
@@ -9,6 +9,7 @@
 
 import
   std/[typetraits, strutils],
+  web3/execution_types,
   json_rpc/errors,
   nimcrypto/sha2,
   stew/endians2,
@@ -17,7 +18,7 @@ import
   ../../db/core_db,
   ../../utils/utils,
   ../../common/common,
-  web3/execution_types,
+  ../../core/chain,
   ../web3_eth_conv
 
 {.push gcsafe, raises:[].}
@@ -185,12 +186,12 @@ proc latestValidHash*(db: CoreDbRef,
     default(Hash32)
 
 proc invalidFCU*(validationError: string,
-                 com: CommonRef,
-                 header: common.Header): ForkchoiceUpdatedResponse =
-  let parent = com.db.getBlockHeader(header.parentHash).valueOr:
+                 chain: ForkedChainRef,
+                 header: Header): ForkchoiceUpdatedResponse =
+  let parent = chain.headerByHash(header.parentHash).valueOr:
     return invalidFCU(validationError)
 
   let blockHash =
-    latestValidHash(com.db, parent, com.ttd.get(high(UInt256)))
+    latestValidHash(chain.db, parent, chain.com.ttd.get(high(UInt256)))
 
   invalidFCU(validationError, blockHash)

--- a/nimbus/beacon/web3_eth_conv.nim
+++ b/nimbus/beacon/web3_eth_conv.nim
@@ -26,11 +26,8 @@ export
 type
   Web3Quantity*      = web3types.Quantity
   Web3ExtraData*     = web3types.DynamicBytes[0, 32]
-  Web3BlockNumber*   = Quantity
   Web3Tx*            = engine_api_types.TypedTransaction
   Web3Blob*          = engine_api_types.Blob
-  Web3KZGProof*      = engine_api_types.KzgProof
-  Web3KZGCommitment* = engine_api_types.KzgCommitment
 
 {.push gcsafe, raises:[].}
 
@@ -57,17 +54,17 @@ func u64*(x: Opt[Web3Quantity]): Opt[uint64] =
   if x.isNone: Opt.none(uint64)
   else: Opt.some(uint64 x.get)
 
-func u256*(x: Web3BlockNumber): UInt256 =
+func u256*(x: Web3Quantity): UInt256 =
   u256(x.uint64)
 
-func u256*(x: common.FixedBytes[32]): UInt256 =
+func u256*(x: FixedBytes[32]): UInt256 =
   UInt256.fromBytesBE(x.data)
 
-func ethTime*(x: Web3Quantity): common.EthTime =
-  common.EthTime(x)
+func ethTime*(x: Web3Quantity): EthTime =
+  EthTime(x)
 
-func ethGasInt*(x: Web3Quantity): common.GasInt =
-  common.GasInt x
+func ethGasInt*(x: Web3Quantity): GasInt =
+  GasInt x
 
 func ethBlob*(x: Web3ExtraData): seq[byte] =
   distinctBase x
@@ -79,14 +76,14 @@ func ethWithdrawal*(x: WithdrawalV1): common.Withdrawal =
   result.amount = x.amount.uint64
 
 func ethWithdrawals*(list: openArray[WithdrawalV1]):
-                       seq[common.Withdrawal] =
-  result = newSeqOfCap[common.Withdrawal](list.len)
+                       seq[Withdrawal] =
+  result = newSeqOfCap[Withdrawal](list.len)
   for x in list:
     result.add ethWithdrawal(x)
 
 func ethWithdrawals*(x: Opt[seq[WithdrawalV1]]):
-                       Opt[seq[common.Withdrawal]] =
-  if x.isNone: Opt.none(seq[common.Withdrawal])
+                       Opt[seq[Withdrawal]] =
+  if x.isNone: Opt.none(seq[Withdrawal])
   else: Opt.some(ethWithdrawals x.get)
 
 func ethTx*(x: Web3Tx): common.Transaction {.gcsafe, raises:[RlpError].} =
@@ -105,10 +102,10 @@ func ethTxs*(list: openArray[Web3Tx]):
 func w3Qty*(x: UInt256): Web3Quantity =
   Web3Quantity x.truncate(uint64)
 
-func w3Qty*(x: common.EthTime): Web3Quantity =
+func w3Qty*(x: EthTime): Web3Quantity =
   Web3Quantity x.uint64
 
-func w3Qty*(x: common.EthTime, y: int): Web3Quantity =
+func w3Qty*(x: EthTime, y: int): Web3Quantity =
   Web3Quantity(x + y.EthTime)
 
 func w3Qty*(x: Web3Quantity, y: int): Web3Quantity =
@@ -129,16 +126,6 @@ func w3Qty*(x: uint64): Web3Quantity =
 
 func w3Qty*(x: int64): Web3Quantity =
   Web3Quantity(x)
-
-func w3BlockNumber*(x: Opt[uint64]): Opt[Web3BlockNumber] =
-  if x.isNone: Opt.none(Web3BlockNumber)
-  else: Opt.some(Web3BlockNumber x.get)
-
-func w3BlockNumber*(x: uint64): Web3BlockNumber =
-  Web3BlockNumber(x)
-
-func w3BlockNumber*(x: UInt256): Web3BlockNumber =
-  Web3BlockNumber x.truncate(uint64)
 
 func w3ExtraData*(x: seq[byte]): Web3ExtraData =
   Web3ExtraData x

--- a/nimbus/core/chain/chain_desc.nim
+++ b/nimbus/core/chain/chain_desc.nim
@@ -61,7 +61,7 @@ proc newChain*(com: CommonRef): ChainRef =
     com: com,
     extraValidation: extraValidation,
   )
-  
+
 # ------------------------------------------------------------------------------
 # Public `Chain` getters
 # ------------------------------------------------------------------------------
@@ -84,12 +84,6 @@ func extraValidation*(c: ChainRef): bool =
 func verifyFrom*(c: ChainRef): BlockNumber =
   ## Getter
   c.verifyFrom
-
-proc currentBlock*(c: ChainRef): Result[Header, string] =
-  ## currentBlock retrieves the current head block of the canonical chain.
-  ## Ideally the block should be retrieved from the blockchain's internal cache.
-  ## but now it's enough to retrieve it from database
-  c.db.getCanonicalHead()
 
 # ------------------------------------------------------------------------------
 # Public `Chain` setters

--- a/nimbus/core/chain/persist_blocks.nim
+++ b/nimbus/core/chain/persist_blocks.nim
@@ -198,30 +198,6 @@ proc persistBlocksImpl(
 
   ok((blks, txs, gas))
 
-# ------------------------------------------------------------------------------
-# Public `ChainDB` methods
-# ------------------------------------------------------------------------------
-
-proc insertBlockWithoutSetHead*(c: ChainRef, blk: Block): Result[void, string] =
-  discard ?c.persistBlocksImpl([blk], {NoPersistHeader, NoPersistReceipts})
-  c.db.persistHeader(blk.header.blockHash, blk.header, c.com.startOfHistory)
-  
-proc setCanonical*(c: ChainRef, header: Header): Result[void, string] =
-  if header.parentHash == default(Hash32):
-    return c.db.setHead(header)
-      
-  var body = ?c.db.getBlockBody(header)    
-  discard
-    ?c.persistBlocksImpl(
-      [Block.init(header, move(body))], {NoPersistHeader, NoPersistTransactions}
-    )
-
-  c.db.setHead(header)
-    
-proc setCanonical*(c: ChainRef, blockHash: Hash32): Result[void, string] =
-  let header = ?c.db.getBlockHeader(blockHash)
-  setCanonical(c, header)
-
 proc persistBlocks*(
     c: ChainRef, blocks: openArray[Block], flags: PersistBlockFlags = {}
 ): Result[PersistStats, string] =

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -433,14 +433,14 @@ proc rpcMain*() =
     test "eth_getTransactionByHash":
       let res = await client.eth_getTransactionByHash(env.txHash)
       check res.isNil.not
-      check res.blockNumber.get() == w3BlockNumber(1'u64)
+      check res.blockNumber.get() == w3Qty(1'u64)
       let res2 = await client.eth_getTransactionByHash(env.blockHash)
       check res2.isNil
 
     test "eth_getTransactionByBlockHashAndIndex":
       let res = await client.eth_getTransactionByBlockHashAndIndex(env.blockHash, w3Qty(0'u64))
       check res.isNil.not
-      check res.blockNumber.get() == w3BlockNumber(1'u64)
+      check res.blockNumber.get() == w3Qty(1'u64)
 
       let res2 = await client.eth_getTransactionByBlockHashAndIndex(env.blockHash, w3Qty(3'u64))
       check res2.isNil
@@ -451,7 +451,7 @@ proc rpcMain*() =
     test "eth_getTransactionByBlockNumberAndIndex":
       let res = await client.eth_getTransactionByBlockNumberAndIndex("latest", w3Qty(1'u64))
       check res.isNil.not
-      check res.blockNumber.get() == w3BlockNumber(1'u64)
+      check res.blockNumber.get() == w3Qty(1'u64)
 
       let res2 = await client.eth_getTransactionByBlockNumberAndIndex("latest", w3Qty(3'u64))
       check res2.isNil
@@ -470,7 +470,7 @@ proc rpcMain*() =
     # test "eth_getTransactionReceipt":
     #   let res = await client.eth_getTransactionReceipt(env.txHash)
     #   check res.isNil.not
-    #   check res.blockNumber == w3BlockNumber(1'u64)
+    #   check res.blockNumber == w3Qty(1'u64)
 
     #   let res2 = await client.eth_getTransactionReceipt(env.blockHash)
     #   check res2.isNil
@@ -478,7 +478,7 @@ proc rpcMain*() =
     test "eth_getUncleByBlockHashAndIndex":
       let res = await client.eth_getUncleByBlockHashAndIndex(env.blockHash, w3Qty(0'u64))
       check res.isNil.not
-      check res.number == w3BlockNumber(1'u64)
+      check res.number == w3Qty(1'u64)
 
       let res2 = await client.eth_getUncleByBlockHashAndIndex(env.blockHash, w3Qty(1'u64))
       check res2.isNil
@@ -489,7 +489,7 @@ proc rpcMain*() =
     test "eth_getUncleByBlockNumberAndIndex":
       let res = await client.eth_getUncleByBlockNumberAndIndex("latest", w3Qty(0'u64))
       check res.isNil.not
-      check res.number == w3BlockNumber(1'u64)
+      check res.number == w3Qty(1'u64)
 
       let res2 = await client.eth_getUncleByBlockNumberAndIndex("latest", w3Qty(1'u64))
       check res2.isNil


### PR DESCRIPTION
Apart from wiring engine API to ForkedChain in some places, the so called `markCanonicalChain` also removed. 
ForkedChain will handle reorgs in memory.