### PR TITLE
Re-name metrics variable to better fit into the current naming schemes

### DIFF
--- a/nimbus/sync/beacon/README.md
+++ b/nimbus/sync/beacon/README.md
@@ -307,19 +307,19 @@ The following metrics are defined in *worker/update/metrics.nim* which will
 be available if *nimbus* is compiled with the additional make flags
 *NIMFLAGS="-d:metrics \-\-threads:on"*:
 
-| *Variable*         | *Logic type* | *Short description* |
-|:-------------------|:------------:|:--------------------|
-|                    |              |                     |
-| beacon_base        | block height | **B**, *increasing* |
-| beacon_latest      | block height | **L**, *increasing* |
-| beacon_coupler     | block height | **C**, *increasing* |
-| beacon_dangling    | block height | **D**               |
-| beacon_head        | block height | **H**, *increasing* |
-| beacon_target      | block height | **T**, *increasing* |
-|                            |      |                     |
-| beacon_header_lists_staged | size | # of staged header list records      |
-| beacon_headers_unprocessed | size | # of accumulated header block numbers|
-| beacon_block_lists_staged  | size | # of staged block list records       |
-| beacon_blocks_unprocessed  | size | # of accumulated body block numbers  |
-|                            |      |                                      |
-| beacon_buddies             | size | # of peers working concurrently      |
+| *Variable*                   | *Logic type* | *Short description* |
+|:-----------------------------|:------------:|:--------------------|
+|                              |              |                     |
+| nec_base                     | block height | **B**, *increasing* |
+| nec_execution_head           | block height | **L**, *increasing* |
+| nec_sync_coupler             | block height | **C**, *increasing* |
+| nec_sync_dangling            | block height | **D**               |
+| nec_sync_head                | block height | **H**, *increasing* |
+| nec_consensus_head           | block height | **T**, *increasing* |
+|                              |              |                     |
+| nec_sync_header_lists_staged | size | # of staged header list records      |
+| nec_sync_headers_unprocessed | size | # of accumulated header block numbers|
+| nec_sync_block_lists_staged  | size | # of staged block list records       |
+| nec_sync_blocks_unprocessed  | size | # of accumulated body block numbers  |
+|                              |      |                                      |
+| nec_sync_peers               | size | # of peers working concurrently      |

--- a/nimbus/sync/beacon/worker.nim
+++ b/nimbus/sync/beacon/worker.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at
 #     https://opensource.org/licenses/MIT).

--- a/nimbus/sync/beacon/worker/start_stop.nim
+++ b/nimbus/sync/beacon/worker/start_stop.nim
@@ -17,6 +17,7 @@ import
   ../worker_desc,
   ./blocks_staged/staged_queue,
   ./headers_staged/staged_queue,
+  ./update/metrics,
   "."/[blocks_unproc, db, headers_unproc, update]
 
 when enableTicker:
@@ -155,11 +156,14 @@ proc startBuddy*(buddy: BeaconBuddyRef): bool =
     ctx = buddy.ctx
     peer = buddy.peer
   if peer.supports(protocol.eth) and peer.state(protocol.eth).initialized:
-    ctx.pool.nBuddies.inc # for metrics
+    ctx.pool.nBuddies.inc
+    ctx.updateMetrics()
     return true
 
 proc stopBuddy*(buddy: BeaconBuddyRef) =
-  buddy.ctx.pool.nBuddies.dec # for metrics
+  let ctx = buddy.ctx
+  ctx.pool.nBuddies.dec
+  ctx.updateMetrics(force=(ctx.pool.nBuddies == 0))
 
 # ------------------------------------------------------------------------------
 # End

--- a/nimbus/sync/beacon/worker/start_stop.nim
+++ b/nimbus/sync/beacon/worker/start_stop.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at
 #     https://opensource.org/licenses/MIT).

--- a/nimbus/sync/beacon/worker/update/metrics.nim
+++ b/nimbus/sync/beacon/worker/update/metrics.nim
@@ -79,7 +79,7 @@ template updateMetricsImpl(ctx: BeaconCtxRef) =
 
 proc updateMetrics*(ctx: BeaconCtxRef; force = false) =
   let now = Moment.now()
-    if ctx.pool.nextMetricsUpdate < now or force:
+  if ctx.pool.nextMetricsUpdate < now or force:
     ctx.updateMetricsImpl()
     ctx.pool.nextMetricsUpdate = now + metricsUpdateInterval
 

--- a/nimbus/sync/beacon/worker/update/metrics.nim
+++ b/nimbus/sync/beacon/worker/update/metrics.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at
 #     https://opensource.org/licenses/MIT).
@@ -18,68 +18,68 @@ import
   ../headers_staged/staged_queue,
   ".."/[blocks_unproc, headers_unproc]
 
-declareGauge beacon_base, "" &
+declareGauge nec_base, "" &
   "Max block number of imported finalised blocks"
 
-declareGauge beacon_latest, "" &
+declareGauge nec_execution_head, "" &
   "Block number of latest imported blocks"
   
-declareGauge beacon_coupler, "" &
+declareGauge nec_sync_coupler, "" &
   "Max block number for header chain starting at genesis"
 
-declareGauge beacon_dangling, "" &
+declareGauge nec_sync_dangling, "" &
   "Starting/min block number for higher up headers chain"
 
-declareGauge beacon_head, "" &
+declareGauge nec_sync_head, "" &
   "Ending/max block number of higher up headers chain"
 
-declareGauge beacon_target, "" &
+declareGauge nec_consensus_head, "" &
   "Block number of sync target (would be consensus header)"
 
 
-declareGauge beacon_header_lists_staged, "" &
+declareGauge nec_sync_header_lists_staged, "" &
   "Number of header list records staged for serialised processing"
 
-declareGauge beacon_headers_unprocessed, "" &
+declareGauge nec_sync_headers_unprocessed, "" &
   "Number of block numbers ready to fetch and stage headers"
 
-declareGauge beacon_block_lists_staged, "" &
+declareGauge nec_sync_block_lists_staged, "" &
   "Number of block list records staged for importing"
 
-declareGauge beacon_blocks_unprocessed, "" &
+declareGauge nec_sync_blocks_unprocessed, "" &
   "Number of block numbers ready to fetch and stage block data"
 
 
-declareGauge beacon_buddies, "" &
+declareGauge nec_sync_peers, "" &
   "Number of currently active worker instances"
 
 
 template updateMetricsImpl(ctx: BeaconCtxRef) =
-  metrics.set(beacon_base, ctx.chain.baseNumber().int64)
-  metrics.set(beacon_latest, ctx.chain.latestNumber().int64)
-  metrics.set(beacon_coupler, ctx.layout.coupler.int64)
-  metrics.set(beacon_dangling, ctx.layout.dangling.int64)
-  metrics.set(beacon_head, ctx.layout.head.int64)
+  metrics.set(nec_base, ctx.chain.baseNumber().int64)
+  metrics.set(nec_execution_head, ctx.chain.latestNumber().int64)
+  metrics.set(nec_sync_coupler, ctx.layout.coupler.int64)
+  metrics.set(nec_sync_dangling, ctx.layout.dangling.int64)
+  metrics.set(nec_sync_head, ctx.layout.head.int64)
 
   # Show last valid state.
   if 0 < ctx.target.consHead.number:
-    metrics.set(beacon_target, ctx.target.consHead.number.int64)
+    metrics.set(nec_consensus_head, ctx.target.consHead.number.int64)
 
-  metrics.set(beacon_header_lists_staged, ctx.headersStagedQueueLen())
-  metrics.set(beacon_headers_unprocessed,
+  metrics.set(nec_sync_header_lists_staged, ctx.headersStagedQueueLen())
+  metrics.set(nec_sync_headers_unprocessed,
               (ctx.headersUnprocTotal() + ctx.headersUnprocBorrowed()).int64)
 
-  metrics.set(beacon_block_lists_staged, ctx.blocksStagedQueueLen())
-  metrics.set(beacon_blocks_unprocessed,
+  metrics.set(nec_sync_block_lists_staged, ctx.blocksStagedQueueLen())
+  metrics.set(nec_sync_blocks_unprocessed,
               (ctx.blocksUnprocTotal() + ctx.blocksUnprocBorrowed()).int64)
 
-  metrics.set(beacon_buddies, ctx.pool.nBuddies)
+  metrics.set(nec_sync_peers, ctx.pool.nBuddies)
 
 # ---------------
 
-proc updateMetrics*(ctx: BeaconCtxRef) =
+proc updateMetrics*(ctx: BeaconCtxRef; force = false) =
   let now = Moment.now()
-  if ctx.pool.nextUpdate < now:
+  if ctx.pool.nextUpdate < now or force:
     ctx.updateMetricsImpl()
     ctx.pool.nextUpdate = now + metricsUpdateInterval
 


### PR DESCRIPTION
also:
  Force metrics update when all peers vanish. There might be not much
  activity in that case so that the set of metrics might become stale.