### PR TITLE
Speed up evm stack

### DIFF
--- a/nimbus/db/ledger.nim
+++ b/nimbus/db/ledger.nim
@@ -453,7 +453,6 @@ proc getNonce*(ac: LedgerRef, address: Address): AccountNonce =
 proc getCode*(ac: LedgerRef,
               address: Address,
               returnHash: static[bool] = false): auto =
-  # Always returns non-nil!
   let acc = ac.getAccount(address, false)
   if acc.isNil:
     when returnHash:
@@ -526,7 +525,7 @@ proc getDelegateAddress*(ac: LedgerRef, address: Address): Address =
   let delegateTo = parseDelegationAddress(code).valueOr:
     return
   delegateTo
-  
+
 proc getCommittedStorage*(ac: LedgerRef, address: Address, slot: UInt256): UInt256 =
   let acc = ac.getAccount(address, false)
   if acc.isNil:

--- a/nimbus/evm/computation.nim
+++ b/nimbus/evm/computation.nim
@@ -11,6 +11,7 @@
 {.push raises: [].}
 
 import
+  std/sequtils,
   ".."/[db/ledger, constants],
   "."/[code_stream, memory, message, stack, state],
   "."/[types],
@@ -21,8 +22,7 @@ import
   ../utils/utils,
   ../common/common,
   eth/common/eth_types_rlp,
-  chronicles, chronos,
-  sets
+  chronicles, chronos
 
 export
   common
@@ -322,7 +322,10 @@ proc commit*(c: Computation) =
 
 proc dispose*(c: Computation) =
   c.vmState.stateDB.safeDispose(c.savePoint)
-  if not c.keepStack and c.stack != nil:
+  if c.stack != nil:
+    if c.keepStack:
+      c.finalStack = toSeq(c.stack.items())
+
     c.stack.dispose()
     c.stack = nil
   c.savePoint = nil

--- a/nimbus/evm/computation.nim
+++ b/nimbus/evm/computation.nim
@@ -260,39 +260,44 @@ template resolveCode*(c: Computation, address: Address): CodeBytesRef =
     c.vmState.readOnlyStateDB.resolveCode(address)
 
 proc newComputation*(vmState: BaseVMState, sysCall: bool, message: Message,
-                     salt: ContractSalt = ZERO_CONTRACTSALT): Computation =
+                     isPrecompile, keepStack: bool, salt: ContractSalt = ZERO_CONTRACTSALT): Computation =
   new result
   result.vmState = vmState
   result.msg = message
-  result.memory = EvmMemory.init()
-  result.stack = EvmStack.init()
-  result.returnStack = @[]
   result.gasMeter.init(message.gas)
   result.sysCall = sysCall
+  result.keepStack = keepStack
 
-  if result.msg.isCreate():
-    result.msg.contractAddress = result.generateContractAddress(salt)
-    result.code = CodeStream.init(message.data)
-    message.data = @[]
-  else:
-    if vmState.fork >= FkPrague:
-      result.code = CodeStream.init(
-        vmState.readOnlyStateDB.resolveCode(message.codeAddress))
+  if not isPrecompile:
+    result.memory = EvmMemory.init()
+    result.stack = EvmStack.init()
+
+    if result.msg.isCreate():
+      result.msg.contractAddress = result.generateContractAddress(salt)
+      result.code = CodeStream.init(message.data)
+      message.data = @[]
     else:
-      result.code = CodeStream.init(
-        vmState.readOnlyStateDB.getCode(message.codeAddress))
+      if vmState.fork >= FkPrague:
+        result.code = CodeStream.init(
+          vmState.readOnlyStateDB.resolveCode(message.codeAddress))
+      else:
+        result.code = CodeStream.init(
+          vmState.readOnlyStateDB.getCode(message.codeAddress))
+
 
 func newComputation*(vmState: BaseVMState, sysCall: bool,
-                     message: Message, code: CodeBytesRef): Computation =
+                     message: Message, code: CodeBytesRef, isPrecompile, keepStack: bool, ): Computation =
   new result
   result.vmState = vmState
   result.msg = message
-  result.memory = EvmMemory.init()
-  result.stack = EvmStack.init()
-  result.returnStack = @[]
   result.gasMeter.init(message.gas)
-  result.code = CodeStream.init(code)
   result.sysCall = sysCall
+  result.keepStack = keepStack
+
+  if not isPrecompile:
+    result.code = CodeStream.init(code)
+    result.memory = EvmMemory.init()
+    result.stack = EvmStack.init()
 
 template gasCosts*(c: Computation): untyped =
   c.vmState.gasCosts
@@ -317,6 +322,9 @@ proc commit*(c: Computation) =
 
 proc dispose*(c: Computation) =
   c.vmState.stateDB.safeDispose(c.savePoint)
+  if not c.keepStack and c.stack != nil:
+    c.stack.dispose()
+    c.stack = nil
   c.savePoint = nil
 
 proc rollback*(c: Computation) =

--- a/nimbus/evm/interpreter/op_handlers/oph_blockdata.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_blockdata.nim
@@ -34,7 +34,7 @@ proc blockhashOp(cpt: VmCpt): EvmResultVoid =
   ## 0x40, Get the hash of one of the 256 most recent complete blocks.
   template block256(top, number, conv) =
     if number > high(BlockNumber).u256:
-      top = zero(UInt256)
+      conv(zero(UInt256), top)
     else:
       conv(cpt.getBlockHash(number.truncate(BlockNumber)), top)
 
@@ -82,7 +82,7 @@ proc blobHashOp(cpt: VmCpt): EvmResultVoid =
     if index < len:
       conv(cpt.getVersionedHash(index).data, top)
     else:
-      top = zero(UInt256)
+      conv(zero(UInt256), top)
 
   cpt.stack.unaryWithTop(blob256)
 

--- a/nimbus/evm/interpreter/op_handlers/oph_call.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_call.nim
@@ -21,6 +21,7 @@ import
   ../../../core/eip7702,
   ../../computation,
   ../../memory,
+  ../../precompiles,
   ../../stack,
   ../../types,
   ../gas_costs,
@@ -215,7 +216,9 @@ else:
     # need to provide explicit <c> and <child> for capturing in chainTo proc()
     # <memPos> and <memLen> are provided by value and need not be captured
     var
-      child = newComputation(c.vmState, false, childMsg)
+      precompile = getPrecompile(c.fork, childMsg.codeAddress)
+      child = newComputation(
+        c.vmState, false, childMsg, isPrecompile = precompile.isSome(), keepStack = false)
 
     c.chainTo(child):
       if not child.shouldBurnGas:

--- a/nimbus/evm/interpreter/op_handlers/oph_create.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_create.nim
@@ -67,7 +67,7 @@ else:
 
     # need to provide explicit <c> and <child> for capturing in chainTo proc()
     var
-      child = newComputation(c.vmState, false, childMsg, salt)
+      child = newComputation(c.vmState, false, childMsg, false, false, salt)
 
     c.chainTo(child):
       if not child.shouldBurnGas:

--- a/nimbus/evm/interpreter/op_handlers/oph_log.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_log.nim
@@ -68,7 +68,7 @@ proc logImpl(c: Computation, opcode: Op, topicCount: static int): EvmResultVoid 
   when evmc_enabled:
     var topics: array[4, evmc_bytes32]
     for i in 0 ..< topicCount:
-      topics[i].bytes = c.stack.lsPeekTopic(^(i+3))
+      topics[i].bytes = c.stack.lsPeekTopic(^(i+3)).data
 
     c.host.emitLog(c.msg.contractAddress,
       c.memory.read(memPos, len),
@@ -77,7 +77,7 @@ proc logImpl(c: Computation, opcode: Op, topicCount: static int): EvmResultVoid 
     var log: Log
     log.topics = newSeqOfCap[Topic](topicCount)
     for i in 0 ..< topicCount:
-      log.topics.add Bytes32 c.stack.lsPeekTopic(^(i+3))
+      log.topics.add c.stack.lsPeekTopic(^(i+3))
 
     assign(log.data, c.memory.read(memPos, len))
     log.address = c.msg.contractAddress

--- a/nimbus/evm/interpreter/op_handlers/oph_memory.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_memory.nim
@@ -178,7 +178,7 @@ proc mstore8Op(cpt: VmCpt): EvmResultVoid =
 proc sloadOp(cpt: VmCpt): EvmResultVoid =
   ## 0x54, Load word from storage.
   template sload256(top, slot, conv) =
-    top = cpt.getStorage(slot)
+    conv(cpt.getStorage(slot), top)
   cpt.stack.unaryWithTop(sload256)
 
 proc sloadEIP2929Op(cpt: VmCpt): EvmResultVoid =
@@ -186,7 +186,7 @@ proc sloadEIP2929Op(cpt: VmCpt): EvmResultVoid =
   template sloadEIP2929(top, slot, conv) =
     let gasCost = cpt.gasEip2929AccountCheck(cpt.msg.contractAddress, slot)
     ? cpt.opcodeGasCost(Sload, gasCost, reason = "sloadEIP2929")
-    top = cpt.getStorage(slot)
+    conv(cpt.getStorage(slot), top)
   cpt.stack.unaryWithTop(sloadEIP2929)
 
 # -------

--- a/nimbus/evm/interpreter_dispatch.nim
+++ b/nimbus/evm/interpreter_dispatch.nim
@@ -197,8 +197,11 @@ proc executeOpcodes*(c: Computation, shouldPrepareTracer: bool = true) =
   let fork = c.fork
 
   block blockOne:
-    if c.continuation.isNil and c.execPrecompiles(fork):
-      break blockOne
+    if c.continuation.isNil:
+      let precompile = c.fork.getPrecompile(c.msg.codeAddress)
+      if precompile.isSome:
+        c.execPrecompile(precompile[])
+        break blockOne
 
     let cont = c.continuation
     if not cont.isNil:

--- a/nimbus/evm/types.nim
+++ b/nimbus/evm/types.nim
@@ -14,6 +14,8 @@ import
   ../db/ledger,
   ../common/[common, evmforks]
 
+export stack, memory
+
 # this import not guarded by `when defined(evmc_enabled)`
 # because we want to use evmc types such as evmc_call_kind
 # and evmc_flags
@@ -76,7 +78,6 @@ type
     msg*:                   Message
     memory*:                EvmMemory
     stack*:                 EvmStack
-    returnStack*:           seq[int]
     gasMeter*:              GasMeter
     code*:                  CodeStream
     output*:                seq[byte]
@@ -93,6 +94,7 @@ type
       parent*, child*:      Computation
     continuation*:          proc(): EvmResultVoid {.gcsafe, raises: [].}
     sysCall*:               bool
+    keepStack*:             bool
 
   Error* = ref object
     evmcStatus*: evmc_status_code

--- a/nimbus/evm/types.nim
+++ b/nimbus/evm/types.nim
@@ -95,6 +95,7 @@ type
     continuation*:          proc(): EvmResultVoid {.gcsafe, raises: [].}
     sysCall*:               bool
     keepStack*:             bool
+    finalStack*:            seq[UInt256]
 
   Error* = ref object
     evmcStatus*: evmc_status_code

--- a/nimbus/transaction/call_common.nim
+++ b/nimbus/transaction/call_common.nim
@@ -309,7 +309,7 @@ proc finishRunningComputation(
                             else: default(HostAddress)
 
     when T is DebugCallResult:
-      result.stack = move(c.stack)
+      result.stack = move(c.finalStack)
       result.memory = move(c.memory)
   elif T is GasInt:
     result = call.gasLimit - gasRemaining

--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -204,6 +204,6 @@ proc txCallEvm*(tx: Transaction,
 
 proc testCallEvm*(tx: Transaction,
                   sender: Address,
-                  vmState: BaseVMState): CallResult =
+                  vmState: BaseVMState): DebugCallResult =
   let call = callParamsForTest(tx, sender, vmState)
-  runComputation(call, CallResult)
+  runComputation(call, DebugCallResult)

--- a/nimbus/transaction/call_types.nim
+++ b/nimbus/transaction/call_types.nim
@@ -17,6 +17,8 @@ import
   ../core/eip7702,
   ./host_types
 
+export types
+
 type
   # Standard call parameters.
   CallParams* = object
@@ -40,11 +42,13 @@ type
 
   # Standard call result.  (Some fields are beyond what EVMC can return,
   # and must only be used from tests because they will not always be set).
-  CallResult* = object
+  CallResult* = object of RootObj
     error*:           string            # Something if the call failed.
     gasUsed*:         GasInt            # Gas used by the call.
     contractAddress*: Address           # Created account (when `isCreate`).
     output*:          seq[byte]         # Output data.
+
+  DebugCallResult* = object of CallResult
     stack*:           EvmStack          # EVM stack on return (for test only).
     memory*:          EvmMemory         # EVM memory on return (for test only).
 

--- a/nimbus/transaction/call_types.nim
+++ b/nimbus/transaction/call_types.nim
@@ -49,7 +49,7 @@ type
     output*:          seq[byte]         # Output data.
 
   DebugCallResult* = object of CallResult
-    stack*:           EvmStack          # EVM stack on return (for test only).
+    stack*:           seq[UInt256]      # EVM stack on return (for test only).
     memory*:          EvmMemory         # EVM memory on return (for test only).
 
 template isCreate(tx: Transaction): bool =

--- a/nimbus/transaction/evmc_host_glue.nim
+++ b/nimbus/transaction/evmc_host_glue.nim
@@ -129,9 +129,9 @@ proc evmcExecComputation*(host: TransactionHost): EvmcResult =
 
   result = vm.execute(vm, hostInterface.unsafeAddr, hostContext,
                         evmc_revision(host.vmState.fork.ord), host.msg,
-                        if host.code.len > 0: host.code.bytes[0].unsafeAddr
+                        if host.code != nil and host.code.len > 0: host.code.bytes[0].unsafeAddr
                         else: nil,
-                        host.code.len.csize_t)
+                        if host.code != nil: host.code.len.csize_t else: 0)
 
   host.showCallReturn(result)
 

--- a/nimbus/transaction/host_call_nested.nim
+++ b/nimbus/transaction/host_call_nested.nim
@@ -35,7 +35,7 @@ proc beforeExecCreateEvmcNested(host: TransactionHost,
     data: @(makeOpenArray(m.input_data, m.input_size.int))
   )
   return newComputation(host.vmState, false, childMsg,
-                        cast[ContractSalt](m.create2_salt))
+                        cast[ContractSalt](m.create2_salt), keepStack = false)
 
 proc afterExecCreateEvmcNested(host: TransactionHost, child: Computation,
                                res: var EvmcResult) {.inline.} =
@@ -71,7 +71,7 @@ proc beforeExecCallEvmcNested(host: TransactionHost,
     data: @(makeOpenArray(m.input_data, m.input_size.int)),
     flags: m.flags,
   )
-  return newComputation(host.vmState, false, childMsg)
+  return newComputation(host.vmState, false, childMsg, keepStack = false)
 
 proc afterExecCallEvmcNested(host: TransactionHost, child: Computation,
                              res: var EvmcResult) {.inline.} =

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -281,7 +281,7 @@ proc initVMEnv*(network: string): BaseVMState =
 
   BaseVMState.new(parent, header, com)
 
-proc verifyAsmResult(vmState: BaseVMState, boa: Assembler, asmResult: CallResult): bool =
+proc verifyAsmResult(vmState: BaseVMState, boa: Assembler, asmResult: DebugCallResult): bool =
   let com = vmState.com
   if not asmResult.isError:
     if boa.success == false:
@@ -307,6 +307,8 @@ proc verifyAsmResult(vmState: BaseVMState, boa: Assembler, asmResult: CallResult
     if actual != val:
       error "different stack value", idx=i, expected=val, actual=actual
       return false
+
+  asmResult.stack.dispose()
 
   const chunkLen = 32
   let numChunks = asmResult.memory.len div chunkLen

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -308,8 +308,6 @@ proc verifyAsmResult(vmState: BaseVMState, boa: Assembler, asmResult: DebugCallR
       error "different stack value", idx=i, expected=val, actual=actual
       return false
 
-  asmResult.stack.dispose()
-
   const chunkLen = 32
   let numChunks = asmResult.memory.len div chunkLen
 

--- a/tests/test_evm_support.nim
+++ b/tests/test_evm_support.nim
@@ -363,7 +363,6 @@ proc runTestOverflow() =
     let privateKey = PrivateKey.fromHex("0000000000000000000000000000000000000000000000000000001000000000")[]
     let tx = signTransaction(unsignedTx, privateKey, false)
     let res = testCallEvm(tx, tx.recoverSender().expect("valid signature"), s)
-    res.stack.dispose()
 
     when defined(evmc_enabled):
       check res.error == "EVMC_FAILURE"

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -48,6 +48,8 @@ template doTest(fixture: JsonNode; vmState: BaseVMState; address: PrecompileAddr
     )
     let tx = signTransaction(unsignedTx, privateKey, false)
     let fixtureResult = testCallEvm(tx, tx.recoverSender().expect("valid signature"), vmState)
+    if fixtureResult.stack != nil:
+      fixtureResult.stack.dispose()
 
     if expectedErr:
       check fixtureResult.isError

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -48,8 +48,6 @@ template doTest(fixture: JsonNode; vmState: BaseVMState; address: PrecompileAddr
     )
     let tx = signTransaction(unsignedTx, privateKey, false)
     let fixtureResult = testCallEvm(tx, tx.recoverSender().expect("valid signature"), vmState)
-    if fixtureResult.stack != nil:
-      fixtureResult.stack.dispose()
 
     if expectedErr:
       check fixtureResult.isError


### PR DESCRIPTION
The EVM stack is a hot spot in EVM execution and we end up paying a nim seq tax in several ways, adding up to ~5% of execution time:

* on initial allocation, all bytes get zeroed - this means we have to choose between allocating a full stack or just a partial one and then growing it
* pushing and popping introduce additional zeroing
* reallocations on growth copy + zero - expensive again!
* redundant range checking on every operation reducing inlining etc

Here a custom stack using C memory is instroduced:

* no zeroing on allocation
* full stack allocated on EVM startup -> no reallocation during execution
* fast push/pop - no zeroing again
* 32-byte alignment - this makes it easier for the compiler to use vector instructions
* no stack allocated for precompiles (these never use it anyway)

Of course, this change also means we have to manage memory manually - for the EVM, this turns out to be not too bad because we already manage database transactions the same way (they have to be freed "manually") so we can simply latch on to this mechanism.

While we're at it, this PR also skips database lookup for known precompiles by resolving such addresses earlier.