### PR TITLE
Bump nim-rocksdb

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/config.nims
+++ b/config.nims
@@ -103,8 +103,8 @@ elif defined(macosx) and defined(arm64):
   switch("passC", "-mcpu=apple-a14")
   switch("passL", "-mcpu=apple-a14")
 elif defined(riscv64):
-  # riscv64 needs specification of ISA with extensions. 'gc' is widely supported 
-  # and seems to be the minimum extensions needed to build. 
+  # riscv64 needs specification of ISA with extensions. 'gc' is widely supported
+  # and seems to be the minimum extensions needed to build.
   switch("passC", "-march=rv64gc")
   switch("passL", "-march=rv64gc")
 else:
@@ -180,17 +180,12 @@ switch("define", "kzgExternalBlst")
 # We lock down rocksdb to a particular version
 # TODO self-build rocksdb dll on windows
 when not defined(use_system_rocksdb) and not defined(windows):
-  switch("define", "rocksdb_static_linking")
 
   # use the C++ linker profile because it's a C++ library
   when defined(macosx):
     switch("clang.linkerexe", "clang++")
   else:
     switch("gcc.linkerexe", "g++")
-
-  switch("dynlibOverride", "rocksdb")
-  switch("dynlibOverride", "lz4")
-  switch("dynlibOverride", "zstd")
 
 # This applies per-file compiler flags to C files
 # which do not support {.localPassC: "...".}


### PR DESCRIPTION
No change to the upstream RocksDb version. 

Updating the library to use the latest changes which includes:
- Nimble install improvements (static linking used by default for Linux and MacOS). Remove unneeded compile flags as a result of this change.
- Skip rebuilding rocksdb when the static libraries already exist in the build directory and the vendered RocksDb version hasn't changed.