### PR TITLE
Fluffy: Cleanup state bridge preimages backend and add logging for transfer limit reached

### DIFF
--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -91,7 +91,11 @@ proc canAddPendingTransfer(
 
   try:
     let contentIds = transfers[nodeId]
-    (contentIds.len() < limit) and not contentIds.contains(contentId)
+    if (contentIds.len() < limit) and not contentIds.contains(contentId):
+      return true
+    else:
+      debug "Pending transfer limit reached for peer", nodeId, contentId
+      return false
   except KeyError as e:
     raiseAssert(e.msg)
 


### PR DESCRIPTION
The Fluffy state bridge preimages lookup is not used anymore so can be removed. 

Also added a log so we can see when the max pending transfers limit is reached in Fluffy.