### PR TITLE
Fluffy: State bridge clean shutdown

### DIFF
--- a/fluffy/tools/portal_bridge/portal_bridge_beacon.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_beacon.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -465,6 +465,3 @@ proc runBeacon*(config: PortalBridgeConf) {.raises: [CatchableError].} =
   )
 
   asyncSpawn runOnSlotLoop()
-
-  while true:
-    poll()

--- a/fluffy/tools/portal_bridge/portal_bridge_history.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_history.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -543,6 +543,3 @@ proc runHistory*(config: PortalBridgeConf) =
       asyncSpawn bridge.runBackfillLoop(
         config.era1Dir.string, config.startEra, config.endEra
       )
-
-  while true:
-    poll()


### PR DESCRIPTION
This PR implements clean shutdown in the state bridge which is important to prevent/reduce the chances of having issues with the database when using ctrl+C to stop the program.

The clean shutdown allows us to close the database and flush the in progress writes to disk before exiting.