### PR TITLE
rm nim-graphql submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -143,11 +143,6 @@
   url = https://github.com/ethereum/tests
   ignore = dirty
   branch = develop
-[submodule "vendor/nim-graphql"]
-  path = vendor/nim-graphql
-  url = https://github.com/status-im/nim-graphql
-  ignore = dirty
-  branch = master
 [submodule "vendor/nim-toml-serialization"]
   path = vendor/nim-toml-serialization
   url = https://github.com/status-im/nim-toml-serialization

--- a/tests/test_jwt_auth.nim
+++ b/tests/test_jwt_auth.nim
@@ -12,24 +12,20 @@
 ## ====================================
 
 import
-  std/[base64, json, options, os, strutils, times],
   ../execution_chain/config,
   ../execution_chain/rpc/jwt_auth,
   ../execution_chain/rpc {.all.},
   ./replay/pp,
   chronicles,
   chronos/apps/http/httpclient as chronoshttpclient,
-  chronos/apps/http/httptable,
-  eth/common/keys,
-  eth/p2p,
   nimcrypto/[hmac, sha2, utils],
-  results,
-  stint,
   unittest2,
-  graphql,
   websock/websock,
-  graphql/[httpserver, httpclient],
   json_rpc/[rpcserver, rpcclient]
+
+from std/base64 import encode
+from std/os import DirSep, fileExists, removeFile, splitFile, splitPath, `/`
+from std/times import getTime, toUnix
 
 type
   UnGuardedKey =
@@ -70,11 +66,6 @@ proc say(noisy = false; pfx = "***"; args: varargs[string, `$`]) =
     else:
       echo pfx, args.toSeq.join
 
-proc setTraceLevel =
-  discard
-  when defined(chronicles_runtime_filtering) and loggingEnabled:
-    setLogLevel(LogLevel.TRACE)
-
 proc setErrorLevel =
   discard
   when defined(chronicles_runtime_filtering) and loggingEnabled:
@@ -86,7 +77,7 @@ proc setErrorLevel =
 
 func fakeGenSecret(fake: JwtSharedKey): JwtGenSecret =
   ## Key random generator, fake version
-  result = proc: JwtSharedKey =
+  proc: JwtSharedKey =
     fake
 
 func base64urlEncode(x: auto): string =
@@ -118,42 +109,13 @@ func getHttpAuthReqHeader2(secret: JwtSharedKey; time: uint64): HttpTable =
   let bearer = secret.UnGuardedKey.getSignedToken2($getIatToken(time))
   result.add("aUtHoRiZaTiOn", "Bearer " & bearer)
 
-proc createServer(serverAddress: TransportAddress, authHooks: seq[AuthHook] = @[]): GraphqlHttpServerRef =
-  let socketFlags = {ServerFlags.TcpNoDelay, ServerFlags.ReuseAddr}
-  var ctx = GraphqlRef.new()
-
-  const schema = """type Query {name: String}"""
-  let r = ctx.parseSchema(schema)
-  if r.isErr:
-    debugEcho r.error
-    return
-
-  let res = GraphqlHttpServerRef.new(
-    graphql = ctx,
-    address = serverAddress,
-    socketFlags = socketFlags,
-    authHooks = authHooks
-  )
-
-  if res.isErr():
-    debugEcho res.error
-    return
-
-  res.get()
-
-proc setupClient(address: TransportAddress): GraphqlHttpClientRef =
-  GraphqlHttpClientRef.new(address, secure = false).get()
-
-func localAddress(server: GraphqlHttpServerRef): TransportAddress =
-  server.server.instance.localAddress()
-
 # ------------------------------------------------------------------------------
-# Http combo helpers
+# HTTP combo helpers
 # ------------------------------------------------------------------------------
 
 func installRPC(server: RpcServer) =
   server.rpc("rpc_echo") do(input: int) -> string:
-    result = "hello: " & $input
+    "hello: " & $input
 
 proc setupComboServer(hooks: sink seq[RpcAuthHook]): HttpResult[NimbusHttpServerRef] =
   var handlers: seq[RpcHandlerProc]
@@ -212,7 +174,7 @@ proc runKeyLoader(noisy = true;
       noisy.say "   ", "text=", hexLine
       noisy.say "   ", "fake=", hexFake
 
-      # Compare key against tcontents of shared key file
+      # Compare key against contents of shared key file
       check hexKey.cmpIgnoreCase(hexLine) == 0
 
       # Just to make sure that there was no random generator used
@@ -236,7 +198,7 @@ proc runKeyLoader(noisy = true;
       noisy.say "   ", "text=", hexLine
       noisy.say "   ", "fake=", hexFake
 
-      # Compare key against tcontents of shared key file
+      # Compare key against contents of shared key file
       check hexKey.cmpIgnoreCase(hexLine) == 0
 
       # Just to make sure that there was no random generator used
@@ -264,16 +226,13 @@ proc runKeyLoader(noisy = true;
       noisy.say "***", "key=", hexKey
       noisy.say "   ", "text=", hexLine
 
-      # Compare key against tcontents of shared key file
+      # Compare key against contents of shared key file
       check hexKey.cmpIgnoreCase(hexLine) == 0
 
 proc runJwtAuth(noisy = true; keyFile = jwtKeyFile) =
   let
     filePath = keyFile.findFilePath.value
-    fileInfo = keyFile.splitFile.name.split(".")[0]
-
     dataDir = filePath.splitPath.head
-
     dataDirCmdOpt = &"--data-dir={dataDir}"
     jwtSecretCmdOpt = &"--jwt-secret={filePath}"
     config = @[dataDirCmdOpt,jwtSecretCmdOpt].makeConfig
@@ -285,78 +244,7 @@ proc runJwtAuth(noisy = true; keyFile = jwtKeyFile) =
     # The wrapper contains the handler function with the captured shared key
     authHook = secret.value.httpJwtAuth
 
-  const
-    serverAddress = initTAddress("127.0.0.1:0")
-    query = """{ __type(name: "ID") { kind }}"""
-
-  suite "EngineAuth: Http/rpc authentication mechanics":
-    let server = createServer(serverAddress, @[authHook])
-    server.start()
-
-    test &"JSW/HS256 authentication using shared secret file {fileInfo}":
-      # Just to make sure that we made a proper choice. Typically, all
-      # ingredients shoud have been tested, already in the preceeding test
-      # suite.
-      let
-        lines = config.jwtSecret.get.string.readLines(1)
-        hexKey = "0x" & secret.value.UnGuardedKey.toHex
-        hexLine = lines[0].strip
-      noisy.say "***", "key=", hexKey
-      noisy.say "   ", "text=", hexLine
-      check hexKey.cmpIgnoreCase(hexLine) == 0
-
-      let
-        time = getTime().toUnix.uint64
-        req = secret.value.getHttpAuthReqHeader(time)
-      noisy.say "***", "request",
-        " Authorization=", req.getString("Authorization")
-
-      setTraceLevel()
-
-      # Run http authorisation request
-      let client = setupClient(server.localAddress)
-      let res = waitFor client.sendRequest(query, req.toList)
-      check res.isOk
-      if res.isErr:
-        noisy.say "***", res.error
-        return
-
-      let resp = res.get()
-      check resp.status == 200
-      check resp.reason == "OK"
-      check resp.response == """{"data":{"__type":{"kind":"SCALAR"}}}"""
-
-      setErrorLevel()
-
-    test &"JSW/HS256, ditto with protected header variant":
-      let
-        time = getTime().toUnix.uint64
-        req = secret.value.getHttpAuthReqHeader2(time)
-
-      # Assemble request header
-      noisy.say "***", "request",
-        " Authorization=", req.getString("Authorization")
-
-      setTraceLevel()
-
-      # Run http authorisation request
-      let client = setupClient(server.localAddress)
-      let res = waitFor client.sendRequest(query, req.toList)
-      check res.isOk
-      if res.isErr:
-        noisy.say "***", res.error
-        return
-
-      let resp = res.get()
-      check resp.status == 200
-      check resp.reason == "OK"
-      check resp.response == """{"data":{"__type":{"kind":"SCALAR"}}}"""
-
-      setErrorLevel()
-
-    waitFor server.closeWait()
-
-  suite "Test combo http server":
+  suite "Test combo HTTP server":
     let res = setupComboServer(@[authHook])
     if res.isErr:
       debugEcho res.error
@@ -369,7 +257,7 @@ proc runJwtAuth(noisy = true; keyFile = jwtKeyFile) =
 
     server.start()
 
-    test "rpc query no auth":
+    test "RPC query no auth":
       let client = newRpcHttpClient()
       waitFor client.connect("http://" & $server.localAddress)
       try:
@@ -379,7 +267,7 @@ proc runJwtAuth(noisy = true; keyFile = jwtKeyFile) =
       except ErrorResponse as exc:
         check exc.msg == "Forbidden"
 
-    test "rpc query with uth":
+    test "RPC query with auth":
       proc authHeaders(): seq[(string, string)] =
         req.toList
       let client = newRpcHttpClient(getHeaders = authHeaders)


### PR DESCRIPTION
The `EngineAuth: Http/rpc authentication mechanics` test suite was exclusively/specifically for GraphQL.

https://github.com/status-im/nimbus-eth1/blob/aa4770d3376ac090a7c956fe4c8968c9b4605fd1/tests/test_jwt_auth.nim#L359-L406
tests this in a JSON-RPC and WebSocket context.