### PR TITLE
rm references to unused nimbus-eth1-blobs, unused imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,12 +246,6 @@ rm vendor/Nim/bin/nim
 make -j8 build-nim
 ```
 
-- some programs in the _tests_ subdirectory do a replay of blockchain
-  database dumps when compiled and run locally. The dumps are found in
-  [this](https://github.com/status-im/nimbus-eth1-blobs) module which
-  need to be cloned as _nimbus-eth1-blobs_ parellel to the _nimbus-eth1_
-  file system root.
-
 #### Git submodule workflow
 
 Working on a dependency:

--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2020-2024 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2020-2025 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license
@@ -301,7 +301,7 @@ for BINARY in ${BINARIES}; do
       | grep -v "failed to insert symbol" \
       | grep -v "could not find object file symbol for symbol" \
       | grep -v "while processing" \
-      | grep -v "warning: line table paramters mismatch. Cannot emit." \
+      | grep -v "warning: line table parameters mismatch. Cannot emit." \
       || true
     cp -a "./build/${BINARY}.dSYM" "${DIST_PATH}/build/"
   fi

--- a/tests/test_aristo.nim
+++ b/tests/test_aristo.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -24,12 +24,12 @@ import
   ./test_aristo/test_portal_proof,
   ./test_aristo/test_compute,
   ./test_aristo/[
-    test_balancer, test_helpers, test_samples_xx, test_tx,
+    test_helpers, test_samples_xx, test_tx,
     undump_accounts, undump_storages]
 
 const
   baseDir = [".", "..", ".."/"..", $DirSep]
-  repoDir = [".", "tests", "nimbus-eth1-blobs"]
+  repoDir = [".", "tests"]
   subDir = ["replay", "test_aristo", "replay"/"snap"]
 
   # Reference file for finding the database directory

--- a/tests/test_aristo/test_merge_proof.nim
+++ b/tests/test_aristo/test_merge_proof.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -13,13 +13,11 @@ import
   results,
   unittest2,
   ../../nimbus/db/opts,
-  ../../nimbus/db/core_db/backend/aristo_rocksdb,
   ../../nimbus/db/aristo/[
     aristo_check,
     aristo_desc,
     aristo_init/persistent,
     aristo_part,
-    aristo_part/part_debug,
     aristo_tx],
   ../replay/xcheck,
   ./test_helpers

--- a/tests/test_aristo/test_portal_proof.nim
+++ b/tests/test_aristo/test_portal_proof.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -18,8 +18,7 @@ import
   unittest2,
   ../test_helpers,
   ../../nimbus/db/aristo,
-  ../../nimbus/db/aristo/[aristo_desc, aristo_get, aristo_hike, aristo_layers,
-                          aristo_part],
+  ../../nimbus/db/aristo/[aristo_desc, aristo_get, aristo_hike, aristo_part],
   ../../nimbus/db/aristo/aristo_part/part_debug
 
 type
@@ -69,7 +68,7 @@ proc preLoadAristoDb(jKvp: JsonNode): PartStateRef =
   ps
 
 
-proc collectAddresses(node: JsonNode, collect: var HashSet[Address]) =
+func collectAddresses(node: JsonNode, collect: var HashSet[Address]) =
   case node.kind:
     of JObject:
       for k,v in node.pairs:

--- a/tests/test_aristo/test_tx.nim
+++ b/tests/test_aristo/test_tx.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -11,23 +11,18 @@
 ## Aristo (aka Patricia) DB records transaction based merge test
 
 import
-  std/[algorithm, bitops, sequtils, sets, tables],
+  std/[algorithm, bitops, sets, tables],
   eth/common,
   results,
   unittest2,
   stew/endians2,
   ../../nimbus/db/opts,
-  ../../nimbus/db/core_db/backend/aristo_rocksdb,
   ../../nimbus/db/aristo/[
     aristo_check,
-    aristo_debug,
-    aristo_delete,
     aristo_desc,
-    aristo_get,
     aristo_hike,
     aristo_init/persistent,
     aristo_nearby,
-    aristo_part,
     aristo_part/part_debug,
     aristo_tx],
   ../replay/xcheck,
@@ -48,13 +43,13 @@ const
 # Private helpers
 # ------------------------------------------------------------------------------
 
-proc posixPrngRand(state: var uint32): byte =
+func posixPrngRand(state: var uint32): byte =
   ## POSIX.1-2001 example of a rand() implementation, see manual page rand(3).
   state = state * 1103515245 + 12345;
   let val = (state shr 16) and 32767    # mod 2^31
   (val shr 8).byte                      # Extract second byte
 
-proc rand[W: SomeInteger|VertexID](ap: var PrngDesc; T: type W): T =
+func rand[W: SomeInteger|VertexID](ap: var PrngDesc; T: type W): T =
   var a: array[sizeof T,byte]
   for n in 0 ..< sizeof T:
     a[n] = ap.prng.posixPrngRand().byte
@@ -73,10 +68,10 @@ proc rand[W: SomeInteger|VertexID](ap: var PrngDesc; T: type W): T =
     # That way the result is independent of endianness
     (addr result).copyMem(unsafeAddr w, sizeof w)
 
-proc init(T: type PrngDesc; seed: int): PrngDesc =
+func init(T: type PrngDesc; seed: int): PrngDesc =
   result.prng = (seed and 0x7fffffff).uint32
 
-proc rand(td: var PrngDesc; top: int): int =
+func rand(td: var PrngDesc; top: int): int =
   if 0 < top:
     let mask = (1 shl (8 * sizeof(int) - top.countLeadingZeroBits)) - 1
     for _ in 0 ..< 100:

--- a/tests/test_coredb.nim
+++ b/tests/test_coredb.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -339,10 +339,6 @@ when isMainModule:
 
   when true and false:
     false.coreDbMain()
-
-  # This one uses the readily available dump: `bulkTest0` and some huge replay
-  # dumps `bulkTest2`, `bulkTest3`, .. from the `nimbus-eth1-blobs` package.
-  # For specs see `tests/test_coredb/bulk_test_xx.nim`.
 
   sampleList = cmdLineConfig().samples
   if sampleList.len == 0:

--- a/tests/test_tracer_json.nim
+++ b/tests/test_tracer_json.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -16,7 +16,7 @@ import
   results,
   ./test_helpers,
   ../nimbus/db/aristo,
-  ../nimbus/db/aristo/[aristo_desc, aristo_layers, aristo_part],
+  ../nimbus/db/aristo/[aristo_desc, aristo_part],
   ../nimbus/db/aristo/aristo_part/part_debug,
   ../nimbus/db/kvt/kvt_utils,
   ../nimbus/[tracer, evm/types],


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth1-blobs/commit/dff4a21f899e6bcacdf06ee5dac209b3cef1f16f removed the contents of this repository anyway.