### PR TITLE
Adjust and activate post-merge proofs for block headers

### DIFF
--- a/fluffy/network/history/history_validation.nim
+++ b/fluffy/network/history/history_validation.nim
@@ -12,11 +12,19 @@ import
   eth/trie/ordered_trie,
   ../../network_metadata,
   ./history_type_conversions,
-  ./validation/historical_hashes_accumulator
+  ./validation/[
+    historical_hashes_accumulator, block_proof_historical_roots,
+    block_proof_historical_summaries,
+  ]
 
 from eth/common/eth_types_rlp import rlpHash
 
 export historical_hashes_accumulator
+
+type HistoryAccumulators* = object
+  historicalHashes*: FinishedHistoricalHashesAccumulator
+  historicalRoots*: HistoricalRoots
+  historicalSummaries*: HistoricalSummaries
 
 func validateHeader(header: Header, blockHash: Hash32): Result[void, string] =
   if not (header.rlpHash() == blockHash):
@@ -50,32 +58,48 @@ func validateHeaderBytes*(
   ok(header)
 
 func verifyBlockHeaderProof*(
-    a: FinishedHistoricalHashesAccumulator,
+    a: HistoryAccumulators,
     header: Header,
     proof: ByteList[MAX_HEADER_PROOF_LENGTH],
+    cfg: RuntimeConfig,
 ): Result[void, string] =
   let timestamp = Moment.init(header.timestamp.int64, Second)
 
   if isShanghai(chainConfig, timestamp):
-    # TODO: Add verification post merge based on historical_summaries
-    err("Shanghai block verification not implemented")
+    let proof = decodeSsz(proof.asSeq(), BlockProofHistoricalSummaries).valueOr:
+      return err("Failed decoding historical_summaries based block proof: " & error)
+
+    if a.historicalSummaries.verifyProof(
+      proof, Digest(data: header.rlpHash().data), cfg
+    ):
+      ok()
+    else:
+      err("Block proof verification failed (historical_summaries)")
   elif isPoSBlock(chainConfig, header.number):
-    # TODO: Add verification post merge based on historical_roots
-    err("PoS block verification not implemented")
+    let proof = decodeSsz(proof.asSeq(), BlockProofHistoricalRoots).valueOr:
+      return err("Failed decoding historical_roots based block proof: " & error)
+
+    if a.historicalRoots.verifyProof(proof, Digest(data: header.rlpHash().data)):
+      ok()
+    else:
+      err("Block proof verification failed (historical_roots)")
   else:
     let accumulatorProof = decodeSsz(proof.asSeq(), HistoricalHashesAccumulatorProof).valueOr:
       return err("Failed decoding accumulator proof: " & error)
 
-    a.verifyAccumulatorProof(header, accumulatorProof)
+    a.historicalHashes.verifyAccumulatorProof(header, accumulatorProof)
 
 func validateCanonicalHeaderBytes*(
-    bytes: openArray[byte], id: uint64 | Hash32, a: FinishedHistoricalHashesAccumulator
+    bytes: openArray[byte],
+    id: uint64 | Hash32,
+    accumulators: HistoryAccumulators,
+    cfg: RuntimeConfig,
 ): Result[Header, string] =
   let headerWithProof = decodeSsz(bytes, BlockHeaderWithProof).valueOr:
     return err("Failed decoding header with proof: " & error)
   let header = ?validateHeaderBytes(headerWithProof.header.asSeq(), id)
 
-  ?a.verifyBlockHeaderProof(header, headerWithProof.proof)
+  ?accumulators.verifyBlockHeaderProof(header, headerWithProof.proof, cfg)
 
   ok(header)
 

--- a/fluffy/network/history/validation/block_proof_common.nim
+++ b/fluffy/network/history/validation/block_proof_common.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -7,46 +7,10 @@
 
 {.push raises: [].}
 
-import results, beacon_chain/spec/presets, beacon_chain/spec/forks
-
-type ExecutionBlockProof* = array[11, Digest]
+import beacon_chain/spec/presets, beacon_chain/spec/forks
 
 func getBlockRootsIndex*(slot: Slot): uint64 =
   slot mod SLOTS_PER_HISTORICAL_ROOT
 
 func getBlockRootsIndex*(beaconBlock: SomeForkyBeaconBlock): uint64 =
   getBlockRootsIndex(beaconBlock.slot)
-
-# Builds proof to be able to verify that the EL block hash is part of the
-# CL BeaconBlock for given root.
-func buildProof*(
-    beaconBlock: SomeForkyBeaconBlock
-): Result[ExecutionBlockProof, string] =
-  let
-    # BeaconBlock level:
-    # - 8 as there are 5 fields
-    # - 4 as index (pos) of field is 4
-    gIndexTopLevel = (1 * 1 * 8 + 4)
-    # BeaconBlockBody level:
-    # - 16 as there are 10 fields
-    # - 9 as index (pos) of field is 9
-    gIndexMidLevel = (gIndexTopLevel * 1 * 16 + 9)
-    # ExecutionPayload level:
-    # - 16 as there are 14 fields
-    # - 12 as pos of field is 12
-    gIndex = GeneralizedIndex(gIndexMidLevel * 1 * 16 + 12)
-
-  var proof: ExecutionBlockProof
-  ?beaconBlock.build_proof(gIndex, proof)
-
-  ok(proof)
-
-func verifyProof*(
-    blockHash: Digest, proof: ExecutionBlockProof, blockRoot: Digest
-): bool =
-  let
-    gIndexTopLevel = (1 * 1 * 8 + 4)
-    gIndexMidLevel = (gIndexTopLevel * 1 * 16 + 9)
-    gIndex = GeneralizedIndex(gIndexMidLevel * 1 * 16 + 12)
-
-  verify_merkle_multiproof(@[blockHash], proof, @[gIndex], blockRoot)

--- a/fluffy/portal_node.nim
+++ b/fluffy/portal_node.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -137,6 +137,7 @@ proc new*(
             discovery,
             contentDB,
             streamManager,
+            networkData.metadata.cfg,
             accumulator,
             bootstrapRecords = bootstrapRecords,
             portalConfig = config.portalConfig,

--- a/fluffy/tests/history_network_tests/test_block_proof_historical_summaries.nim
+++ b/fluffy/tests/history_network_tests/test_block_proof_historical_summaries.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -112,7 +112,7 @@ suite "History Block Proofs - Historical Summaries":
     for i in blocksToTest:
       let beaconBlock = blocks[i].message
 
-      let res = buildProof(beaconBlock)
+      let res = block_proof_historical_summaries.buildProof(beaconBlock)
       check res.isOk()
       let proof = res.get()
 

--- a/fluffy/tests/history_network_tests/test_block_proof_historical_summaries_vectors.nim
+++ b/fluffy/tests/history_network_tests/test_block_proof_historical_summaries_vectors.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -18,30 +18,8 @@ import
   beacon_chain/spec/datatypes/capella,
   ../../network/history/validation/block_proof_historical_summaries,
   ../../network/beacon/beacon_init_loader,
-  ../../eth_data/[yaml_utils, yaml_eth_types]
-
-proc toString(v: IoErrorCode): string =
-  try:
-    ioErrorMsg(v)
-  except Exception as e:
-    raiseAssert e.msg
-
-# Testing only proc as in the real network the historical_summaries are
-# retrieved from the network.
-proc readHistoricalSummaries(
-    file: string
-): Result[HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT], string] =
-  let encodedHistoricalSummaries = ?readAllFile(file).mapErr(toString)
-
-  try:
-    ok(
-      SSZ.decode(
-        encodedHistoricalSummaries,
-        HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT],
-      )
-    )
-  except SerializationError as err:
-    err("Failed decoding historical_summaries: " & err.msg)
+  ../../eth_data/[yaml_utils, yaml_eth_types],
+  ./test_history_util
 
 suite "History Block Proofs - Historical Summaries - Test Vectors":
   test "BlockProofHistoricalSummaries for Execution BlockHeader":
@@ -65,7 +43,9 @@ suite "History Block Proofs - Historical Summaries - Test Vectors":
             beaconBlockProof:
               array[13, Digest].fromHex(testProof.historical_summaries_proof),
             beaconBlockRoot: Digest.fromHex(testProof.beacon_block_root),
-            executionBlockProof: array[11, Digest].fromHex(testProof.beacon_block_proof),
+            executionBlockProof: ExecutionBlockProofList(
+              @(array[11, Digest].fromHex(testProof.beacon_block_proof))
+            ),
             slot: Slot(testProof.slot),
           )
 

--- a/fluffy/tests/history_network_tests/test_history_network.nim
+++ b/fluffy/tests/history_network_tests/test_history_network.nim
@@ -15,6 +15,7 @@ import
   ../../network/history/
     [history_network, history_content, validation/historical_hashes_accumulator],
   ../../database/content_db,
+  ../../network/beacon/beacon_init_loader,
   ../test_helpers,
   ./test_history_util
 
@@ -35,8 +36,10 @@ proc newHistoryNode(
       "", uint32.high, RadiusConfig(kind: Dynamic), node.localNode.id, inMemory = true
     )
     streamManager = StreamManager.new(node)
+    networkData = loadNetworkData("mainnet")
+    cfg = networkData.metadata.cfg
     historyNetwork =
-      HistoryNetwork.new(PortalNetwork.none, node, db, streamManager, accumulator)
+      HistoryNetwork.new(PortalNetwork.none, node, db, streamManager, cfg, accumulator)
 
   return HistoryNode(discoveryProtocol: node, historyNetwork: historyNetwork)
 
@@ -72,7 +75,7 @@ proc createEmptyHeaders(fromNum: int, toNum: int): seq[Header] =
   var headers: seq[Header]
   for i in fromNum .. toNum:
     var bh = Header()
-    bh.number = BlockNumber(i)
+    bh.number = i.uint64
     bh.difficulty = u256(i)
     # empty so that we won't care about creating fake block bodies
     bh.ommersHash = EMPTY_UNCLE_HASH

--- a/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
+++ b/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
@@ -38,7 +38,12 @@ proc newHistoryNode(rng: ref HmacDrbgContext, port: int): HistoryNode =
     )
     streamManager = StreamManager.new(node)
     historyNetwork = HistoryNetwork.new(
-      PortalNetwork.none, node, db, streamManager, FinishedHistoricalHashesAccumulator()
+      PortalNetwork.none,
+      node,
+      db,
+      streamManager,
+      RuntimeConfig(),
+      FinishedHistoricalHashesAccumulator(),
     )
 
   return HistoryNode(discoveryProtocol: node, historyNetwork: historyNetwork)

--- a/fluffy/tests/state_network_tests/state_test_helpers.nim
+++ b/fluffy/tests/state_network_tests/state_test_helpers.nim
@@ -121,7 +121,12 @@ proc newStateNode*(
     )
     sm = StreamManager.new(node)
     hn = HistoryNetwork.new(
-      PortalNetwork.none, node, db, sm, FinishedHistoricalHashesAccumulator()
+      PortalNetwork.none,
+      node,
+      db,
+      sm,
+      RuntimeConfig(),
+      FinishedHistoricalHashesAccumulator(),
     )
     sn =
       StateNetwork.new(PortalNetwork.none, node, db, sm, historyNetwork = Opt.some(hn))

--- a/fluffy/tools/eth_data_exporter/cl_data_exporter.nim
+++ b/fluffy/tools/eth_data_exporter/cl_data_exporter.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -287,7 +287,7 @@ proc exportBeaconBlockProofBellatrix(
       error "Failed to load Bellatrix block", slot
       quit QuitFailure
 
-    blockProof = buildProof(batch, beaconBlock.message).valueOr:
+    blockProof = block_proof_historical_roots.buildProof(batch, beaconBlock.message).valueOr:
       error "Failed to build proof for Bellatrix block", slot, error
       quit QuitFailure
 


### PR DESCRIPTION
Not yet fully activated for proofs based on historical summaries as the historical summaries do not get loaded yet.

This is rather a quick version of this to be able to test https://github.com/ethereum/portal-spec-tests/pull/39

Also, I'm not sure if I like the change of `Vector` instead of `List` for the `ExecutionBlockProof` for capella / deneb / etc. But it is currently what we decided in specs.

