### PR TITLE
fluffy/portal: Add missing imports

### DIFF
--- a/fluffy/network/beacon/beacon_light_client.nim
+++ b/fluffy/network/beacon/beacon_light_client.nim
@@ -9,6 +9,7 @@
 
 import
   chronicles,
+  chronos,
   eth/p2p/discoveryv5/random2,
   beacon_chain/gossip_processing/light_client_processor,
   beacon_chain/beacon_clock,

--- a/fluffy/portal_node.nim
+++ b/fluffy/portal_node.nim
@@ -12,6 +12,7 @@ import
   chronos,
   eth/p2p/discoveryv5/protocol,
   beacon_chain/spec/forks,
+  stew/byteutils,
   ./network_metadata,
   ./eth_data/history_data_ssz_e2s,
   ./database/content_db,


### PR DESCRIPTION
Would/could fail compilation when using portal_node as module, depending on import order.