### PR TITLE
Interpreter dispatch cleanups

### DIFF
--- a/nimbus/core/chain/persist_blocks.nim
+++ b/nimbus/core/chain/persist_blocks.nim
@@ -70,11 +70,8 @@ proc purgeOlderBlocksFromHistory(db: CoreDbRef, bn: BlockNumber) =
   if 0 < bn:
     var blkNum = bn - 1
     while 0 < blkNum:
-      try:
-        if not db.forgetHistory blkNum:
-          break
-      except RlpError as exc:
-        warn "Error forgetting history", err = exc.msg
+      if not db.forgetHistory blkNum:
+        break
       blkNum = blkNum - 1
 
 proc persistBlocksImpl(

--- a/nimbus/core/withdrawals.nim
+++ b/nimbus/core/withdrawals.nim
@@ -22,11 +22,8 @@ proc validateWithdrawals*(
     elif withdrawals.isNone:
       return err("Post-Shanghai block body must have withdrawals")
     else:
-      try:
-        if withdrawals.get.calcWithdrawalsRoot != header.withdrawalsRoot.get:
-          return err("Mismatched withdrawalsRoot blockNumber =" & $header.number)
-      except RlpError as ex:
-        return err(ex.msg)
+      if withdrawals.get.calcWithdrawalsRoot != header.withdrawalsRoot.get:
+        return err("Mismatched withdrawalsRoot blockNumber =" & $header.number)
   else:
     if header.withdrawalsRoot.isSome:
       return err("Pre-Shanghai block header must not have withdrawalsRoot")

--- a/nimbus/evm/interpreter/op_handlers/oph_memory.nim
+++ b/nimbus/evm/interpreter/op_handlers/oph_memory.nim
@@ -122,9 +122,7 @@ func jumpImpl(c: Computation; jumpTarget: UInt256): EvmResultVoid =
 
 proc popOp(cpt: VmCpt): EvmResultVoid =
   ## 0x50, Remove item from stack.
-  cpt.stack.popInt.isOkOr:
-    return err(error)
-  ok()
+  cpt.stack.pop()
 
 proc mloadOp(cpt: VmCpt): EvmResultVoid =
   ## 0x51, Load word from memory

--- a/nimbus/evm/stack.nim
+++ b/nimbus/evm/stack.nim
@@ -132,6 +132,11 @@ func popInt*(stack: EvmStack): EvmResult[UInt256] =
 func popAddress*(stack: EvmStack): EvmResult[Address] =
   popAux(stack, Address)
 
+func pop*(stack: EvmStack): EvmResult[void] =
+  ? ensurePop(stack, 1)
+  stack.len -= 1
+  ok()
+
 proc init*(_: type EvmStack): EvmStack =
   let memory = c_malloc(evmStackSize * sizeof(EvmStackElement) + 31)
 

--- a/tests/test_evm_support.nim
+++ b/tests/test_evm_support.nim
@@ -61,6 +61,14 @@ proc runStackTests() =
         check stack.push(element).isOk
       check(stack.popInt.get == 3.u256)
 
+    test "pop requires stack item":
+      var stack = EvmStack.init()
+      defer: stack.dispose()
+      check:
+        stack.pop().isErr()
+        stack.push(1'u).isOk()
+        stack.pop().isOk()
+
     test "swap correct":
       privateAccess(EvmStack)
       var stack = EvmStack.init()


### PR DESCRIPTION
* `shouldPrepareTracer` always true
* simple `pop` should not copy value (reading the memory shows up in a profiler)
* continuation code simplified
* remove some unnecessary EH