### PR TITLE
Remove trie_defs imports

### DIFF
--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -11,7 +11,6 @@
 
 import
   chronicles,
-  eth/trie/trie_defs,
   ../core/casper,
   ../db/[core_db, ledger, storage_types],
   ../utils/[utils, ec_recover],

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -19,7 +19,6 @@ import
   ../tools/common/helpers as chp,
   ../tools/evmstate/helpers,
   ../tools/common/state_clearing,
-  eth/trie/trie_defs,
   eth/common/transaction_utils,
   unittest2,
   stew/byteutils,
@@ -79,7 +78,7 @@ proc dumpDebugData(ctx: TestCtx, vmState: BaseVMState, gasUsed: GasInt, success:
 proc testFixtureIndexes(ctx: var TestCtx, testStatusIMPL: var TestStatus) =
   let
     com    = CommonRef.new(newCoreDbRef DefaultDbMemory, ctx.chainConfig)
-    parent = Header(stateRoot: emptyRlpHash)
+    parent = Header(stateRoot: emptyRoot)
     tracer = if ctx.trace:
                newLegacyTracer({})
              else:

--- a/tests/test_getproof_json.nim
+++ b/tests/test_getproof_json.nim
@@ -12,7 +12,7 @@ import
   web3/eth_api,
   nimcrypto/[keccak, hash],
   eth/common/[keys, eth_types_rlp],
-  eth/[rlp, trie/trie_defs, trie/hexary_proof_verification],
+  eth/[rlp, trie/hexary_proof_verification],
   ../nimbus/db/[ledger, core_db],
   ../nimbus/common/chain_config,
   ../nimbus/rpc/server_api

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -16,7 +16,6 @@ import
   stew/byteutils,
   results,
   stint,
-  eth/trie/[trie_defs],
   ../../nimbus/[evm/types, evm/state],
   ../../nimbus/db/ledger,
   ../../nimbus/transaction,

--- a/tools/evmstate/helpers.nim
+++ b/tools/evmstate/helpers.nim
@@ -13,7 +13,6 @@ import
   eth/common/keys,
   eth/common/headers,
   eth/common/transactions,
-  eth/trie/trie_defs,
   stint,
   stew/byteutils,
   ../../nimbus/transaction,
@@ -113,7 +112,7 @@ proc parseHeader*(n: JsonNode): Header =
     number     : required(BlockNumber, "currentNumber"),
     gasLimit   : required(GasInt, "currentGasLimit"),
     timestamp  : required(EthTime, "currentTimestamp"),
-    stateRoot  : emptyRlpHash,
+    stateRoot  : emptyRoot,
     mixHash    : omitZero(Bytes32, "currentRandom"),
     baseFeePerGas  : optional(UInt256, "currentBaseFee"),
     withdrawalsRoot: optional(Hash32, "currentWithdrawalsRoot"),
@@ -123,7 +122,7 @@ proc parseHeader*(n: JsonNode): Header =
 
 proc parseParentHeader*(n: JsonNode): Header =
   Header(
-    stateRoot: emptyRlpHash,
+    stateRoot: emptyRoot,
     excessBlobGas: optional(uint64, "parentExcessBlobGas"),
     blobGasUsed: optional(uint64, "parentBlobGasUsed"),
   )


### PR DESCRIPTION
nimbus_execution_layer is not using hexary trie anymore. `trie_defs` also should not be used too.