### PR TITLE
Bump RPC server buffer size

### DIFF
--- a/nimbus/rpc/rpc_server.nim
+++ b/nimbus/rpc/rpc_server.nim
@@ -64,7 +64,10 @@ func defaultRpcHttpServerParams(): RpcHttpServerParams =
     serverUri: Uri(),
     serverIdent: "",
     maxConnections: -1,
-    bufferSize: 4096,
+    # Assuming blocks take up to 16mb, it takes up to 64 reads to fetch the
+    # block from the OS buffer (which fills up quickly when the block is arriving
+    # from a local socket)
+    bufferSize: 256 * 1024,
     backlogSize: 100,
     httpHeadersTimeout: 10.seconds,
     maxHeadersSize: 64 * 1024,

--- a/nimbus/rpc/rpc_server.nim
+++ b/nimbus/rpc/rpc_server.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))


### PR DESCRIPTION
When large blocks arrive via RPC, we need to be able to read them from the socket in reasonable time - at 4kb, we might need thousands of reads before the JSON can be parsed - 256kb ensures that most blocks can be read in a few loop iterations - the size doesn't greatly matter since we only have one of these (unlike p2p connections)