### PR TITLE
Fluffy: Randomize gossip in neighborhoodGossip

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -1589,13 +1589,15 @@ proc neighborhoodGossip*(
 
   # For selecting the closest nodes to whom to gossip the content a mixed
   # approach is taken:
-  # 1. Select the closest neighbours in the routing table
-  # 2. Check if the radius is known for these these nodes and whether they are
+  # 1. Select the closest neighbours in the routing table.
+  # 2. Shuffle the selected nodes to randomize the gossip process so that we
+  # don't always offer to the same closest nodes.
+  # 3. Check if the radius is known for these these nodes and whether they are
   # in range of the content to be offered.
-  # 3. If more than n (= maxGossipNodes) nodes are in range, offer these nodes
+  # 4. If more than n (= maxGossipNodes) nodes are in range, offer these nodes
   # the content (maxed out at n).
-  # 4. If less than n nodes are in range, do a node lookup, and offer the nodes
-  # returned from the lookup the content (max nodes set at 8)
+  # 5. If less than n nodes are in range, do a node lookup, and offer the nodes
+  # returned from the lookup the content (max nodes set at 8).
   #
   # This should give a bigger rate of success and avoid the data being stopped
   # in its propagation than when looking only for nodes in the own routing

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -1602,8 +1602,12 @@ proc neighborhoodGossip*(
   # table, but at the same time avoid unnecessary node lookups.
   # It might still cause issues in data getting propagated in a wider id range.
 
-  let closestLocalNodes =
+  var closestLocalNodes =
     p.routingTable.neighbours(NodeId(contentId), k = 16, seenOnly = true)
+
+  # Shuffling the order of the nodes in order to not always hit the same node
+  # first for the same request.
+  p.baseProtocol.rng[].shuffle(closestLocalNodes)
 
   var gossipNodes: seq[Node]
   for node in closestLocalNodes:


### PR DESCRIPTION
The idea here is to randomize the gossip process so that we don't always offer to the same closest nodes. My goal is to better spread the data across the network. We still choose the 16 closest nodes but if we set the gossip number (`max-gossip-nodes`) to a value less than 16 then we will choose a random subset.

I noticed that when running the state bridge I would sometimes see that all nodes which we were sending offers to were rejecting the offers (probably because they already had the content). If the nodes selected has a random component then when rerunning the bridge we are likely to hit some nodes that don't yet have the content. 

