### PR TITLE
add custom `hash` for `RootedVertexID`

### DIFF
--- a/execution_chain/db/aristo/aristo_desc/desc_identifiers.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_identifiers.nim
@@ -130,15 +130,21 @@ func `$`*(vid: VertexID): string =
   "$" & (if vid == VertexID(0): "ø"
          else: vid.uint64.toHex.strip(trailing=false,chars={'0'}).toLowerAscii)
 
-func `$`*(rvid: RootedVertexID): string =
-  $rvid.root & "/" & $rvid.vid
-
 func `==`*(a: VertexID; b: static[uint]): bool = (a == VertexID(b))
 
 # Scalar model extension as in `IntervalSetRef[VertexID,uint64]`
 func `+`*(a: VertexID; b: uint64): VertexID = (a.uint64+b).VertexID
 func `-`*(a: VertexID; b: uint64): VertexID = (a.uint64-b).VertexID
 func `-`*(a, b: VertexID): uint64 = (a.uint64 - b.uint64)
+
+func `==`*(a, b: RootedVertexID): bool {.inline.} =
+  a.vid == b.vid
+
+func hash*(rvid: RootedVertexID): Hash {.inline.} =
+  hash(rvid.vid)
+
+func `$`*(rvid: RootedVertexID): string =
+  $rvid.root & "/" & $rvid.vid
 
 # ------------------------------------------------------------------------------
 # Public helpers: `PathID` ordered scalar data model

--- a/execution_chain/db/aristo/aristo_desc/desc_identifiers.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_identifiers.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/execution_chain/sync/protocol/eth68.nim
+++ b/execution_chain/sync/protocol/eth68.nim
@@ -9,7 +9,7 @@
 # at your option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-## This module implements Ethereum Wire Protocol version 67, `eth/67`.
+## This module implements Ethereum Wire Protocol version 68, `eth/68`.
 ## Specification:
 ##   `eth/68 <https://github.com/ethereum/devp2p/blob/master/caps/eth.md>`_
 


### PR DESCRIPTION
There's no benefit hashing `root` since `vid` is already unique and the "default" hash is not free - this trivially brings a small perf boost to one of the key lookup tables in aristo_layers.