### PR TITLE
fluffy: revert iplimit/bitperhop debug flags

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -232,7 +232,7 @@ type
         "the same machines. The option might be removed/adjusted in the future",
       defaultValue: defaultPortalProtocolConfig.tableIpLimits.tableIpLimit,
       defaultValueDesc: $defaultTableIpLimitDesc,
-      name: "debug-table-ip-limit"
+      name: "table-ip-limit"
     .}: uint
 
     bucketIpLimit* {.
@@ -243,7 +243,7 @@ type
         "the same machines. The option might be removed/adjusted in the future",
       defaultValue: defaultPortalProtocolConfig.tableIpLimits.bucketIpLimit,
       defaultValueDesc: $defaultBucketIpLimitDesc,
-      name: "debug-bucket-ip-limit"
+      name: "bucket-ip-limit"
     .}: uint
 
     bitsPerHop* {.
@@ -251,7 +251,7 @@ type
       desc: "Kademlia's b variable, increase for less hops per lookup",
       defaultValue: defaultPortalProtocolConfig.bitsPerHop,
       defaultValueDesc: $defaultBitsPerHopDesc,
-      name: "debug-bits-per-hop"
+      name: "bits-per-hop"
     .}: int
 
     maxGossipNodes* {.

--- a/fluffy/scripts/launch_local_testnet.sh
+++ b/fluffy/scripts/launch_local_testnet.sh
@@ -342,9 +342,9 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --metrics \
     --metrics-address="127.0.0.1" \
     --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE ))" \
-    --debug-table-ip-limit=1024 \
-    --debug-bucket-ip-limit=24 \
-    --debug-bits-per-hop=1 \
+    --table-ip-limit=1024 \
+    --bucket-ip-limit=24 \
+    --bits-per-hop=1 \
     --portal-subnetworks="${PORTAL_SUBNETWORKS}" \
     --disable-state-root-validation="${DISABLE_STATE_ROOT_VALIDATION}" \
     ${TRUSTED_BLOCK_ROOT_ARG} \


### PR DESCRIPTION
Revert for now to their previous names to avoid fluffy fleet breakage.