### PR TITLE
Fluffy State Bridge: Support running without an EL for block ranges where we have the state diffs in the database

### DIFF
--- a/fluffy/tools/portal_bridge/portal_bridge_common.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_common.nim
@@ -32,8 +32,9 @@ proc newRpcClientConnect*(url: JsonRpcUrl): RpcClient =
     try:
       waitFor client.connect(url.value)
     except CatchableError as e:
-      fatal "Failed to connect to JSON-RPC server", error = $e.msg, url = url.value
-      quit QuitFailure
+      warn "Failed to connect to JSON-RPC server", error = $e.msg, url = url.value
+      # The Websocket client supports reconnecting so we don't need to quit here
+      #quit QuitFailure
     client
 
 proc tryReconnect*(client: RpcClient, url: JsonRpcUrl) {.async: (raises: []).} =


### PR DESCRIPTION
Support running without having an EL up to serve the web3 API when the state diffs are stored locally. For now, this is only supported when using WebSocket to connect to the web3 API (which is recommended over HTTP in this case anyway).

This is useful because the database directory holding the state diffs is much smaller than the the archive EL node data directory. This makes it easier to copy or share the data required to run the state bridge without having to run an archive node such as Erigon. This allows re-running the state bridge to seed the state into the network just from the state diffs.

Note that the size of the database storing the state diffs will depend on whether the state has been executed locally or not. Executing the state uses much more space and should be avoided before preparing the state diff database to be shared or copied. 