### PR TITLE
Fluffy: Minor refactor, cleanup and improve variable names in JSON-RPC handlers

### DIFF
--- a/fluffy/rpc/rpc_portal_history_api.nim
+++ b/fluffy/rpc/rpc_portal_history_api.nim
@@ -47,108 +47,111 @@ proc installPortalHistoryApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
         let res = ContentInfo(
           content: foundContent.content.to0xHex(), utpTransfer: foundContent.utpTransfer
         )
-        return JrpcConv.encode(res).JsonString
+        JrpcConv.encode(res).JsonString
       of Nodes:
         let enrs = foundContent.nodes.map(
           proc(n: Node): Record =
             n.record
         )
         let jsonEnrs = JrpcConv.encode(enrs)
-        return ("{\"enrs\":" & jsonEnrs & "}").JsonString
+        ("{\"enrs\":" & jsonEnrs & "}").JsonString
 
   rpcServer.rpc("portal_historyOffer") do(
     enr: Record, contentItems: seq[ContentItem]
   ) -> string:
     let node = toNodeWithAddress(enr)
 
-    var contentItemsToOffer: seq[ContentKV]
+    var contentOffers: seq[ContentKV]
     for contentItem in contentItems:
       let
-        contentKey = hexToSeqByte(contentItem[0])
-        contentValue = hexToSeqByte(contentItem[1])
-        contentKV = ContentKV(
-          contentKey: ContentKeyByteList.init(contentKey), content: contentValue
-        )
-      contentItemsToOffer.add(contentKV)
+        keyBytes = ContentKeyByteList.init(hexToSeqByte(contentItem[0]))
+        offerValueBytes = hexToSeqByte(contentItem[1])
 
-    let offerResult = (await p.offer(node, contentItemsToOffer)).valueOr:
+      contentOffers.add(ContentKV(contentKey: keyBytes, content: offerValueBytes))
+
+    let offerResult = (await p.offer(node, contentOffers)).valueOr:
       raise newException(ValueError, $error)
 
     SSZ.encode(offerResult).to0xHex()
 
   rpcServer.rpc("portal_historyGetContent") do(contentKey: string) -> ContentInfo:
     let
-      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
-      contentId = p.toContentId(key).valueOr:
+      keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentId = p.toContentId(keyBytes).valueOr:
         raise invalidKeyErr()
-      maybeContent = p.getLocalContent(key, contentId)
+      maybeValueBytes = p.getLocalContent(keyBytes, contentId)
 
-    if maybeContent.isSome():
-      return ContentInfo(content: maybeContent.get().to0xHex(), utpTransfer: false)
+    if maybeValueBytes.isSome():
+      return ContentInfo(content: maybeValueBytes.get().to0xHex(), utpTransfer: false)
 
-    let contentResult = (await p.contentLookup(key, contentId)).valueOr:
+    let contentLookupResult = (await p.contentLookup(keyBytes, contentId)).valueOr:
       raise contentNotFoundErr()
 
-    return ContentInfo(
-      content: contentResult.content.to0xHex(), utpTransfer: contentResult.utpTransfer
+    ContentInfo(
+      content: contentLookupResult.content.to0xHex(),
+      utpTransfer: contentLookupResult.utpTransfer,
     )
 
   rpcServer.rpc("portal_historyTraceGetContent") do(
     contentKey: string
   ) -> TraceContentLookupResult:
     let
-      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
-      contentId = p.toContentId(key).valueOr:
+      keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentId = p.toContentId(keyBytes).valueOr:
         raise invalidKeyErr()
-      maybeContent = p.getLocalContent(key, contentId)
+      maybeValueBytes = p.getLocalContent(keyBytes, contentId)
 
-    if maybeContent.isSome():
-      return TraceContentLookupResult(content: maybeContent, utpTransfer: false)
-
-    let res = await p.traceContentLookup(key, contentId)
+    if maybeValueBytes.isSome():
+      return TraceContentLookupResult(content: maybeValueBytes, utpTransfer: false)
 
     # TODO: Might want to restructure the lookup result here. Potentially doing
     # the json conversion in this module.
-    if res.content.isSome():
-      return res
-    else:
-      let data = Opt.some(JrpcConv.encode(res.trace).JsonString)
-      raise contentNotFoundErrWithTrace(data)
+    let
+      res = await p.traceContentLookup(keyBytes, contentId)
+      _ = res.content.valueOr:
+        let data = Opt.some(JrpcConv.encode(res.trace).JsonString)
+        raise contentNotFoundErrWithTrace(data)
+
+    res
 
   rpcServer.rpc("portal_historyStore") do(
     contentKey: string, contentValue: string
   ) -> bool:
     let
-      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
-      contentValueBytes = hexToSeqByte(contentValue)
-      contentId = p.toContentId(key).valueOr:
+      keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      offerValueBytes = hexToSeqByte(contentValue)
+      contentId = p.toContentId(keyBytes).valueOr:
         raise invalidKeyErr()
 
-    p.storeContent(key, contentId, contentValueBytes)
+    # TODO: Do we need to convert the received offer to a value without proofs before storing?
+
+    p.storeContent(keyBytes, contentId, offerValueBytes)
 
   rpcServer.rpc("portal_historyLocalContent") do(contentKey: string) -> string:
     let
-      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
-      contentId = p.toContentId(key).valueOr:
+      keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentId = p.toContentId(keyBytes).valueOr:
         raise invalidKeyErr()
 
-      contentResult = p.dbGet(key, contentId).valueOr:
+      valueBytes = p.dbGet(keyBytes, contentId).valueOr:
         raise contentNotFoundErr()
 
-    return contentResult.to0xHex()
+    valueBytes.to0xHex()
 
   rpcServer.rpc("portal_historyPutContent") do(
     contentKey: string, contentValue: string
   ) -> PutContentResult:
     let
-      key = ContentKeyByteList.init(hexToSeqByte(contentKey))
-      contentId = p.toContentId(key).valueOr:
+      keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
+      contentId = p.toContentId(keyBytes).valueOr:
         raise invalidKeyErr()
-      content = hexToSeqByte(contentValue)
-      contentKeys = ContentKeysList(@[key])
+      offerValueBytes = hexToSeqByte(contentValue)
 
-      # TODO: validate content
-      storedLocally = p.storeContent(key, contentId, content)
-      peerCount = await p.neighborhoodGossip(Opt.none(NodeId), contentKeys, @[content])
+      # TODO: Do we need to convert the received offer to a value without proofs before storing?
+      # TODO: validate and store content locally
+      # storedLocally = p.storeContent(keyBytes, contentId, valueBytes)
+      peerCount = await p.neighborhoodGossip(
+        Opt.none(NodeId), ContentKeysList(@[keyBytes]), @[offerValueBytes]
+      )
 
-    PutContentResult(storedLocally: storedLocally, peerCount: peerCount)
+    PutContentResult(storedLocally: false, peerCount: peerCount)

--- a/fluffy/rpc/rpc_portal_state_api.nim
+++ b/fluffy/rpc/rpc_portal_state_api.nim
@@ -39,21 +39,21 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
       keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
       (key, _) = validateGetContentKey(keyBytes).valueOr:
         raise invalidKeyErr()
-      foundContent = (await p.findContent(node, keyBytes)).valueOr:
+      foundContentResult = (await p.findContent(node, keyBytes)).valueOr:
         raise newException(ValueError, $error)
 
-    case foundContent.kind
+    case foundContentResult.kind
     of Content:
-      let contentValue = foundContent.content
-      validateRetrieval(key, contentValue).isOkOr:
+      let valueBytes = foundContentResult.content
+      validateRetrieval(key, valueBytes).isOkOr:
         raise invalidValueErr()
 
       let res = ContentInfo(
-        content: contentValue.to0xHex(), utpTransfer: foundContent.utpTransfer
+        content: valueBytes.to0xHex(), utpTransfer: foundContentResult.utpTransfer
       )
       JrpcConv.encode(res).JsonString
     of Nodes:
-      let enrs = foundContent.nodes.map(
+      let enrs = foundContentResult.nodes.map(
         proc(n: Node): Record =
           n.record
       )
@@ -65,20 +65,19 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
   ) -> string:
     let node = toNodeWithAddress(enr)
 
-    var contentItemsToOffer: seq[ContentKV]
+    var contentOffers: seq[ContentKV]
     for contentItem in contentItems:
       let
         keyBytes = ContentKeyByteList.init(hexToSeqByte(contentItem[0]))
         (key, _) = validateGetContentKey(keyBytes).valueOr:
           raise invalidKeyErr()
-        contentBytes = hexToSeqByte(contentItem[1])
-        contentKV = ContentKV(contentKey: keyBytes, content: contentBytes)
+        offerValueBytes = hexToSeqByte(contentItem[1])
 
-      discard validateOfferGetRetrieval(key, contentBytes).valueOr:
+      discard validateOfferGetRetrieval(key, offerValueBytes).valueOr:
         raise invalidValueErr()
-      contentItemsToOffer.add(contentKV)
+      contentOffers.add(ContentKV(contentKey: keyBytes, content: offerValueBytes))
 
-    let offerResult = (await p.offer(node, contentItemsToOffer)).valueOr:
+    let offerResult = (await p.offer(node, contentOffers)).valueOr:
       raise newException(ValueError, $error)
 
     SSZ.encode(offerResult).to0xHex()
@@ -88,20 +87,22 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
       keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
       (key, contentId) = validateGetContentKey(keyBytes).valueOr:
         raise invalidKeyErr()
-      maybeContent = p.getLocalContent(keyBytes, contentId)
-    if maybeContent.isSome():
-      return ContentInfo(content: maybeContent.get().to0xHex(), utpTransfer: false)
+      maybeValueBytes = p.getLocalContent(keyBytes, contentId)
+    if maybeValueBytes.isSome():
+      return ContentInfo(content: maybeValueBytes.get().to0xHex(), utpTransfer: false)
 
     let
-      foundContent = (await p.contentLookup(keyBytes, contentId)).valueOr:
+      contentLookupResult = (await p.contentLookup(keyBytes, contentId)).valueOr:
         raise contentNotFoundErr()
-      contentValue = foundContent.content
+      valueBytes = contentLookupResult.content
 
-    validateRetrieval(key, contentValue).isOkOr:
+    validateRetrieval(key, valueBytes).isOkOr:
       raise invalidValueErr()
-    p.storeContent(keyBytes, contentId, contentValue, cacheContent = true)
+    p.storeContent(keyBytes, contentId, valueBytes, cacheContent = true)
 
-    ContentInfo(content: contentValue.to0xHex(), utpTransfer: foundContent.utpTransfer)
+    ContentInfo(
+      content: valueBytes.to0xHex(), utpTransfer: contentLookupResult.utpTransfer
+    )
 
   rpcServer.rpc("portal_stateTraceGetContent") do(
     contentKey: string
@@ -110,34 +111,36 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
       keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
       (key, contentId) = validateGetContentKey(keyBytes).valueOr:
         raise invalidKeyErr()
-      maybeContent = p.getLocalContent(keyBytes, contentId)
-    if maybeContent.isSome():
-      return TraceContentLookupResult(content: maybeContent, utpTransfer: false)
+      maybeValueBytes = p.getLocalContent(keyBytes, contentId)
+    if maybeValueBytes.isSome():
+      return TraceContentLookupResult(content: maybeValueBytes, utpTransfer: false)
 
     # TODO: Might want to restructure the lookup result here. Potentially doing
     # the json conversion in this module.
     let
       res = await p.traceContentLookup(keyBytes, contentId)
-      contentValue = res.content.valueOr:
+      valueBytes = res.content.valueOr:
         let data = Opt.some(JrpcConv.encode(res.trace).JsonString)
         raise contentNotFoundErrWithTrace(data)
 
-    validateRetrieval(key, contentValue).isOkOr:
+    validateRetrieval(key, valueBytes).isOkOr:
       raise invalidValueErr()
-    p.storeContent(keyBytes, contentId, contentValue, cacheContent = true)
+    p.storeContent(keyBytes, contentId, valueBytes, cacheContent = true)
 
     res
 
-  rpcServer.rpc("portal_stateStore") do(contentKey: string, content: string) -> bool:
+  rpcServer.rpc("portal_stateStore") do(
+    contentKey: string, contentValue: string
+  ) -> bool:
     let
       keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
       (key, contentId) = validateGetContentKey(keyBytes).valueOr:
         raise invalidKeyErr()
-      contentBytes = hexToSeqByte(content)
-      contentValue = validateOfferGetRetrieval(key, contentBytes).valueOr:
+      offerValueBytes = hexToSeqByte(contentValue)
+      valueBytes = validateOfferGetRetrieval(key, offerValueBytes).valueOr:
         raise invalidValueErr()
 
-    p.storeContent(keyBytes, contentId, contentValue)
+    p.storeContent(keyBytes, contentId, valueBytes)
 
   rpcServer.rpc("portal_stateLocalContent") do(contentKey: string) -> string:
     let
@@ -145,25 +148,25 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
       (_, contentId) = validateGetContentKey(keyBytes).valueOr:
         raise invalidKeyErr()
 
-      contentResult = p.getLocalContent(keyBytes, contentId).valueOr:
+      valueBytes = p.getLocalContent(keyBytes, contentId).valueOr:
         raise contentNotFoundErr()
 
-    contentResult.to0xHex()
+    valueBytes.to0xHex()
 
   rpcServer.rpc("portal_statePutContent") do(
-    contentKey: string, content: string
+    contentKey: string, contentValue: string
   ) -> PutContentResult:
     let
       keyBytes = ContentKeyByteList.init(hexToSeqByte(contentKey))
       (key, contentId) = validateGetContentKey(keyBytes).valueOr:
         raise invalidKeyErr()
-      contentBytes = hexToSeqByte(content)
-      contentValue = validateOfferGetRetrieval(key, contentBytes).valueOr:
+      offerValueBytes = hexToSeqByte(contentValue)
+      valueBytes = validateOfferGetRetrieval(key, offerValueBytes).valueOr:
         raise invalidValueErr()
 
-      storedLocally = p.storeContent(keyBytes, contentId, contentValue)
+      storedLocally = p.storeContent(keyBytes, contentId, valueBytes)
       peerCount = await p.neighborhoodGossip(
-        Opt.none(NodeId), ContentKeysList(@[keyBytes]), @[contentBytes]
+        Opt.none(NodeId), ContentKeysList(@[keyBytes]), @[offerValueBytes]
       )
 
     PutContentResult(storedLocally: storedLocally, peerCount: peerCount)


### PR DESCRIPTION
This change cleans up the Fluffy state, history and beacon JSON-RPC handlers. Variables are renamed to be more clear and consistent across the handlers. Implemented some other minor cleanups.