### PR TITLE
Fluffy: Log nodeId when receiving offers

### DIFF
--- a/fluffy/network/beacon/beacon_network.nim
+++ b/fluffy/network/beacon/beacon_network.nim
@@ -340,7 +340,10 @@ proc validateContent(
     n.validateHistoricalSummaries(summariesWithProof)
 
 proc validateContent(
-    n: BeaconNetwork, srcNodeId: Opt[NodeId], contentKeys: ContentKeysList, contentItems: seq[seq[byte]]
+    n: BeaconNetwork,
+    srcNodeId: Opt[NodeId],
+    contentKeys: ContentKeysList,
+    contentItems: seq[seq[byte]],
 ): Future[bool] {.async: (raises: [CancelledError]).} =
   # content passed here can have less items then contentKeys, but not more.
   for i, contentItem in contentItems:

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -359,7 +359,10 @@ proc new*(
   )
 
 proc validateContent(
-    n: HistoryNetwork, srcNodeId: Opt[NodeId], contentKeys: ContentKeysList, contentItems: seq[seq[byte]]
+    n: HistoryNetwork,
+    srcNodeId: Opt[NodeId],
+    contentKeys: ContentKeysList,
+    contentItems: seq[seq[byte]],
 ): Future[bool] {.async: (raises: [CancelledError]).} =
   # content passed here can have less items then contentKeys, but not more.
   for i, contentItem in contentItems:
@@ -374,7 +377,8 @@ proc validateContent(
 
       debug "Received offered content validated successfully", srcNodeId, contentKey
     else:
-      debug "Received offered content failed validation", srcNodeId, contentKey, error = res.error
+      debug "Received offered content failed validation",
+        srcNodeId, contentKey, error = res.error
       return false
 
   return true

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -359,7 +359,7 @@ proc new*(
   )
 
 proc validateContent(
-    n: HistoryNetwork, contentKeys: ContentKeysList, contentItems: seq[seq[byte]]
+    n: HistoryNetwork, srcNodeId: Opt[NodeId], contentKeys: ContentKeysList, contentItems: seq[seq[byte]]
 ): Future[bool] {.async: (raises: [CancelledError]).} =
   # content passed here can have less items then contentKeys, but not more.
   for i, contentItem in contentItems:
@@ -367,14 +367,14 @@ proc validateContent(
     let res = await n.validateContent(contentItem, contentKey)
     if res.isOk():
       let contentId = n.portalProtocol.toContentId(contentKey).valueOr:
-        warn "Received offered content with invalid content key", contentKey
+        warn "Received offered content with invalid content key", srcNodeId, contentKey
         return false
 
       n.portalProtocol.storeContent(contentKey, contentId, contentItem)
 
-      debug "Received offered content validated successfully", contentKey
+      debug "Received offered content validated successfully", srcNodeId, contentKey
     else:
-      debug "Received offered content failed validation", contentKey, error = res.error
+      debug "Received offered content failed validation", srcNodeId, contentKey, error = res.error
       return false
 
   return true
@@ -388,7 +388,7 @@ proc processContentLoop(n: HistoryNetwork) {.async: (raises: []).} =
       # dropped and not gossiped around.
       # TODO: Differentiate between failures due to invalid data and failures
       # due to missing network data for validation.
-      if await n.validateContent(contentKeys, contentItems):
+      if await n.validateContent(srcNodeId, contentKeys, contentItems):
         asyncSpawn n.portalProtocol.neighborhoodGossipDiscardPeers(
           srcNodeId, contentKeys, contentItems
         )

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -226,11 +226,11 @@ proc processContentLoop(n: StateNetwork) {.async: (raises: []).} =
 
         if offerRes.isOk():
           state_network_offers_success.inc(labelValues = [$n.portalProtocol.protocolId])
-          debug "Received offered content validated successfully", contentKeyBytes
+          debug "Received offered content validated successfully", srcNodeId, contentKeyBytes
         else:
           state_network_offers_failed.inc(labelValues = [$n.portalProtocol.protocolId])
           error "Received offered content failed validation",
-            contentKeyBytes, error = offerRes.error()
+            srcNodeId, contentKeyBytes, error = offerRes.error()
   except CancelledError:
     trace "processContentLoop canceled"
 

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -226,7 +226,8 @@ proc processContentLoop(n: StateNetwork) {.async: (raises: []).} =
 
         if offerRes.isOk():
           state_network_offers_success.inc(labelValues = [$n.portalProtocol.protocolId])
-          debug "Received offered content validated successfully", srcNodeId, contentKeyBytes
+          debug "Received offered content validated successfully",
+            srcNodeId, contentKeyBytes
         else:
           state_network_offers_failed.inc(labelValues = [$n.portalProtocol.protocolId])
           error "Received offered content failed validation",


### PR DESCRIPTION
This should make it easier to debug validation failures by logging the source nodeId. We can easily lookup the enr using the nodeId to determine which node sent the failing offer.