### PR TITLE
Improved logging

### DIFF
--- a/nimbus/common/common.nim
+++ b/nimbus/common/common.nim
@@ -11,6 +11,7 @@
 
 import
   chronicles,
+  logging,
   ../db/[core_db, ledger, storage_types],
   ../utils/[utils],
   ".."/[constants, errors, version],
@@ -26,7 +27,8 @@ export
   hardforks,
   genesis,
   utils,
-  taskpools
+  taskpools,
+  logging
 
 type
   SyncProgress = object

--- a/nimbus/common/logging.nim
+++ b/nimbus/common/logging.nim
@@ -1,0 +1,35 @@
+# Nimbus
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  std/[typetraits, net],
+  json_serialization,
+  web3/primitives,
+  confutils/defs,
+  eth/common/eth_types_json_serialization
+
+# nim-eth
+proc writeValue*(
+    w: var JsonWriter, v: EthTime | NetworkId | ChainId
+) {.inline, raises: [IOError].} =
+  w.writeValue distinctBase(v)
+
+# nim-web3
+proc writeValue*(w: var JsonWriter, v: Quantity) {.inline, raises: [IOError].} =
+  w.writeValue distinctBase(v)
+
+# nim-confutils
+proc writeValue*(
+    w: var JsonWriter, v: InputFile | OutDir | OutFile | RestOfCmdLine | OutPath
+) {.inline, raises: [IOError].} =
+  w.writeValue distinctBase(v)
+
+# build-system
+proc writeValue*(w: var JsonWriter, v: Port) {.inline, raises: [IOError].} =
+  w.writeValue distinctBase(v)

--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -28,7 +28,9 @@ import
   common/chain_config,
   db/opts
 
-export net, defs
+from beacon_chain/nimbus_binary_common import setupLogging, StdoutLogKind
+
+export net, defs, StdoutLogKind
 
 
 const
@@ -217,13 +219,16 @@ type
     logLevel* {.
       separator: "\pLOGGING AND DEBUGGING OPTIONS:"
       desc: "Sets the log level for process and topics (" & logLevelDesc & ")"
-      defaultValue: LogLevel.INFO
-      defaultValueDesc: $LogLevel.INFO
-      name: "log-level" }: LogLevel
+      defaultValue: "INFO"
+      defaultValueDesc: "Info topic level logging"
+      name: "log-level" }: string
 
-    logFile* {.
-      desc: "Specifies a path for the written Json log file"
-      name: "log-file" }: Option[OutFile]
+    logStdout* {.
+      hidden
+      desc: "Specifies what kind of logs should be written to stdout (auto, colors, nocolors, json)"
+      defaultValueDesc: "auto"
+      defaultValue: StdoutLogKind.Auto
+      name: "log-format" .}: StdoutLogKind
 
     logMetricsEnabled* {.
       desc: "Enable metrics logging"
@@ -821,6 +826,8 @@ proc makeConfig*(cmdLine = commandLineParams()): NimbusConf
     {.pop.}
   except CatchableError as e:
     raise e
+
+  setupLogging(result.logLevel, result.logStdout, none(OutFile))
 
   var networkId = result.getNetworkId()
 

--- a/nimbus/nimbus_execution_client.nim
+++ b/nimbus/nimbus_execution_client.nim
@@ -161,7 +161,7 @@ proc preventLoadingDataDirForTheWrongNetwork(db: CoreDbRef; conf: NimbusConf) =
     kvt.put(dataDirIdKey().toOpenArray, calculatedId.data).isOkOr:
       fatal "Cannot write data dir ID", ID=calculatedId
       quit(QuitFailure)
-      
+
   let
     kvt = db.ctx.getKvt()
     calculatedId = calcHash(conf.networkId, conf.networkParams)
@@ -173,7 +173,7 @@ proc preventLoadingDataDirForTheWrongNetwork(db: CoreDbRef; conf: NimbusConf) =
   if conf.rewriteDatadirId:
     writeDataDirId(kvt, calculatedId)
     return
-  
+
   if calculatedId.data != dataDirIdBytes:
     fatal "Data dir already initialized with other network configuration",
       get=dataDirIdBytes.toHex,

--- a/nimbus/nimbus_execution_client.nim
+++ b/nimbus/nimbus_execution_client.nim
@@ -181,14 +181,6 @@ proc preventLoadingDataDirForTheWrongNetwork(db: CoreDbRef; conf: NimbusConf) =
     quit(QuitFailure)
 
 proc run(nimbus: NimbusNode, conf: NimbusConf) =
-  ## logging
-  setLogLevel(conf.logLevel)
-  if conf.logFile.isSome:
-    let logFile = string conf.logFile.get()
-    defaultChroniclesStream.output.outFile = nil # to avoid closing stdout
-    discard defaultChroniclesStream.output.open(logFile, fmAppend)
-
-  setupFileLimits()
 
   info "Launching execution client",
       version = FullVersionStr,
@@ -297,19 +289,18 @@ proc run(nimbus: NimbusNode, conf: NimbusConf) =
 when isMainModule:
   var nimbus = NimbusNode(state: NimbusState.Starting, ctx: newEthContext())
 
+  ## Processing command line arguments
+  let conf = makeConfig()
+
+  setupFileLimits()
+
   ## Ctrl+C handling
   proc controlCHandler() {.noconv.} =
     when defined(windows):
       # workaround for https://github.com/nim-lang/Nim/issues/4057
       setupForeignThreadGc()
     nimbus.state = NimbusState.Stopping
-    echo "\nCtrl+C pressed. Waiting for a graceful shutdown."
+    notice "\nCtrl+C pressed. Waiting for a graceful shutdown."
   setControlCHook(controlCHandler)
-
-  ## Show logs on stdout until we get the user's logging choice
-  discard defaultChroniclesStream.output.open(stdout)
-
-  ## Processing command line arguments
-  let conf = makeConfig()
 
   nimbus.run(conf)

--- a/nimbus/nimbus_execution_client.nim.cfg
+++ b/nimbus/nimbus_execution_client.nim.cfg
@@ -1,0 +1,7 @@
+-d:"chronicles_sinks=textlines[dynamic],json[dynamic]"
+-d:"chronicles_runtime_filtering=on"
+-d:"chronicles_disable_thread_id"
+
+@if release:
+  -d:"chronicles_line_numbers:0"
+@end

--- a/nimbus/nimbus_import.nim
+++ b/nimbus/nimbus_import.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -277,7 +277,7 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
         else:
           raiseAssert "Other networks are unsupported or do not have an era1"
       db = Era1DbRef.init(conf.era1Dir.string, era1Name).valueOr:
-        fatal "Could not open era1 database", era1Dir = conf.era1Dir, era1Name, error
+        fatal "Could not open era1 database", era1Dir=conf.era1Dir, era1Name=era1Name, error=error
         quit(QuitFailure)
 
     notice "Importing era1 archive",

--- a/nimbus/sync/protocol/eth68.nim
+++ b/nimbus/sync/protocol/eth68.nim
@@ -1,6 +1,6 @@
 # Nimbus - Ethereum Wire Protocol
 #
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -21,7 +21,8 @@ import
   stew/byteutils,
   ./trace_config,
   ./eth/eth_types,
-  ../../utils/utils
+  ../../utils/utils,
+  ../../common/logging
 
 export
   eth_types

--- a/nimbus/sync/sync_sched.nim
+++ b/nimbus/sync/sync_sched.nim
@@ -86,7 +86,7 @@
 import
   std/hashes,
   chronos,
-  eth/[p2p, p2p/peer_pool, common/eth_types_json_serialization],
+  eth/[p2p, p2p/peer_pool],
   stew/keyed_queue,
   ./sync_desc
 
@@ -430,7 +430,7 @@ proc onPeerConnected[S,W](dsc: RunnerSyncRef[S,W]; peer: Peer) =
       # This could happen if there are idle entries in the table, i.e.
       # somehow hanging runners.
       if dsc.ctx.noisyLog: trace "Peer table full! Dequeuing least used entry",
-        oldest.peer, oldest.only, nPeers, nWorkers=dsc.buddies.len, maxWorkers
+        oldestPeer=oldest.peer, oldestOnly=oldest.only, nPeers=nPeers, nWorkers=dsc.buddies.len, maxWorkers
       # Setting to `zombie` will trigger the worker to terminate (if any.)
       oldest.ctrl.zombie = true
 

--- a/nimbus/sync/sync_sched.nim
+++ b/nimbus/sync/sync_sched.nim
@@ -86,7 +86,7 @@
 import
   std/hashes,
   chronos,
-  eth/[p2p, p2p/peer_pool],
+  eth/[p2p, p2p/peer_pool, common/eth_types_json_serialization],
   stew/keyed_queue,
   ./sync_desc
 
@@ -430,7 +430,7 @@ proc onPeerConnected[S,W](dsc: RunnerSyncRef[S,W]; peer: Peer) =
       # This could happen if there are idle entries in the table, i.e.
       # somehow hanging runners.
       if dsc.ctx.noisyLog: trace "Peer table full! Dequeuing least used entry",
-        oldest, nPeers, nWorkers=dsc.buddies.len, maxWorkers
+        oldest.peer, oldest.only, nPeers, nWorkers=dsc.buddies.len, maxWorkers
       # Setting to `zombie` will trigger the worker to terminate (if any.)
       oldest.ctrl.zombie = true
 


### PR DESCRIPTION
Improved eth1 logging:
- using nimbus-eth2 options
- log file support removal
- auto detection of tty, colour support and related.

fix #2544 