### PR TITLE
fluffy: Make concurrent offers configurable at cli

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -232,7 +232,7 @@ type
         "the same machines. The option might be removed/adjusted in the future",
       defaultValue: defaultPortalProtocolConfig.tableIpLimits.tableIpLimit,
       defaultValueDesc: $defaultTableIpLimitDesc,
-      name: "table-ip-limit"
+      name: "debug-table-ip-limit"
     .}: uint
 
     bucketIpLimit* {.
@@ -243,7 +243,7 @@ type
         "the same machines. The option might be removed/adjusted in the future",
       defaultValue: defaultPortalProtocolConfig.tableIpLimits.bucketIpLimit,
       defaultValueDesc: $defaultBucketIpLimitDesc,
-      name: "bucket-ip-limit"
+      name: "debug-bucket-ip-limit"
     .}: uint
 
     bitsPerHop* {.
@@ -251,7 +251,7 @@ type
       desc: "Kademlia's b variable, increase for less hops per lookup",
       defaultValue: defaultPortalProtocolConfig.bitsPerHop,
       defaultValueDesc: $defaultBitsPerHopDesc,
-      name: "bits-per-hop"
+      name: "debug-bits-per-hop"
     .}: int
 
     maxGossipNodes* {.
@@ -259,7 +259,14 @@ type
       desc: "The maximum number of nodes to send content to during gossip",
       defaultValue: defaultPortalProtocolConfig.maxGossipNodes,
       defaultValueDesc: $defaultMaxGossipNodesDesc,
-      name: "max-gossip-nodes"
+      name: "debug-max-gossip-nodes"
+    .}: int
+
+    maxConcurrentOffers* {.
+      hidden,
+      desc: "The maximum number of offers to send concurrently",
+      defaultValue: defaultPortalProtocolConfig.maxConcurrentOffers,
+      name: "debug-max-concurrent-offers"
     .}: int
 
     radiusConfig* {.
@@ -316,14 +323,14 @@ type
         "Size of the in memory local content cache. This is the max number " &
         "of content values that can be stored in the cache.",
       defaultValue: defaultPortalProtocolConfig.contentCacheSize,
-      name: "content-cache-size"
+      name: "debug-content-cache-size"
     .}: int
 
     disableContentCache* {.
       hidden,
       desc: "Disable the in memory local content cache",
       defaultValue: defaultPortalProtocolConfig.disableContentCache,
-      name: "disable-content-cache"
+      name: "debug-disable-content-cache"
     .}: bool
 
     disablePoke* {.

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -183,7 +183,7 @@ proc run(
     portalProtocolConfig = PortalProtocolConfig.init(
       config.tableIpLimit, config.bucketIpLimit, config.bitsPerHop, config.radiusConfig,
       config.disablePoke, config.maxGossipNodes, config.contentCacheSize,
-      config.disableContentCache,
+      config.disableContentCache, config.maxConcurrentOffers,
     )
 
     portalNodeConfig = PortalNodeConfig(

--- a/fluffy/network/wire/portal_protocol_config.nim
+++ b/fluffy/network/wire/portal_protocol_config.nim
@@ -43,6 +43,7 @@ type
     maxGossipNodes*: int
     contentCacheSize*: int
     disableContentCache*: bool
+    maxConcurrentOffers*: int
 
 const
   defaultRadiusConfig* = RadiusConfig(kind: Dynamic)
@@ -51,6 +52,7 @@ const
   defaultMaxGossipNodes* = 4
   defaultContentCacheSize* = 100
   defaultDisableContentCache* = false
+  defaultMaxConcurrentOffers* = 50
   revalidationTimeout* = chronos.seconds(30)
 
   defaultPortalProtocolConfig* = PortalProtocolConfig(
@@ -61,6 +63,7 @@ const
     maxGossipNodes: defaultMaxGossipNodes,
     contentCacheSize: defaultContentCacheSize,
     disableContentCache: defaultDisableContentCache,
+    maxConcurrentOffers: defaultMaxConcurrentOffers,
   )
 
 proc init*(
@@ -73,6 +76,7 @@ proc init*(
     maxGossipNodes: int,
     contentCacheSize: int,
     disableContentCache: bool,
+    maxConcurrentOffers: int,
 ): T =
   PortalProtocolConfig(
     tableIpLimits:
@@ -83,6 +87,7 @@ proc init*(
     maxGossipNodes: maxGossipNodes,
     contentCacheSize: contentCacheSize,
     disableContentCache: disableContentCache,
+    maxConcurrentOffers: maxConcurrentOffers,
   )
 
 func fromLogRadius*(T: type UInt256, logRadius: uint16): T =

--- a/fluffy/scripts/launch_local_testnet.sh
+++ b/fluffy/scripts/launch_local_testnet.sh
@@ -342,9 +342,9 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --metrics \
     --metrics-address="127.0.0.1" \
     --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE ))" \
-    --table-ip-limit=1024 \
-    --bucket-ip-limit=24 \
-    --bits-per-hop=1 \
+    --debug-table-ip-limit=1024 \
+    --debug-bucket-ip-limit=24 \
+    --debug-bits-per-hop=1 \
     --portal-subnetworks="${PORTAL_SUBNETWORKS}" \
     --disable-state-root-validation="${DISABLE_STATE_ROOT_VALIDATION}" \
     ${TRUSTED_BLOCK_ROOT_ARG} \


### PR DESCRIPTION
Also prefix some of the current hidden config options with "debug"