### PR TITLE
Enable nimbus execution client to build on RISC-V boards

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -102,6 +102,11 @@ elif defined(macosx) and defined(arm64):
   # Apple's Clang can't handle "-march=native" on M1: https://github.com/status-im/nimbus-eth2/issues/2758
   switch("passC", "-mcpu=apple-a14")
   switch("passL", "-mcpu=apple-a14")
+elif defined(riscv64):
+  # riscv64 needs specification of ISA with extensions. 'gc' is widely supported 
+  # and seems to be the minimum extensions needed to build. 
+  switch("passC", "-march=rv64gc")
+  switch("passL", "-march=rv64gc")
 else:
   switch("passC", "-march=native")
   switch("passL", "-march=native")


### PR DESCRIPTION
To build the nimbus execution client on RISC-V boards, the ISA instruction set supported needs to be specified in the build instructions. A minimal version to build is to define the 'gc' extensions. In the future we might have to add the 'v' extension as well, but many boards do not support this extension yet. These changes are the same that were necessary for the nimbus consensus client: https://github.com/status-im/nimbus-eth2/pull/6439

It builds on my LicheePi 3a using these settings. The binary does start and seems to be working fine. I have not tested to sync an actual testnet or even mainnet with it yet. Will try to do so later.