### PR TITLE
Fluffy: Update portal_*PutContent JSON-RPC endpoints to return metadata

### DIFF
--- a/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
@@ -28,7 +28,9 @@ createRpcSigsFromNim(RpcClient):
   proc portal_stateGetContent(contentKey: string): ContentInfo
   proc portal_stateStore(contentKey: string, contentValue: string): bool
   proc portal_stateLocalContent(contentKey: string): string
-  proc portal_statePutContent(contentKey: string, contentValue: string): int
+  proc portal_statePutContent(
+    contentKey: string, contentValue: string
+  ): PutContentResult
 
   ## Portal History Network json-rpc calls
   proc portal_historyNodeInfo(): NodeInfo
@@ -49,7 +51,9 @@ createRpcSigsFromNim(RpcClient):
   proc portal_historyGetContent(contentKey: string): ContentInfo
   proc portal_historyStore(contentKey: string, contentValue: string): bool
   proc portal_historyLocalContent(contentKey: string): string
-  proc portal_historyPutContent(contentKey: string, contentValue: string): int
+  proc portal_historyPutContent(
+    contentKey: string, contentValue: string
+  ): PutContentResult
 
   ## Portal Beacon Light Client Network json-rpc calls
   proc portal_beaconNodeInfo(): NodeInfo
@@ -67,5 +71,8 @@ createRpcSigsFromNim(RpcClient):
   proc portal_beaconGetContent(contentKey: string): ContentInfo
   proc portal_beaconStore(contentKey: string, contentValue: string): bool
   proc portal_beaconLocalContent(contentKey: string): string
-  proc portal_beaconPutContent(contentKey: string, contentValue: string): int
+  proc portal_beaconPutContent(
+    contentKey: string, contentValue: string
+  ): PutContentResult
+
   proc portal_beaconRandomGossip(contentKey: string, contentValue: string): int

--- a/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_portal_calls.nim
@@ -1,5 +1,5 @@
 # fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/fluffy/rpc/rpc_portal_beacon_api.nim
+++ b/fluffy/rpc/rpc_portal_beacon_api.nim
@@ -131,15 +131,19 @@ proc installPortalBeaconApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
 
   rpcServer.rpc("portal_beaconPutContent") do(
     contentKey: string, contentValue: string
-  ) -> int:
+  ) -> PutContentResult:
     let
-      key = hexToSeqByte(contentKey)
+      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentId = p.toContentId(key).valueOr:
+        raise invalidKeyErr()
       content = hexToSeqByte(contentValue)
-      contentKeys = ContentKeysList(@[ContentKeyByteList.init(key)])
-      numberOfPeers =
-        await p.neighborhoodGossip(Opt.none(NodeId), contentKeys, @[content])
+      contentKeys = ContentKeysList(@[key])
 
-    return numberOfPeers
+      # TODO: validate content
+      storedLocally = p.storeContent(key, contentId, content)
+      peerCount = await p.neighborhoodGossip(Opt.none(NodeId), contentKeys, @[content])
+
+    PutContentResult(storedLocally: storedLocally, peerCount: peerCount)
 
   rpcServer.rpc("portal_beaconRandomGossip") do(
     contentKey: string, contentValue: string

--- a/fluffy/rpc/rpc_portal_beacon_api.nim
+++ b/fluffy/rpc/rpc_portal_beacon_api.nim
@@ -1,5 +1,5 @@
 # fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/fluffy/rpc/rpc_portal_history_api.nim
+++ b/fluffy/rpc/rpc_portal_history_api.nim
@@ -1,5 +1,5 @@
 # fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/fluffy/rpc/rpc_portal_state_api.nim
+++ b/fluffy/rpc/rpc_portal_state_api.nim
@@ -1,5 +1,5 @@
 # fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/fluffy/rpc/rpc_types.nim
+++ b/fluffy/rpc/rpc_types.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/fluffy/rpc/rpc_types.nim
+++ b/fluffy/rpc/rpc_types.nim
@@ -62,10 +62,15 @@ type
 
   ContentItem* = array[2, string]
 
+  PutContentResult* = object
+    peerCount*: int
+    storedLocally*: bool
+
 NodeInfo.useDefaultSerializationIn JrpcConv
 RoutingTableInfo.useDefaultSerializationIn JrpcConv
 (string, string).useDefaultSerializationIn JrpcConv
 ContentInfo.useDefaultSerializationIn JrpcConv
+PutContentResult.useDefaultSerializationIn JrpcConv
 
 func getNodeInfo*(r: RoutingTable): NodeInfo =
   NodeInfo(enr: r.localNode.record, nodeId: r.localNode.id)

--- a/fluffy/tools/portal_bridge/portal_bridge_state.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_state.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -333,8 +333,10 @@ proc runBackfillGossipBlockOffersLoop(
 
       if gossipContent:
         try:
-          let numPeers =
-            await portalClient.portal_statePutContent(k.to0xHex(), v.to0xHex())
+          let
+            putContentResult =
+              await portalClient.portal_statePutContent(k.to0xHex(), v.to0xHex())
+            numPeers = putContentResult.peerCount
           if numPeers > 0:
             debug "Offer successfully gossipped to peers: ", numPeers, workerId
           elif numPeers == 0:


### PR DESCRIPTION
This PR updates the Fluffy `portal_*PutContent` JSON-RPC endpoints to return metadata as defined in the portal specs.