### PR TITLE
Unroll nibble ops

### DIFF
--- a/nimbus/db/aristo/aristo_desc/desc_nibbles.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_nibbles.nim
@@ -33,7 +33,7 @@ type
 func high*(T: type NibblesBuf): int =
   63
 
-func nibble*(T: type NibblesBuf, nibble: byte): T =
+func nibble*(T: type NibblesBuf, nibble: byte): T {.noinit.} =
   result.limbs[0] = uint64(nibble) shl (64 - 4)
   result.iend = 1
 

--- a/nimbus/db/aristo/aristo_desc/desc_nibbles.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_nibbles.nim
@@ -8,7 +8,7 @@
 # at your option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-{.push raises: [], gcsafe, noinline.}
+{.push raises: [], gcsafe, inline.}
 
 import stew/[arraybuf, arrayops, bitops2, endians2, staticfor]
 

--- a/nimbus/db/aristo/aristo_fetch.nim
+++ b/nimbus/db/aristo/aristo_fetch.nim
@@ -26,12 +26,9 @@ import
 proc retrieveLeaf(
     db: AristoDbRef;
     root: VertexID;
-    path: openArray[byte];
+    path: Hash32;
       ): Result[VertexRef,AristoError] =
-  if path.len == 0:
-    return err(FetchPathInvalid)
-
-  for step in stepUp(NibblesBuf.fromBytes(path), root, db):
+  for step in stepUp(NibblesBuf.fromBytes(path.data), root, db):
     let vtx = step.valueOr:
       if error in HikeAcceptableStopsNotFound:
         return err(FetchPathNotFound)
@@ -68,7 +65,7 @@ proc retrieveAccountLeaf(
   # Updated payloads are stored in the layers so if we didn't find them there,
   # it must have been in the database
   let
-    leafVtx = db.retrieveLeaf(VertexID(1), accPath.data).valueOr:
+    leafVtx = db.retrieveLeaf(VertexID(1), accPath).valueOr:
       if error == FetchPathNotFound:
         db.accLeaves.put(accPath, nil)
       return err(error)
@@ -168,7 +165,7 @@ proc retrieveStoragePayload(
 
   # Updated payloads are stored in the layers so if we didn't find them there,
   # it must have been in the database
-  let leafVtx = db.retrieveLeaf(? db.fetchStorageIdImpl(accPath), stoPath.data).valueOr:
+  let leafVtx = db.retrieveLeaf(? db.fetchStorageIdImpl(accPath), stoPath).valueOr:
     if error == FetchPathNotFound:
       db.stoLeaves.put(mixPath, nil)
     return err(error)

--- a/tests/test_aristo/test_nibbles.nim
+++ b/tests/test_aristo/test_nibbles.nim
@@ -11,7 +11,7 @@
 {.used.}
 
 import
-  std/sequtils,
+  std/[sequtils, strutils],
   stew/byteutils,
   unittest2,
   ../../nimbus/db/aristo/aristo_desc/desc_nibbles
@@ -30,7 +30,13 @@ suite "Nibbles":
         n[1] == 0
         $n.slice(1) == "0"
         $n.slice(2) == ""
+        $n.slice(0, 0) == ""
+        $n.slice(1, 1) == ""
+        $n.slice(0, 1) == "1"
 
+        $(n & n) == "1010"
+
+        NibblesBuf.nibble(0) != NibblesBuf.nibble(1)
     block:
       let n = NibblesBuf.fromBytes(repeat(byte 0x12, 32))
       check:
@@ -52,7 +58,6 @@ suite "Nibbles":
       let
         he = n.toHexPrefix(true)
         ho = n.slice(1).toHexPrefix(true)
-
       check:
         NibblesBuf.fromHexPrefix(he.data()) == (true, n)
         NibblesBuf.fromHexPrefix(ho.data()) == (true, n.slice(1))
@@ -72,11 +77,33 @@ suite "Nibbles":
 
   test "long":
     let n = NibblesBuf.fromBytes(
-      hexToSeqByte("0100000000000000000000000000000000000000000000000000000000000000")
+      hexToSeqByte("0100000000000000000000000000000000000000000000000000000000000012")
     )
+    check:
+      n.getBytes() ==
+        hexToSeqByte("0100000000000000000000000000000000000000000000000000000000000012")
 
-    check $n == "0100000000000000000000000000000000000000000000000000000000000000"
-    check $n.slice(1) == "100000000000000000000000000000000000000000000000000000000000000"
+      $n == "0100000000000000000000000000000000000000000000000000000000000012"
+      $(n & default(NibblesBuf)) ==
+        "0100000000000000000000000000000000000000000000000000000000000012"
+
+      $n.slice(1) == "100000000000000000000000000000000000000000000000000000000000012"
+      $n.slice(1, 2) == "1"
+      $(n.slice(1) & NibblesBuf.nibble(1)) ==
+        "1000000000000000000000000000000000000000000000000000000000000121"
+
+      $n.replaceSuffix(n.slice(1, 2)) ==
+        "0100000000000000000000000000000000000000000000000000000000000011"
+
+    for i in 0 ..< 64:
+      check:
+        $n.slice(0, i) ==
+          "0100000000000000000000000000000000000000000000000000000000000012"[0 ..< i]
+
+    for i in 0 ..< 64:
+      check:
+        $n.slice(i) ==
+          "0100000000000000000000000000000000000000000000000000000000000012"[i ..< 64]
 
     let
       he = n.toHexPrefix(true)
@@ -84,3 +111,64 @@ suite "Nibbles":
     check:
       NibblesBuf.fromHexPrefix(he.data()) == (true, n)
       NibblesBuf.fromHexPrefix(ho.data()) == (true, n.slice(1))
+
+  test "sharedPrefixLen":
+    let n0 = NibblesBuf.fromBytes(hexToSeqByte("01000000"))
+    let n2 = NibblesBuf.fromBytes(hexToSeqByte("10"))
+    let n = NibblesBuf.fromBytes(
+      hexToSeqByte("0100000000000000000000000000000000000000000000000000000000000012")
+    )
+    let nn = NibblesBuf.fromBytes(
+      hexToSeqByte("0100000000000000000000000000000000000000000000000000000000000013")
+    )
+
+    check:
+      n0.sharedPrefixLen(n0) == 8
+      n0.sharedPrefixLen(n2) == 0
+      n0.slice(1).sharedPrefixLen(n0.slice(1)) == 7
+      n0.slice(7).sharedPrefixLen(n0.slice(7)) == 1
+      n0.slice(1).sharedPrefixLen(n2) == 2
+
+    for i in 0 .. 64:
+      check:
+        n.slice(0, i).sharedPrefixLen(n) == i
+
+    for i in 0 .. 63:
+      check:
+        n.slice(0, i).sharedPrefixLen(nn.slice(0, i)) == i
+    check:
+      n.sharedPrefixLen(nn) == 63
+
+  test "join":
+    block:
+      let
+        n0 = NibblesBuf.fromBytes(repeat(0x00'u8, 32))
+        n1 = NibblesBuf.fromBytes(repeat(0x11'u8, 32))
+
+      for i in 0 ..< 64:
+        check:
+          $(n0.slice(0, 64 - i) & n1.slice(0, i)) ==
+            (strutils.repeat('0', 64 - i) & strutils.repeat('1', i))
+
+          $(n0.slice(0, 1) & n1.slice(0, i)) ==
+            (strutils.repeat('0', 1) & strutils.repeat('1', i))
+
+      for i in 0 ..< 63:
+        check:
+          $(n0.slice(1, 64 - i) & n1.slice(0, i)) ==
+            (strutils.repeat('0', 63 - i) & strutils.repeat('1', i))
+
+  test "replaceSuffix":
+    let
+      n0 = NibblesBuf.fromBytes(repeat(0x00'u8, 32))
+      n1 = NibblesBuf.fromBytes(repeat(0x11'u8, 32))
+
+    check:
+      n0.replaceSuffix(default(NibblesBuf)) == n0
+      n0.replaceSuffix(n0) == n0
+      n0.replaceSuffix(n1) == n1
+
+    for i in 0 ..< 64:
+      check:
+        $n0.replaceSuffix(n1.slice(0, i)) ==
+          (strutils.repeat('0', 64 - i) & strutils.repeat('1', i))


### PR DESCRIPTION
A bit unexpectedly, nibble handling shows up in the profiler - this PR reuses unrolling similar to that of `stint` to process nibbles in 16-nibble chunks using uint64 as underlying storage instead of byte