### PR TITLE
fix level reporting

### DIFF
--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -73,8 +73,7 @@ type
     accLeaves*: Table[Hash32, VertexRef]   ## Account path -> VertexRef
     stoLeaves*: Table[Hash32, VertexRef]   ## Storage path -> VertexRef
 
-    cTop*: VertexID                        ## Last committed vertex ID
-    blockNumber*: Opt[uint64]              ## Block number set when freezing the frame
+    blockNumber*: Opt[uint64]              ## Block number set when checkpointing the frame
 
   AristoDbRef* = ref object
     ## Three tier database object supporting distributed instances.
@@ -202,6 +201,7 @@ iterator rstack*(tx: AristoTxRef): (AristoTxRef, int) =
     let level = if tx.parent == nil: -1 else: i
     yield (tx, level)
     tx = tx.parent
+    i += 1
 
 proc deltaAtLevel*(db: AristoTxRef, level: int): AristoTxRef =
   if level == -2:

--- a/execution_chain/db/aristo/aristo_layers.nim
+++ b/execution_chain/db/aristo/aristo_layers.nim
@@ -124,6 +124,7 @@ func isEmpty*(ly: AristoTxRef): bool =
 proc mergeAndReset*(trg, src: AristoTxRef) =
   ## Merges the argument `src` into the argument `trg` and clears `src`.
   trg.vTop = src.vTop
+  trg.blockNumber = src.blockNumber
 
   if trg.kMap.len > 0:
     # Invalidate cached keys in the lower layer

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -73,7 +73,6 @@ proc txFramePersist*(
       if frame == db.txRef:
         continue
       mergeAndReset(db.txRef, frame)
-      db.txRef.blockNumber = frame.blockNumber
 
       frame.dispose() # This will also dispose `txFrame` itself!
 
@@ -82,7 +81,7 @@ proc txFramePersist*(
     db.txRef = txFrame
 
   # Store structural single trie entries
-  for rvid, vtx in db.txRef.sTab:
+  for rvid, vtx in txFrame.sTab:
     txFrame.kMap.withValue(rvid, key) do:
       be.putVtxFn(batch, rvid, vtx, key[])
     do:
@@ -107,6 +106,7 @@ proc txFramePersist*(
   txFrame.kMap.clear()
   txFrame.accLeaves.clear()
   txFrame.stoLeaves.clear()
+  txFrame.blockNumber.reset()
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -221,13 +221,6 @@ proc getScore*(
     warn info, data = data.toHex(), error=exc.msg
     Opt.none(UInt256)
 
-proc setScore*(db: CoreDbTxRef; blockHash: Hash32, score: UInt256) =
-  ## for testing purpose
-  let scoreKey = blockHashToScoreKey blockHash
-  db.put(scoreKey.toOpenArray, rlp.encode(score)).isOkOr:
-    warn "setScore()", scoreKey, error=($$error)
-    return
-
 proc headTotalDifficulty*(
     db: CoreDbTxRef;
       ): UInt256 =


### PR DESCRIPTION
Oops, level 0 was always used which needlessly increases mem usage - comes with an assortment of simplifications