### PR TITLE
Sort subkey lookups by VertexID when computing keys

### DIFF
--- a/nimbus/db/aristo/aristo_layers.nim
+++ b/nimbus/db/aristo/aristo_layers.nim
@@ -69,11 +69,6 @@ func layersGetVtx*(db: AristoDbRef; rvid: RootedVertexID): Opt[(VertexRef, int)]
 
   Opt.none((VertexRef, int))
 
-func layersGetVtxOrVoid*(db: AristoDbRef; rvid: RootedVertexID): VertexRef =
-  ## Simplified version of `layersGetVtx()`
-  db.layersGetVtx(rvid).valueOr((VertexRef(nil), 0))[0]
-
-
 func layersGetKey*(db: AristoDbRef; rvid: RootedVertexID): Opt[(HashKey, int)] =
   ## Find a hash key on the cache layers. An `ok()` result might contain a void
   ## hash key if it is stored on the cache that way.


### PR DESCRIPTION
Since data is ordered by VertexID on disk, with this simple trick we can make much better use of the various rocksdb caches.

Computing the state root of the full mainnet state is down to 4 hours (from 9) on my laptop.