### PR TITLE
Fluffy: Limit concurrent offers that can be received from each peer

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -406,7 +406,7 @@ proc handleFindContent(
   )
 
   # Check first if content is in range, as this is a cheaper operation
-  if p.inRange(contentId):
+  if p.inRange(contentId) and p.stream.canAddPendingTransfer(srcId, contentId):
     let contentResult = p.dbGet(fc.contentKey, contentId)
     if contentResult.isOk():
       let content = contentResult.get()
@@ -417,7 +417,8 @@ proc handleFindContent(
           )
         )
       else:
-        let connectionId = p.stream.addContentRequest(srcId, content)
+        p.stream.addPendingTransfer(srcId, contentId)
+        let connectionId = p.stream.addContentRequest(srcId, contentId, content)
 
         return encodeMessage(
           ContentMessage(

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -90,7 +90,8 @@ proc canAddPendingTransfer(
     return true
 
   try:
-    (transfers[nodeId].len() < limit) and not transfers[nodeId].contains(contentId)
+    let contentIds = transfers[nodeId]
+    (contentIds.len() < limit) and not contentIds.contains(contentId)
   except KeyError as e:
     raiseAssert(e.msg)
 
@@ -99,13 +100,15 @@ proc addPendingTransfer(
     nodeId: NodeId,
     contentId: ContentId,
 ) =
-  if not transfers.contains(nodeId):
-    transfers[nodeId] = initHashSet[ContentId]()
-
-  try:
-    transfers[nodeId].incl(contentId)
-  except KeyError as e:
-    raiseAssert(e.msg)
+  if transfers.contains(nodeId):
+    try:
+      transfers[nodeId].incl(contentId)
+    except KeyError as e:
+      raiseAssert(e.msg)
+  else:
+    var contentIds = initHashSet[ContentId]()
+    contentIds.incl(contentId)
+    transfers[nodeId] = contentIds
 
 proc removePendingTransfer(
     transfers: TableRef[NodeId, HashSet[ContentId]],

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -35,7 +35,7 @@ const
   talkReqOverhead = getTalkReqOverhead(utpProtocolId)
   utpHeaderOverhead = 20
   maxUtpPayloadSize = maxDiscv5PacketSize - talkReqOverhead - utpHeaderOverhead
-  maxPendingTransfersPerPeer = 50
+  maxPendingTransfersPerPeer = 128
 
 type
   ContentRequest = object


### PR DESCRIPTION
Related to this issue: https://github.com/status-im/nimbus-eth1/issues/2874

We currently just limit transfers of offers per stream/subnetwork. This means transfers on one subnetwork won't effect the other subnetworks.

The limit is per offer so sending 2 batches of 64 offers will use up 128 of the quota for a peer.

I'm thinking to also limit the content lookup responses which will also share the pending transfers quota.