### PR TITLE
Fix getPayloadBodiesByRangeV1 fetching too many payloads

### DIFF
--- a/nimbus/beacon/api_handler/api_getbodies.nim
+++ b/nimbus/beacon/api_handler/api_getbodies.nim
@@ -71,7 +71,7 @@ proc getPayloadBodiesByRange*(ben: BeaconEngineRef,
     last = ben.chain.latestNumber
 
   # get bodies from database
-  for bn in start..ben.chain.baseNumber:
+  for bn in start..min(last, ben.chain.baseNumber):
     let blk = ben.chain.blockByNumber(bn).valueOr:
       result.add Opt.none(ExecutionPayloadBodyV1)
       continue
@@ -80,4 +80,5 @@ proc getPayloadBodiesByRange*(ben: BeaconEngineRef,
   if last > ben.chain.baseNumber:
     let blocks = ben.chain.blockFromBaseTo(last)
     for i in countdown(blocks.len-1, 0):
-      result.add Opt.some(toPayloadBody(blocks[i]))
+      if blocks[i].header.number >= start:
+        result.add Opt.some(toPayloadBody(blocks[i]))


### PR DESCRIPTION
Fixes #3055 

Also deals with the case where `start > ben.chain.baseNumber`. 