### PR TITLE
For the `FC` module, never add the `base` block to base tree

### DIFF
--- a/nimbus/core/chain/forked_chain.nim
+++ b/nimbus/core/chain/forked_chain.nim
@@ -646,13 +646,14 @@ proc latestBlock*(c: ForkedChainRef): Block =
   c.blocks.withValue(c.cursorHash, val) do:
     return val.blk
   do:
-    # This can happen if block pointed by cursorHash is not loaded yet
     result = c.db.getEthBlock(c.cursorHash).expect("cursorBlock exists")
-    c.blocks[c.cursorHash] = BlockDesc(
-      blk: result,
-      receipts: c.db.getReceipts(result.header.receiptsRoot).
-        expect("receipts exists"),
-    )
+    if c.cursorHash != c.baseHash:
+      # This can happen if the block pointed to by cursorHash is not loaded yet
+      c.blocks[c.cursorHash] = BlockDesc(
+        blk: result,
+        receipts: c.db.getReceipts(result.header.receiptsRoot).
+          expect("receipts exists"),
+      )
 
 proc headerByNumber*(c: ForkedChainRef, number: BlockNumber): Result[Header, string] =
   if number > c.cursorHeader.number:


### PR DESCRIPTION
The `base` block is ancestor to all blocks of the base tree bust stays
outside the tree.

Some fringe condition uses an opportunistic fix when the `cursor` is not in
the base tree, which is legit if `cursor != base`.