### PR TITLE
Beacon sync revisting fc automove base

### DIFF
--- a/nimbus/beacon/api_handler/api_forkchoice.nim
+++ b/nimbus/beacon/api_handler/api_forkchoice.nim
@@ -110,7 +110,7 @@ proc forkchoiceUpdated*(ben: BeaconEngineRef,
 
     # Update sync header (if any)
     com.syncReqNewHead(header)
-    com.reqBeaconSyncTargetCB(header, update.finalizedBlockHash)
+    com.reqBeaconSyncTargetCB(header)
 
     return simpleFCU(PayloadExecutionStatus.syncing)
 

--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -43,7 +43,7 @@ type
   SyncReqNewHeadCB* = proc(header: Header) {.gcsafe, raises: [].}
     ## Update head for syncing
 
-  ReqBeaconSyncTargetCB* = proc(header: Header; finHash: Hash32) {.gcsafe, raises: [].}
+  ReqBeaconSyncTargetCB* = proc(header: Header) {.gcsafe, raises: [].}
     ## Ditto (for beacon sync)
 
   NotifyBadBlockCB* = proc(invalid, origin: Header) {.gcsafe, raises: [].}
@@ -350,10 +350,10 @@ proc syncReqNewHead*(com: CommonRef; header: Header)
   if not com.syncReqNewHead.isNil:
     com.syncReqNewHead(header)
 
-proc reqBeaconSyncTargetCB*(com: CommonRef; header: Header; finHash: Hash32) =
+proc reqBeaconSyncTargetCB*(com: CommonRef; header: Header) =
   ## Used by RPC updater
   if not com.reqBeaconSyncTargetCB.isNil:
-    com.reqBeaconSyncTargetCB(header, finHash)
+    com.reqBeaconSyncTargetCB(header)
 
 proc notifyBadBlock*(com: CommonRef; invalid, origin: Header)
     {.gcsafe, raises: [].} =

--- a/nimbus/core/chain/forked_chain.nim
+++ b/nimbus/core/chain/forked_chain.nim
@@ -448,6 +448,50 @@ proc updateHeadIfNecessary(c: ForkedChainRef, pvarc: PivotArc) =
 
   c.setHead(pvarc)
 
+proc autoUpdateBase(c: ForkedChainRef): Result[void, string] =
+  ## To be called after`importBlock()` for implied `base` update so that
+  ## there is no need to know about a finalised block. Here the `base` is
+  ## kept at a certain distance from the current `latest` cursor head.
+  ##
+  # This function code is a tweaked version of `importBlockBlindly()`
+  # from draft PR #2845.
+  #
+  let
+    distanceFromBase = c.cursorHeader.number - c.baseHeader.number
+    hysteresis = max(1'u64, min(c.baseDistance div 4'u64, 32'u64))
+  # Finalizer threshold is baseDistance + 25% of baseDistancce capped at 32.
+  if distanceFromBase < c.baseDistance + hysteresis:
+    return ok()
+
+  # Move the base forward and stay away `baseDistance` blocks from
+  # the top block.
+  let
+    target = c.cursorHeader.number - c.baseDistance
+    pvarc = ?c.findCursorArc(c.cursorHash)
+    newBase = c.calculateNewBase(target, pvarc)
+
+  doAssert newBase.pvHash != c.baseHash
+
+  # Write segment from base+1 to newBase into database
+  c.stagingTx.rollback()
+  c.stagingTx = c.db.ctx.txFrameBegin()
+  c.replaySegment(newBase.pvHash)
+  c.writeBaggage(newBase.pvHash)
+  c.stagingTx.commit()
+  c.stagingTx = nil
+
+  # Update base forward to newBase
+  c.updateBase(newBase)
+  c.db.persistent(newBase.pvNumber).isOkOr:
+    return err("Failed to save state: " & $$error)
+
+  # Move chain state forward to current head
+  c.stagingTx = c.db.ctx.txFrameBegin()
+  c.replaySegment(pvarc.pvHash)
+  c.setHead(pvarc)
+
+  ok()
+
 # ------------------------------------------------------------------------------
 # Public functions
 # ------------------------------------------------------------------------------
@@ -509,7 +553,11 @@ proc newForkedChain*(com: CommonRef,
   com.syncStart = baseHeader.number
   chain
 
-proc importBlock*(c: ForkedChainRef, blk: Block): Result[void, string] =
+proc importBlock*(
+    c: ForkedChainRef;
+    blk: Block;
+    autoRebase = false;
+      ): Result[void, string] =
   # Try to import block to canonical or side chain.
   # return error if the block is invalid
   if c.stagingTx.isNil:
@@ -519,7 +567,10 @@ proc importBlock*(c: ForkedChainRef, blk: Block): Result[void, string] =
     blk.header
 
   if header.parentHash == c.cursorHash:
-    return c.validateBlock(c.cursorHeader, blk)
+    ?c.validateBlock(c.cursorHeader, blk)
+    if autoRebase:
+      return c.autoUpdateBase()
+    return ok()
 
   if header.parentHash == c.baseHash:
     c.stagingTx.rollback()
@@ -541,7 +592,12 @@ proc importBlock*(c: ForkedChainRef, blk: Block): Result[void, string] =
   # `base` is the point of no return, we only update it on finality.
 
   c.replaySegment(header.parentHash)
-  c.validateBlock(c.cursorHeader, blk)
+  ?c.validateBlock(c.cursorHeader, blk)
+  if autoRebase:
+    return c.autoUpdateBase()
+
+  ok()
+
 
 proc forkChoice*(c: ForkedChainRef,
                  headHash: Hash32,

--- a/nimbus/sync/beacon/README.md
+++ b/nimbus/sync/beacon/README.md
@@ -219,7 +219,7 @@ Running the sync process for *MainNet*
 --------------------------------------
 
 For syncing, a beacon node is needed that regularly informs via *RPC* of a
-recently finalised block header.
+recent target block header.
 
 The beacon node program used here is the *nimbus_beacon_node* binary from the
 *nimbus-eth2* project (any other, e.g.the *light client*  will do.)
@@ -230,7 +230,7 @@ The beacon node program used here is the *nimbus_beacon_node* binary from the
          --jwt-secret=/tmp/jwtsecret
 
 where *http://127.0.0.1:8551* is the URL of the sync process that receives the
-finalised block header (here on the same physical machine) and `/tmp/jwtsecret`
+target block headers (here on the same physical machine) and `/tmp/jwtsecret`
 is the shared secret file needed for mutual communication authentication.
 
 It will take a while for *nimbus_beacon_node* to catch up (see the

--- a/nimbus/sync/beacon/worker.nim
+++ b/nimbus/sync/beacon/worker.nim
@@ -170,10 +170,6 @@ proc runPeer*(
     buddy.only.multiRunIdle = Moment.now() - buddy.only.stoppedMultiRun
   buddy.only.nMultiLoop.inc                     # statistics/debugging
 
-  # Update consensus header target when needed. It comes with a finalised
-  # header hash where we need to complete the block number.
-  await buddy.headerStagedUpdateTarget info
-
   if not await buddy.napUnlessSomethingToFetch():
     #
     # Layout of a triple of linked header chains (see `README.md`)

--- a/nimbus/sync/beacon/worker/blocks_staged.nim
+++ b/nimbus/sync/beacon/worker/blocks_staged.nim
@@ -342,7 +342,7 @@ proc blocksStagedImport*(
   ctx.updateMetrics()
 
   debug info & ": import done", iv, nBlocks, B=ctx.chain.baseNumber.bnStr,
-    L=ctx.chain.latestNumber.bnStr, F=ctx.layout.final.bnStr
+    L=ctx.chain.latestNumber.bnStr
   return true
 
 # ------------------------------------------------------------------------------

--- a/nimbus/sync/beacon/worker/blocks_staged.nim
+++ b/nimbus/sync/beacon/worker/blocks_staged.nim
@@ -311,7 +311,7 @@ proc blocksStagedImport*(
           B=ctx.chain.baseNumber.bnStr, L=ctx.chain.latestNumber.bnStr,
           nthBn=nBn.bnStr, nthHash=qItem.data.getNthHash(n).short
         continue
-      ctx.pool.chain.importBlock(qItem.data.blocks[n]).isOkOr:
+      ctx.pool.chain.importBlock(qItem.data.blocks[n], autoRebase=true).isOkOr:
         warn info & ": import block error", n, iv,
           B=ctx.chain.baseNumber.bnStr, L=ctx.chain.latestNumber.bnStr,
           nthBn=nBn.bnStr, nthHash=qItem.data.getNthHash(n).short, `error`=error
@@ -329,30 +329,6 @@ proc blocksStagedImport*(
         # Shutdown?
         maxImport = ctx.chain.latestNumber()
         break importLoop
-
-      # Occasionally mark the chain finalized
-      if (n + 1) mod finaliserChainLengthMax == 0 or (n + 1) == nBlocks:
-        let
-          nthHash = qItem.data.getNthHash(n)
-          finHash = if nBn < ctx.layout.final: nthHash
-                    else: ctx.layout.finalHash
-
-        doAssert nBn == ctx.chain.latestNumber()
-        ctx.pool.chain.forkChoice(nthHash, finHash).isOkOr:
-          warn info & ": fork choice error", n, iv,
-            B=ctx.chain.baseNumber.bnStr, L=ctx.chain.latestNumber.bnStr,
-            F=ctx.layout.final.bnStr, nthBn=nBn.bnStr, nthHash=nthHash.short,
-            finHash=(if finHash == nthHash: "nthHash" else: "F"), `error`=error
-          # Restore what is left over below
-          maxImport = ctx.chain.latestNumber()
-          break importLoop
-
-        # Allow pseudo/async thread switch.
-        try: await sleepAsync asyncThreadSwitchTimeSlot
-        except CancelledError: discard
-        if not ctx.daemon:
-          maxImport = ctx.chain.latestNumber()
-          break importLoop
 
   # Import probably incomplete, so a partial roll back may be needed
   if maxImport < iv.maxPt:

--- a/nimbus/sync/beacon/worker/db.nim
+++ b/nimbus/sync/beacon/worker/db.nim
@@ -92,10 +92,6 @@ proc dbLoadSyncStateLayout*(ctx: BeaconCtxRef; info: static[string]): bool =
   # If there was a manual import after a previous sync, then saved state
   # might be outdated.
   if rc.isOk and
-     # The base number is the least record of the FCU chains/tree. So the
-     # finalised entry must not be smaller.
-     ctx.chain.baseNumber() <= rc.value.final and
-
      # If the latest FCU number is not larger than the head, there is nothing
      # to do (might also happen after a manual import.)
      latest < rc.value.head and

--- a/nimbus/sync/beacon/worker/headers_staged.nim
+++ b/nimbus/sync/beacon/worker/headers_staged.nim
@@ -19,7 +19,7 @@ import
   ../worker_desc,
   ./update/metrics,
   ./headers_staged/[headers, linked_hchain],
-  "."/[headers_unproc, update]
+  ./headers_unproc
 
 # ------------------------------------------------------------------------------
 # Private functions
@@ -52,35 +52,6 @@ proc fetchAndCheck(
 # ------------------------------------------------------------------------------
 # Public functions
 # ------------------------------------------------------------------------------
-
-proc headerStagedUpdateTarget*(
-    buddy: BeaconBuddyRef;
-    info: static[string];
-      ) {.async: (raises: []).} =
-  ## Fetch finalised beacon header if there is an update available
-  let
-    ctx = buddy.ctx
-    peer = buddy.peer
-  if ctx.layout.lastState == idleSyncState and
-     ctx.target.final == 0 and
-     ctx.target.finalHash != zeroHash32 and
-     not ctx.target.locked:
-    const iv = BnRange.new(1u,1u) # dummy interval
-
-    ctx.target.locked = true
-    let rc = await buddy.headersFetchReversed(iv, ctx.target.finalHash, info)
-    ctx.target.locked = false
-
-    if rc.isOk:
-      let hash = rlp.encode(rc.value[0]).keccak256
-      if hash != ctx.target.finalHash:
-        # Oops
-        buddy.ctrl.zombie = true
-        trace info & ": finalised header hash mismatch", peer, hash,
-          expected=ctx.target.finalHash
-      else:
-        ctx.updateFinalBlockHeader(rc.value[0], ctx.target.finalHash, info)
-
 
 proc headersStagedCollect*(
     buddy: BeaconBuddyRef;

--- a/nimbus/sync/beacon/worker/update.nim
+++ b/nimbus/sync/beacon/worker/update.nim
@@ -156,8 +156,6 @@ proc setupCollectingHeaders(ctx: BeaconCtxRef; info: static[string]) =
     ctx.sst.layout = SyncStateLayout(
       coupler:   c,
       dangling:  h,
-      final:     ctx.target.final,
-      finalHash: ctx.target.finalHash,
       head:      h,
       lastState: collectingHeaders)           # state transition
 
@@ -282,8 +280,7 @@ proc updateSyncState*(ctx: BeaconCtxRef; info: static[string]) =
     # Check whether the system has been idle and a new header download
     # session can be set up
     if prevState == idleSyncState and
-       ctx.target.changed and            # and there is a new target from CL
-       ctx.target.final != 0:            # .. ditto
+       ctx.target.changed:               # and there is a new target from CL
       ctx.setupCollectingHeaders info    # set up new header sync
     return
     # Notreached
@@ -313,33 +310,14 @@ proc updateSyncState*(ctx: BeaconCtxRef; info: static[string]) =
   ctx.startHibernating info
 
 
-proc updateFinalBlockHeader*(
-    ctx: BeaconCtxRef;
-    finHdr: Header;
-    finHash: Hash32;
-    info: static[string];
-      ) =
-  ## Update the finalised header cache. If the finalised header is acceptable,
-  ## the syncer will be activated from hibernation if necessary.
-  ##
-  let
-    b = ctx.chain.baseNumber()
-    f = finHdr.number
-  if f < b:
-    trace info & ": finalised block # too low",
-      B=b.bnStr, finalised=f.bnStr, delta=(b - f)
+proc updateFromHibernating*(ctx: BeaconCtxRef; info: static[string]) =
+  ## Activate syncer if hibernating.
+  if ctx.hibernate:
+    ctx.hibernate = false            # activates syncer
+    debug info & ": activating syncer", T=ctx.target.consHead.bnStr
 
-    ctx.target.reset
-
-  else:
-    ctx.target.final = f
-    ctx.target.finalHash = finHash
-
-    # Activate running (unless done yet)
-    if ctx.hibernate:
-      ctx.hibernate = false
-      debug info & ": activating syncer", B=b.bnStr,
-        finalised=f.bnStr, head=ctx.target.consHead.bnStr
+    # Re-calculate sync state
+    ctx.updateSyncState info
 
     # Update, so it can be followed nicely
     ctx.updateMetrics()

--- a/nimbus/sync/beacon/worker_config.nim
+++ b/nimbus/sync/beacon/worker_config.nim
@@ -128,10 +128,6 @@ const
     ## entry block number is too high and so leaves a gap to the ledger state
     ## block number.)
 
-  finaliserChainLengthMax* = 32
-    ## When importing with `importBlock()`, finalise after at most this many
-    ## invocations of `importBlock()`.
-
   # ----------------------
 
 static:

--- a/nimbus/sync/beacon/worker_desc.nim
+++ b/nimbus/sync/beacon/worker_desc.nim
@@ -72,11 +72,8 @@ type
 
   SyncStateTarget* = object
     ## Beacon state to be implicitely updated by RPC method
-    locked*: bool                    ## Don't update while fetching header
     changed*: bool                   ## Tell that something has changed
     consHead*: Header                ## Consensus head
-    final*: BlockNumber              ## Finalised block number
-    finalHash*: Hash32               ## Finalised hash
 
   SyncStateLayout* = object
     ## Layout of a linked header chains defined by the triple `(C,D,H)` as
@@ -95,13 +92,8 @@ type
     ##
     coupler*: BlockNumber            ## Bottom end `C` of full chain `(C,H]`
     dangling*: BlockNumber           ## Left end `D` of linked chain `[D,H]`
-    head*: BlockNumber               ## `H`, block num of some finalised block
+    head*: BlockNumber               ## `H`, block number of some target block
     lastState*: SyncLayoutState      ## Last known layout state
-
-    # Legacy entries, will be removed some time. This is currently needed
-    # for importing blocks into `FC` the support of which will be deprecated.
-    final*: BlockNumber              ## Finalised block number `F`
-    finalHash*: Hash32               ## Hash of `F`
 
   SyncState* = object
     ## Sync state for header and block chains


### PR DESCRIPTION
This is a **proof of concept** for the beacon syncer running without knowledge of a finalised header.

The `FC` module part using a modified `importBlock()` function has been adapted from PR #2845 (`fc-automove-base`).

The automatic finaliser part of `importBlock()` needs to be double checked for compliance. But it will be invalidated anyway by the upcoming PR #2960 (`forked-layers`) and so needs to be rewritten.

The beacon sync part of this PR works well and there should be no functionality updates necessary regarding the usage of the modified `importBlock()` function.