### PR TITLE
Fluffy: Portal stream improvements and pending transfers prune fix.

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -408,7 +408,7 @@ proc handleFindContent(
   )
 
   # Check first if content is in range, as this is a cheaper operation
-  if p.inRange(contentId):
+  if p.inRange(contentId) and p.stream.canAddPendingTransfer(srcId, contentId):
     let contentResult = p.dbGet(fc.contentKey, contentId)
     if contentResult.isOk():
       let content = contentResult.get()
@@ -419,7 +419,8 @@ proc handleFindContent(
           )
         )
       else:
-        let connectionId = p.stream.addContentRequest(srcId, content)
+        p.stream.addPendingTransfer(srcId, contentId)
+        let connectionId = p.stream.addContentRequest(srcId, contentId, content)
 
         return encodeMessage(
           ContentMessage(
@@ -448,8 +449,10 @@ proc handleOffer(p: PortalProtocol, o: OfferMessage, srcId: NodeId): seq[byte] =
       )
     )
 
-  var contentKeysBitList = ContentKeysBitList.init(o.contentKeys.len)
-  var contentKeys = ContentKeysList.init(@[])
+  var
+    contentKeysBitList = ContentKeysBitList.init(o.contentKeys.len)
+    contentKeys = ContentKeysList.init(@[])
+    contentIds = newSeq[ContentId]()
   # TODO: Do we need some protection against a peer offering lots (64x) of
   # content that fits our Radius but is actually bogus?
   # Additional TODO, but more of a specification clarification: What if we don't
@@ -465,17 +468,19 @@ proc handleOffer(p: PortalProtocol, o: OfferMessage, srcId: NodeId): seq[byte] =
         int64(logDistance), labelValues = [$p.protocolId]
       )
 
-      if p.inRange(contentId):
-        if not p.dbContains(contentKey, contentId):
-          contentKeysBitList.setBit(i)
-          discard contentKeys.add(contentKey)
+      if p.inRange(contentId) and p.stream.canAddPendingTransfer(srcId, contentId) and
+          not p.dbContains(contentKey, contentId):
+        p.stream.addPendingTransfer(srcId, contentId)
+        contentKeysBitList.setBit(i)
+        discard contentKeys.add(contentKey)
+        contentIds.add(contentId)
     else:
       # Return empty response when content key validation fails
       return @[]
 
   let connectionId =
     if contentKeysBitList.countOnes() != 0:
-      p.stream.addContentOffer(srcId, contentKeys)
+      p.stream.addContentOffer(srcId, contentKeys, contentIds)
     else:
       # When the node does not accept any of the content offered, reply with an
       # all zeroes bitlist and connectionId.

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -407,6 +407,9 @@ proc handleFindContent(
     int64(logDistance), labelValues = [$p.protocolId]
   )
 
+  # Clear out the timed out connections and pending transfers
+  p.stream.pruneAllowedRequestConnections()
+
   # Check first if content is in range, as this is a cheaper operation
   if p.inRange(contentId) and p.stream.canAddPendingTransfer(srcId, contentId):
     let contentResult = p.dbGet(fc.contentKey, contentId)
@@ -448,6 +451,9 @@ proc handleOffer(p: PortalProtocol, o: OfferMessage, srcId: NodeId): seq[byte] =
         contentKeys: ContentKeysBitList.init(o.contentKeys.len),
       )
     )
+
+  # Clear out the timed out connections and pending transfers
+  p.stream.pruneAllowedOfferConnections()
 
   var
     contentKeysBitList = ContentKeysBitList.init(o.contentKeys.len)

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import
-  std/sequtils,
+  std/[sequtils, sets],
   chronos,
   stew/[byteutils, leb128, endians2],
   chronicles,
@@ -35,17 +35,20 @@ const
   talkReqOverhead = getTalkReqOverhead(utpProtocolId)
   utpHeaderOverhead = 20
   maxUtpPayloadSize = maxDiscv5PacketSize - talkReqOverhead - utpHeaderOverhead
+  maxPendingTransfersPerPeer = 128
 
 type
   ContentRequest = object
     connectionId: uint16
     nodeId: NodeId
+    contentId: ContentId
     content: seq[byte]
     timeout: Moment
 
   ContentOffer = object
     connectionId: uint16
     nodeId: NodeId
+    contentIds: seq[ContentId]
     contentKeys: ContentKeysList
     timeout: Moment
 
@@ -69,6 +72,7 @@ type
     connectionTimeout: Duration
     contentReadTimeout*: Duration
     rng: ref HmacDrbgContext
+    pendingTransfers: TableRef[NodeId, HashSet[ContentId]]
     contentQueue*: AsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])]
 
   StreamManager* = ref object
@@ -76,21 +80,93 @@ type
     streams: seq[PortalStream]
     rng: ref HmacDrbgContext
 
+proc canAddPendingTransfer(
+    transfers: TableRef[NodeId, HashSet[ContentId]],
+    nodeId: NodeId,
+    contentId: ContentId,
+    limit: int,
+): bool =
+  if not transfers.contains(nodeId):
+    return true
+
+  try:
+    let contentIds = transfers[nodeId]
+    if (contentIds.len() < limit) and not contentIds.contains(contentId):
+      return true
+    else:
+      debug "Pending transfer limit reached for peer", nodeId, contentId
+      return false
+  except KeyError as e:
+    raiseAssert(e.msg)
+
+proc addPendingTransfer(
+    transfers: TableRef[NodeId, HashSet[ContentId]],
+    nodeId: NodeId,
+    contentId: ContentId,
+) =
+  if transfers.contains(nodeId):
+    try:
+      transfers[nodeId].incl(contentId)
+    except KeyError as e:
+      raiseAssert(e.msg)
+  else:
+    var contentIds = initHashSet[ContentId]()
+    contentIds.incl(contentId)
+    transfers[nodeId] = contentIds
+
+proc removePendingTransfer(
+    transfers: TableRef[NodeId, HashSet[ContentId]],
+    nodeId: NodeId,
+    contentId: ContentId,
+) =
+  doAssert transfers.contains(nodeId)
+
+  try:
+    transfers[nodeId].excl(contentId)
+
+    if transfers[nodeId].len() == 0:
+      transfers.del(nodeId)
+  except KeyError as e:
+    raiseAssert(e.msg)
+
+template canAddPendingTransfer*(
+    stream: PortalStream, nodeId: NodeId, contentId: ContentId
+): bool =
+  stream.pendingTransfers.canAddPendingTransfer(
+    srcId, contentId, maxPendingTransfersPerPeer
+  )
+
+template addPendingTransfer*(
+    stream: PortalStream, nodeId: NodeId, contentId: ContentId
+) =
+  addPendingTransfer(stream.pendingTransfers, nodeId, contentId)
+
+template removePendingTransfer*(
+    stream: PortalStream, nodeId: NodeId, contentId: ContentId
+) =
+  removePendingTransfer(stream.pendingTransfers, nodeId, contentId)
+
 proc pruneAllowedConnections(stream: PortalStream) =
   # Prune requests and offers that didn't receive a connection request
   # before `connectionTimeout`.
   let now = Moment.now()
-  stream.contentRequests.keepIf(
-    proc(x: ContentRequest): bool =
-      x.timeout > now
-  )
-  stream.contentOffers.keepIf(
-    proc(x: ContentOffer): bool =
-      x.timeout > now
-  )
+
+  for i, request in stream.contentRequests:
+    if request.timeout <= now:
+      stream.removePendingTransfer(request.nodeId, request.contentId)
+      stream.contentRequests.del(i)
+
+  for i, offer in stream.contentOffers:
+    if offer.timeout <= now:
+      for contentId in offer.contentIds:
+        stream.removePendingTransfer(offer.nodeId, contentId)
+      stream.contentOffers.del(i)
 
 proc addContentOffer*(
-    stream: PortalStream, nodeId: NodeId, contentKeys: ContentKeysList
+    stream: PortalStream,
+    nodeId: NodeId,
+    contentKeys: ContentKeysList,
+    contentIds: seq[ContentId],
 ): Bytes2 =
   stream.pruneAllowedConnections()
 
@@ -107,6 +183,7 @@ proc addContentOffer*(
   let contentOffer = ContentOffer(
     connectionId: id,
     nodeId: nodeId,
+    contentIds: contentIds,
     contentKeys: contentKeys,
     timeout: Moment.now() + stream.connectionTimeout,
   )
@@ -115,7 +192,7 @@ proc addContentOffer*(
   return connectionId
 
 proc addContentRequest*(
-    stream: PortalStream, nodeId: NodeId, content: seq[byte]
+    stream: PortalStream, nodeId: NodeId, contentId: ContentId, content: seq[byte]
 ): Bytes2 =
   stream.pruneAllowedConnections()
 
@@ -129,6 +206,7 @@ proc addContentRequest*(
   let contentRequest = ContentRequest(
     connectionId: id,
     nodeId: nodeId,
+    contentId: contentId,
     content: content,
     timeout: Moment.now() + stream.connectionTimeout,
   )
@@ -285,6 +363,7 @@ proc new(
     transport: transport,
     connectionTimeout: connectionTimeout,
     contentReadTimeout: contentReadTimeout,
+    pendingTransfers: newTable[NodeId, HashSet[ContentId]](),
     contentQueue: contentQueue,
     rng: rng,
   )
@@ -317,6 +396,8 @@ proc handleIncomingConnection(
       if request.connectionId == socket.connectionId and
           request.nodeId == socket.remoteAddress.nodeId:
         let fut = socket.writeContentRequest(stream, request)
+
+        stream.removePendingTransfer(request.nodeId, request.contentId)
         stream.contentRequests.del(i)
         return noCancel(fut)
 
@@ -324,6 +405,9 @@ proc handleIncomingConnection(
       if offer.connectionId == socket.connectionId and
           offer.nodeId == socket.remoteAddress.nodeId:
         let fut = socket.readContentOffer(stream, offer)
+
+        for contentId in offer.contentIds:
+          stream.removePendingTransfer(offer.nodeId, contentId)
         stream.contentOffers.del(i)
         return noCancel(fut)
 

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import
-  std/[sequtils, sets],
+  std/sets,
   chronos,
   stew/[byteutils, leb128, endians2],
   chronicles,
@@ -38,15 +38,15 @@ const
   maxPendingTransfersPerPeer = 128
 
 type
+  ConnectionId* = uint16
+
   ContentRequest = object
-    connectionId: uint16
     nodeId: NodeId
     contentId: ContentId
     content: seq[byte]
     timeout: Moment
 
   ContentOffer = object
-    connectionId: uint16
     nodeId: NodeId
     contentIds: seq[ContentId]
     contentKeys: ContentKeysList
@@ -67,8 +67,8 @@ type
     # values of the discovery v5 talkresp message.
     # TODO: Should the content key also be stored to be able to validate the
     # received data?
-    contentRequests: seq[ContentRequest]
-    contentOffers: seq[ContentOffer]
+    contentRequests: TableRef[ConnectionId, ContentRequest]
+    contentOffers: TableRef[ConnectionId, ContentOffer]
     connectionTimeout: Duration
     contentReadTimeout*: Duration
     rng: ref HmacDrbgContext
@@ -151,29 +151,29 @@ proc pruneAllowedRequestConnections*(stream: PortalStream) =
   # before `connectionTimeout`.
   let now = Moment.now()
 
-  var i = 0
-  while i < stream.contentRequests.len():
-    let request = stream.contentRequests[i]
+  var connectionIdsToPrune = newSeq[ConnectionId]()
+  for connectionId, request in stream.contentRequests:
     if request.timeout <= now:
       stream.removePendingTransfer(request.nodeId, request.contentId)
-      stream.contentRequests.del(i)
-    else:
-      inc i
+      connectionIdsToPrune.add(connectionId)
+
+  for connectionId in connectionIdsToPrune:
+    stream.contentRequests.del(connectionId)
 
 proc pruneAllowedOfferConnections*(stream: PortalStream) =
   # Prune offers that didn't receive a connection request
   # before `connectionTimeout`.
   let now = Moment.now()
 
-  var i = 0
-  while i < stream.contentOffers.len():
-    let offer = stream.contentOffers[i]
+  var connectionIdsToPrune = newSeq[ConnectionId]()
+  for connectionId, offer in stream.contentOffers:
     if offer.timeout <= now:
       for contentId in offer.contentIds:
         stream.removePendingTransfer(offer.nodeId, contentId)
-      stream.contentOffers.del(i)
-    else:
-      inc i
+      connectionIdsToPrune.add(connectionId)
+
+  for connectionId in connectionIdsToPrune:
+    stream.contentOffers.del(connectionId)
 
 proc addContentOffer*(
     stream: PortalStream,
@@ -187,18 +187,22 @@ proc addContentOffer*(
   stream.rng[].generate(connectionId)
 
   # uTP protocol uses BE for all values in the header, incl. connection id.
-  let id = uint16.fromBytesBE(connectionId)
+  var id = ConnectionId.fromBytesBE(connectionId)
+
+  # Generate a new id if already existing to avoid using a duplicate
+  if stream.contentOffers.contains(id):
+    stream.rng[].generate(connectionId)
+    id = ConnectionId.fromBytesBE(connectionId)
 
   debug "Register new incoming offer", contentKeys
 
   let contentOffer = ContentOffer(
-    connectionId: id,
     nodeId: nodeId,
     contentIds: contentIds,
     contentKeys: contentKeys,
     timeout: Moment.now() + stream.connectionTimeout,
   )
-  stream.contentOffers.add(contentOffer)
+  stream.contentOffers[id] = contentOffer
 
   return connectionId
 
@@ -208,23 +212,27 @@ proc addContentRequest*(
   # TODO: Should we check if `NodeId` & `connectionId` combo already exists?
   # What happens if we get duplicates?
   var connectionId: Bytes2
-  stream.rng[].generate(connectionId)
 
   # uTP protocol uses BE for all values in the header, incl. connection id.
-  let id = uint16.fromBytesBE(connectionId)
+  var id = ConnectionId.fromBytesBE(connectionId)
+
+  # Generate a new id if already existing to avoid using a duplicate
+  if stream.contentRequests.contains(id):
+    stream.rng[].generate(connectionId)
+    id = ConnectionId.fromBytesBE(connectionId)
+
   let contentRequest = ContentRequest(
-    connectionId: id,
     nodeId: nodeId,
     contentId: contentId,
     content: content,
     timeout: Moment.now() + stream.connectionTimeout,
   )
-  stream.contentRequests.add(contentRequest)
+  stream.contentRequests[id] = contentRequest
 
   return connectionId
 
 proc connectTo*(
-    stream: PortalStream, nodeAddress: NodeAddress, connectionId: uint16
+    stream: PortalStream, nodeAddress: NodeAddress, connectionId: ConnectionId
 ): Future[Result[UtpSocket[NodeAddress], string]] {.async: (raises: [CancelledError]).} =
   let connectRes = await stream.transport.connectTo(nodeAddress, connectionId)
   if connectRes.isErr():
@@ -370,6 +378,8 @@ proc new(
 ): T =
   let stream = PortalStream(
     transport: transport,
+    contentRequests: newTable[ConnectionId, ContentRequest](),
+    contentOffers: newTable[ConnectionId, ContentOffer](),
     connectionTimeout: connectionTimeout,
     contentReadTimeout: contentReadTimeout,
     pendingTransfers: newTable[NodeId, HashSet[ContentId]](),
@@ -380,17 +390,17 @@ proc new(
   stream
 
 proc allowedConnection(
-    stream: PortalStream, address: NodeAddress, connectionId: uint16
+    stream: PortalStream, address: NodeAddress, connectionId: ConnectionId
 ): bool =
-  return
-    stream.contentRequests.any(
-      proc(x: ContentRequest): bool =
-        x.connectionId == connectionId and x.nodeId == address.nodeId
-    ) or
-    stream.contentOffers.any(
-      proc(x: ContentOffer): bool =
-        x.connectionId == connectionId and x.nodeId == address.nodeId
-    )
+  if stream.contentRequests.contains(connectionId) and
+      stream.contentRequests.getOrDefault(connectionId).nodeId == address.nodeId:
+    return true
+
+  if stream.contentOffers.contains(connectionId) and
+      stream.contentOffers.getOrDefault(connectionId).nodeId == address.nodeId:
+    return true
+
+  return false
 
 proc handleIncomingConnection(
     server: UtpRouter[NodeAddress], socket: UtpSocket[NodeAddress]
@@ -401,23 +411,24 @@ proc handleIncomingConnection(
     # Note: Connection id of uTP SYN is different from other packets, it is
     # actually the peers `send_conn_id`, opposed to `receive_conn_id` for all
     # other packets.
-    for i, request in stream.contentRequests:
-      if request.connectionId == socket.connectionId and
-          request.nodeId == socket.remoteAddress.nodeId:
+
+    if stream.contentRequests.contains(socket.connectionId):
+      let request = stream.contentRequests.getOrDefault(socket.connectionId)
+      if request.nodeId == socket.remoteAddress.nodeId:
         let fut = socket.writeContentRequest(stream, request)
 
         stream.removePendingTransfer(request.nodeId, request.contentId)
-        stream.contentRequests.del(i)
+        stream.contentRequests.del(socket.connectionId)
         return noCancel(fut)
 
-    for i, offer in stream.contentOffers:
-      if offer.connectionId == socket.connectionId and
-          offer.nodeId == socket.remoteAddress.nodeId:
+    if stream.contentOffers.contains(socket.connectionId):
+      let offer = stream.contentOffers.getOrDefault(socket.connectionId)
+      if offer.nodeId == socket.remoteAddress.nodeId:
         let fut = socket.readContentOffer(stream, offer)
 
         for contentId in offer.contentIds:
           stream.removePendingTransfer(offer.nodeId, contentId)
-        stream.contentOffers.del(i)
+        stream.contentOffers.del(socket.connectionId)
         return noCancel(fut)
 
   # TODO: Is there a scenario where this can happen,
@@ -427,7 +438,7 @@ proc handleIncomingConnection(
   return fut
 
 proc allowIncomingConnection(
-    r: UtpRouter[NodeAddress], remoteAddress: NodeAddress, connectionId: uint16
+    r: UtpRouter[NodeAddress], remoteAddress: NodeAddress, connectionId: ConnectionId
 ): bool =
   let manager = getUserData[NodeAddress, StreamManager](r)
   for stream in manager.streams:

--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -151,16 +151,25 @@ proc pruneAllowedConnections(stream: PortalStream) =
   # before `connectionTimeout`.
   let now = Moment.now()
 
-  for i, request in stream.contentRequests:
-    if request.timeout <= now:
-      stream.removePendingTransfer(request.nodeId, request.contentId)
-      stream.contentRequests.del(i)
+  block:
+    var i = 0
+    while i < stream.contentRequests.len():
+      let request = stream.contentRequests[i]
+      if request.timeout <= now:
+        stream.removePendingTransfer(request.nodeId, request.contentId)
+        stream.contentRequests.del(i)
+      else:
+        inc i
 
-  for i, offer in stream.contentOffers:
+  var i = 0
+  while i < stream.contentOffers.len():
+    let offer = stream.contentOffers[i]
     if offer.timeout <= now:
       for contentId in offer.contentIds:
         stream.removePendingTransfer(offer.nodeId, contentId)
       stream.contentOffers.del(i)
+    else:
+      inc i
 
 proc addContentOffer*(
     stream: PortalStream,


### PR DESCRIPTION
Changes in this PR:
- Fix issue causing crash in prune function.
- Add more tests.
- Separated the pruning for offers and requests to improve performance
- Prune requests and offers before attempting to accept in order to allow clearing connections and pending transfers beforehand.
- Changed the data structure holding requests and offers to improve usage performance. Now using nim tables with connectionId as the key so that looking up offers and requests uses less resources.
- When creating new offers and requests, we now regenerate the connectionId if it already exists in the tables to prevent overwriting and dropping an existing request or offer.