### PR TITLE
rm macOS amd64 builds from CI/releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,6 @@ jobs:
             cpu: amd64
             evmc: evmc
           - os: macos
-            cpu: amd64
-            evmc: evmc
-          - os: macos
             cpu: arm64
             evmc: evmc
           - os: windows
@@ -49,9 +46,6 @@ jobs:
             cpu: amd64
             evmc: nimvm
           - os: windows
-            cpu: amd64
-            evmc: nimvm
-          - os: macos
             cpu: amd64
             evmc: nimvm
           - os: macos

--- a/.github/workflows/fluffy.yml
+++ b/.github/workflows/fluffy.yml
@@ -112,8 +112,6 @@ jobs:
         target:
           - os: linux
             cpu: amd64
-          # - os: linux
-          #   cpu: i386
           - os: macos
             cpu: amd64
           - os: windows

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -140,45 +140,6 @@ jobs:
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_execution_client.sha512sum
           retention-days: 2
 
-  build-macos-amd64:
-    name: macOS AMD64 release asset
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Build project
-        id: make_dist
-        run: |
-          make dist-macos
-          cd dist
-          ARCHIVE=$(echo *.tar.gz)
-          tar -xzf ${ARCHIVE}
-          NEW_ARCHIVE_DIR="nimbus-eth1_macOS_amd64_$(date +%Y%m%d)_$(git rev-parse --short=8 HEAD)"
-          mv ${ARCHIVE%.tar.gz} ${NEW_ARCHIVE_DIR}
-          tar -czf ${NEW_ARCHIVE_DIR}.tar.gz ${NEW_ARCHIVE_DIR}
-          cp ${NEW_ARCHIVE_DIR}.tar.gz nimbus-eth1_macOS_amd64_nightly_latest.tar.gz
-          echo "archive=${NEW_ARCHIVE_DIR}.tar.gz" >> $GITHUB_OUTPUT
-          echo "archive_dir=${NEW_ARCHIVE_DIR}" >> $GITHUB_OUTPUT
-
-      - name: Upload archive artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS_amd64_archive
-          path: |
-            ./dist/${{ steps.make_dist.outputs.archive }}
-            ./dist/nimbus-eth1_macOS_amd64_nightly_latest.tar.gz
-          retention-days: 2
-
-      - name: Upload checksum artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS_amd64_checksum
-          path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_execution_client.sha512sum
-          retention-days: 2
-
   build-macos-arm64:
     name: macOS ARM64 release asset
     runs-on: ubuntu-latest
@@ -220,7 +181,7 @@ jobs:
 
   prepare-prerelease:
     name: Prepare pre-release
-    needs: [build-amd64, build-arm64, build-win64, build-macos-amd64, build-macos-arm64]
+    needs: [build-amd64, build-arm64, build-win64, build-macos-arm64]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -244,8 +205,6 @@ jobs:
           cat Linux_arm64_checksum/* >> release_notes.md
           echo '# Windows AMD64' >> release_notes.md
           cat Windows_amd64_checksum/* >> release_notes.md
-          echo '# macOS AMD64' >> release_notes.md
-          cat macOS_amd64_checksum/* >> release_notes.md
           echo '# macOS ARM64' >> release_notes.md
           cat macOS_arm64_checksum/* >> release_notes.md
           echo '```' >> release_notes.md
@@ -263,7 +222,6 @@ jobs:
             Linux_amd64_archive/*
             Linux_arm64_archive/*
             Windows_amd64_archive/*
-            macOS_amd64_archive/*
             macOS_arm64_archive/*
 
       - name: Delete artefacts
@@ -277,8 +235,6 @@ jobs:
             Linux_arm64_checksum
             Windows_amd64_archive
             Windows_amd64_checksum
-            macOS_amd64_archive
-            macOS_amd64_checksum
             macOS_arm64_archive
             macOS_arm64_checksum
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,33 +137,6 @@ jobs:
           name: Windows_amd64_checksum
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_execution_client.sha512sum
           retention-days: 2
-  build-macos-amd64:
-    name: macOS AMD64 release asset
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Build project
-        id: make_dist
-        run: |
-          make dist-macos
-          cd dist
-          ARCHIVE=$(echo nimbus-eth1_macOS_amd64_*.tar.gz)
-          echo "archive=${ARCHIVE}" >> $GITHUB_OUTPUT
-          echo "archive_dir=${ARCHIVE%.tar.gz}" >> $GITHUB_OUTPUT
-          tar -xzf ${ARCHIVE} ${ARCHIVE%.tar.gz}/build/nimbus_execution_client.sha512sum
-      - name: Upload archive artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS_amd64_archive
-          path: ./dist/${{ steps.make_dist.outputs.archive }}
-          retention-days: 2
-      - name: Upload checksum artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS_amd64_checksum
-          path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_execution_client.sha512sum
-          retention-days: 2
   build-macos-arm64:
     name: macOS ARM64 release asset
     runs-on: ubuntu-latest
@@ -193,7 +166,7 @@ jobs:
           retention-days: 2
   prepare-release:
     name: Prepare release draft
-    needs: [build-amd64, build-arm64, build-win64, build-macos-amd64, build-macos-arm64]
+    needs: [build-amd64, build-arm64, build-win64, build-macos-arm64]
     runs-on: ubuntu-latest
     steps:
       - name: Download artefacts
@@ -213,8 +186,6 @@ jobs:
           cat Linux_arm64_checksum/* >> release_notes.md
           echo '# Windows AMD64' >> release_notes.md
           cat Windows_amd64_checksum/* >> release_notes.md
-          echo '# macOS AMD64' >> release_notes.md
-          cat macOS_amd64_checksum/* >> release_notes.md
           echo '# macOS ARM64' >> release_notes.md
           cat macOS_arm64_checksum/* >> release_notes.md
           echo '```' >> release_notes.md
@@ -231,7 +202,6 @@ jobs:
             Linux_amd64_archive/*
             Linux_arm64_archive/*
             Windows_amd64_archive/*
-            macOS_amd64_archive/*
             macOS_arm64_archive/*
       - name: Delete artefacts
         uses: geekyeggo/delete-artifact@v1
@@ -244,8 +214,6 @@ jobs:
             Linux_arm64_checksum
             Windows_amd64_archive
             Windows_amd64_checksum
-            macOS_amd64_archive
-            macOS_amd64_checksum
             macOS_arm64_archive
             macOS_arm64_checksum
 


### PR DESCRIPTION
Fluffy doesn't currently have the `arm64` builds set up, so leaving the `amd64` builds in place there.