### PR TITLE
Portal history JSON-RPC: Add validation, where reasonable

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -261,9 +261,7 @@ proc run(
           rpcServer.installPortalCommonApiHandlers(
             node.historyNetwork.value.portalProtocol, PortalSubnetwork.history
           )
-          rpcServer.installPortalHistoryApiHandlers(
-            node.historyNetwork.value.portalProtocol
-          )
+          rpcServer.installPortalHistoryApiHandlers(node.historyNetwork.value)
         if node.beaconNetwork.isSome():
           rpcServer.installPortalCommonApiHandlers(
             node.beaconNetwork.value.portalProtocol, PortalSubnetwork.beacon

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -284,7 +284,7 @@ proc getReceipts*(
   # Receipts were requested `1 + requestRetries` times and all failed on validation
   Opt.none(seq[Receipt])
 
-proc validateContent(
+proc validateContent*(
     n: HistoryNetwork, content: seq[byte], contentKeyBytes: ContentKeyByteList
 ): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
   let contentKey = contentKeyBytes.decode().valueOr:

--- a/fluffy/network/history/history_validation.nim
+++ b/fluffy/network/history/history_validation.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -34,12 +34,15 @@ func validateHeaderBytes*(
     bytes: openArray[byte], id: uint64 | Hash32
 ): Result[Header, string] =
   # Note:
-  # No additional quick-checks are addedhere such as timestamp vs the optional
-  # (later forks) added fields. E.g. Shanghai field, Cancun fields,
+  # No additional quick-checks are added here such as timestamp vs the optional
+  # (per hardfork) added fields. E.g. Shanghai field, Cancun fields,
   # zero ommersHash, etc.
   # This is because the block hash comparison + canonical verification will
-  # catch these. For comparison by number this is will also be caught by the
+  # catch these. For comparison by number this is will be caught by the
   # canonical verification.
+  # The hash or number verification does still need to be done because else
+  # it would only be verified that a header is canonical and not that the
+  # returned header is the one that was requested.
   let header = ?decodeRlp(bytes, Header)
 
   ?header.validateHeader(id)

--- a/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
+++ b/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
@@ -1,5 +1,5 @@
 # Nimbus - Portal Network
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -110,9 +110,7 @@ proc setupTest(rng: ref HmacDrbgContext): Future[TestCase] {.async.} =
 
   let rpcHttpServer = RpcHttpServer.new()
   rpcHttpServer.addHttpServer(ta, maxRequestBodySize = 16 * 1024 * 1024)
-  rpcHttpServer.installPortalHistoryApiHandlers(
-    historyNode1.historyNetwork.portalProtocol
-  )
+  rpcHttpServer.installPortalHistoryApiHandlers(historyNode1.historyNetwork)
   rpcHttpServer.start()
 
   await client.connect(localSrvAddress, rpcHttpServer.localAddress[0].port, false)


### PR DESCRIPTION
Add content validation + local storing to Portal history JSON-RPC methods:
- portal_historyGetContent
- portal_historyTraceGetContent

This means that for bodies and receipts being requested an additional network lookup (the header) is done. This is likely acceptable as they are considered high level calls.

Not adding the validation however for portal_historyPutContent method as this would highly limit the bridge gossip efficiency.

In general the Portal JSON-RPC API specifications are not very clear on which type of validation checks should be done in these methods.