### PR TITLE
Collect keys of all read storage slots even if zero when building MultiKeys

### DIFF
--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -790,7 +790,6 @@ proc update(wd: var WitnessData, acc: AccountRef) =
 
   if not acc.originalStorage.isNil:
     for k, v in acc.originalStorage:
-      if v.isZero: continue
       wd.storageKeys.incl k
 
   for k, v in acc.overlayStorage:

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -713,6 +713,45 @@ proc runLedgerBasicOperationsTests() =
       check 2.u256 in vals
       check 3.u256 in vals
 
+    test "Test MultiKeys - Set storage":
+      var
+        ac = LedgerRef.init(memDB.baseTxFrame())
+        addr1 = initAddr(1)
+
+      ac.setStorage(addr1, 1.u256, 1.u256) # Non-zero value
+      ac.setStorage(addr1, 2.u256, 0.u256) # Zero value
+
+      ac.collectWitnessData()
+      let multikeys = ac.makeMultiKeys().keys
+
+      check:
+        multikeys.len() == 1
+        multikeys[0].storageMode == false
+        multikeys[0].address == addr1
+        multikeys[0].storageKeys.keys.len() == 2
+        multikeys[0].storageKeys.keys[0].storageSlot == 2.u256.toBytesBE()
+        multikeys[0].storageKeys.keys[1].storageSlot == 1.u256.toBytesBE()
+
+    test "Test MultiKeys - Get storage":
+      var
+        ac = LedgerRef.init(memDB.baseTxFrame())
+        addr1 = initAddr(1)
+
+      ac.setStorage(addr1, 3.u256, 1.u256)
+      discard ac.getStorage(addr1, 3.u256) # Returns non-zero value
+      discard ac.getStorage(addr1, 4.u256) # Returns default zero value
+
+      ac.collectWitnessData()
+      let multikeys = ac.makeMultiKeys().keys
+
+      check:
+        multikeys.len() == 1
+        multikeys[0].storageMode == false
+        multikeys[0].address == addr1
+        multikeys[0].storageKeys.keys.len() == 2
+        multikeys[0].storageKeys.keys[0].storageSlot == 4.u256.toBytesBE()
+        multikeys[0].storageKeys.keys[1].storageSlot == 3.u256.toBytesBE()
+
 # ------------------------------------------------------------------------------
 # Main function(s)
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This change is needed for the Fluffy EVM which uses the Nimbus in memory EVM. 

In this case the EVM is looking up a slot that hasn't yet been set so it returns a zero value. It fails with InvalidJumpDest because the transaction doesn't yet have the correct state set.

In Fluffy and also Nimbus Verified Proxy we need to figure out what state is accessed when the transaction is executed so that we can fetch that state over the network, store it in the memory evm and then finally execute the transaction with the correct state. In this case we still want to know about the slot keys accessed that returned zero values so that we can look them up over the network to get the correct non zero values.

