### PR TITLE
Avoid re-compacting historical data

### DIFF
--- a/nimbus/db/core_db/backend/aristo_rocksdb.nim
+++ b/nimbus/db/core_db/backend/aristo_rocksdb.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/nimbus/db/core_db/backend/aristo_rocksdb.nim
+++ b/nimbus/db/core_db/backend/aristo_rocksdb.nim
@@ -119,6 +119,10 @@ proc toRocksDb*(
   cfOpts.targetFileSizeBase = cfOpts.writeBufferSize
   cfOpts.targetFileSizeMultiplier = 6
 
+  # We certainly don't want to re-compact historical data over and over
+  cfOpts.ttl = 0
+  cfOpts.periodicCompactionSeconds = 0
+
   let dbOpts = defaultDbOptions(autoClose = true)
   dbOpts.maxOpenFiles = opts.maxOpenFiles
 


### PR DESCRIPTION
Per rocksdb docs, it will by default re-compact any data not touched for 30 days - this is obviously wasteful since our historical data rarely changes and _hopefully_ can stay untouched once written (with a bit of key sorting luck).