### PR TITLE
Faster local testing with `Dockerfile.debug`

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -17,8 +17,7 @@ COPY ./ /nimbus-eth1
 
 WORKDIR /nimbus-eth1
 
-RUN  --mount=type=cache,target=/nimbus-eth1/build \
-  make -j${NPROC} nimbus_execution_client && \
+RUN make -j${NPROC} nimbus_execution_client && \
   mv build/nimbus_execution_client /usr/local/bin/nimbus_execution_client
 
 # --------------------------------- #

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,0 +1,30 @@
+# Nimbus
+# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+FROM debian:stable-slim AS build
+
+ENV DEBIAN_FRONTEND=noninteractive TZ="Etc/UTC"
+ENV NPROC=8
+
+RUN apt update \
+  && apt install make bash build-essential curl git -y
+
+COPY ./ /nimbus-eth1
+
+WORKDIR /nimbus-eth1
+
+RUN  --mount=type=cache,target=/nimbus-eth1/build \
+  make -j${NPROC} nimbus_execution_client && \
+  mv build/nimbus_execution_client /usr/local/bin/nimbus_execution_client
+
+# --------------------------------- #
+# Starting new image to reduce size #
+# --------------------------------- #
+FROM debian:stable-slim AS deploy
+COPY --from=build /usr/local/bin/nimbus_execution_client /usr/local/bin/nimbus_execution_client
+
+ENTRYPOINT ["/usr/local/bin/nimbus_execution_client"]

--- a/run-kurtosis-check.sh
+++ b/run-kurtosis-check.sh
@@ -16,10 +16,25 @@
 echo
 printf "Do you want to run the checks in terminal or visit the assertoor URL? (terminal/url) "
 read reply
+if [[ "$reply" != "terminal" && "$reply" != "url" ]]; then
+  echo "Invalid input: '$reply'. Please enter 'terminal' or 'url'."
+  exit 1
+fi
 
 echo
 printf "Build new changes (yes/no)? "
 read use_previous_image
+if [[ "$use_previous_image" != "yes" && "$use_previous_image" != "no" ]]; then
+  echo "Invalid input: '$use_previous_image'. Please enter 'yes' or 'no'."
+  exit 1
+fi
+
+# Set dockerfile_name based on --debug argument
+if [[ "$1" == "--debug" ]]; then
+    dockerfile_name="Dockerfile.debug"
+else
+    dockerfile_name="Dockerfile"
+fi
 
 # ------------------------------------------------
 #             Installation Checks
@@ -71,7 +86,7 @@ if [[ "$use_previous_image" == "no" ]]; then
 else
   echo "Starting the Docker Build!"
   # Build the docker Image
-  sudo docker build . -t localtestnet
+  sudo docker build -t localtestnet -f $dockerfile_name .
   # The new el_image value
   new_el_image="localtestnet"
 fi
@@ -82,8 +97,7 @@ fi
 # ------------------------------------------------
 
 # Use sed to replace the el_image value in the file
-cat kurtosis-network-params.yml | envsubst > assertoor.yaml
-sed -i "s/el_image: .*/el_image: $new_el_image/" assertoor.yaml
+sed "s/el_image: .*/el_image: $new_el_image/" kurtosis-network-params.yml > assertoor.yaml
 
 sudo kurtosis run \
   --enclave nimbus-localtestnet \

--- a/run-kurtosis-check.sh
+++ b/run-kurtosis-check.sh
@@ -105,7 +105,7 @@ sudo kurtosis run \
   --args-file assertoor.yaml
 
 enclave_dump=$(kurtosis enclave inspect nimbus-localtestnet)
-assertoor_url=$(echo "$enclave_dump" | grep assertoor | grep http | sed 's/.*\(http:\/\/[0-9.:]\+\).*/\1/')
+assertoor_url=$(echo "$enclave_dump" | grep assertoor | grep -Eo "http://[0-9.:]+")
 
 # ------------------------------------------------
 #               Remove Generated File


### PR DESCRIPTION
Inspired from the debug dockerfile of fluffy, this PR adds a debug Docker file for nimbus. This helps us speed the testing process using kurtosis locally, or during trying out small changes we used to need a 30min long docker build time, but with the `Dockerfile.debug` it's around 10mins

It is baked into the `run-kurtosis-check.sh`, it will use the debug file, only when a flag `--debug` is passed along with the script invocation