### PR TITLE
Add branch cache

### DIFF
--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -386,17 +386,23 @@ type
       defaultValueDesc: $defaultBlockCacheSize
       name: "debug-rocksdb-block-cache-size".}: int
 
+    rdbVtxCacheSize {.
+      hidden
+      defaultValue: defaultRdbVtxCacheSize
+      defaultValueDesc: $defaultRdbVtxCacheSize
+      name: "debug-rdb-vtx-cache-size".}: int
+
     rdbKeyCacheSize {.
       hidden
       defaultValue: defaultRdbKeyCacheSize
       defaultValueDesc: $defaultRdbKeyCacheSize
       name: "debug-rdb-key-cache-size".}: int
 
-    rdbVtxCacheSize {.
+    rdbBranchCacheSize {.
       hidden
-      defaultValue: defaultRdbVtxCacheSize
-      defaultValueDesc: $defaultRdbVtxCacheSize
-      name: "debug-rdb-vtx-cache-size".}: int
+      defaultValue: defaultRdbBranchCacheSize
+      defaultValueDesc: $defaultRdbBranchCacheSize
+      name: "debug-rdb-branch-cache-size".}: int
 
     rdbPrintStats {.
       hidden
@@ -773,11 +779,13 @@ func dbOptions*(conf: NimbusConf, noKeyCache = false): DbOptions =
     rowCacheSize = conf.rocksdbRowCacheSize,
     blockCacheSize = conf.rocksdbBlockCacheSize,
     rdbKeyCacheSize =
-      if noKeyCache: 0 else: conf.rdbKeyCacheSize ,
-    rdbVtxCacheSize =
-      # The import command does not use the key cache - better give it to vtx
-      if noKeyCache: conf.rdbKeyCacheSize + conf.rdbVtxCacheSize
-      else: conf.rdbVtxCacheSize,
+      if noKeyCache: 0 else: conf.rdbKeyCacheSize,
+    rdbVtxCacheSize = conf.rdbVtxCacheSize,
+    rdbBranchCacheSize =
+      # The import command does not use the key cache - better give it to branch
+      if noKeyCache: conf.rdbKeyCacheSize + conf.rdbBranchCacheSize
+      else: conf.rdbBranchCacheSize,
+
     rdbPrintStats = conf.rdbPrintStats,
   )
 

--- a/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/nimbus/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -60,6 +60,9 @@ type
     rdVtxLru*: LruCache[VertexID,VertexRef] ## Read cache
     rdVtxSize*: int
 
+    rdBranchLru*: LruCache[VertexID, (VertexID, uint16)]
+    rdBranchSize*: int
+
     basePath*: string                  ## Database directory
     trgWriteEvent*: RdbWriteEventCb    ## Database piggiback call back handler
 
@@ -84,6 +87,7 @@ var
   # happens from a separate thread.
   # TODO maybe turn this into more general framework for LRU reporting since
   #      we have lots of caches of this sort
+  rdbBranchLruStats*: array[RdbStateType, RdbLruCounter]
   rdbVtxLruStats*: array[RdbStateType, array[VertexType, RdbLruCounter]]
   rdbKeyLruStats*: array[RdbStateType, RdbLruCounter]
 

--- a/nimbus/db/opts.nim
+++ b/nimbus/db/opts.nim
@@ -33,10 +33,12 @@ const
     ## re-reads from file.
     ##
     ## A bit of space on top of the filter is left for data block caching
-  defaultRdbVtxCacheSize* = 768 * 1024 * 1024
+  defaultRdbVtxCacheSize* = 512 * 1024 * 1024
     ## Cache of branches and leaves in the state MPTs (world and account)
   defaultRdbKeyCacheSize* = 256 * 1024 * 1024
     ## Hashes of the above
+  defaultRdbBranchCacheSize* = 1024 * 1024 * 1024
+    ## Cache of branches and leaves in the state MPTs (world and account)
 
 
 type DbOptions* = object # Options that are transported to the database layer
@@ -46,6 +48,7 @@ type DbOptions* = object # Options that are transported to the database layer
   blockCacheSize*: int
   rdbVtxCacheSize*: int
   rdbKeyCacheSize*: int
+  rdbBranchCacheSize*: int
   rdbPrintStats*: bool
 
 func init*(
@@ -56,6 +59,7 @@ func init*(
     blockCacheSize = defaultBlockCacheSize,
     rdbVtxCacheSize = defaultRdbVtxCacheSize,
     rdbKeyCacheSize = defaultRdbKeyCacheSize,
+    rdbBranchCacheSize = defaultRdbBranchCacheSize,
     rdbPrintStats = false,
 ): T =
   T(
@@ -65,5 +69,6 @@ func init*(
     blockCacheSize: blockCacheSize,
     rdbVtxCacheSize: rdbVtxCacheSize,
     rdbKeyCacheSize: rdbKeyCacheSize,
+    rdbBranchCacheSize: rdbBranchCacheSize,
     rdbPrintStats: rdbPrintStats,
   )


### PR DESCRIPTION
Now that branches are small, we can add a branch cache that fits more verticies in memory by only storing the branch portion (16 bytes) of the VertexRef (136 bytes).

Where the original vertex cache hovers around a hit rate of ~60:ish, this branch cache reaches >90% hit rate instead around block 20M which gives a nice boost to processing.

A downside of this approach is that a new VertexRef must be allocated for every cache hit instead of reusing an existing instance - this causes some GC overhead that needs to be addressed.

Nice 15% improvement nonetheless, can't complain!

```
blocks: 19630784, baseline: 161h18m38s, contender: 136h23m23s
Time (total): -24h55m14s, -15.45%
```

![image](https://github.com/user-attachments/assets/fb31bfa1-23f2-4464-a8ae-c233ed76f7d9)
