### PR TITLE
Only hashing immutable part of network configuration for dataDir ID

### DIFF
--- a/nimbus/common/chain_config_hash.nim
+++ b/nimbus/common/chain_config_hash.nim
@@ -74,7 +74,7 @@ func calcHash*(networkId: NetworkId, conf: ChainConfig, genesis: Genesis): Hash3
   var ctx: sha256
   ctx.init()
   ctx.update(networkId)
-  ctx.update(conf)
+  ctx.update(conf.chainId)
   if genesis.isNil.not:
     ctx.update(genesis)
   ctx.finish(result.data)

--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -417,6 +417,11 @@ type
       desc: "Print RDB statistics at exit"
       name: "debug-rdb-print-stats".}: bool
 
+    rewriteDatadirId* {.
+      hidden
+      desc: "Rewrite selected network config hash to database"
+      name: "rewrite-datadir-id".}: bool
+
     case cmd* {.
       command
       defaultValue: NimbusCmd.noCommand }: NimbusCmd

--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -420,7 +420,7 @@ type
     rewriteDatadirId* {.
       hidden
       desc: "Rewrite selected network config hash to database"
-      name: "rewrite-datadir-id".}: bool
+      name: "debug-rewrite-datadir-id".}: bool
 
     case cmd* {.
       command

--- a/nimbus/nimbus_execution_client.nim
+++ b/nimbus/nimbus_execution_client.nim
@@ -158,17 +158,24 @@ proc setupMetrics(nimbus: NimbusNode, conf: NimbusConf) =
     waitFor nimbus.metricsServer.start()
 
 proc preventLoadingDataDirForTheWrongNetwork(db: CoreDbRef; conf: NimbusConf) =
+  proc writeDataDirId(kvt: CoreDbKvtRef, calculatedId: Hash32) =
+    info "Writing data dir ID", ID=calculatedId
+    kvt.put(dataDirIdKey().toOpenArray, calculatedId.data).isOkOr:
+      fatal "Cannot write data dir ID", ID=calculatedId
+      quit(QuitFailure)
+      
   let
     kvt = db.ctx.getKvt()
     calculatedId = calcHash(conf.networkId, conf.networkParams)
     dataDirIdBytes = kvt.get(dataDirIdKey().toOpenArray).valueOr:
       # an empty database
-      info "Writing data dir ID", ID=calculatedId
-      kvt.put(dataDirIdKey().toOpenArray, calculatedId.data).isOkOr:
-        fatal "Cannot write data dir ID", ID=calculatedId
-        quit(QuitFailure)
+      writeDataDirId(kvt, calculatedId)
       return
 
+  if conf.rewriteDatadirId:
+    writeDataDirId(kvt, calculatedId)
+    return
+  
   if calculatedId.data != dataDirIdBytes:
     fatal "Data dir already initialized with other network configuration",
       get=dataDirIdBytes.toHex,


### PR DESCRIPTION
@mjfh; @agnxsh ; @arnetheduck you can use hidden config `--rewrite-datadir-id` to reconfigure your existing database if you encounter "Data dir already initialized with other network configuration"


Future hardfork time or in the case of holesky and mainnet, got new `depositContractAddress` make the network configuration can change when new features added.

Because we need something stable to identify dataDir with network configuration, the new dataDir ID is calculated using only immutable parts of network configuration.