### PR TITLE
Fix bn256ecPairing precompile bug

### DIFF
--- a/nimbus/evm/precompiles.nim
+++ b/nimbus/evm/precompiles.nim
@@ -343,10 +343,10 @@ func bn256ecPairing(c: Computation, fork: EVMFork = FkByzantium): EvmResultVoid 
                else:
                  GasECPairingBaseIstanbul + numPoints * GasECPairingPerPointIstanbul
   ? c.gasMeter.consumeGas(gasFee, reason="ecPairing Precompile")
-
-  c.output.setLen(32)
+  
   if msglen == 0:
     # we can discard here because we supply buffer of proper size
+    c.output.setLen(32)
     discard BNU256.one().toBytesBE(c.output)
   else:
     # Calculate number of pairing pairs
@@ -357,12 +357,13 @@ func bn256ecPairing(c: Computation, fork: EVMFork = FkByzantium): EvmResultVoid 
     for i in 0..<count:
       let s = i * 192
       # Loading AffinePoint[G1], bytes from [0..63]
-      var p1 = ? G1.getPoint(c.msg.data.toOpenArray(s, s + 63))
+      let p1 = ?G1.getPoint(c.msg.data.toOpenArray(s, s + 63))       
       # Loading AffinePoint[G2], bytes from [64..191]
-      var p2 = ? G2.getPoint(c.msg.data.toOpenArray(s + 64, s + 191))
+      let p2 = ?G2.getPoint(c.msg.data.toOpenArray(s + 64, s + 191))
       # Accumulate pairing result
       acc = acc * pairing(p1, p2)
-
+    
+    c.output.setLen(32)
     if acc == FQ12.one():
       # we can discard here because we supply buffer of proper size
       discard BNU256.one().toBytesBE(c.output)

--- a/tools/evmstate/testdata/00155493-mixed-6.json
+++ b/tools/evmstate/testdata/00155493-mixed-6.json
@@ -1,0 +1,58 @@
+{
+  "00155493-mixed-6": {
+    "env": {
+      "currentCoinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "currentDifficulty": "0x200000",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000200000",
+      "currentGasLimit": "0x26e1f476fe1e22",
+      "currentNumber": "0x1",
+      "currentTimestamp": "0x3e8",
+      "previousHash": "0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
+      "currentBaseFee": "0x10"
+    },
+    "pre": {
+      "0x00000000000000000000000000000ca1100b1a7e": {
+        "code": "0x7fc159603ab9942405d1c9c45c46403949f0540852afe082105fc3a184493589735f527f8b41207c5455d20952700be296752727b5c785a3c98008ff1b17b294063790316020527f98b88c965d50c9819aaa0a0624d2c9b7877fbd9cf2a83c78f0160a905405c22f6040527f02387436d9f90772b29bd504eb1f51807eb41fd80e1212c9e943eb38390049ac6060527fd967451dd73af75c795fa076f72b8f79be28f7bcc5e9dffb4050a1e92ff42f536080527fb5c867b470093c5875dd382716de4a9237a9504d4c8ca8116ebb8271544577d560a0526040600060c06000600060087fd3df89e74862a721f44dd39049e4f1f2715eda1a02999ea688e6fc9372443c81f261133755600051600055",
+        "storage": {},
+        "balance": "0x0",
+        "nonce": "0x0"
+      },
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "code": "0x",
+        "storage": {},
+        "balance": "0xffffffffff",
+        "nonce": "0x0"
+      }
+    },
+    "transaction": {
+      "gasPrice": "0x20",
+      "nonce": "0x0",
+      "to": "0x00000000000000000000000000000Ca1100b1A7E",
+      "data": [
+        ""
+      ],
+      "gasLimit": [
+        "0x1a3909"
+      ],
+      "value": [
+        "0xbf"
+      ],
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+    },
+    "out": "0x",
+    "post": {
+      "Cancun": [
+        {
+          "hash": "0x0ee0b777f341f09960165022c833eb33fc8898c443077fde314b08521e4c9601",
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Thanks to @holiman of goevmlab for his fuzzer.
Similar with Blake2b precompile regression https://github.com/status-im/nimbus-eth1/pull/2919.
When error, the precompile should not return any output.