### PR TITLE
Fix fringe case where the final `checkpoint()` must not be applied

### DIFF
--- a/execution_chain/nimbus_import.nim
+++ b/execution_chain/nimbus_import.nim
@@ -358,13 +358,8 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
         persistBlock()
         checkpoint()
 
-  # There is some fringe case where the `persister` is not in sync to the DB
-  # state. Checkpointing here would then produce a mismatch of the
-  # `getSavedStateBlockNumber()` value and the state which typically fails
-  # with a state root mismatch when the next program uses the DB.
-  #
-  # This all happens only if there were no `era` or `era1` files that could be
-  # imported.
+  # If there were no blocks written, we will not have loaded the block number
+  # and therefore should not call checkpoint().
   if 0 < persister.stats.blocks:
     checkpoint(true)
 

--- a/execution_chain/nimbus_import.nim
+++ b/execution_chain/nimbus_import.nim
@@ -358,7 +358,15 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
         persistBlock()
         checkpoint()
 
-  checkpoint(true)
+  # There is some fringe case where the `persister` is not in sync to the DB
+  # state. Checkpointing here would then produce a mismatch of the
+  # `getSavedStateBlockNumber()` value and the state which typically fails
+  # with a state root mismatch when the next program uses the DB.
+  #
+  # This all happens only if there were no `era` or `era1` files that could be
+  # imported.
+  if 0 < persister.stats.blocks:
+    checkpoint(true)
 
   notice "Import complete",
     blockNumber,


### PR DESCRIPTION
why
  If there are no `era` or `era1` files that can be imported from,
  then the internal state will not be in sync with the DB state. This
  would lead to overwriting the saved state block number with something
  fancy. As a consequence the database becomes unusable for the next
  process which will eventually fail with a state root mismatch.