### PR TITLE
Inline gas cost/instruction fetching

### DIFF
--- a/nimbus/evm/computation.nim
+++ b/nimbus/evm/computation.nim
@@ -451,9 +451,9 @@ func traceError*(c: Computation) =
 func prepareTracer*(c: Computation) =
   c.vmState.capturePrepare(c, c.msg.depth)
 
-func opcodeGasCost*(
+template opcodeGasCost*(
     c: Computation, op: Op, gasCost: static GasInt, tracingEnabled: static bool,
-    reason: static string): EvmResultVoid {.inline.} =
+    reason: static string): EvmResultVoid =
   # Special case of the opcodeGasCost function used for fixed-gas opcodes - since
   # the parameters are known at compile time, we inline and specialize it
   when tracingEnabled:
@@ -465,16 +465,17 @@ func opcodeGasCost*(
       c.msg.depth + 1)
   c.gasMeter.consumeGas(gasCost, reason)
 
-func opcodeGasCost*(
+template opcodeGasCost*(
     c: Computation, op: Op, gasCost: GasInt, reason: static string): EvmResultVoid =
+  let cost = gasCost
   if c.vmState.tracingEnabled:
     c.vmState.captureGasCost(
       c,
       op,
-      gasCost,
+      cost,
       c.gasMeter.gasRemaining,
       c.msg.depth + 1)
-  c.gasMeter.consumeGas(gasCost, reason)
+  c.gasMeter.consumeGas(cost, reason)
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/evm/interpreter/gas_meter.nim
+++ b/nimbus/evm/interpreter/gas_meter.nim
@@ -19,16 +19,17 @@ func init*(m: var GasMeter, startGas: GasInt) =
   m.gasRemaining = startGas
   m.gasRefunded = 0
 
-func consumeGas*(
-    gasMeter: var GasMeter; amount: GasInt; reason: static string): EvmResultVoid {.inline.} =
+template consumeGas*(
+    gasMeter: var GasMeter; amount: GasInt; reason: static string): EvmResultVoid =
   # consumeGas is a hotspot in the vm due to it being called for every
   # instruction
   # TODO report reason - consumeGas is a hotspot in EVM execution so it has to
   #      be done carefully
   if amount > gasMeter.gasRemaining:
-    return err(gasErr(OutOfGas))
-  gasMeter.gasRemaining -= amount
-  ok()
+    EvmResultVoid.err(gasErr(OutOfGas))
+  else:
+    gasMeter.gasRemaining -= amount
+    EvmResultVoid.ok()
 
 func returnGas*(gasMeter: var GasMeter; amount: GasInt) =
   gasMeter.gasRemaining += amount

--- a/nimbus/evm/interpreter/op_handlers/oph_call.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_call.nim
@@ -203,10 +203,10 @@ else:
         c.gasMeter.refundGas(child.gasMeter.gasRefunded)
         c.stack.lsTop(1)
 
-      c.returnData = child.output
       let actualOutputSize = min(memLen, child.output.len)
       if actualOutputSize > 0:
         ? c.memory.write(memPos, child.output.toOpenArray(0, actualOutputSize - 1))
+      c.returnData = move(child.output)
       ok()
 
 # ------------------------------------------------------------------------------

--- a/nimbus/evm/interpreter/op_handlers/oph_create.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_create.nim
@@ -78,7 +78,7 @@ else:
         c.stack.lsTop child.msg.contractAddress
       elif not child.error.burnsGas: # Means return was `REVERT`.
         # From create, only use `outputData` if child returned with `REVERT`.
-        c.returnData = child.output
+        c.returnData = move(child.output)
       ok()
 
 

--- a/nimbus/evm/precompiles.nim
+++ b/nimbus/evm/precompiles.nim
@@ -301,18 +301,18 @@ func bn256ecAdd(c: Computation, fork: EVMFork = FkByzantium): EvmResultVoid =
 
   var
     input: array[128, byte]
-    output: array[64, byte]
   # Padding data
   let len = min(c.msg.data.len, 128) - 1
   input[0..len] = c.msg.data[0..len]
   var p1 = ? G1.getPoint(input.toOpenArray(0, 63))
   var p2 = ? G1.getPoint(input.toOpenArray(64, 127))
   var apo = (p1 + p2).toAffine()
+
+  c.output.setLen(64)
   if isSome(apo):
     # we can discard here because we supply proper buffer
-    discard apo.get().toBytes(output)
+    discard apo.get().toBytes(c.output)
 
-  assign(c.output, output)
   ok()
 
 func bn256ecMul(c: Computation, fork: EVMFork = FkByzantium): EvmResultVoid =
@@ -321,7 +321,6 @@ func bn256ecMul(c: Computation, fork: EVMFork = FkByzantium): EvmResultVoid =
 
   var
     input: array[96, byte]
-    output: array[64, byte]
 
   # Padding data
   let len = min(c.msg.data.len, 96) - 1
@@ -329,11 +328,12 @@ func bn256ecMul(c: Computation, fork: EVMFork = FkByzantium): EvmResultVoid =
   var p1 = ? G1.getPoint(input.toOpenArray(0, 63))
   var fr = ? getFR(input.toOpenArray(64, 95))
   var apo = (p1 * fr).toAffine()
+
+  c.output.setLen(64)
   if isSome(apo):
     # we can discard here because we supply buffer of proper size
-    discard apo.get().toBytes(output)
+    discard apo.get().toBytes(c.output)
 
-  assign(c.output, output)
   ok()
 
 func bn256ecPairing(c: Computation, fork: EVMFork = FkByzantium): EvmResultVoid =
@@ -348,10 +348,10 @@ func bn256ecPairing(c: Computation, fork: EVMFork = FkByzantium): EvmResultVoid 
                  GasECPairingBaseIstanbul + numPoints * GasECPairingPerPointIstanbul
   ? c.gasMeter.consumeGas(gasFee, reason="ecPairing Precompile")
 
-  var output: array[32, byte]
+  c.output.setLen(32)
   if msglen == 0:
     # we can discard here because we supply buffer of proper size
-    discard BNU256.one().toBytes(output)
+    discard BNU256.one().toBytes(c.output)
   else:
     # Calculate number of pairing pairs
     let count = msglen div 192
@@ -369,9 +369,8 @@ func bn256ecPairing(c: Computation, fork: EVMFork = FkByzantium): EvmResultVoid 
 
     if acc == FQ12.one():
       # we can discard here because we supply buffer of proper size
-      discard BNU256.one().toBytes(output)
+      discard BNU256.one().toBytes(c.output)
 
-  assign(c.output, output)
   ok()
 
 func blake2bf(c: Computation): EvmResultVoid =
@@ -382,11 +381,9 @@ func blake2bf(c: Computation): EvmResultVoid =
     let gasFee = GasInt(beLoad32(input, 0))
     ? c.gasMeter.consumeGas(gasFee, reason="blake2bf Precompile")
 
-  var output: array[64, byte]
-  if not blake2b_F(input, output):
+  c.output.setLen(64)
+  if not blake2b_F(input, c.output):
     return err(prcErr(PrcInvalidParam))
-  else:
-    assign(c.output, output)
   ok()
 
 func blsG1Add(c: Computation): EvmResultVoid =
@@ -407,7 +404,7 @@ func blsG1Add(c: Computation): EvmResultVoid =
 
   a.add b
 
-  c.output = newSeq[byte](128)
+  c.output.setLen(128)
   if not encodePoint(a, c.output):
     return err(prcErr(PrcInvalidPoint))
   ok()
@@ -431,7 +428,7 @@ func blsG1Mul(c: Computation): EvmResultVoid =
 
   a.mul(scalar)
 
-  c.output = newSeq[byte](128)
+  c.output.setLen(128)
   if not encodePoint(a, c.output):
     return err(prcErr(PrcInvalidPoint))
   ok()
@@ -504,7 +501,7 @@ func blsG1MultiExp(c: Computation): EvmResultVoid =
     else:
       acc.add(p)
 
-  c.output = newSeq[byte](128)
+  c.output.setLen(128)
   if not encodePoint(acc, c.output):
     return err(prcErr(PrcInvalidPoint))
   ok()
@@ -527,7 +524,7 @@ func blsG2Add(c: Computation): EvmResultVoid =
 
   a.add b
 
-  c.output = newSeq[byte](256)
+  c.output.setLen(256)
   if not encodePoint(a, c.output):
     return err(prcErr(PrcInvalidPoint))
   ok()
@@ -551,7 +548,7 @@ func blsG2Mul(c: Computation): EvmResultVoid =
 
   a.mul(scalar)
 
-  c.output = newSeq[byte](256)
+  c.output.setLen(256)
   if not encodePoint(a, c.output):
     return err(prcErr(PrcInvalidPoint))
   ok()
@@ -593,7 +590,7 @@ func blsG2MultiExp(c: Computation): EvmResultVoid =
     else:
       acc.add(p)
 
-  c.output = newSeq[byte](256)
+  c.output.setLen(256)
   if not encodePoint(acc, c.output):
     return err(prcErr(PrcInvalidPoint))
   ok()
@@ -643,7 +640,7 @@ func blsPairing(c: Computation): EvmResultVoid =
     else:
       acc.mul(millerLoop(g1, g2))
 
-  c.output = newSeq[byte](32)
+  c.output.setLen(32)
   if acc.check():
     c.output[^1] = 1.byte
   ok()
@@ -663,7 +660,7 @@ func blsMapG1(c: Computation): EvmResultVoid =
 
   let p = fe.mapFPToG1()
 
-  c.output = newSeq[byte](128)
+  c.output.setLen(128)
   if not encodePoint(p, c.output):
     return err(prcErr(PrcInvalidPoint))
   ok()
@@ -683,7 +680,7 @@ func blsMapG2(c: Computation): EvmResultVoid =
 
   let p = fe.mapFPToG2()
 
-  c.output = newSeq[byte](256)
+  c.output.setLen(256)
   if not encodePoint(p, c.output):
     return err(prcErr(PrcInvalidPoint))
   ok()

--- a/nimbus/evm/precompiles.nim
+++ b/nimbus/evm/precompiles.nim
@@ -98,7 +98,7 @@ func getSignature(c: Computation): EvmResult[SigRes]  =
   # used for R and S
   if maxPos >= 64:
     # Copy message data to buffer
-    bytes[0..(maxPos-64)] = data[64..maxPos]
+    assign(bytes.toOpenArray(0, (maxPos-64)), data.toOpenArray(64, maxPos))
 
   let sig = Signature.fromRaw(bytes).valueOr:
     return err(prcErr(PrcInvalidSig))
@@ -324,7 +324,7 @@ func bn256ecMul(c: Computation, fork: EVMFork = FkByzantium): EvmResultVoid =
 
   # Padding data
   let len = min(c.msg.data.len, 96) - 1
-  input[0..len] = c.msg.data[0..len]
+  assign(input.toOpenArray(0, len), c.msg.data.toOpenArray(0, len))
   var p1 = ? G1.getPoint(input.toOpenArray(0, 63))
   var fr = ? getFR(input.toOpenArray(64, 95))
   var apo = (p1 * fr).toAffine()

--- a/tools/t8n/testdata/00-519/exp.txt
+++ b/tools/t8n/testdata/00-519/exp.txt
@@ -1,2 +1,2 @@
 {"pc":0,"op":0,"gas":"0x0","gasCost":"0xfffffffffffecb68","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"STOP","error":"PrcInvalidParam"}
-{"output":"","gasUsed":"0x13498","error":"PrcInvalidParam"}
+{"output":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","gasUsed":"0x13498","error":"PrcInvalidParam"}


### PR DESCRIPTION
These make up 5:ish % of EVM execution time - even though they're trivial they end up not being inlined - this little change gives a practically free perf boost ;)

Also unify the style of creating the output to `setLen`..