### PR TITLE
Fluffy:  Rename portal_*Gossip JSON-RPC endpoints to be in line with updated portal spec

### DIFF
--- a/fluffy/network/wire/portal_stream.nim
+++ b/fluffy/network/wire/portal_stream.nim
@@ -190,8 +190,7 @@ proc addContentOffer*(
   var id = ConnectionId.fromBytesBE(connectionId)
 
   # Generate a new id if already existing to avoid using a duplicate
-  # or if we happen to get an id of zero from the generator
-  if id == 0 or stream.contentOffers.contains(id):
+  if stream.contentOffers.contains(id):
     stream.rng[].generate(connectionId)
     id = ConnectionId.fromBytesBE(connectionId)
 
@@ -219,8 +218,7 @@ proc addContentRequest*(
   var id = ConnectionId.fromBytesBE(connectionId)
 
   # Generate a new id if already existing to avoid using a duplicate
-  # or if we happen to get an id of zero from the generator
-  if id == 0 or stream.contentRequests.contains(id):
+  if stream.contentRequests.contains(id):
     stream.rng[].generate(connectionId)
     id = ConnectionId.fromBytesBE(connectionId)
 

--- a/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
@@ -28,7 +28,7 @@ createRpcSigsFromNim(RpcClient):
   proc portal_stateGetContent(contentKey: string): ContentInfo
   proc portal_stateStore(contentKey: string, contentValue: string): bool
   proc portal_stateLocalContent(contentKey: string): string
-  proc portal_stateGossip(contentKey: string, contentValue: string): int
+  proc portal_statePutContent(contentKey: string, contentValue: string): int
 
   ## Portal History Network json-rpc calls
   proc portal_historyNodeInfo(): NodeInfo
@@ -49,7 +49,7 @@ createRpcSigsFromNim(RpcClient):
   proc portal_historyGetContent(contentKey: string): ContentInfo
   proc portal_historyStore(contentKey: string, contentValue: string): bool
   proc portal_historyLocalContent(contentKey: string): string
-  proc portal_historyGossip(contentKey: string, contentValue: string): int
+  proc portal_historyPutContent(contentKey: string, contentValue: string): int
 
   ## Portal Beacon Light Client Network json-rpc calls
   proc portal_beaconNodeInfo(): NodeInfo
@@ -67,5 +67,5 @@ createRpcSigsFromNim(RpcClient):
   proc portal_beaconGetContent(contentKey: string): ContentInfo
   proc portal_beaconStore(contentKey: string, contentValue: string): bool
   proc portal_beaconLocalContent(contentKey: string): string
-  proc portal_beaconGossip(contentKey: string, contentValue: string): int
+  proc portal_beaconPutContent(contentKey: string, contentValue: string): int
   proc portal_beaconRandomGossip(contentKey: string, contentValue: string): int

--- a/fluffy/rpc/rpc_portal_beacon_api.nim
+++ b/fluffy/rpc/rpc_portal_beacon_api.nim
@@ -129,7 +129,7 @@ proc installPortalBeaconApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
 
     return contentResult.to0xHex()
 
-  rpcServer.rpc("portal_beaconGossip") do(
+  rpcServer.rpc("portal_beaconPutContent") do(
     contentKey: string, contentValue: string
   ) -> int:
     let

--- a/fluffy/rpc/rpc_portal_history_api.nim
+++ b/fluffy/rpc/rpc_portal_history_api.nim
@@ -137,7 +137,7 @@ proc installPortalHistoryApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
 
     return contentResult.to0xHex()
 
-  rpcServer.rpc("portal_historyGossip") do(
+  rpcServer.rpc("portal_historyPutContent") do(
     contentKey: string, contentValue: string
   ) -> int:
     let

--- a/fluffy/rpc/rpc_portal_state_api.nim
+++ b/fluffy/rpc/rpc_portal_state_api.nim
@@ -150,7 +150,7 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
 
     contentResult.to0xHex()
 
-  rpcServer.rpc("portal_stateGossip") do(contentKey: string, content: string) -> int:
+  rpcServer.rpc("portal_statePutContent") do(contentKey: string, content: string) -> int:
     let
       keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
       (key, contentId) = validateGetContentKey(keyBytes).valueOr:

--- a/fluffy/scripts/test_portal_testnet.nim
+++ b/fluffy/scripts/test_portal_testnet.nim
@@ -264,7 +264,9 @@ procSuite "Portal testnet tests":
     # require them for validation.
     for (contentKey, contentValue) in blockHeadersWithProof:
       discard (
-        await clients[0].portal_historyGossip(contentKey.toHex(), contentValue.toHex())
+        await clients[0].portal_historyPutContent(
+          contentKey.toHex(), contentValue.toHex()
+        )
       )
 
     # TODO: Fix iteration order: Because the blockData gets parsed into a
@@ -291,7 +293,7 @@ procSuite "Portal testnet tests":
             contentKey = history_content.encode(value[0]).asSeq().toHex()
             contentValue = value[1].toHex()
 
-          discard (await clients[0].portal_historyGossip(contentKey, contentValue))
+          discard (await clients[0].portal_historyPutContent(contentKey, contentValue))
 
     await clients[0].close()
 

--- a/fluffy/tools/portal_bridge/portal_bridge_history.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_history.nim
@@ -516,7 +516,7 @@ proc runHistory*(config: PortalBridgeConf) =
           contentValueHex = contentValue.toHex()
 
         try:
-          let peers = await bridge.portalClient.portal_historyGossip(
+          let peers = await bridge.portalClient.portal_historyPutContent(
             contentKeyHex, contentValueHex
           )
           debug "Content gossiped", peers, contentKey = contentKeyHex
@@ -524,7 +524,7 @@ proc runHistory*(config: PortalBridgeConf) =
           trace "Cancelled gossipWorker"
           raise e
         except CatchableError as e:
-          error "JSON-RPC portal_historyGossip failed",
+          error "JSON-RPC portal_historyPutContent failed",
             error = $e.msg, contentKey = contentKeyHex
     except CancelledError:
       trace "gossipWorker canceled"

--- a/fluffy/tools/portal_bridge/portal_bridge_state.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_state.nim
@@ -333,7 +333,8 @@ proc runBackfillGossipBlockOffersLoop(
 
       if gossipContent:
         try:
-          let numPeers = await portalClient.portal_stateGossip(k.to0xHex(), v.to0xHex())
+          let numPeers =
+            await portalClient.portal_statePutContent(k.to0xHex(), v.to0xHex())
           if numPeers > 0:
             debug "Offer successfully gossipped to peers: ", numPeers, workerId
           elif numPeers == 0:


### PR DESCRIPTION
This change renames all the portal_*Gossip JSON-RPC endpoints to portal_*PutContent to be in line with the updated portal specs.

This relates to this PR in the portal network specs: https://github.com/ethereum/portal-network-specs/pull/346

