### PR TITLE
reduce tx naming overload

### DIFF
--- a/hive_integration/nodocker/engine/node.nim
+++ b/hive_integration/nodocker/engine/node.nim
@@ -42,7 +42,7 @@ proc processBlock(
   ## implementations (but can be savely removed, as well.)
   ## variant of `processBlock()` where the `header` argument is explicitely set.
   template header: Header = blk.header
-  var dbTx = vmState.com.db.ctx.newTransaction()
+  var dbTx = vmState.com.db.ctx.txFrameBegin()
   defer: dbTx.dispose()
 
   let com = vmState.com
@@ -89,7 +89,7 @@ proc getVmState(c: ChainRef, header: Header):
 # intended to accepts invalid block
 proc setBlock*(c: ChainRef; blk: Block): Result[void, string] =
   template header: Header = blk.header
-  let dbTx = c.db.ctx.newTransaction()
+  let dbTx = c.db.ctx.txFrameBegin()
   defer: dbTx.dispose()
 
   # Needed for figuring out whether KVT cleanup is due (see at the end)

--- a/nimbus/core/chain/persist_blocks.nim
+++ b/nimbus/core/chain/persist_blocks.nim
@@ -117,6 +117,9 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
 
   let c = p.c
 
+  if p.dbTx == nil:
+    p.dbTx = p.c.db.ctx.txFrameBegin()
+
   # Full validation means validating the state root at every block and
   # performing the more expensive hash computations on the block itself, ie
   # verifying that the transaction and receipts roots are valid - when not

--- a/nimbus/core/tx_pool/tx_packer.nim
+++ b/nimbus/core/tx_pool/tx_packer.nim
@@ -292,7 +292,7 @@ proc packerVmExec*(xp: TxPoolRef): Result[TxPacker, string]
   ## Rebuild `packed` bucket by selection items from the `staged` bucket
   ## after executing them in the VM.
   let db = xp.vmState.com.db
-  let dbTx = db.ctx.newTransaction()
+  let dbTx = db.ctx.txFrameBegin()
   defer: dbTx.dispose()
 
   var pst = xp.vmExecInit.valueOr:

--- a/nimbus/db/aristo/aristo_desc/desc_error.nim
+++ b/nimbus/db/aristo/aristo_desc/desc_error.nim
@@ -232,8 +232,8 @@ type
     TxArgStaleTx
     TxArgsUseless
     TxBackendNotWritable
-    TxLevelTooDeep
-    TxLevelUseless
+    TxFrameLevelTooDeep
+    TxFrameLevelUseless
     TxNoPendingTx
     TxNotFound
     TxNotTopTx

--- a/nimbus/db/aristo/aristo_tx.nim
+++ b/nimbus/db/aristo/aristo_tx.nim
@@ -18,26 +18,7 @@ import
   ./aristo_tx/[tx_frame, tx_stow],
   ./aristo_desc
 
-# ------------------------------------------------------------------------------
-# Public functions, getters
-# ------------------------------------------------------------------------------
-
-func txTop*(db: AristoDbRef): Result[AristoTxRef,AristoError] =
-  ## Getter, returns top level transaction if there is any.
-  db.txFrameTop()
-
-func isTop*(tx: AristoTxRef): bool =
-  ## Getter, returns `true` if the argument `tx` referes to the current top
-  ## level transaction.
-  tx.txFrameIsTop()
-
-func txLevel*(tx: AristoTxRef): int =
-  ## Getter, positive nesting level of transaction argument `tx`
-  tx.txFrameLevel()
-
-func level*(db: AristoDbRef): int =
-  ## Getter, non-negative nesting level (i.e. number of pending transactions)
-  db.txFrameLevel()
+export tx_frame
 
 # ------------------------------------------------------------------------------
 # Public functions
@@ -50,51 +31,6 @@ func to*(tx: AristoTxRef; T: type[AristoDbRef]): T =
 # ------------------------------------------------------------------------------
 # Public functions: Transaction frame
 # ------------------------------------------------------------------------------
-
-proc txBegin*(db: AristoDbRef): Result[AristoTxRef,AristoError] =
-  ## Starts a new transaction.
-  ##
-  ## Example:
-  ## ::
-  ##   proc doSomething(db: AristoDbRef) =
-  ##     let tx = db.begin
-  ##     defer: tx.rollback()
-  ##     ... continue using db ...
-  ##     tx.commit()
-  ##
-  db.txFrameBegin()
-
-proc rollback*(
-    tx: AristoTxRef;                  # Top transaction on database
-      ): Result[void,AristoError] =
-  ## Given a *top level* handle, this function discards all database operations
-  ## performed for this transactio. The previous transaction is returned if
-  ## there was any.
-  ##
-  tx.txFrameRollback()
-
-proc commit*(
-    tx: AristoTxRef;                  # Top transaction on database
-      ): Result[void,AristoError] =
-  ## Given a *top level* handle, this function accepts all database operations
-  ## performed through this handle and merges it to the previous layer. The
-  ## previous transaction is returned if there was any.
-  ##
-  tx.txFrameCommit()
-
-proc collapse*(
-    tx: AristoTxRef;                  # Top transaction on database
-    commit: bool;                     # Commit if `true`, otherwise roll back
-      ): Result[void,AristoError] =
-  ## Iterated application of `commit()` or `rollback()` performing the
-  ## something similar to
-  ## ::
-  ##   while true:
-  ##     discard tx.commit() # ditto for rollback()
-  ##     if db.txTop.isErr: break
-  ##     tx = db.txTop.value
-  ##
-  tx.txFrameCollapse commit
 
 # ------------------------------------------------------------------------------
 # Public functions: save to database
@@ -119,20 +55,7 @@ proc persist*(
   ## next recovery journal record. If non-zero, this ID must be greater than
   ## all previous IDs (e.g. block number when stowing after block execution.)
   ##
-  db.txStow(nxtSid, persistent=true)
-
-proc stow*(
-    db: AristoDbRef;                  # Database
-      ): Result[void,AristoError] =
-  ## This function is similar to `persist()` stopping short of performing the
-  ## final step storing on the persistent database. It fails if there is a
-  ## pending transaction.
-  ##
-  ## The function merges all staged data from the top layer cache onto the
-  ## backend stage area and leaves it there. This function can be seen as
-  ## a sort of a bottom level transaction `commit()`.
-  ##
-  db.txStow(nxtSid=0u64, persistent=false)
+  db.txPersist(nxtSid)
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/db/aristo/aristo_tx/tx_frame.nim
+++ b/nimbus/db/aristo/aristo_tx/tx_frame.nim
@@ -17,14 +17,14 @@ import
   results,
   ".."/[aristo_desc, aristo_layers]
 
-func txFrameIsTop*(tx: AristoTxRef): bool
+func isTop*(tx: AristoTxRef): bool
 
 # ------------------------------------------------------------------------------
 # Private helpers
 # ------------------------------------------------------------------------------
 
 func getDbDescFromTopTx(tx: AristoTxRef): Result[AristoDbRef,AristoError] =
-  if not tx.txFrameIsTop():
+  if not tx.isTop():
     return err(TxNotTopTx)
   let db = tx.db
   if tx.level != db.stack.len:
@@ -48,14 +48,10 @@ func txFrameTop*(db: AristoDbRef): Result[AristoTxRef,AristoError] =
   else:
     ok(db.txRef)
 
-func txFrameIsTop*(tx: AristoTxRef): bool =
+func isTop*(tx: AristoTxRef): bool =
   ## Getter, returns `true` if the argument `tx` referes to the current top
   ## level transaction.
   tx.db.txRef == tx and tx.db.top.txUid == tx.txUid
-
-func txFrameLevel*(tx: AristoTxRef): int =
-  ## Getter, positive nesting level of transaction argument `tx`
-  tx.level
 
 func txFrameLevel*(db: AristoDbRef): int =
   ## Getter, non-negative nesting level (i.e. number of pending transactions)
@@ -95,7 +91,7 @@ proc txFrameBegin*(db: AristoDbRef): Result[AristoTxRef,AristoError] =
   ok db.txRef
 
 
-proc txFrameRollback*(
+proc rollback*(
     tx: AristoTxRef;                  # Top transaction on database
       ): Result[void,AristoError] =
   ## Given a *top level* handle, this function discards all database operations
@@ -112,7 +108,7 @@ proc txFrameRollback*(
   ok()
 
 
-proc txFrameCommit*(
+proc commit*(
     tx: AristoTxRef;                  # Top transaction on database
       ): Result[void,AristoError] =
   ## Given a *top level* handle, this function accepts all database operations
@@ -139,7 +135,7 @@ proc txFrameCommit*(
   ok()
 
 
-proc txFrameCollapse*(
+proc collapse*(
     tx: AristoTxRef;                  # Top transaction on database
     commit: bool;                     # Commit if `true`, otherwise roll back
       ): Result[void,AristoError] =
@@ -148,8 +144,8 @@ proc txFrameCollapse*(
   ## ::
   ##   while true:
   ##     discard tx.commit() # ditto for rollback()
-  ##     if db.txTop.isErr: break
-  ##     tx = db.txTop.value
+  ##     if db.txFrameTop.isErr: break
+  ##     tx = db.txFrameTop.value
   ##
   let db = ? tx.getDbDescFromTopTx()
 
@@ -162,7 +158,7 @@ proc txFrameCollapse*(
 # Public iterators
 # ------------------------------------------------------------------------------
 
-iterator txFrameWalk*(tx: AristoTxRef): (int,AristoTxRef,LayerRef,AristoError) =
+iterator walk*(tx: AristoTxRef): (int,AristoTxRef,LayerRef,AristoError) =
   ## Walk down the transaction stack chain.
   let db = tx.db
   var tx = tx

--- a/nimbus/db/core_db/base/api_tracking.nim
+++ b/nimbus/db/core_db/base/api_tracking.nim
@@ -52,7 +52,7 @@ type
     BaseFinishFn        = "finish"
     BaseLevelFn         = "level"
     BasePushCaptureFn   = "pushCapture"
-    BaseNewTxFn         = "newTransaction"
+    BaseNewTxFn         = "txFrameBegin"
     BasePersistentFn    = "persistent"
     BaseStateBlockNumberFn = "stateBlockNumber"
     BaseVerifyFn        = "verify"
@@ -77,7 +77,7 @@ type
 
     TxCommitFn          = "commit"
     TxDisposeFn         = "dispose"
-    TxLevelFn           = "level"
+    TxFrameLevelFn           = "level"
     TxRollbackFn        = "rollback"
     TxSaveDisposeFn     = "safeDispose"
 

--- a/nimbus/db/kvt/kvt_desc/desc_error.nim
+++ b/nimbus/db/kvt/kvt_desc/desc_error.nim
@@ -33,8 +33,8 @@ type
     # Transaction wrappers
     TxArgStaleTx
     TxBackendNotWritable
-    TxLevelTooDeep
-    TxLevelUseless
+    TxFrameLevelTooDeep
+    TxFrameLevelUseless
     TxNoPendingTx
     TxNotTopTx
     TxPendingTx

--- a/nimbus/db/kvt/kvt_tx/tx_frame.nim
+++ b/nimbus/db/kvt/kvt_tx/tx_frame.nim
@@ -18,14 +18,14 @@ import
   results,
   ".."/[kvt_desc, kvt_layers]
 
-func txFrameIsTop*(tx: KvtTxRef): bool
+func isTop*(tx: KvtTxRef): bool
 
 # ------------------------------------------------------------------------------
 # Private helpers
 # ------------------------------------------------------------------------------
 
 func getDbDescFromTopTx(tx: KvtTxRef): Result[KvtDbRef,KvtError] =
-  if not tx.txFrameIsTop():
+  if not tx.isTop():
     return err(TxNotTopTx)
   let db = tx.db
   if tx.level != db.stack.len:
@@ -49,14 +49,10 @@ func txFrameTop*(db: KvtDbRef): Result[KvtTxRef,KvtError] =
   else:
     ok(db.txRef)
 
-func txFrameIsTop*(tx: KvtTxRef): bool =
+func isTop*(tx: KvtTxRef): bool =
   ## Getter, returns `true` if the argument `tx` referes to the current top
   ## level transaction.
   tx.db.txRef == tx and tx.db.top.txUid == tx.txUid
-
-func txFrameLevel*(tx: KvtTxRef): int =
-  ## Getter, positive nesting level of transaction argument `tx`
-  tx.level
 
 func txFrameLevel*(db: KvtDbRef): int =
   ## Getter, non-negative nesting level (i.e. number of pending transactions)
@@ -93,7 +89,7 @@ proc txFrameBegin*(db: KvtDbRef): Result[KvtTxRef,KvtError] =
   ok db.txRef
 
 
-proc txFrameRollback*(
+proc rollback*(
     tx: KvtTxRef;                     # Top transaction on database
       ): Result[void,KvtError] =
   ## Given a *top level* handle, this function discards all database operations
@@ -110,7 +106,7 @@ proc txFrameRollback*(
   ok()
 
 
-proc txFrameCommit*(
+proc commit*(
     tx: KvtTxRef;                     # Top transaction on database
       ): Result[void,KvtError] =
   ## Given a *top level* handle, this function accepts all database operations
@@ -135,7 +131,7 @@ proc txFrameCommit*(
   ok()
 
 
-proc txFrameCollapse*(
+proc collapse*(
     tx: KvtTxRef;                     # Top transaction on database
     commit: bool;                     # Commit if `true`, otherwise roll back
       ): Result[void,KvtError] =

--- a/nimbus/sync/beacon/worker/db.nim
+++ b/nimbus/sync/beacon/worker/db.nim
@@ -81,7 +81,7 @@ proc dbStoreSyncStateLayout*(ctx: BeaconCtxRef; info: static[string]) =
 
   # While executing blocks there are frequent save cycles. Otherwise, an
   # extra save request might help to pick up an interrupted sync session.
-  if ctx.db.level() == 0 and ctx.stash.len == 0:
+  if ctx.db.txFrameLevel() == 0 and ctx.stash.len == 0:
     let number = ctx.db.getSavedStateBlockNumber()
     ctx.db.persistent(number).isOkOr:
       raiseAssert info & " persistent() failed: " & $$error
@@ -165,9 +165,9 @@ proc dbHeadersStash*(
   ##    ..
   ##
   let
-    txLevel = ctx.db.level()
+    txFrameLevel = ctx.db.txFrameLevel()
     last = first + revBlobs.len.uint64 - 1
-  if 0 < txLevel:
+  if 0 < txFrameLevel:
     # Need to cache it because FCU has blocked writing through to disk.
     for n,data in revBlobs:
       ctx.stash[last - n.uint64] = data

--- a/nimbus/transaction/call_evm.nim
+++ b/nimbus/transaction/call_evm.nim
@@ -38,7 +38,7 @@ proc rpcCallEvm*(args: TransactionArgs,
   let vmState = ? BaseVMState.new(topHeader, com)
   let params  = ? toCallParams(vmState, args, globalGasCap, header.baseFeePerGas)
 
-  var dbTx = com.db.ctx.newTransaction()
+  var dbTx = com.db.ctx.txFrameBegin()
   defer: dbTx.dispose() # always dispose state changes
 
   ok(runComputation(params, CallResult))
@@ -50,7 +50,7 @@ proc rpcCallEvm*(args: TransactionArgs,
   const globalGasCap = 0 # TODO: globalGasCap should configurable by user
   let params  = ? toCallParams(vmState, args, globalGasCap, header.baseFeePerGas)
 
-  var dbTx = com.db.ctx.newTransaction()
+  var dbTx = com.db.ctx.txFrameBegin()
   defer: dbTx.dispose() # always dispose state changes
 
   ok(runComputation(params, CallResult))
@@ -75,7 +75,7 @@ proc rpcEstimateGas*(args: TransactionArgs,
     hi : GasInt = GasInt args.gas.get(0.Quantity)
     cap: GasInt
 
-  var dbTx = com.db.ctx.newTransaction()
+  var dbTx = com.db.ctx.txFrameBegin()
   defer: dbTx.dispose() # always dispose state changes
 
   # Determine the highest gas limit can be used during the estimation.

--- a/tests/test_aristo/test_compute.nim
+++ b/tests/test_aristo/test_compute.nim
@@ -123,7 +123,7 @@ suite "Aristo compute":
       check:
         db.mergeAccountRecord(k, v) == Result[bool, AristoError].ok(true)
 
-    check db.txStow(1, true).isOk()
+    check db.txPersist(1).isOk()
 
     check db.computeKeys(root).isOk()
 

--- a/tests/test_aristo/test_helpers.nim
+++ b/tests/test_aristo/test_helpers.nim
@@ -213,10 +213,7 @@ proc schedStow*(
     filterMeter = if db.balancer.isNil: 0
                   else: db.balancer.sTab.len + db.balancer.kMap.len
     persistent = MaxFilterBulk < max(layersMeter, filterMeter)
-  if persistent:
-    db.persist()
-  else:
-    db.stow()
+  db.persist()
 
 # ------------------
 

--- a/tests/test_aristo/test_merge_proof.nim
+++ b/tests/test_aristo/test_merge_proof.nim
@@ -55,7 +55,7 @@ proc saveToBackend(
     xCheckRc rc.error == 0
 
   block:
-    let rc = db.txTop()
+    let rc = db.txFrameTop()
     xCheckRc rc.error == 0
     tx = rc.value
 
@@ -72,7 +72,7 @@ proc saveToBackend(
     xCheckRc rc.error == 0
 
   block:
-    let rc = db.txTop()
+    let rc = db.txFrameTop()
     xCheckErr rc.value.level < 0 # force error
 
   block:
@@ -80,7 +80,7 @@ proc saveToBackend(
     xCheckRc rc.error == 0
 
   # Update layers to original level
-  tx = db.txBegin().value.to(AristoDbRef).txBegin().value
+  tx = db.txFrameBegin().value.to(AristoDbRef).txFrameBegin().value
 
   true
 
@@ -120,7 +120,7 @@ proc testMergeProofAndKvpList*(
   #     ps = PartStateRef.init(db)
 
   #     # Start transaction (double frame for testing)
-  #     tx = ps.db.txBegin().value.to(AristoDbRef).txBegin().value
+  #     tx = ps.db.txFrameBegin().value.to(AristoDbRef).txFrameBegin().value
   #     xCheck tx.isTop()
 
   #     # Update root

--- a/tests/test_aristo/test_tx.nim
+++ b/tests/test_aristo/test_tx.nim
@@ -109,7 +109,7 @@ proc randomisedLeafs(
 proc innerCleanUp(db: var AristoDbRef): bool {.discardable.}  =
   ## Defer action
   if not db.isNil:
-    let rx = db.txTop()
+    let rx = db.txFrameTop()
     if rx.isOk:
       let rc = rx.value.collapse(commit=false)
       xCheckRc rc.error == 0
@@ -140,7 +140,7 @@ proc saveToBackend(
     xCheckRc rc.error == 0
 
   block:
-    let rc = db.txTop()
+    let rc = db.txFrameTop()
     xCheckRc rc.error == 0
     tx = rc.value
 
@@ -157,7 +157,7 @@ proc saveToBackend(
     xCheckRc rc.error == 0
 
   block:
-    let rc = db.txTop()
+    let rc = db.txFrameTop()
     xCheckErr rc.value.level < 0 # force error
 
   block:
@@ -170,7 +170,7 @@ proc saveToBackend(
       noisy.say "***", "saveToBackend (8)", " debugID=", debugID
 
   # Update layers to original level
-  tx = db.txBegin().value.to(AristoDbRef).txBegin().value
+  tx = db.txFrameBegin().value.to(AristoDbRef).txFrameBegin().value
 
   true
 
@@ -268,8 +268,8 @@ proc testTxMergeAndDeleteOneByOne*(
   #       AristoDbRef.init(MemBackendRef)
 
   #   # Start transaction (double frame for testing)
-  #   xCheck db.txTop.isErr
-  #   var tx = db.txBegin().value.to(AristoDbRef).txBegin().value
+  #   xCheck db.txFrameTop.isErr
+  #   var tx = db.txFrameBegin().value.to(AristoDbRef).txFrameBegin().value
   #   xCheck tx.isTop()
   #   xCheck tx.level == 2
 
@@ -375,8 +375,8 @@ proc testTxMergeAndDeleteSubTree*(
   #       AristoDbRef.init(MemBackendRef)
 
   #   # Start transaction (double frame for testing)
-  #   xCheck db.txTop.isErr
-  #   var tx = db.txBegin().value.to(AristoDbRef).txBegin().value
+  #   xCheck db.txFrameTop.isErr
+  #   var tx = db.txFrameBegin().value.to(AristoDbRef).txFrameBegin().value
   #   xCheck tx.isTop()
   #   xCheck tx.level == 2
 

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -116,7 +116,7 @@ proc forkedChainMain*() =
       blk2 = cc.makeBlk(2, blk1)
       blk3 = cc.makeBlk(3, blk2)
 
-      dbTx = cc.db.ctx.newTransaction()
+      dbTx = cc.db.ctx.txFrameBegin()
       blk4 = cc.makeBlk(4, blk3)
       blk5 = cc.makeBlk(5, blk4)
       blk6 = cc.makeBlk(6, blk5)

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -212,7 +212,7 @@ proc runTrial3Survive(env: TestEnv, ledger: LedgerRef; inx: int; noisy = false) 
   let eAddr = env.txs[inx].getRecipient
 
   block:
-    let dbTx = env.xdb.ctx.newTransaction()
+    let dbTx = env.xdb.ctx.txFrameBegin()
 
     block:
       let accTx = ledger.beginSavepoint
@@ -228,7 +228,7 @@ proc runTrial3Survive(env: TestEnv, ledger: LedgerRef; inx: int; noisy = false) 
     dbTx.rollback()
 
   block:
-    let dbTx = env.xdb.ctx.newTransaction()
+    let dbTx = env.xdb.ctx.txFrameBegin()
 
     block:
       let accTx = ledger.beginSavepoint
@@ -247,7 +247,7 @@ proc runTrial4(env: TestEnv, ledger: LedgerRef; inx: int; rollback: bool) =
   let eAddr = env.txs[inx].getRecipient
 
   block:
-    let dbTx = env.xdb.ctx.newTransaction()
+    let dbTx = env.xdb.ctx.txFrameBegin()
 
     block:
       let accTx = ledger.beginSavepoint
@@ -277,7 +277,7 @@ proc runTrial4(env: TestEnv, ledger: LedgerRef; inx: int; rollback: bool) =
     dbTx.commit()
 
   block:
-    let dbTx = env.xdb.ctx.newTransaction()
+    let dbTx = env.xdb.ctx.txFrameBegin()
 
     block:
       let accTx = ledger.beginSavepoint
@@ -350,14 +350,14 @@ proc runLedgerTransactionTests(noisy = true) =
 
     test &"Run {env.txi.len} two-step trials with rollback":
       for n in env.txi:
-        let dbTx = env.xdb.ctx.newTransaction()
+        let dbTx = env.xdb.ctx.txFrameBegin()
         defer: dbTx.dispose()
         let ledger = env.com.getLedger()
         env.runTrial2ok(ledger, n)
 
     test &"Run {env.txi.len} three-step trials with rollback":
       for n in env.txi:
-        let dbTx = env.xdb.ctx.newTransaction()
+        let dbTx = env.xdb.ctx.txFrameBegin()
         defer: dbTx.dispose()
         let ledger = env.com.getLedger()
         env.runTrial3(ledger, n, rollback = true)
@@ -365,21 +365,21 @@ proc runLedgerTransactionTests(noisy = true) =
     test &"Run {env.txi.len} three-step trials with extra db frame rollback" &
         " throwing Exceptions":
       for n in env.txi:
-        let dbTx = env.xdb.ctx.newTransaction()
+        let dbTx = env.xdb.ctx.txFrameBegin()
         defer: dbTx.dispose()
         let ledger = env.com.getLedger()
         env.runTrial3Survive(ledger, n, noisy)
 
     test &"Run {env.txi.len} tree-step trials without rollback":
       for n in env.txi:
-        let dbTx = env.xdb.ctx.newTransaction()
+        let dbTx = env.xdb.ctx.txFrameBegin()
         defer: dbTx.dispose()
         let ledger = env.com.getLedger()
         env.runTrial3(ledger, n, rollback = false)
 
     test &"Run {env.txi.len} four-step trials with rollback and db frames":
       for n in env.txi:
-        let dbTx = env.xdb.ctx.newTransaction()
+        let dbTx = env.xdb.ctx.txFrameBegin()
         defer: dbTx.dispose()
         let ledger = env.com.getLedger()
         env.runTrial4(ledger, n, rollback = true)


### PR DESCRIPTION
* if it's a db function, use `txFrame...`
* if it's not a db function, don't use `txFrame...`