### PR TITLE
Simplify state root api

### DIFF
--- a/nimbus/db/aristo/aristo_api.nim
+++ b/nimbus/db/aristo/aristo_api.nim
@@ -93,13 +93,11 @@ type
         {.noRaise.}
       ## Fetch an account record from the database indexed by `accPath`.
 
-  AristoApiFetchAccountStateRootFn* =
+  AristoApiFetchStateRootFn* =
     proc(db: AristoDbRef;
-         updateOk: bool;
         ): Result[Hash32,AristoError]
         {.noRaise.}
-      ## Fetch the Merkle hash of the account root. Force update if the
-      ## argument `updateOK` is set `true`.
+      ## Fetch the Merkle hash of the account root.
 
   AristoApiFetchStorageDataFn* =
     proc(db: AristoDbRef;
@@ -113,11 +111,9 @@ type
   AristoApiFetchStorageRootFn* =
     proc(db: AristoDbRef;
          accPath: Hash32;
-         updateOk: bool;
         ): Result[Hash32,AristoError]
         {.noRaise.}
-      ## Fetch the Merkle hash of the storage root related to `accPath`. Force
-      ## update if the argument `updateOK` is set `true`.
+      ## Fetch the Merkle hash of the storage root related to `accPath`.
 
   AristoApiFindTxFn* =
     proc(db: AristoDbRef;
@@ -425,7 +421,7 @@ type
     fetchLastSavedState*: AristoApiFetchLastSavedStateFn
 
     fetchAccountRecord*: AristoApiFetchAccountRecordFn
-    fetchAccountStateRoot*: AristoApiFetchAccountStateRootFn
+    fetchStateRoot*: AristoApiFetchStateRootFn
     fetchStorageData*: AristoApiFetchStorageDataFn
     fetchStorageRoot*: AristoApiFetchStorageRootFn
 
@@ -472,7 +468,7 @@ type
     AristoApiProfFetchLastSavedStateFn  = "fetchLastSavedState"
 
     AristoApiProfFetchAccountRecordFn   = "fetchAccountRecord"
-    AristoApiProfFetchAccountStateRootFn = "fetchAccountStateRoot"
+    AristoApiProfFetchStateRootFn = "fetchStateRoot"
     AristoApiProfFetchStorageDataFn     = "fetchStorageData"
     AristoApiProfFetchStorageRootFn     = "fetchStorageRoot"
 
@@ -534,7 +530,7 @@ when AutoValidateApiHooks:
     doAssert not api.fetchLastSavedState.isNil
 
     doAssert not api.fetchAccountRecord.isNil
-    doAssert not api.fetchAccountStateRoot.isNil
+    doAssert not api.fetchStateRoot.isNil
     doAssert not api.fetchStorageData.isNil
     doAssert not api.fetchStorageRoot.isNil
 
@@ -601,7 +597,7 @@ func init*(api: var AristoApiObj) =
   api.fetchLastSavedState = fetchLastSavedState
 
   api.fetchAccountRecord = fetchAccountRecord
-  api.fetchAccountStateRoot = fetchAccountStateRoot
+  api.fetchStateRoot = fetchStateRoot
   api.fetchStorageData = fetchStorageData
   api.fetchStorageRoot = fetchStorageRoot
 
@@ -650,7 +646,7 @@ func dup*(api: AristoApiRef): AristoApiRef =
 
     fetchLastSavedState:  api.fetchLastSavedState,
     fetchAccountRecord:   api.fetchAccountRecord,
-    fetchAccountStateRoot: api.fetchAccountStateRoot,
+    fetchStateRoot: api.fetchStateRoot,
     fetchStorageData:     api.fetchStorageData,
     fetchStorageRoot:     api.fetchStorageRoot,
 
@@ -742,10 +738,10 @@ func init*(
       AristoApiProfFetchAccountRecordFn.profileRunner:
         result = api.fetchAccountRecord(a, b)
 
-  profApi.fetchAccountStateRoot =
+  profApi.fetchStateRoot =
     proc(a: AristoDbRef; b: bool): auto =
-      AristoApiProfFetchAccountStateRootFn.profileRunner:
-        result = api.fetchAccountStateRoot(a, b)
+      AristoApiProfFetchStateRootFn.profileRunner:
+        result = api.fetchStateRoot(a, b)
 
   profApi.fetchStorageData =
     proc(a: AristoDbRef; b, stoPath: Hash32): auto =
@@ -753,9 +749,9 @@ func init*(
         result = api.fetchStorageData(a, b, stoPath)
 
   profApi.fetchStorageRoot =
-    proc(a: AristoDbRef; b: Hash32; c: bool): auto =
+    proc(a: AristoDbRef; b: Hash32): auto =
       AristoApiProfFetchStorageRootFn.profileRunner:
-        result = api.fetchStorageRoot(a, b, c)
+        result = api.fetchStorageRoot(a, b)
 
   profApi.findTx =
     proc(a: AristoDbRef; b: RootedVertexID; c: HashKey): auto =

--- a/nimbus/db/core_db/backend/aristo_trace.nim
+++ b/nimbus/db/core_db/backend/aristo_trace.nim
@@ -243,7 +243,7 @@ proc jLogger(
 func to(w: AristoApiProfNames; T: type TracePfx): T =
   case w:
   of AristoApiProfFetchAccountRecordFn,
-     AristoApiProfFetchAccountStateRootFn,
+     AristoApiProfFetchStateRootFn,
      AristoApiProfDeleteAccountRecordFn,
      AristoApiProfMergeAccountRecordFn:
     return TrpAccounts
@@ -466,26 +466,25 @@ proc ariTraceRecorder(tr: TraceRecorderRef) =
         debug logTxt $info, level, accPath, accRec
       ok accRec
 
-  tracerApi.fetchAccountStateRoot =
+  tracerApi.fetchStateRoot =
     proc(mpt: AristoDbRef;
-         updateOk: bool;
         ): Result[Hash32,AristoError] =
-      const info = AristoApiProfFetchAccountStateRootFn
+      const info = AristoApiProfFetchStateRootFn
 
       when CoreDbNoisyCaptJournal:
         let level = tr.topLevel()
 
       # Find entry on DB
-      let state = api.fetchAccountStateRoot(mpt, updateOk).valueOr:
+      let state = api.fetchStateRoot(mpt).valueOr:
         when CoreDbNoisyCaptJournal:
-          debug logTxt $info, level, updateOk, error
+          debug logTxt $info, level, error
         tr.jLogger logRecord(info, TrqFind, error)
         return err(error)
 
       tr.jLogger logRecord(info, TrqFind, state)
 
       when CoreDbNoisyCaptJournal:
-        debug logTxt $info, level, updateOk, state
+        debug logTxt $info, level, state
       ok state
 
   tracerApi.fetchStorageData =
@@ -514,7 +513,6 @@ proc ariTraceRecorder(tr: TraceRecorderRef) =
   tracerApi.fetchStorageRoot =
     proc(mpt: AristoDbRef;
          accPath: Hash32;
-         updateOk: bool;
         ): Result[Hash32,AristoError] =
       const info = AristoApiProfFetchStorageRootFn
 
@@ -522,16 +520,16 @@ proc ariTraceRecorder(tr: TraceRecorderRef) =
         let level = tr.topLevel()
 
       # Find entry on DB
-      let state = api.fetchStorageRoot(mpt, accPath, updateOk).valueOr:
+      let state = api.fetchStorageRoot(mpt, accPath).valueOr:
         when CoreDbNoisyCaptJournal:
-          debug logTxt $info, level, accPath, updateOk, error
+          debug logTxt $info, level, accPath, error
         tr.jLogger(accPath, logRecord(info, TrqFind, error))
         return err(error)
 
       tr.jLogger(accPath, logRecord(info, TrqFind, state))
 
       when CoreDbNoisyCaptJournal:
-        debug logTxt $info, level, accPath, updateOk, state
+        debug logTxt $info, level, accPath, state
       ok state
 
   tracerApi.deleteAccountRecord =

--- a/nimbus/db/core_db/base/api_tracking.nim
+++ b/nimbus/db/core_db/base/api_tracking.nim
@@ -45,9 +45,9 @@ type
     AccSlotHasPathFn    = "slotHasPath"
     AccSlotMergeFn      = "slotMerge"
     AccSlotProofFn      = "slotProof"
-    AccSlotStateFn      = "slotState"
-    AccSlotStateEmptyFn = "slotStateEmpty"
-    AccSlotStateEmptyOrVoidFn = "slotStateEmptyOrVoid"
+    AccSlotStorageRootFn = "slotStorageRoot"
+    AccSlotStorageEmptyFn = "slotStorageEmpty"
+    AccSlotStorageEmptyOrVoidFn = "slotStorageEmptyOrVoid"
     AccSlotPairsIt      = "slotPairs"
 
     BaseFinishFn        = "finish"

--- a/nimbus/tracer.nim
+++ b/nimbus/tracer.nim
@@ -189,14 +189,14 @@ proc traceTransactionImpl(
       before.captureAccount(stateDb, miner, minerName)
       stateDb.persist()
       stateDiff["beforeRoot"] = %(stateDb.getStateRoot().toHex)
-      discard com.db.ctx.getAccounts.stateRoot(updateOk=true) # lazy hashing!
+      discard com.db.ctx.getAccounts.getStateRoot() # lazy hashing!
       stateCtx = CaptCtxRef.init(com, stateDb.getStateRoot())
 
     let rc = vmState.processTransaction(tx, sender, header)
     gasUsed = if rc.isOk: rc.value else: 0
 
     if idx.uint64 == txIndex:
-      discard com.db.ctx.getAccounts.stateRoot(updateOk=true) # lazy hashing!
+      discard com.db.ctx.getAccounts.getStateRoot() # lazy hashing!
       after.captureAccount(stateDb, sender, senderName)
       after.captureAccount(stateDb, recipient, recipientName)
       after.captureAccount(stateDb, miner, minerName)

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -59,7 +59,7 @@ proc parseEnv(node: JsonNode): TestEnv =
   result.pre = node["pre"]
 
 proc rootExists(db: CoreDbRef; root: Hash32): bool =
-  let state = db.ctx.getAccounts().stateRoot(updateOk=true).valueOr:
+  let state = db.ctx.getAccounts().getStateRoot().valueOr:
     return false
   state == root
 


### PR DESCRIPTION
`updateOk` is obsolete and always set to true - callers should not have to care about this detail

also take the opportunity to clean up storage root naming