### PR TITLE
Portal history: Add ephemeral content type

### DIFF
--- a/fluffy/network/history/content/content_keys.nim
+++ b/fluffy/network/history/content/content_keys.nim
@@ -1,5 +1,5 @@
 # fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -31,12 +31,17 @@ type
     blockBody = 0x01
     receipts = 0x02
     blockNumber = 0x03
+    ephemeralBlockHeader = 0x04
 
   BlockKey* = object
     blockHash*: Hash32
 
   BlockNumberKey* = object
     blockNumber*: uint64
+
+  EphemeralBlockHeaderKey = object
+    blockHash*: Hash32
+    ancestorCount*: uint8
 
   ContentKey* = object
     case contentType*: ContentType
@@ -48,6 +53,8 @@ type
       receiptsKey*: BlockKey
     of blockNumber:
       blockNumberKey*: BlockNumberKey
+    of ephemeralBlockHeader:
+      ephemeralBlockHeaderKey*: EphemeralBlockHeaderKey
 
 func blockHeaderContentKey*(id: Hash32 | uint64): ContentKey =
   when id is Hash32:
@@ -62,6 +69,15 @@ func blockBodyContentKey*(blockHash: Hash32): ContentKey =
 
 func receiptsContentKey*(blockHash: Hash32): ContentKey =
   ContentKey(contentType: receipts, receiptsKey: BlockKey(blockHash: blockHash))
+
+func ephemeralBlockHeaderContentKey*(
+    blockHash: Hash32, ancestorCount: uint8
+): ContentKey =
+  ContentKey(
+    contentType: ephemeralBlockHeader,
+    ephemeralBlockHeaderKey:
+      EphemeralBlockHeaderKey(blockHash: blockHash, ancestorCount: ancestorCount),
+  )
 
 func encode*(contentKey: ContentKey): ContentKeyByteList =
   ContentKeyByteList.init(SSZ.encode(contentKey))
@@ -95,6 +111,8 @@ func `$`*(x: ContentKey): string =
     res.add($x.receiptsKey)
   of blockNumber:
     res.add($x.blockNumberKey)
+  of ephemeralBlockHeader:
+    res.add($x.ephemeralBlockHeaderKey)
 
   res.add(")")
 

--- a/fluffy/network/history/content/content_values.nim
+++ b/fluffy/network/history/content/content_values.nim
@@ -1,5 +1,5 @@
 # fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -20,10 +20,12 @@ const
   MAX_TRANSACTION_LENGTH = 2 ^ 24 # ~= 16 million
   MAX_TRANSACTION_COUNT = 2 ^ 14 # ~= 16k
   MAX_RECEIPT_LENGTH = 2 ^ 27 # ~= 134 million
-  MAX_HEADER_LENGTH = 2 ^ 11 # = 2048
+  MAX_HEADER_LENGTH* = 2 ^ 11 # = 2048
   MAX_ENCODED_UNCLES_LENGTH = MAX_HEADER_LENGTH * 2 ^ 4 # = 2 ^ 17 ~= 131k
   MAX_WITHDRAWAL_LENGTH = 64
   MAX_WITHDRAWALS_COUNT = MAX_WITHDRAWALS_PER_PAYLOAD
+
+  MAX_EPHEMERAL_HEADER_PAYLOAD = 256
 
 type
   ## BlockHeader types
@@ -43,6 +45,10 @@ type
   BlockHeaderWithProof* = object
     header*: ByteList[MAX_HEADER_LENGTH] # RLP data
     proof*: BlockHeaderProof
+
+  ## Ephemeral BlockHeader list
+  EphemeralBlockHeaderList* =
+    List[ByteList[MAX_HEADER_LENGTH], MAX_EPHEMERAL_HEADER_PAYLOAD]
 
   ## BlockBody types
   TransactionByteList* = ByteList[MAX_TRANSACTION_LENGTH] # RLP data

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -321,6 +321,8 @@ proc validateContent(
       return err("Failed validating block header: " & error)
 
     ok()
+  of ephemeralBlockHeader:
+    err("Ephemeral block headers are not yet supported")
 
 proc new*(
     T: type HistoryNetwork,

--- a/fluffy/network/history/history_validation.nim
+++ b/fluffy/network/history/history_validation.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -34,12 +34,15 @@ func validateHeaderBytes*(
     bytes: openArray[byte], id: uint64 | Hash32
 ): Result[Header, string] =
   # Note:
-  # No additional quick-checks are addedhere such as timestamp vs the optional
-  # (later forks) added fields. E.g. Shanghai field, Cancun fields,
+  # No additional quick-checks are added here such as timestamp vs the optional
+  # (per hardfork) added fields. E.g. Shanghai field, Cancun fields,
   # zero ommersHash, etc.
   # This is because the block hash comparison + canonical verification will
-  # catch these. For comparison by number this is will also be caught by the
+  # catch these. For comparison by number this will be caught by the
   # canonical verification.
+  # The hash or number verification does still need to be done because else
+  # it would only be verified that a header is canonical and not that the
+  # returned header is the one that was requested.
   let header = ?decodeRlp(bytes, Header)
 
   ?header.validateHeader(id)
@@ -58,7 +61,9 @@ func verifyBlockHeaderProof*(
     else:
       # TODO:
       # Add verification post merge based on historical_roots & historical_summaries
-      ok()
+      # Lets for now no longer accept other headers without a proof and the most
+      # recent ones are now a different type.
+      err("Post merge header proofs not yet activated")
 
 func validateCanonicalHeaderBytes*(
     bytes: openArray[byte], id: uint64 | Hash32, a: FinishedHistoricalHashesAccumulator

--- a/fluffy/tests/history_network_tests/test_history_content_keys.nim
+++ b/fluffy/tests/history_network_tests/test_history_content_keys.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -139,6 +139,40 @@ suite "History Content Keys":
     check:
       contentKeyDecoded.contentType == contentKey.contentType
       contentKeyDecoded.blockNumberKey == contentKey.blockNumberKey
+
+      toContentId(contentKey) == parse(contentId, StUint[256], 10)
+      # In stint this does BE hex string
+      toContentId(contentKey).toHex() == contentIdHexBE
+
+  test "Ehpemeral BlockHeaders":
+    # Input
+    const
+      blockHash = Hash32.fromHex(
+        "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+      )
+      ancestorCount = 242'u8
+
+    # Output
+    const
+      contentKeyHex =
+        "04d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621df2"
+      contentId =
+        "107754593760180144978479156856849717135578675732374967927631096183784899947859"
+      # or
+      contentIdHexBE =
+        "ee3af053669ddd2130227b62f899547d6b6cc94f2492e9bbc731025a5ff92d53"
+
+    let contentKey = ephemeralBlockHeaderContentKey(blockHash, ancestorCount)
+
+    let encoded = encode(contentKey)
+    check encoded.asSeq.toHex == contentKeyHex
+    let decoded = decode(encoded)
+    check decoded.isSome()
+
+    let contentKeyDecoded = decoded.get()
+    check:
+      contentKeyDecoded.contentType == contentKey.contentType
+      contentKeyDecoded.ephemeralBlockHeaderKey == contentKey.ephemeralBlockHeaderKey
 
       toContentId(contentKey) == parse(contentId, StUint[256], 10)
       # In stint this does BE hex string


### PR DESCRIPTION
This does not yet enable the offer/accept and storage of the ephemeral headers as it requires database changes. Follow-up PR for that functionality.