### PR TITLE
Offload signature checking to taskpools (gigagas!)

### DIFF
--- a/hive_integration/nodocker/consensus/consensus_sim.nim
+++ b/hive_integration/nodocker/consensus/consensus_sim.nim
@@ -23,6 +23,7 @@ proc processChainData(cd: ChainData): TestStatus =
   let
     networkId = NetworkId(cd.params.config.chainId)
     com = CommonRef.new(newCoreDbRef DefaultDbMemory,
+      Taskpool.new(),
       networkId,
       cd.params
     )

--- a/hive_integration/nodocker/engine/engine_env.nim
+++ b/hive_integration/nodocker/engine/engine_env.nim
@@ -59,6 +59,7 @@ const
 proc makeCom*(conf: NimbusConf): CommonRef =
   CommonRef.new(
     newCoreDbRef DefaultDbMemory,
+    Taskpool.new(),
     conf.networkId,
     conf.networkParams
   )

--- a/hive_integration/nodocker/engine/node.nim
+++ b/hive_integration/nodocker/engine/node.nim
@@ -54,7 +54,7 @@ proc processBlock(
   if header.parentBeaconBlockRoot.isSome:
     ? vmState.processBeaconBlockRoot(header.parentBeaconBlockRoot.get)
 
-  ? processTransactions(vmState, header, blk.transactions)
+  ? processTransactions(vmState, header, blk.transactions, taskpool = com.taskpool)
 
   if com.isShanghaiOrLater(header.timestamp):
     for withdrawal in blk.withdrawals.get:

--- a/hive_integration/nodocker/graphql/graphql_sim.nim
+++ b/hive_integration/nodocker/graphql/graphql_sim.nim
@@ -79,7 +79,8 @@ proc main() =
     ethCtx  = newEthContext()
     ethNode = setupEthNode(conf, ethCtx, eth)
     com     = CommonRef.new(newCoreDbRef DefaultDbMemory,
-      conf.networkId,
+     Taskpool.new(),
+     conf.networkId,
       conf.networkParams
     )
 

--- a/hive_integration/nodocker/pyspec/test_env.nim
+++ b/hive_integration/nodocker/pyspec/test_env.nim
@@ -38,7 +38,7 @@ proc setupELClient*(conf: ChainConfig, node: JsonNode): TestEnv =
   let
     memDB = newCoreDbRef DefaultDbMemory
     genesisHeader = node.genesisHeader
-    com = CommonRef.new(memDB, conf)
+    com = CommonRef.new(memDB, Taskpool.new(), conf)
     stateDB = LedgerRef.init(memDB)
     chain = newForkedChain(com, genesisHeader)
 

--- a/hive_integration/nodocker/rpc/test_env.nim
+++ b/hive_integration/nodocker/rpc/test_env.nim
@@ -46,11 +46,11 @@ proc manageAccounts(ctx: EthContext, conf: NimbusConf) =
 proc setupRpcServer(ctx: EthContext, com: CommonRef,
                     ethNode: EthereumNode, txPool: TxPoolRef,
                     conf: NimbusConf, chain: ForkedChainRef): RpcServer  =
-  let 
+  let
     rpcServer = newRpcHttpServer([initTAddress(conf.httpAddress, conf.httpPort)])
     serverApi = newServerAPI(chain, txPool)
 
-  
+
   setupCommonRpc(ethNode, conf, rpcServer)
   setupServerAPI(serverApi, rpcServer, ctx)
 
@@ -80,6 +80,7 @@ proc setupEnv*(): TestEnv =
     ethCtx  = newEthContext()
     ethNode = setupEthNode(conf, ethCtx, eth)
     com     = CommonRef.new(newCoreDbRef DefaultDbMemory,
+      Taskpool.new(),
       conf.networkId,
       conf.networkParams
     )

--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -356,6 +356,12 @@ type
       defaultValueDesc: $ClientId
       name: "agent-string" .}: string
 
+    numThreads* {.
+      separator: "\pPERFORMANCE OPTIONS",
+      defaultValue: 0,
+      desc: "Number of worker threads (\"0\" = use as many threads as there are CPU cores available)"
+      name: "num-threads" .}: int
+
     beaconChunkSize* {.
       hidden
       desc: "Number of blocks per database transaction for beacon sync"

--- a/nimbus/core/chain/persist_blocks.nim
+++ b/nimbus/core/chain/persist_blocks.nim
@@ -149,6 +149,7 @@ proc persistBlocksImpl(
       skipValidation,
       skipReceipts = skipValidation and NoPersistReceipts in flags,
       skipUncles = NoPersistUncles in flags,
+      taskpool = c.com.taskpool,
     )
 
     let blockHash = header.blockHash()

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -265,7 +265,7 @@ proc initVMEnv*(network: string): BaseVMState =
     cdb = DefaultDbMemory.newCoreDbRef()
     com = CommonRef.new(
       cdb,
-      conf,
+      nil, conf,
       conf.chainId.NetworkId)
     parent = Header(stateRoot: EMPTY_ROOT_HASH)
     parentHash = rlpHash(parent)

--- a/tests/persistBlockTestGen.nim
+++ b/tests/persistBlockTestGen.nim
@@ -57,7 +57,7 @@ proc main() {.used.} =
   var conf = makeConfig()
   let db = newCoreDbRef(
     DefaultDbPersistent, string conf.dataDir, DbOptions.init())
-  let com = CommonRef.new(db)
+  let com = CommonRef.new(db, nil)
 
   com.dumpTest(97)
   com.dumpTest(98) # no uncles and no tx

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -69,7 +69,7 @@ proc executeCase(node: JsonNode): bool =
     memDB   = newCoreDbRef DefaultDbMemory
     stateDB = LedgerRef.init(memDB)
     config  = getChainConfig(env.network)
-    com     = CommonRef.new(memDB, config)
+    com     = CommonRef.new(memDB, nil, config)
 
   setupStateDB(env.pre, stateDB)
   stateDB.persist()

--- a/tests/test_coredb.nim
+++ b/tests/test_coredb.nim
@@ -181,6 +181,7 @@ proc initRunnerDB(
 
   result = CommonRef.new(
     db = coreDB,
+    taskpool = nil,
     networkId = networkId,
     params = params,
     pruneHistory = pruneHistory)

--- a/tests/test_engine_api.nim
+++ b/tests/test_engine_api.nim
@@ -61,6 +61,7 @@ proc setupConfig(genesisFile: string): NimbusConf =
 proc setupCom(conf: NimbusConf): CommonRef =
   CommonRef.new(
     newCoreDbRef DefaultDbMemory,
+    nil,
     conf.networkId,
     conf.networkParams
   )

--- a/tests/test_evm_support.nim
+++ b/tests/test_evm_support.nim
@@ -347,6 +347,7 @@ proc runTestOverflow() =
 
     let com = CommonRef.new(
       newCoreDbRef(DefaultDbMemory),
+      nil,
       config = chainConfigForNetwork(MainNet)
     )
 

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -37,6 +37,7 @@ proc setupEnv(): TestEnv =
 proc newCom(env: TestEnv): CommonRef =
   CommonRef.new(
       newCoreDbRef DefaultDbMemory,
+      nil,
       env.conf.networkId,
       env.conf.networkParams
     )

--- a/tests/test_forkid.nim
+++ b/tests/test_forkid.nim
@@ -72,7 +72,7 @@ template runTest(network: untyped, name: string) =
   test name:
     var
       params = networkParams(network)
-      com    = CommonRef.new(newCoreDbRef DefaultDbMemory, network, params)
+      com    = CommonRef.new(newCoreDbRef DefaultDbMemory, nil, network, params)
 
     for i, x in `network IDs`:
       let id = com.forkId(x.number, x.time)

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -77,7 +77,7 @@ proc dumpDebugData(ctx: TestCtx, vmState: BaseVMState, gasUsed: GasInt, success:
 
 proc testFixtureIndexes(ctx: var TestCtx, testStatusIMPL: var TestStatus) =
   let
-    com    = CommonRef.new(newCoreDbRef DefaultDbMemory, ctx.chainConfig)
+    com    = CommonRef.new(newCoreDbRef DefaultDbMemory, nil, ctx.chainConfig)
     parent = Header(stateRoot: emptyRoot)
     tracer = if ctx.trace:
                newLegacyTracer({})

--- a/tests/test_genesis.nim
+++ b/tests/test_genesis.nim
@@ -27,11 +27,11 @@ proc findFilePath(file: string): string =
         return path
 
 proc makeGenesis(networkId: NetworkId): Header =
-  let com = CommonRef.new(newCoreDbRef DefaultDbMemory, params = networkParams(networkId))
+  let com = CommonRef.new(newCoreDbRef DefaultDbMemory, taskpool = nil, params = networkParams(networkId))
   com.genesisHeader
 
 proc proofOfStake(params: NetworkParams): bool =
-  let com = CommonRef.new(newCoreDbRef DefaultDbMemory,
+  let com = CommonRef.new(newCoreDbRef DefaultDbMemory, taskpool = nil,
     networkId = params.config.chainId.NetworkId,
     params = params)
   let header = com.genesisHeader
@@ -66,7 +66,7 @@ proc customGenesisTest() =
     test "Devnet4.json (aka Kintsugi in all but chainId)":
       var cg: NetworkParams
       check loadNetworkParams("devnet4.json".findFilePath, cg)
-      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, params = cg)
+      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, taskpool = nil, params = cg)
       let stateRoot = hash32"3b84f313bfd49c03cc94729ade2e0de220688f813c0c895a99bd46ecc9f45e1e"
       let genesisHash = hash32"a28d8d73e087a01d09d8cb806f60863652f30b6b6dfa4e0157501ff07d422399"
       check com.genesisHeader.stateRoot == stateRoot
@@ -76,7 +76,7 @@ proc customGenesisTest() =
     test "Devnet5.json (aka Kiln in all but chainId and TTD)":
       var cg: NetworkParams
       check loadNetworkParams("devnet5.json".findFilePath, cg)
-      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, params = cg)
+      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, taskpool = nil, params = cg)
       let stateRoot = hash32"52e628c7f35996ba5a0402d02b34535993c89ff7fc4c430b2763ada8554bee62"
       let genesisHash = hash32"51c7fe41be669f69c45c33a56982cbde405313342d9e2b00d7c91a7b284dd4f8"
       check com.genesisHeader.stateRoot == stateRoot
@@ -86,7 +86,7 @@ proc customGenesisTest() =
     test "Mainnet shadow fork 1":
       var cg: NetworkParams
       check loadNetworkParams("mainshadow1.json".findFilePath, cg)
-      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, params = cg)
+      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, taskpool = nil, params = cg)
       let stateRoot = hash32"d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544"
       let genesisHash = hash32"d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
       let ttd = "46_089_003_871_917_200_000_000".parse(UInt256)
@@ -99,7 +99,7 @@ proc customGenesisTest() =
       # parse using geth format should produce the same result with nimbus format
       var cg: NetworkParams
       check loadNetworkParams("geth_mainshadow1.json".findFilePath, cg)
-      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, params = cg)
+      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, taskpool = nil, params = cg)
       let stateRoot = hash32"d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544"
       let genesisHash = hash32"d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
       let ttd = "46_089_003_871_917_200_000_000".parse(UInt256)
@@ -114,7 +114,7 @@ proc customGenesisTest() =
     test "Holesky":
       var cg: NetworkParams
       check loadNetworkParams("holesky.json".findFilePath, cg)
-      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, params = cg)
+      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, taskpool = nil, params = cg)
       let stateRoot = hash32"69D8C9D72F6FA4AD42D4702B433707212F90DB395EB54DC20BC85DE253788783"
       let genesisHash = hash32"b5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4"
       check com.genesisHeader.stateRoot == stateRoot
@@ -125,7 +125,7 @@ proc customGenesisTest() =
       # parse using geth format should produce the same result with nimbus format
       var cg: NetworkParams
       check loadNetworkParams("geth_holesky.json".findFilePath, cg)
-      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, params = cg)
+      let com = CommonRef.new(newCoreDbRef DefaultDbMemory, taskpool = nil, params = cg)
       let stateRoot = hash32"69D8C9D72F6FA4AD42D4702B433707212F90DB395EB54DC20BC85DE253788783"
       let genesisHash = hash32"b5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4"
       check com.genesisHeader.stateRoot == stateRoot

--- a/tests/test_graphql.nim
+++ b/tests/test_graphql.nim
@@ -69,7 +69,7 @@ proc setupChain(): CommonRef =
   )
 
   let com = CommonRef.new(
-    newCoreDbRef DefaultDbMemory,
+    newCoreDbRef DefaultDbMemory, nil,
     CustomNet,
     customNetwork
   )

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -97,7 +97,7 @@ proc initEnv(): TestEnv =
 
   let
     com = CommonRef.new(
-      newCoreDbRef DefaultDbMemory,
+      newCoreDbRef DefaultDbMemory, nil,
       conf.networkId,
       conf.networkParams
     )

--- a/tests/test_persistblock_json.nim
+++ b/tests/test_persistblock_json.nim
@@ -19,7 +19,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus) =
     blockNumber = UInt256.fromHex(node["blockNumber"].getStr())
     memoryDB    = newCoreDbRef DefaultDbMemory
     config      = chainConfigForNetwork(MainNet)
-    com         = CommonRef.new(memoryDB, config)
+    com         = CommonRef.new(memoryDB, nil, config)
     state       = node["state"]
 
   for k, v in state:

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -71,7 +71,7 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
     conf  = getChainConfig(parseFork(fixtures["fork"].getStr))
     data  = fixtures["data"]
     privateKey = PrivateKey.fromHex("7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d")[]
-    com = CommonRef.new(newCoreDbRef DefaultDbMemory, config = conf)
+    com = CommonRef.new(newCoreDbRef DefaultDbMemory, nil, config = conf)
     vmState = BaseVMState.new(
       Header(number: 1'u64, stateRoot: emptyRlpHash),
       Header(),

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -222,7 +222,7 @@ proc rpcMain*() =
       ctx  = newEthContext()
       ethNode = setupEthNode(conf, ctx, eth)
       com = CommonRef.new(
-        newCoreDbRef DefaultDbMemory,
+        newCoreDbRef DefaultDbMemory, nil,
         conf.networkId,
         conf.networkParams
       )

--- a/tests/test_tracer_json.nim
+++ b/tests/test_tracer_json.nim
@@ -130,7 +130,7 @@ proc testFixtureImpl(node: JsonNode, testStatusIMPL: var TestStatus, memoryDB: C
   var
     blockNumberHex = node["blockNumber"].getStr()
     blockNumber = parseHexInt(blockNumberHex).uint64
-    com = CommonRef.new(memoryDB, chainConfigForNetwork(MainNet))
+    com = CommonRef.new(memoryDB, nil, chainConfigForNetwork(MainNet))
     state = node["state"]
     receipts = node["receipts"]
 

--- a/tests/test_txpool/setup.nim
+++ b/tests/test_txpool/setup.nim
@@ -92,7 +92,7 @@ proc setupTxPool*(getStatus: proc(): TxItemStatus): (CommonRef, TxPoolRef, int) 
   txEnv.fillGenesis(conf.networkParams)
 
   let com = CommonRef.new(
-    newCoreDbRef DefaultDbMemory,
+    newCoreDbRef DefaultDbMemory, nil,
     conf.networkId,
     conf.networkParams
   )

--- a/tests/test_txpool2.nim
+++ b/tests/test_txpool2.nim
@@ -124,7 +124,7 @@ proc initEnv(envFork: HardFork): TestEnv =
 
   let
     com =
-      CommonRef.new(newCoreDbRef DefaultDbMemory, conf.networkId, conf.networkParams)
+      CommonRef.new(newCoreDbRef DefaultDbMemory, nil, conf.networkId, conf.networkParams)
     chain = newForkedChain(com, com.genesisHeader)
 
   result = TestEnv(

--- a/tests/tracerTestGen.nim
+++ b/tests/tracerTestGen.nim
@@ -56,7 +56,7 @@ proc main() {.used.} =
   var conf = makeConfig()
   let db = newCoreDbRef(
     DefaultDbPersistent, string conf.dataDir, DbOptions.init())
-  let com = CommonRef.new(db)
+  let com = CommonRef.new(db, nil)
 
   com.dumpTest(97)
   com.dumpTest(46147)

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -105,7 +105,7 @@ proc writeRootHashToStderr(stateRoot: Hash32) =
 
 proc runExecution(ctx: var StateContext, conf: StateConf, pre: JsonNode): StateResult =
   let
-    com     = CommonRef.new(newCoreDbRef DefaultDbMemory, ctx.chainConfig)
+    com     = CommonRef.new(newCoreDbRef DefaultDbMemory, nil, ctx.chainConfig)
     stream  = newFileStream(stderr)
     tracer  = if conf.jsonEnabled:
                 newJsonTracer(stream, ctx.tracerFlags, conf.pretty)

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -349,11 +349,11 @@ proc exec(ctx: TransContext,
     excessBlobGas = ctx.env.currentExcessBlobGas
   elif ctx.env.parentExcessBlobGas.isSome and ctx.env.parentBlobGasUsed.isSome:
     excessBlobGas = Opt.some calcExcessBlobGas(vmState.parent)
-      
+
   if excessBlobGas.isSome:
     result.result.blobGasUsed = Opt.some vmState.blobGasUsed
     result.result.currentExcessBlobGas = excessBlobGas
-    
+
   if vmState.com.isPragueOrLater(ctx.env.currentTimestamp):
     var allLogs: seq[Log]
     for rec in result.result.receipts:
@@ -469,7 +469,7 @@ proc transitionAction*(ctx: var TransContext, conf: T8NConf) =
     config.depositContractAddress = ctx.env.depositContractAddress
     config.chainId = conf.stateChainId.ChainId
 
-    let com = CommonRef.new(newCoreDbRef DefaultDbMemory, config)
+    let com = CommonRef.new(newCoreDbRef DefaultDbMemory, Taskpool.new(), config)
 
     # Sanity check, to not `panic` in state_transition
     if com.isLondonOrLater(ctx.env.currentNumber):


### PR DESCRIPTION
In block processing, depending on the complexity of a transaction and hotness of caches etc, signature checking can actually make up the majority of time needed to process a transaction (60% observed in some randomly sampled block ranges).

Fortunately, this is a task that trivially can be offloaded to a task pool similar to how nimbus-eth2 does it.

This PR introduces taskpools in the most simple way possible, by performing signature checking concurrently with other TX processing, assigning a taskpool task per TX effectively.

With this little trick, we're in gigagas land 🎉 on my laptop!

```
INF 2024-12-10 21:05:35.170+01:00 Imported blocks
blockNumber=3874817 b... mgps=1222.707 ...
```

Tests don't use the taskpool for now because it needs manual cleanup and we don't have a good mechanism in place. Future PR:s should address this by creating a common shutdown sequence that also closes and cleans up other resources like the DB.