### PR TITLE
Speedup `eth_getLogs`

### DIFF
--- a/nimbus/core/chain/forked_chain.nim
+++ b/nimbus/core/chain/forked_chain.nim
@@ -640,9 +640,10 @@ func memoryTxHashesForBlock*(c: ForkedChainRef, blockHash: Hash32): seq[Hash32] 
     if blkHash == blockHash:
       cachedTxHashes.add((txHash, txIdx))
 
-  cachedTxHashes.sorted(proc(a, b: (Hash32, uint64)): int =
+  cachedTxHashes.sort(proc(a, b: (Hash32, uint64)): int =
       cmp(a[1], b[1])
-    ).mapIt(it[0])
+    )
+  cachedTxHashes.mapIt(it[0])
 
 proc latestBlock*(c: ForkedChainRef): Block =
   if c.activeBranch.headNumber == c.baseBranch.tailNumber:


### PR DESCRIPTION
Currently in devnet-6-pectra noticed a very slow `eth_getLogs` calls from mainly lighthouse
And it was taking around 30seconds to complete a `eth_getLogs` call, which was also responsible for pushing `nimbus-eth1` off from synced state

This implements
- Fetches the transactionHashes from in-memory blocks using txRecords
- Removes the `.blockHash` call for every log despite of being from the same block