### PR TITLE
Fix tools helper and allow GST to parse new eest devnet-6 test vectors

### DIFF
--- a/tests/test_config.nim
+++ b/tests/test_config.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -28,7 +28,7 @@ type
     index*: Opt[int]
     trace*: bool
     legacy*: bool
-    pruning*: bool
+    subFixture*: Opt[int]
     json*: bool
 
 var testConfig {.threadvar.}: Configuration
@@ -36,7 +36,6 @@ var testConfig {.threadvar.}: Configuration
 proc initConfiguration(): Configuration =
   result = new Configuration
   result.trace = true
-  result.pruning = true
 
 proc getConfiguration*(): Configuration {.gcsafe.} =
   if isNil(testConfig):
@@ -59,7 +58,7 @@ proc processArguments*(msg: var string): ConfigStatus =
       of "index": config.index = Opt.some(parseInt(value))
       of "trace": config.trace = parseBool(value)
       of "legacy": config.legacy = parseBool(value)
-      of "pruning": config.pruning = parseBool(value)
+      of "sub": config.subFixture = Opt.some(parseInt(value))
       of "json": config.json = parseBool(value)
       else:
         msg = "Unknown option " & key

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
@@ -37,6 +37,7 @@ type
     debugMode: bool
     trace: bool
     index: int
+    subFixture: int
     fork: string
 
 var
@@ -73,7 +74,8 @@ proc dumpDebugData(ctx: TestCtx, vmState: BaseVMState, gasUsed: GasInt, success:
   }
   let status = if success: "_success" else: "_failed"
   let fileName = normalizeFileName(ctx.name)
-  writeFile(fileName & "_" & ctx.fork & "_" & $ctx.index & status & ".json", debugData.pretty())
+  writeFile(fileName & "_" & $ctx.subFixture & "_" &
+    ctx.fork & "_" & $ctx.index & status & ".json", debugData.pretty())
 
 proc testFixtureIndexes(ctx: var TestCtx, testStatusIMPL: var TestStatus) =
   let
@@ -129,15 +131,8 @@ proc testFixtureIndexes(ctx: var TestCtx, testStatusIMPL: var TestStatus) =
       let success = ctx.expectedLogs == actualLogsHash and obtainedHash == ctx.expectedHash
       ctx.dumpDebugData(vmState, gasUsed, success)
 
-proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus,
+proc testSubFixture(ctx: var TestCtx, fixture: JsonNode, testStatusIMPL: var TestStatus,
                  trace = false, debugMode = false) =
-  var ctx: TestCtx
-  var fixture: JsonNode
-  for label, child in fixtures:
-    fixture = child
-    ctx.name = label
-    break
-
   ctx.pre    = fixture["pre"]
   ctx.parent = parseParentHeader(fixture["env"])
   ctx.header = parseHeader(fixture["env"])
@@ -193,12 +188,28 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus,
         runSubTest(subTest)
         inc ctx.index
 
+proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus,
+                 trace = false, debugMode = false) =
+  let
+    conf = getConfiguration()
+
+  var
+    ctx: TestCtx
+    subFixture = 0
+
+  for label, child in fixtures:
+    ctx.name = label
+    ctx.subFixture = subFixture
+    inc subFixture
+    if conf.subFixture.isSome and conf.subFixture.get != ctx.subFixture:
+      continue
+    testSubFixture(ctx, child, testStatusIMPL, trace, debugMode)
+
 proc generalStateJsonMain*(debugMode = false) =
   const
     legacyFolder = "eth_tests/LegacyTests/Constantinople/GeneralStateTests"
     newFolder = "eth_tests/GeneralStateTests"
-    #newFolder = "eth_tests/EIPTests/StateTests"
-
+    
   let config = getConfiguration()
   if config.testSubject == "" or not debugMode:
     # run all test fixtures

--- a/tools/common/helpers.nim
+++ b/tools/common/helpers.nim
@@ -62,10 +62,13 @@ proc assignTime(c: ChainConfig, transitionFork: HardFork, t: EthTime) =
   c.terminalTotalDifficulty = Opt.some(0.u256)
 
 func getChainConfig*(network: string, c: ChainConfig) =
+  const DEPOSIT_CONTRACT_ADDRESS = address"0x00000000219ab540356cbb839cbe05303d7705fa"
+
   c.daoForkSupport = false
   c.chainId = 1.ChainId
   c.terminalTotalDifficulty = Opt.none(UInt256)
   c.blobSchedule = defaultBlobSchedule()
+  c.depositContractAddress = Opt.some(DEPOSIT_CONTRACT_ADDRESS)
 
   case network
   of $TestFork.Frontier:
@@ -126,6 +129,8 @@ func getChainConfig*(network: string, c: ChainConfig) =
     c.assignTime(HardFork.Cancun, EthTime(15000))
   of $TestFork.Prague:
     c.assignTime(HardFork.Prague, TimeZero)
+  of $TestFork.CancunToPragueAtTime15k:
+    c.assignTime(HardFork.Prague, EthTime(15000))
   else:
     raise newException(ValueError, "unsupported network " & network)
 

--- a/tools/common/types.nim
+++ b/tools/common/types.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -38,6 +38,7 @@ type
     Cancun
     ShanghaiToCancunAtTime15k
     Prague
+    CancunToPragueAtTime15k
 
   LogLevel* = enum
     Silent


### PR DESCRIPTION
The new eest of devnet-6 test vector contains multiple sub fixtures in one json file. The old format(Frontier-Cancun), only contains one sub fixture.