### PR TITLE
fix benchmark comparing script for mismatching ranges

### DIFF
--- a/scripts/block-import-stats.py
+++ b/scripts/block-import-stats.py
@@ -77,6 +77,13 @@ contender = readStats(args.contender)
 start = max(min(baseline.index), min(contender.index))
 end = min(max(baseline.index), max(contender.index))
 
+# Check if there's any overlap in the time ranges
+if start > max(max(baseline.index), max(contender.index)) or end < min(min(baseline.index), min(contender.index)):
+    print(f"Error: No overlapping time ranges between baseline and contender datasets")
+    print(f"Baseline range: {min(baseline.index)} to {max(baseline.index)}")
+    print(f"Contender range: {min(contender.index)} to {max(contender.index)}")
+    exit(1)
+
 baseline = baseline.loc[baseline.index >= start and baseline.index <= end]
 contender = contender.loc[contender.index >= start and contender.index <= end]
 


### PR DESCRIPTION
## Summary

This PR modifies the benchmark comparing script.

I faced the following issue initially on `bench-01`

```
python /home/data/nimbus-eth1-mainnet-master-short-benchmark/
repo/scripts/block-import-stats.py /home/data/nimbus-eth1-benchmarks/blocks-import-benchmark.csv 
/home/data/nimbus-eth1-benchmarks/short-benchmark/20241205T134425_3878071/blocks-import-benchmark.csv
Traceback (most recent call last):
  File "/home/data/nimbus-eth1-mainnet-master-short-benchmark/repo/scripts/block-import-stats.py", 
  line 80, in <module>
    baseline = baseline.loc[baseline.index >= start and baseline.index <= end]
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

update: I later learnt that this issue was caused because of mismatching ranges in csv files that were being passed as the arguments to this script.

We now warn about the error and exit gracefully with a code of 1 instead of crashing.
