### PR TITLE
Build nimbus evmc shared library and fix issue to enable loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2018-2025 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license
@@ -83,11 +83,11 @@ FLUFFY_TOOLS_DIRS := \
 FLUFFY_TOOLS_CSV := $(subst $(SPACE),$(COMMA),$(FLUFFY_TOOLS))
 
 # Namespaced variables to avoid conflicts with other makefiles
-OS = $(shell $(CC) -dumpmachine)
-ifneq (, $(findstring darwin, $(OS)))
+OS_PLATFORM = $(shell $(CC) -dumpmachine)
+ifneq (, $(findstring darwin, $(OS_PLATFORM)))
   SHAREDLIBEXT = dylib
 else
-ifneq (, $(findstring mingw, $(OS))$(findstring cygwin, $(OS))$(findstring msys, $(OS)))
+ifneq (, $(findstring mingw, $(OS_PLATFORM))$(findstring cygwin, $(OS_PLATFORM))$(findstring msys, $(OS_PLATFORM)))
   SHAREDLIBEXT = dll
 else
   SHAREDLIBEXT = so

--- a/Makefile
+++ b/Makefile
@@ -83,14 +83,14 @@ FLUFFY_TOOLS_DIRS := \
 FLUFFY_TOOLS_CSV := $(subst $(SPACE),$(COMMA),$(FLUFFY_TOOLS))
 
 # Namespaced variables to avoid conflicts with other makefiles
-VERIF_PROXY_OS = $(shell $(CC) -dumpmachine)
-ifneq (, $(findstring darwin, $(VERIF_PROXY_OS)))
-  VERIF_PROXY_SHAREDLIBEXT = dylib
+OS = $(shell $(CC) -dumpmachine)
+ifneq (, $(findstring darwin, $(OS)))
+  SHAREDLIBEXT = dylib
 else
-ifneq (, $(findstring mingw, $(VERIF_PROXY_OS))$(findstring cygwin, $(VERIF_PROXY_OS))$(findstring msys, $(VERIF_PROXY_OS)))
-  VERIF_PROXY_SHAREDLIBEXT = dll
+ifneq (, $(findstring mingw, $(OS))$(findstring cygwin, $(OS))$(findstring msys, $(OS)))
+  SHAREDLIBEXT = dll
 else
-  VERIF_PROXY_SHAREDLIBEXT = so
+  SHAREDLIBEXT = so
 endif
 endif
 
@@ -333,7 +333,7 @@ nimbus-verified-proxy-test: | build deps rocksdb
 libverifproxy: | build deps rocksdb
 	+ echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim --version && \
-		$(ENV_SCRIPT) nim c --app:lib -d:"libp2p_pki_schemes=secp256k1" --noMain:on --threads:on --nimcache:nimcache/libverifproxy -o:$(VERIF_PROXY_OUT_PATH)/$@.$(VERIF_PROXY_SHAREDLIBEXT) $(NIM_PARAMS) nimbus_verified_proxy/libverifproxy/verifproxy.nim
+		$(ENV_SCRIPT) nim c --app:lib -d:"libp2p_pki_schemes=secp256k1" --noMain:on --threads:on --nimcache:nimcache/libverifproxy -o:$(VERIF_PROXY_OUT_PATH)/$@.$(SHAREDLIBEXT) $(NIM_PARAMS) nimbus_verified_proxy/libverifproxy/verifproxy.nim
 	cp nimbus_verified_proxy/libverifproxy/verifproxy.h $(VERIF_PROXY_OUT_PATH)/
 	echo -e $(BUILD_END_MSG) "build/$@"
 
@@ -356,6 +356,10 @@ evmstate_test: | build deps evmstate
 # builds txparse tool
 txparse: | build deps
 	$(ENV_SCRIPT) nim c $(NIM_PARAMS) "tools/txparse/$@.nim"
+
+# builds the nimbus evmc shared library
+libnimbusevm: | build deps
+	$(ENV_SCRIPT) nim c $(NIM_PARAMS) -d:evmc_enabled --app:lib --noMain -o:build/libnimbusevm/$@.$(SHAREDLIBEXT) nimbus/transaction/evmc_vm_glue.nim
 
 # usual cleaning
 clean: | clean-common

--- a/nimbus/transaction/evmc_dynamic_loader.nim
+++ b/nimbus/transaction/evmc_dynamic_loader.nim
@@ -14,9 +14,9 @@ import
   evmc/evmc, ../config
 
 # The built-in Nimbus EVM, via imported C function.
-proc evmc_create_nimbus_evm(): ptr evmc_vm {.cdecl, importc, raises: [], gcsafe.}
+proc evmc_create_nimbusevm(): ptr evmc_vm {.cdecl, importc, raises: [], gcsafe.}
 
-# Import this module to link in the definition of `evmc_create_nimbus_evm`.
+# Import this module to link in the definition of `evmc_create_nimbusevm`.
 # Nim thinks the module is unused because the function is only called via
 # `.exportc` -> `.importc`.
 {.warning[UnusedImport]: off.}:
@@ -36,7 +36,7 @@ proc evmcLoadVMGetCreateFn(): (evmc_create_vm_name_fn, string) =
 
   # Use built-in EVM if no other is specified.
   if path.len == 0:
-    return (evmc_create_nimbus_evm, "built-in")
+    return (evmc_create_nimbusevm, "built-in")
 
   # The steps below match the EVMC Loader documentation, copied here:
   #

--- a/nimbus/transaction/evmc_dynamic_loader.nim
+++ b/nimbus/transaction/evmc_dynamic_loader.nim
@@ -1,6 +1,6 @@
 # Nimbus - Dynamic loader for EVM modules as shared libraries / DLLs
 #
-# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)

--- a/nimbus/transaction/evmc_vm_glue.nim
+++ b/nimbus/transaction/evmc_vm_glue.nim
@@ -91,13 +91,13 @@ proc evmc_create_nimbusevm*(): ptr evmc_vm {.cdecl, exportc, dynlib.} =
 
   let vm = cast[ptr evmc_vm](alloc(sizeof(evmc_vm)))
 
-  vm[].abi_version = EVMC_ABI_VERSION
-  vm[].name = evmcName
-  vm[].version = evmcVersion
-  vm[].destroy = evmcDestroy
-  vm[].execute = evmcExecute
-  vm[].get_capabilities = evmcGetCapabilities
-  vm[].set_option = evmcSetOption
+  vm.abi_version = EVMC_ABI_VERSION
+  vm.name = evmcName
+  vm.version = evmcVersion
+  vm.destroy = evmcDestroy
+  vm.execute = evmcExecute
+  vm.get_capabilities = evmcGetCapabilities
+  vm.set_option = evmcSetOption
 
   return vm
 

--- a/nimbus/transaction/evmc_vm_glue.nim
+++ b/nimbus/transaction/evmc_vm_glue.nim
@@ -1,6 +1,6 @@
 # Nimbus - Binary compatibility on the VM side of the EVMC API interface
 #
-# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)


### PR DESCRIPTION
Using the evmc-vmtester tool which is a part of the evmone project to verify and test if the Nimbus EVM can be used as a standalone EVMC VM. 

Before this change:
```
$ ./evmc-vmtester /home/user/development/status-im/nimbus-eth1/libnimbusevm.so
EVMC VM Tester 12.0.0
Testing /home/user/development/status-im/nimbus-eth1/build/libnimbusevm.so
Segmentation fault (core dumped)
```

After this change:
```
$ ./evmc-vmtester /home/user/development/status-im/nimbus-eth1/build/libnimbusevm.so
EVMC VM Tester 12.0.0
Testing /home/user/development/status-im/nimbus-eth1/build/libnimbusevm.so

[==========] Running 10 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 10 tests from evmc_vm_test
[ RUN      ] evmc_vm_test.abi_version_match
[       OK ] evmc_vm_test.abi_version_match (0 ms)
[ RUN      ] evmc_vm_test.name
[       OK ] evmc_vm_test.name (0 ms)
[ RUN      ] evmc_vm_test.version
[       OK ] evmc_vm_test.version (0 ms)
[ RUN      ] evmc_vm_test.capabilities
[       OK ] evmc_vm_test.capabilities (0 ms)
[ RUN      ] evmc_vm_test.execute_call
Segmentation fault (core dumped)
```

Execute call is still failing for other reasons but this gets us closer.