### PR TITLE
Reduce getCanonicalHead usage, and delegate to ForkedChain

### DIFF
--- a/hive_integration/nodocker/consensus/consensus_sim.nim
+++ b/hive_integration/nodocker/consensus/consensus_sim.nim
@@ -36,14 +36,13 @@ proc processChainData(cd: ChainData, taskPool: Taskpool): TestStatus =
     # bad blocks
     discard importRlpBlocks(bytes, c, finalize = true)
 
-  let head = com.db.getCanonicalHead().expect("canonical head exists")
-  let blockHash = "0x" & head.blockHash.data.toHex
+  let blockHash = $c.latestHash
   if blockHash == cd.lastBlockHash:
     TestStatus.OK
   else:
     trace "block hash not equal",
       got=blockHash,
-      number=head.number,
+      number=c.latestHeader.number,
       expected=cd.lastBlockHash
     TestStatus.Failed
 

--- a/hive_integration/nodocker/engine/node.nim
+++ b/hive_integration/nodocker/engine/node.nim
@@ -99,8 +99,7 @@ proc setBlock*(c: ChainRef; blk: Block): Result[void, string] =
     _ = vmState.parent.stateRoot # Check point
   ? vmState.processBlock(blk)
 
-  ? c.db.persistHeader(
-      header, c.com.proofOfStake(header), c.com.startOfHistory)
+  ? c.db.persistHeaderAndSetHead(header, c.com.startOfHistory)
 
   c.db.persistTransactions(header.number, header.txRoot, blk.transactions)
   c.db.persistReceipts(header.receiptsRoot, vmState.receipts)

--- a/hive_integration/nodocker/pyspec/test_env.nim
+++ b/hive_integration/nodocker/pyspec/test_env.nim
@@ -34,22 +34,27 @@ proc genesisHeader(node: JsonNode): Header =
   let genesisRLP = hexToSeqByte(node["genesisRLP"].getStr)
   rlp.decode(genesisRLP, Block).header
 
-proc setupELClient*(conf: ChainConfig, taskPool: Taskpool, node: JsonNode): TestEnv =
+proc initializeDb(memDB: CoreDbRef, node: JsonNode): Hash32 =
   let
-    memDB = newCoreDbRef DefaultDbMemory
     genesisHeader = node.genesisHeader
-    com = CommonRef.new(memDB, taskPool, conf)
     stateDB = LedgerRef.init(memDB)
-    chain = newForkedChain(com, genesisHeader)
 
+  memDB.persistHeaderAndSetHead(genesisHeader).expect("persistHeader no error")
   setupStateDB(node["pre"], stateDB)
   stateDB.persist()
   doAssert stateDB.getStateRoot == genesisHeader.stateRoot
 
-  com.db.persistHeader(genesisHeader,
-    com.proofOfStake(genesisHeader)).expect("persistHeader no error")
-  let head = com.db.getCanonicalHead().expect("canonical head exists")
-  doAssert(head.blockHash == genesisHeader.blockHash)
+  genesisHeader.blockHash
+
+proc setupELClient*(conf: ChainConfig, taskPool: Taskpool, node: JsonNode): TestEnv =
+  let
+    memDB = newCoreDbRef DefaultDbMemory
+    genesisHash = initializeDb(memDB, node)
+    com = CommonRef.new(memDB, taskPool, conf)
+    chain = ForkedChainRef.init(com)
+
+  let headHash = chain.latestHash
+  doAssert(headHash == genesisHash)
 
   let
     txPool  = TxPoolRef.new(chain)

--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -144,8 +144,7 @@ proc initializeDb(com: CommonRef) =
       nonce = com.genesisHeader.nonce
     doAssert(com.genesisHeader.number == 0.BlockNumber,
       "can't commit genesis block with number > 0")
-    com.db.persistHeader(com.genesisHeader,
-      com.proofOfStake(com.genesisHeader),
+    com.db.persistHeaderAndSetHead(com.genesisHeader,
       startOfHistory=com.genesisHeader.parentHash).
       expect("can persist genesis header")
     doAssert(canonicalHeadHashKey().toOpenArray in kvt)

--- a/nimbus/core/block_import.nim
+++ b/nimbus/core/block_import.nim
@@ -79,11 +79,7 @@ proc importRlpBlocks*(importFile: string,
   importRlpBlocks(bytes, chain, finalize)
 
 proc importRlpBlocks*(conf: NimbusConf, com: CommonRef) =
-  let head = com.db.getCanonicalHead().valueOr:
-    error "cannot get canonical head from db", msg=error
-    quit(QuitFailure)
-
-  let chain = newForkedChain(com, head, baseDistance = 0)
+  let chain = ForkedChainRef.init(com, baseDistance = 0)
 
   # success or not, we quit after importing blocks
   for i, blocksFile in conf.blocksFile:

--- a/nimbus/core/chain/chain_desc.nim
+++ b/nimbus/core/chain/chain_desc.nim
@@ -31,23 +31,13 @@ type
 # ------------------------------------------------------------------------------
 
 func newChain*(com: CommonRef,
-               extraValidation: bool): ChainRef =
+               extraValidation: bool = true): ChainRef =
   ## Constructor for the `Chain` descriptor object.
   ## The argument `extraValidation` enables extra block
   ## chain validation if set `true`.
   ChainRef(
     com: com,
     extraValidation: extraValidation
-  )
-
-proc newChain*(com: CommonRef): ChainRef =
-  ## Constructor for the `Chain` descriptor object. All sub-object descriptors
-  ## are initialised with defaults. So is extra block chain validation
-  let header = com.db.getCanonicalHead().expect("canonical head exists")
-  let extraValidation = com.proofOfStake(header)
-  return ChainRef(
-    com: com,
-    extraValidation: extraValidation,
   )
 
 # ------------------------------------------------------------------------------

--- a/nimbus/core/chain/persist_blocks.nim
+++ b/nimbus/core/chain/persist_blocks.nim
@@ -151,9 +151,8 @@ proc persistBlocksImpl(
 
     let blockHash = header.blockHash()
     if NoPersistHeader notin flags:
-      ?c.db.persistHeader(
-        blockHash, header,
-        c.com.proofOfStake(header), c.com.startOfHistory)
+      ?c.db.persistHeaderAndSetHead(
+        blockHash, header, c.com.startOfHistory)
 
     if NoPersistTransactions notin flags:
       c.db.persistTransactions(header.number, header.txRoot, blk.transactions)

--- a/nimbus/core/tx_pool.nim
+++ b/nimbus/core/tx_pool.nim
@@ -261,7 +261,7 @@
 ##
 ## In the most complex case, the newly mined block was added to some block
 ## chain branch which has become an uncle to the new canonical head retrieved
-## by `getCanonicalHead()`. In order to update the pool to the very state
+## by `latestHeader()`. In order to update the pool to the very state
 ## one would have arrived if worked on the retrieved canonical head branch
 ## in the first place, the directive `smartHead()` calculates the actions of
 ## what is needed to get just there from the locally cached head state of the
@@ -303,7 +303,7 @@
 ## --------------------
 ## head
 ##   Cached block chain insertion point, not necessarily the same header as
-##   retrieved by the `getCanonicalHead()`. This insertion point can be
+##   retrieved by the `latestHeader()`. This insertion point can be
 ##   adjusted with the `smartHead()` function.
 
 

--- a/nimbus/core/tx_pool/tx_desc.nim
+++ b/nimbus/core/tx_pool/tx_desc.nim
@@ -224,7 +224,7 @@ proc getNonce*(xp: TxPoolRef; account: Address): AccountNonce =
 
 func head*(xp: TxPoolRef): Header =
   ## Getter, cached block chain insertion point. Typocally, this should be the
-  ## the same header as retrieved by the `getCanonicalHead()` (unless in the
+  ## the same header as retrieved by the `ForkedChainRef.latestHeader` (unless in the
   ## middle of a mining update.)
   xp.vmState.parent
 

--- a/nimbus/core/tx_pool/tx_info.nim
+++ b/nimbus/core/tx_pool/tx_info.nim
@@ -99,25 +99,9 @@ type
 
     # ------- update/move block chain head -------------------------------------
 
-    txInfoErrAncestorMissing = ##\
-      ## Cannot forward current head as it is detached from the block chain
-      "Lost header ancestor"
-
-    txInfoErrChainHeadMissing = ##\
-      ## Must not back move current head as it is detached from the block chain
-      "Lost header position"
-
     txInfoErrForwardHeadMissing = ##\
       ## Cannot move forward current head to non-existing target position
       "Non-existing forward header"
-
-    txInfoErrUnrootedCurChain = ##\
-      ## Some orphan block found in current branch of the block chain
-      "Orphan block in current branch"
-
-    txInfoErrUnrootedNewChain = ##\
-      ## Some orphan block found in new branch of the block chain
-      "Orphan block in new branch"
 
     txInfoChainHeadUpdate = ##\
       ## Tx becomes obsolete as it is in a mined block, already

--- a/nimbus/db/core_db/core_apps.nim
+++ b/nimbus/db/core_db/core_apps.nim
@@ -598,16 +598,15 @@ proc persistHeader*(
   db.addBlockNumberToHashLookup(header.number, blockHash)
   ok()
 
-proc persistHeader*(
+proc persistHeaderAndSetHead*(
     db: CoreDbRef;
     blockHash: Hash32;
     header: Header;
-    forceCanonical: bool;
     startOfHistory = GENESIS_PARENT_HASH;
       ): Result[void, string] =
   ?db.persistHeader(blockHash, header, startOfHistory)
 
-  if not forceCanonical and header.parentHash != startOfHistory:
+  if header.parentHash != startOfHistory:
     let
       canonicalHash = ?db.getCanonicalHeaderHash()
       canonScore = db.getScore(canonicalHash).valueOr:
@@ -621,15 +620,14 @@ proc persistHeader*(
 
   db.setHead(blockHash)
 
-proc persistHeader*(
+proc persistHeaderAndSetHead*(
     db: CoreDbRef;
     header: Header;
-    forceCanonical: bool;
     startOfHistory = GENESIS_PARENT_HASH;
       ): Result[void, string] =
   let
     blockHash = header.blockHash
-  db.persistHeader(blockHash, header, forceCanonical, startOfHistory)
+  db.persistHeaderAndSetHead(blockHash, header, startOfHistory)
 
 proc persistUncles*(db: CoreDbRef, uncles: openArray[Header]): Hash32 =
   ## Persists the list of uncles to the database.

--- a/nimbus/sync/handlers/eth.nim
+++ b/nimbus/sync/handlers/eth.nim
@@ -301,7 +301,7 @@ method getStatus*(ctx: EthWireRef): Result[EthState, string]
   let
     db = ctx.db
     com = ctx.chain.com
-    bestBlock = ?db.getCanonicalHead()
+    bestBlock = ctx.chain.latestHeader
     forkId = com.forkId(bestBlock.number, bestBlock.timestamp)
 
   return ok(EthState(

--- a/tests/test_coredb/test_chainsync.nim
+++ b/tests/test_coredb/test_chainsync.nim
@@ -146,7 +146,7 @@ proc test_chainSync*(
   ## Store persistent blocks from dump into chain DB
   let
     sayBlocks = 900'u64
-    chain = com.newChain
+    chain = com.newChain()
     blockOnDb = com.db.getSavedStateBlockNumber()
     lastBlock = max(1, numBlocks).BlockNumber
 

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -339,7 +339,7 @@ proc runLedgerTransactionTests(noisy = true) =
         for tx in body.transactions:
           env.txs.add tx
 
-    let head = env.xdb.getCanonicalHead().expect("canonicalHead exists")
+    let head = env.chain.latestHeader
     test &"Collect unique recipient addresses from {env.txs.len} txs," &
         &" head=#{head.number}":
       # since we generate our own transactions instead of replaying

--- a/tests/test_txpool2.nim
+++ b/tests/test_txpool2.nim
@@ -277,7 +277,7 @@ proc runTxHeadDelta(noisy = true) =
         xp = env.xp
         com = env.com
         chain = env.chain
-        head = com.db.getCanonicalHead().expect("canonical head exists")
+        head = chain.latestHeader
         timestamp = head.timestamp
 
       const
@@ -327,7 +327,7 @@ proc runTxHeadDelta(noisy = true) =
           setErrorLevel() # in case we set trace level
 
       check com.syncCurrent == 10.BlockNumber
-      head = com.db.getBlockHeader(com.syncCurrent).expect("block header exists")
+      head = chain.headerByNumber(com.syncCurrent).expect("block header exists")
       let
         sdb = LedgerRef.init(com.db)
         expected = u256(txPerblock * numBlocks) * amount


### PR DESCRIPTION
The current getCanonicalHead of core db should not be confused with ForkedChain.latestHeader.
Therefore we need to to use getCanonicalHead to restricted case only, e.g. initializing ForkedChain.
