### PR TITLE
Small deserialization speedup

### DIFF
--- a/nimbus/db/aristo/aristo_blobify.nim
+++ b/nimbus/db/aristo/aristo_blobify.nim
@@ -68,10 +68,12 @@ proc deblobify*[T: uint64|VertexID](data: openArray[byte], _: type T): Result[T,
   if data.len < 1 or data.len > 8:
     return err(Deblob64LenUnsupported)
 
-  var tmp: array[8, byte]
-  discard tmp.toOpenArray(8 - data.len, 7).copyFrom(data)
+  var tmp = 0'u64
+  let start = 8 - data.len
+  for i in 0..<data.len:
+    tmp += uint64(data[i]) shl (8*(7-(i + start)))
 
-  ok T(uint64.fromBytesBE(tmp))
+  ok T(tmp)
 
 proc deblobify*(data: openArray[byte], _: type UInt256): Result[UInt256,AristoError] =
   if data.len < 1 or data.len > 32:

--- a/tests/test_aristo.nim
+++ b/tests/test_aristo.nim
@@ -20,6 +20,7 @@ import
   ./replay/pp,
   ./test_aristo/test_blobify,
   ./test_aristo/test_merge_proof,
+  ./test_aristo/test_nibbles,
   ./test_aristo/test_portal_proof,
   ./test_aristo/test_compute,
   ./test_aristo/[

--- a/tests/test_aristo/test_nibbles.nim
+++ b/tests/test_aristo/test_nibbles.nim
@@ -1,0 +1,86 @@
+# Nimbus
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+{.used.}
+
+import
+  std/sequtils,
+  stew/byteutils,
+  unittest2,
+  ../../nimbus/db/aristo/aristo_desc/desc_nibbles
+
+suite "Nibbles":
+  test "trivial cases":
+    block:
+      let n = NibblesBuf.fromBytes([])
+      check:
+        n.len == 0
+    block:
+      let n = NibblesBuf.fromBytes([byte 0x10])
+      check:
+        n.len == 2
+        n[0] == 1
+        n[1] == 0
+        $n.slice(1) == "0"
+        $n.slice(2) == ""
+
+    block:
+      let n = NibblesBuf.fromBytes(repeat(byte 0x12, 32))
+      check:
+        n.len == 64
+        n[0] == 1
+        n[63] == 2
+
+    block:
+      let n = NibblesBuf.fromBytes(repeat(byte 0x12, 33))
+      check:
+        n.len == 64
+        n[0] == 1
+        n[63] == 2
+
+  test "to/from hex encoding":
+    block:
+      let n = NibblesBuf.fromBytes([byte 0x12, 0x34, 0x56])
+
+      let
+        he = n.toHexPrefix(true)
+        ho = n.slice(1).toHexPrefix(true)
+
+      check:
+        NibblesBuf.fromHexPrefix(he.data()) == (true, n)
+        NibblesBuf.fromHexPrefix(ho.data()) == (true, n.slice(1))
+    block:
+      let n = NibblesBuf.fromBytes(repeat(byte 0x12, 32))
+
+      let
+        he = n.toHexPrefix(true)
+        ho = n.slice(1).toHexPrefix(true)
+
+      check:
+        NibblesBuf.fromHexPrefix(he.data()) == (true, n)
+        NibblesBuf.fromHexPrefix(ho.data()) == (true, n.slice(1))
+
+        NibblesBuf.fromHexPrefix(@(he.data()) & @[byte 1]) == (true, n)
+        NibblesBuf.fromHexPrefix(@(ho.data()) & @[byte 1]) == (true, n.slice(1))
+
+  test "long":
+    let n = NibblesBuf.fromBytes(
+      hexToSeqByte("0100000000000000000000000000000000000000000000000000000000000000")
+    )
+
+    check $n == "0100000000000000000000000000000000000000000000000000000000000000"
+    check $n.slice(1) == "100000000000000000000000000000000000000000000000000000000000000"
+
+    let
+      he = n.toHexPrefix(true)
+      ho = n.slice(1).toHexPrefix(true)
+    check:
+      NibblesBuf.fromHexPrefix(he.data()) == (true, n)
+      NibblesBuf.fromHexPrefix(ho.data()) == (true, n.slice(1))


### PR DESCRIPTION
When walking AriVtx, parsing integers and nibbles actually becomes a hotspot - these trivial changes reduces CPU usage during initial key cache computation by ~15%.