### PR TITLE
Move nim-eth/p2p code to execution client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
         run: |
           gcc --version
           DEFAULT_MAKE_FLAGS="-j${ncpu} ENABLE_EVMC=${ENABLE_EVMC} ENABLE_VMLOWMEM=${ENABLE_VMLOWMEM}"
-          mingw32-make ${DEFAULT_MAKE_FLAGS} all test_import
+          mingw32-make ${DEFAULT_MAKE_FLAGS} all test_import build_fuzzers
           build/nimbus_execution_client.exe --help
           # give us more space
           # find . -type d -name ".git" -exec rm -rf {} +
@@ -220,7 +220,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib"
           DEFAULT_MAKE_FLAGS="-j${ncpu} ENABLE_EVMC=${ENABLE_EVMC}"
-          env CC=gcc make ${DEFAULT_MAKE_FLAGS} all test_import
+          env CC=gcc make ${DEFAULT_MAKE_FLAGS} all test_import build_fuzzers
           build/nimbus_execution_client --help
           # CC, GOARCH, and CGO_ENABLED are needed to select correct compiler 32/64 bit
           # pushd vendor/nimbus-eth2
@@ -235,7 +235,7 @@ jobs:
         run: |
           export ZERO_AR_DATE=1 # avoid timestamps in binaries
           DEFAULT_MAKE_FLAGS="-j${ncpu} ENABLE_EVMC=${ENABLE_EVMC}"
-          make ${DEFAULT_MAKE_FLAGS} all test_import
+          make ${DEFAULT_MAKE_FLAGS} all test_import build_fuzzers
           build/nimbus_execution_client --help
           # "-static" option will not work for osx unless static system libraries are provided
           # pushd vendor/nimbus-eth2

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,9 @@ test_import: nimbus_execution_client
 test-evm: | build deps rocksdb
 	$(ENV_SCRIPT) nim test_evm $(NIM_PARAMS) nimbus.nims
 
+build_fuzzers:
+	$(ENV_SCRIPT) nim build_fuzzers $(NIM_PARAMS) nimbus.nims
+  
 # Primitive reproducibility test.
 #
 # On some platforms, with some GCC versions, it may not be possible to get a

--- a/execution_chain/common/chain_config.nim
+++ b/execution_chain/common/chain_config.nim
@@ -11,13 +11,14 @@
 
 import
   std/[tables, strutils, times, macros],
-  eth/[rlp, p2p], eth/common/eth_types_json_serialization,
+  eth/rlp, eth/common/eth_types_json_serialization,
   eth/common/eth_types_rlp,
   stint, stew/[byteutils],
   json_serialization, chronicles,
   json_serialization/stew/results,
   json_serialization/lexer,
-  "."/[genesis_alloc, hardforks]
+  ../networking/p2p,
+  ./[genesis_alloc, hardforks]
 
 export
   tables, hardforks

--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -23,10 +23,11 @@ import
     confutils/defs,
     confutils/std/net
   ],
-  eth/[common, net/utils, net/nat, p2p/bootnodes, p2p/enode, p2p/discoveryv5/enr],
-  "."/[constants, compile_info, version],
-  common/chain_config,
-  db/opts
+  eth/[common, net/utils, net/nat, p2p/discoveryv5/enr],
+  ./networking/[bootnodes, discoveryv4/enode],
+  ./[constants, compile_info, version],
+  ./common/chain_config,
+  ./db/opts
 
 from beacon_chain/nimbus_binary_common import setupLogging, StdoutLogKind
 

--- a/execution_chain/networking/bootnodes.nim
+++ b/execution_chain/networking/bootnodes.nim
@@ -1,0 +1,41 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+const
+  MainnetBootnodes* = [
+    # Ethereum Foundation Go Bootnodes
+    "enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666@18.138.108.67:30303",   # bootnode-aws-ap-southeast-1-001
+    "enode://22a8232c3abc76a16ae9d6c3b164f98775fe226f0917b0ca871128a74a8e9630b458460865bab457221f1d448dd9791d24c4e5d88786180ac185df813a68d4de@3.209.45.79:30303",     # bootnode-aws-us-east-1-001
+    "enode://8499da03c47d637b20eee24eec3c356c9a2e6148d6fe25ca195c7949ab8ec2c03e3556126b0d7ed644675e78c4318b08691b7b57de10e5f0d40d05b09238fa0a@52.187.207.27:30303",   # bootnode-azure-australiaeast-001
+    "enode://103858bdb88756c71f15e9b5e09b56dc1be52f0a5021d46301dbbfb7e130029cc9d0d6f73f693bc29b665770fff7da4d34f3c6379fe12721b5d7a0bcb5ca1fc1@191.234.162.198:30303", # bootnode-azure-brazilsouth-001
+    "enode://715171f50508aba88aecd1250af392a45a330af91d7b90701c436b618c86aaa1589c9184561907bebbb56439b8f8787bc01f49a7c77276c58c1b09822d75e8e8@52.231.165.108:30303",  # bootnode-azure-koreasouth-001
+    "enode://5d6d7cd20d6da4bb83a1d28cadb5d409b64edf314c0335df658c1a54e32c7c4a7ab7823d57c39b6a757556e68ff1df17c748b698544a55cb488b52479a92b60f@104.42.217.25:30303",   # bootnode-azure-westus-001
+    "enode://2b252ab6a1d0f971d9722cb839a42cb81db019ba44c08754628ab4a823487071b5695317c8ccd085219c3a03af063495b2f1da8d18218da2d6a82981b45e6ffc@65.108.70.101:30303",   # bootnode-hetzner-hel
+    "enode://4aeb4ab6c14b23e2c4cfdce879c04b0748a20d8e9b59e25ded2a08143e265c6c25936e74cbc8e641e3312ca288673d91f2f93f8e277de3cfa444ecdaaf982052@157.90.35.166:30303",   # bootnode-hetzner-fsn
+  ]
+
+  # https://github.com/eth-clients/sepolia/blob/a192392161577b273e0beea447647e7df3e291a3/metadata/enodes.yaml
+  SepoliaBootnodes* = [
+    # EF
+    "enode://4e5e92199ee224a01932a377160aa432f31d0b351f84ab413a8e0a42f4f36476f8fb1cbe914af0d9aef0d51665c214cf653c651c4bbd9d5550a934f241f1682b@138.197.51.181:30303",  # sepolia-bootnode-1-nyc3
+    "enode://143e11fb766781d22d92a2e33f8f104cddae4411a122295ed1fdb6638de96a6ce65f5b7c964ba3763bba27961738fef7d3ecc739268f3e5e771fb4c87b6234ba@146.190.1.103:30303",   # sepolia-bootnode-1-sfo3
+    "enode://8b61dc2d06c3f96fddcbebb0efb29d60d3598650275dc469c22229d3e5620369b0d3dedafd929835fe7f489618f19f456fe7c0df572bf2d914a9f4e006f783a9@170.64.250.88:30303",   # sepolia-bootnode-1-syd1
+    "enode://10d62eff032205fcef19497f35ca8477bea0eadfff6d769a147e895d8b2b8f8ae6341630c645c30f5df6e67547c03494ced3d9c5764e8622a26587b083b028e8@139.59.49.206:30303",   # sepolia-bootnode-1-blr1
+    "enode://9e9492e2e8836114cc75f5b929784f4f46c324ad01daf87d956f98b3b6c5fcba95524d6e5cf9861dc96a2c8a171ea7105bb554a197455058de185fa870970c7c@138.68.123.152:30303",   # sepolia-bootnode-1-ams3
+  ]
+
+  # https://github.com/eth-clients/holesky/blob/37eaaf80084489af9459836c03c6e24b9e431c2a/metadata/enodes.yaml
+  HoleskyBootnodes* = [
+    # EF
+    "enode://ac906289e4b7f12df423d654c5a962b6ebe5b3a74cc9e06292a85221f9a64a6f1cfdd6b714ed6dacef51578f92b34c60ee91e9ede9c7f8fadc4d347326d95e2b@146.190.13.128:30303",
+    "enode://a3435a0155a3e837c02f5e7f5662a2f1fbc25b48e4dc232016e1c51b544cb5b4510ef633ea3278c0e970fa8ad8141e2d4d0f9f95456c537ff05fdf9b31c15072@178.128.136.233:30303",
+
+    # Lodestar
+    "enode://7fa09f1e8bb179ab5e73f45d3a7169a946e7b3de5ef5cea3a0d4546677e4435ee38baea4dd10b3ddfdc1f1c5e869052932af8b8aeb6f9738598ec4590d0b11a6@65.109.94.124:30303",
+  ]

--- a/execution_chain/networking/discoveryv4.nim
+++ b/execution_chain/networking/discoveryv4.nim
@@ -1,0 +1,412 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [].}
+
+import
+  std/[times, net],
+  chronos,
+  stint,
+  nimcrypto/keccak,
+  chronicles,
+  stew/objects,
+  results,
+  eth/rlp,
+  eth/common/keys,
+  ./discoveryv4/[kademlia, enode]
+
+export
+  Node,
+  results,
+  kademlia,
+  enode
+
+logScope:
+  topics = "eth p2p discovery"
+
+const
+  # UDP packet constants.
+  MAC_SIZE = 256 div 8 # 32
+  SIG_SIZE = 520 div 8 # 65
+  HEAD_SIZE = MAC_SIZE + SIG_SIZE # 97
+  EXPIRATION = 60 # let messages expire after N seconds
+  PROTO_VERSION = 4
+
+type
+  DiscoveryProtocol* = ref object
+    privKey: PrivateKey
+    address: Address
+    bootstrapNodes*: seq[Node]
+    localNode*: Node
+    kademlia*: KademliaProtocol[DiscoveryProtocol]
+    transp: DatagramTransport
+    bindIp: IpAddress
+    bindPort: Port
+
+  DiscProtocolError* = object of CatchableError
+
+  DiscResult*[T] = Result[T, cstring]
+
+  keccak256 = keccak.keccak256
+
+const MinListLen: array[CommandId, int] = [4, 3, 2, 2, 1, 2]
+
+proc append*(w: var RlpWriter, a: IpAddress) =
+  case a.family
+  of IpAddressFamily.IPv6:
+    w.append(a.address_v6)
+  of IpAddressFamily.IPv4:
+    w.append(a.address_v4)
+
+proc append(w: var RlpWriter, p: Port) =
+  w.append(p.uint)
+
+proc append(w: var RlpWriter, pk: PublicKey) =
+  w.append(pk.toRaw())
+
+proc append(w: var RlpWriter, h: MDigest[256]) =
+  w.append(h.data)
+
+proc pack(cmdId: CommandId, payload: openArray[byte], pk: PrivateKey): seq[byte] =
+  ## Create and sign a UDP message to be sent to a remote node.
+  ##
+  ## See https://github.com/ethereum/devp2p/blob/master/rlpx.md#node-discovery for information on
+  ## how UDP packets are structured.
+
+  result = newSeq[byte](HEAD_SIZE + 1 + payload.len)
+  result[HEAD_SIZE] = cmdId.byte
+  result[HEAD_SIZE + 1 ..< result.len] = payload
+  result[MAC_SIZE ..< MAC_SIZE + SIG_SIZE] =
+    pk.sign(result.toOpenArray(HEAD_SIZE, result.high)).toRaw()
+  result[0 ..< MAC_SIZE] =
+    keccak256.digest(result.toOpenArray(MAC_SIZE, result.high)).data
+
+proc validateMsgHash(msg: openArray[byte]): DiscResult[MDigest[256]] =
+  if msg.len > HEAD_SIZE:
+    var ret: MDigest[256]
+    ret.data[0 .. ^1] = msg.toOpenArray(0, ret.data.high)
+    if ret == keccak256.digest(msg.toOpenArray(MAC_SIZE, msg.high)):
+      ok(ret)
+    else:
+      err("disc: invalid message hash")
+  else:
+    err("disc: msg missing hash")
+
+proc recoverMsgPublicKey(msg: openArray[byte]): DiscResult[PublicKey] =
+  if msg.len <= HEAD_SIZE:
+    return err("disc: can't get public key")
+  let sig = ?Signature.fromRaw(msg.toOpenArray(MAC_SIZE, HEAD_SIZE))
+  recover(sig, msg.toOpenArray(HEAD_SIZE, msg.high))
+
+proc unpack(
+    msg: openArray[byte]
+): tuple[cmdId: CommandId, payload: seq[byte]] {.raises: [DiscProtocolError].} =
+  # Check against possible RangeDefect
+  if msg[HEAD_SIZE].int < CommandId.low.ord or msg[HEAD_SIZE].int > CommandId.high.ord:
+    raise newException(DiscProtocolError, "Unsupported packet id")
+
+  (cmdId: msg[HEAD_SIZE].CommandId, payload: msg[HEAD_SIZE + 1 .. ^1])
+
+proc expiration(): uint64 =
+  uint64(getTime().toUnix() + EXPIRATION)
+
+# Wire protocol
+
+proc send(d: DiscoveryProtocol, n: Node, data: seq[byte]) =
+  let ta = initTAddress(n.node.address.ip, n.node.address.udpPort)
+  let f = d.transp.sendTo(ta, data)
+  let cb = proc(data: pointer) {.gcsafe.} =
+    if f.failed:
+      when defined(chronicles_log_level):
+        try:
+          # readError will raise FutureError
+          debug "Discovery send failed",
+            msg = f.readError.msg, address = $n.node.address
+        except FutureError as exc:
+          error "Failed to get discovery send future error", msg = exc.msg
+
+  f.addCallback cb
+
+proc sendPing*(d: DiscoveryProtocol, n: Node): seq[byte] =
+  let payload =
+    rlp.encode((PROTO_VERSION.uint, d.address, n.node.address, expiration()))
+  let msg = pack(cmdPing, payload, d.privKey)
+  result = msg[0 ..< MAC_SIZE]
+  trace ">>> ping ", n
+  d.send(n, msg)
+
+proc sendPong*(d: DiscoveryProtocol, n: Node, token: MDigest[256]) =
+  let payload = rlp.encode((n.node.address, token, expiration()))
+  let msg = pack(cmdPong, payload, d.privKey)
+  trace ">>> pong ", n
+  d.send(n, msg)
+
+proc sendFindNode*(d: DiscoveryProtocol, n: Node, targetNodeId: NodeId) =
+  var data: array[64, byte]
+  data[32 .. ^1] = targetNodeId.toBytesBE()
+  let payload = rlp.encode((data, expiration()))
+  let msg = pack(cmdFindNode, payload, d.privKey)
+  trace ">>> find_node to ", n #, ": ", msg.toHex()
+  d.send(n, msg)
+
+proc sendNeighbours*(d: DiscoveryProtocol, node: Node, neighbours: seq[Node]) =
+  const MAX_NEIGHBOURS_PER_PACKET = 12 # TODO: Implement a smarter way to compute it
+  type Neighbour = tuple[ip: IpAddress, udpPort, tcpPort: Port, pk: PublicKey]
+  var nodes = newSeqOfCap[Neighbour](MAX_NEIGHBOURS_PER_PACKET)
+
+  template flush() =
+    block:
+      let payload = rlp.encode((nodes, expiration()))
+      let msg = pack(cmdNeighbours, payload, d.privKey)
+      trace "Neighbours to", node, nodes = $nodes
+      d.send(node, msg)
+      nodes.setLen(0)
+
+  for i, n in neighbours:
+    nodes.add(
+      (n.node.address.ip, n.node.address.udpPort, n.node.address.tcpPort, n.node.pubkey)
+    )
+    if nodes.len == MAX_NEIGHBOURS_PER_PACKET:
+      flush()
+
+  if nodes.len != 0:
+    flush()
+
+proc newDiscoveryProtocol*(
+    privKey: PrivateKey,
+    address: Address,
+    bootstrapNodes: openArray[ENode],
+    bindPort: Port,
+    bindIp = IPv6_any(),
+    rng = newRng(),
+): DiscoveryProtocol =
+  let
+    localNode = newNode(privKey.toPublicKey(), address)
+    discovery = DiscoveryProtocol(
+      privKey: privKey,
+      address: address,
+      localNode: localNode,
+      bindIp: bindIp,
+      bindPort: bindPort,
+    )
+    kademlia = newKademliaProtocol(localNode, discovery, rng = rng)
+
+  discovery.kademlia = kademlia
+
+  for n in bootstrapNodes:
+    discovery.bootstrapNodes.add(newNode(n))
+
+  discovery
+
+proc recvPing(
+    d: DiscoveryProtocol, node: Node, msgHash: MDigest[256]
+) {.raises: [ValueError].} =
+  d.kademlia.recvPing(node, msgHash)
+
+proc recvPong(
+    d: DiscoveryProtocol, node: Node, payload: seq[byte]
+) {.raises: [RlpError].} =
+  let rlp = rlpFromBytes(payload)
+  let tok = rlp.listElem(1).toBytes()
+  d.kademlia.recvPong(node, tok)
+
+proc recvNeighbours(
+    d: DiscoveryProtocol, node: Node, payload: seq[byte]
+) {.raises: [RlpError].} =
+  let rlp = rlpFromBytes(payload)
+  let neighboursList = rlp.listElem(0)
+  let sz = neighboursList.listLen()
+
+  var neighbours = newSeqOfCap[Node](16)
+  for i in 0 ..< sz:
+    let n = neighboursList.listElem(i)
+    if n.listLen() != 4:
+      raise newException(RlpError, "Invalid nodes list")
+
+    let ipBlob = n.listElem(0).toBytes
+    var ip: IpAddress
+    case ipBlob.len
+    of 4:
+      ip = IpAddress(family: IpAddressFamily.IPv4, address_v4: toArray(4, ipBlob))
+    of 16:
+      ip = IpAddress(family: IpAddressFamily.IPv6, address_v6: toArray(16, ipBlob))
+    else:
+      raise newException(RlpError, "Invalid RLP byte string length for IP address")
+
+    let udpPort = n.listElem(1).toInt(uint16).Port
+    let tcpPort = n.listElem(2).toInt(uint16).Port
+    let pk = PublicKey.fromRaw(n.listElem(3).toBytes).valueOr:
+      raise newException(RlpError, "Invalid RLP byte string for node id")
+
+    neighbours.add(newNode(pk, Address(ip: ip, udpPort: udpPort, tcpPort: tcpPort)))
+  d.kademlia.recvNeighbours(node, neighbours)
+
+proc recvFindNode(
+    d: DiscoveryProtocol, node: Node, payload: openArray[byte]
+) {.raises: [RlpError, ValueError].} =
+  let rlp = rlpFromBytes(payload)
+  trace "<<< find_node from ", node
+  let rng = rlp.listElem(0).toBytes
+  # Check for pubkey len
+  if rng.len == 64:
+    let nodeId = UInt256.fromBytesBE(rng.toOpenArray(32, 63))
+    d.kademlia.recvFindNode(node, nodeId)
+  else:
+    trace "Invalid target public key received"
+
+proc expirationValid(
+    cmdId: CommandId, rlpEncodedPayload: openArray[byte]
+): bool {.raises: [DiscProtocolError, RlpError].} =
+  ## Can only raise `DiscProtocolError` and all of `RlpError`
+  # Check if there is a payload
+  if rlpEncodedPayload.len <= 0:
+    raise newException(DiscProtocolError, "RLP stream is empty")
+  let rlp = rlpFromBytes(rlpEncodedPayload)
+  # Check payload is an RLP list and if the list has the minimum items required
+  # for this packet type
+  if rlp.isList and rlp.listLen >= MinListLen[cmdId]:
+    # Expiration is always the last mandatory item of the list
+    let expiration = rlp.listElem(MinListLen[cmdId] - 1).toInt(uint32)
+    result = epochTime() <= expiration.float
+  else:
+    raise newException(DiscProtocolError, "Invalid RLP list for this packet id")
+
+proc receive*(
+    d: DiscoveryProtocol, a: Address, msg: openArray[byte]
+) {.raises: [DiscProtocolError, RlpError, ValueError].} =
+  # Note: export only needed for testing
+  let msgHash = validateMsgHash(msg)
+  if msgHash.isOk():
+    let remotePubkey = recoverMsgPublicKey(msg)
+    if remotePubkey.isOk:
+      let (cmdId, payload) = unpack(msg)
+
+      if expirationValid(cmdId, payload):
+        let node = newNode(remotePubkey[], a)
+        case cmdId
+        of cmdPing:
+          d.recvPing(node, msgHash[])
+        of cmdPong:
+          d.recvPong(node, payload)
+        of cmdNeighbours:
+          d.recvNeighbours(node, payload)
+        of cmdFindNode:
+          d.recvFindNode(node, payload)
+        of cmdENRRequest, cmdENRResponse:
+          # TODO: Implement EIP-868
+          discard
+      else:
+        trace "Received msg already expired", cmdId, a
+    else:
+      notice "Wrong public key from ", a, err = remotePubkey.error
+  else:
+    notice "Wrong msg mac from ", a
+
+proc processClient(
+    transp: DatagramTransport, raddr: TransportAddress
+): Future[void] {.async: (raises: []).} =
+  var proto = getUserData[DiscoveryProtocol](transp)
+  let buf =
+    try:
+      transp.getMessage()
+    except TransportOsError as e:
+      # This is likely to be local network connection issues.
+      warn "Transport getMessage", exception = e.name, msg = e.msg
+      return
+    except TransportError as exc:
+      debug "getMessage error", msg = exc.msg
+      return
+  try:
+    let a = Address(ip: raddr.address, udpPort: raddr.port, tcpPort: raddr.port)
+    proto.receive(a, buf)
+  except RlpError as e:
+    debug "Receive failed", exc = e.name, err = e.msg
+  except DiscProtocolError as e:
+    debug "Receive failed", exc = e.name, err = e.msg
+  except ValueError as e:
+    debug "Receive failed", exc = e.name, err = e.msg
+
+proc open*(d: DiscoveryProtocol) {.raises: [CatchableError].} =
+  # TODO: allow binding to both IPv4 and IPv6
+  let ta = initTAddress(d.bindIp, d.bindPort)
+  d.transp = newDatagramTransport(processClient, udata = d, local = ta)
+
+proc lookupRandom*(d: DiscoveryProtocol): Future[seq[Node]] =
+  d.kademlia.lookupRandom()
+
+proc run(d: DiscoveryProtocol) {.async.} =
+  while true:
+    discard await d.lookupRandom()
+    await sleepAsync(chronos.seconds(3))
+    trace "Discovered nodes", nodes = d.kademlia.nodesDiscovered
+
+proc bootstrap*(d: DiscoveryProtocol) {.async.} =
+  await d.kademlia.bootstrap(d.bootstrapNodes)
+  discard d.run()
+
+proc resolve*(d: DiscoveryProtocol, n: NodeId): Future[Node] =
+  d.kademlia.resolve(n)
+
+proc randomNodes*(d: DiscoveryProtocol, count: int): seq[Node] =
+  d.kademlia.randomNodes(count)
+
+when isMainModule:
+  import stew/byteutils, ./bootnodes
+
+  block:
+    let m =
+      hexToSeqByte"79664bff52ee17327b4a2d8f97d8fb32c9244d719e5038eb4f6b64da19ca6d271d659c3ad9ad7861a928ca85f8d8debfbe6b7ade26ad778f2ae2ba712567fcbd55bc09eb3e74a893d6b180370b266f6aaf3fe58a0ad95f7435bf3ddf1db940d20102f2cb842edbd4d182944382765da0ab56fb9e64a85a597e6bb27c656b4f1afb7e06b0fd4e41ccde6dba69a3c4a150845aaa4de2"
+    discard validateMsgHash(m).expect("valid hash")
+    var remotePubkey = recoverMsgPublicKey(m).expect("valid key")
+
+    let (cmdId, payload) = unpack(m)
+    doAssert(
+      payload ==
+        hexToSeqByte"f2cb842edbd4d182944382765da0ab56fb9e64a85a597e6bb27c656b4f1afb7e06b0fd4e41ccde6dba69a3c4a150845aaa4de2"
+    )
+    doAssert(cmdId == cmdPong)
+    doAssert(
+      remotePubkey ==
+        PublicKey.fromHex(
+          "78de8a0916848093c73790ead81d1928bec737d565119932b98c6b100d944b7a95e94f847f689fc723399d2e31129d182f7ef3863f2b4c820abbf3ab2722344d"
+        )[]
+    )
+
+  let privKey = PrivateKey.fromHex(
+    "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a617"
+  )[]
+
+  # echo privKey
+
+  # block:
+  #   var b = @[1.byte, 2, 3]
+  #   let m = pack(cmdPing, b.initBytesRange, privKey)
+  #   let (remotePubkey, cmdId, payload) = unpack(m)
+  #   doAssert(remotePubkey.raw_key.toHex == privKey.public_key.raw_key.toHex)
+
+  var nodes = newSeq[ENode]()
+  for item in MainnetBootnodes:
+    nodes.add(ENode.fromString(item)[])
+
+  let listenPort = Port(30310)
+  var address = Address(udpPort: listenPort, tcpPort: listenPort)
+  address.ip.family = IpAddressFamily.IPv4
+  let discovery = newDiscoveryProtocol(privKey, address, nodes, bindPort = listenPort)
+
+  echo discovery.localNode.node.pubkey
+  echo "this_node.id: ", discovery.localNode.id.toHex()
+
+  discovery.open()
+
+  proc test() {.async.} =
+    {.gcsafe.}:
+      await discovery.bootstrap()
+      for node in discovery.randomNodes(discovery.kademlia.nodesDiscovered):
+        echo node
+  waitFor test()

--- a/execution_chain/networking/discoveryv4/enode.nim
+++ b/execution_chain/networking/discoveryv4/enode.nim
@@ -1,0 +1,138 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [].}
+
+import
+  std/[uri, strutils, net],
+  pkg/chronicles,
+  eth/common/keys
+
+export keys
+
+type
+  ENodeError* = enum
+    ## ENode status codes
+    IncorrectNodeId   = "enode: incorrect public key"
+    IncorrectScheme   = "enode: incorrect URI scheme"
+    IncorrectIP       = "enode: incorrect IP address"
+    IncorrectPort     = "enode: incorrect TCP port"
+    IncorrectDiscPort = "enode: incorrect UDP discovery port"
+    IncorrectUri      = "enode: incorrect URI"
+    IncompleteENode   = "enode: incomplete ENODE object"
+
+  Address* = object
+    ## Network address object
+    ip*: IpAddress        ## IPv4/IPv6 address
+    udpPort*: Port        ## UDP discovery port number
+    tcpPort*: Port        ## TCP port number
+
+  ENode* = object
+    ## ENode object
+    pubkey*: PublicKey    ## Node public key
+    address*: Address     ## Node address
+
+  ENodeResult*[T] = Result[T, ENodeError]
+
+proc mapErrTo[T, E](r: Result[T, E], v: static ENodeError): ENodeResult[T] =
+  r.mapErr(proc (e: E): ENodeError = v)
+
+proc fromString*(T: type ENode, e: string): ENodeResult[ENode] =
+  ## Initialize ENode ``node`` from URI string ``uri``.
+  var
+    uport: int = 0
+    tport: int = 0
+    uri: Uri = initUri()
+
+  if len(e) == 0:
+    return err(IncorrectUri)
+
+  parseUri(e, uri)
+
+  if len(uri.scheme) == 0 or uri.scheme.toLowerAscii() != "enode":
+    return err(IncorrectScheme)
+
+  if len(uri.username) != 128:
+    return err(IncorrectNodeId)
+
+  for i in uri.username:
+    if i notin {'A'..'F', 'a'..'f', '0'..'9'}:
+      return err(IncorrectNodeId)
+
+  if len(uri.password) != 0 or len(uri.path) != 0 or len(uri.anchor) != 0:
+    return err(IncorrectUri)
+
+  if len(uri.hostname) == 0:
+    return err(IncorrectIP)
+
+  try:
+    if len(uri.port) == 0:
+      return err(IncorrectPort)
+    tport = parseInt(uri.port)
+    if tport <= 0 or tport > 65535:
+      return err(IncorrectPort)
+  except ValueError:
+    return err(IncorrectPort)
+
+  if len(uri.query) > 0:
+    if not uri.query.toLowerAscii().startsWith("discport="):
+      return err(IncorrectDiscPort)
+    try:
+      uport = parseInt(uri.query[9..^1])
+      if uport <= 0 or uport > 65535:
+        return err(IncorrectDiscPort)
+    except ValueError:
+      return err(IncorrectDiscPort)
+  else:
+    uport = tport
+
+  var ip: IpAddress
+  try:
+    ip = parseIpAddress(uri.hostname)
+  except ValueError:
+    return err(IncorrectIP)
+
+  let pubkey = ? PublicKey.fromHex(uri.username).mapErrTo(IncorrectNodeId)
+
+  ok(ENode(
+    pubkey: pubkey,
+    address: Address(
+      ip: ip,
+      tcpPort: Port(tport),
+      udpPort: Port(uport)
+    )
+  ))
+
+proc `$`*(n: ENode): string =
+  ## Returns string representation of ENode.
+  var ipaddr: string
+  if n.address.ip.family == IpAddressFamily.IPv4:
+    ipaddr = $(n.address.ip)
+  else:
+    ipaddr = "[" & $(n.address.ip) & "]"
+  result = newString(0)
+  result.add("enode://")
+  result.add($n.pubkey)
+  result.add("@")
+  result.add(ipaddr)
+  if uint16(n.address.tcpPort) != 0:
+    result.add(":")
+    result.add($int(n.address.tcpPort))
+  if uint16(n.address.udpPort) != uint16(n.address.tcpPort):
+    result.add("?")
+    result.add("discport=")
+    result.add($int(n.address.udpPort))
+
+proc `$`*(a: Address): string =
+  result.add($a.ip)
+  result.add(":" & $a.udpPort)
+  result.add(":" & $a.tcpPort)
+
+chronicles.formatIt(Address): $it
+chronicles.formatIt(ENode): $it

--- a/execution_chain/networking/discoveryv4/kademlia.nim
+++ b/execution_chain/networking/discoveryv4/kademlia.nim
@@ -1,0 +1,706 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+{.push raises: [].}
+
+import
+  std/[tables, hashes, times, algorithm, sets, sequtils],
+  chronos, chronicles, stint, nimcrypto/keccak, metrics,
+  eth/common/keys, eth/p2p/discoveryv5/random2,
+  ./enode
+
+export sets # TODO: This should not be needed, but compilation fails otherwise
+
+declareGauge discv4_routing_table_nodes,
+  "Discovery v4 routing table nodes"
+
+logScope:
+  topics = "eth p2p kademlia"
+
+type
+  # 32 bytes NodeId | 16 bytes ip | 1 byte mode
+  TimeKey = array[49, byte]
+
+  KademliaProtocol* [Wire] = ref object
+    wire: Wire
+    thisNode: Node
+    routing: RoutingTable
+    pongFutures: Table[seq[byte], Future[bool]]
+    pingFutures: Table[Node, Future[bool]]
+    neighboursCallbacks: Table[Node, proc(n: seq[Node]) {.gcsafe, raises: [].}]
+    rng: ref HmacDrbgContext
+    pingPongTime: OrderedTable[TimeKey, int64] # int64 -> unix time
+
+  NodeId* = UInt256
+
+  Node* = ref object
+    node*: ENode
+    id*: NodeId
+
+  RoutingTable = object
+    thisNode: Node
+    buckets: seq[KBucket]
+
+  KBucket = ref object
+    istart, iend: UInt256
+    nodes: seq[Node]
+    replacementCache: seq[Node]
+
+  CommandId* = enum
+    cmdPing = 1
+    cmdPong = 2
+    cmdFindNode = 3
+    cmdNeighbours = 4
+    cmdENRRequest = 5
+    cmdENRResponse = 6
+
+const
+  BUCKET_SIZE = 16
+  BITS_PER_HOP = 8
+  REQUEST_TIMEOUT = chronos.milliseconds(5000) # timeout of message round trips
+  FIND_CONCURRENCY = 3                  # parallel find node lookups
+  ID_SIZE = 256
+  BOND_EXPIRATION = initDuration(hours = 12)
+
+proc len(r: RoutingTable): int
+
+proc toNodeId*(pk: PublicKey): NodeId =
+  readUintBE[256](keccak256.digest(pk.toRaw()).data)
+
+proc newNode*(pk: PublicKey, address: Address): Node =
+  result.new()
+  result.node = ENode(pubkey: pk, address: address)
+  result.id = pk.toNodeId()
+
+proc newNode*(uriString: string): Node =
+  result.new()
+  result.node = ENode.fromString(uriString)[]
+  result.id = result.node.pubkey.toNodeId()
+
+proc newNode*(enode: ENode): Node =
+  result.new()
+  result.node = enode
+  result.id = result.node.pubkey.toNodeId()
+
+proc distanceTo(n: Node, id: NodeId): UInt256 = n.id xor id
+
+proc `$`*(n: Node): string =
+  if n == nil:
+    "Node[local]"
+  else:
+    "Node[" & $n.node.address.ip & ":" & $n.node.address.udpPort & "]"
+
+chronicles.formatIt(Node): $it
+chronicles.formatIt(seq[Node]): $it
+
+proc hash*(n: Node): hashes.Hash = hash(n.node.pubkey.toRaw)
+proc `==`*(a, b: Node): bool = (a.isNil and b.isNil) or
+  (not a.isNil and not b.isNil and a.node.pubkey == b.node.pubkey)
+
+proc timeKey(id: NodeId, ip: IpAddress, cmd: CommandId): TimeKey =
+  result[0..31] = id.toBytesBE()[0..31]
+  case ip.family
+  of IpAddressFamily.IPv6:
+    result[32..47] = ip.address_v6[0..15]
+  of IpAddressFamily.IPv4:
+    result[32..35] = ip.address_v4[0..3]
+  result[48] = cmd.byte
+
+proc ip(n: Node): IpAddress =
+  n.node.address.ip
+
+proc timeKeyPong(n: Node): TimeKey =
+  timeKey(n.id, n.ip, cmdPong)
+
+proc timeKeyPing(n: Node): TimeKey =
+  timeKey(n.id, n.ip, cmdPing)
+
+when false:
+  proc lastPingReceived(k: KademliaProtocol, n: Node): Time =
+    k.pingPongTime.getOrDefault(n.timeKeyPing, 0'i64).fromUnix
+
+proc lastPongReceived(k: KademliaProtocol, n: Node): Time =
+  k.pingPongTime.getOrDefault(n.timeKeyPong, 0'i64).fromUnix
+
+proc cmp(x, y: (TimeKey, int64)): int =
+  if x[1] < y[1]: return -1
+  if x[1] > y[1]: return 1
+  0
+
+proc removeTooOldPingPongTime(k: KademliaProtocol) =
+  const
+    MinEntries = 128
+    MaxRC = MinEntries div 8
+
+  # instead of using fixed limit, we use dynamic limit
+  # with minimum entries = 128.
+  # remove 25% of too old entries if we need more space.
+  # the reason maxEntries is twice routing table because we
+  # store ping and pong time.
+  let
+    maxEntries = max(k.routing.len * 2, MinEntries)
+    maxRemove = maxEntries div 4
+
+  if k.pingPongTime.len < maxEntries:
+    return
+
+  # it is safe to remove this table sort?
+  # because we already using ordered table to store time from
+  # older value to newer value
+  when false:
+    k.pingPongTime.sort(cmp, order = SortOrder.Descending)
+
+  var
+    rci = 0
+    numRemoved = 0
+    rc: array[MaxRC, TimeKey] # 784 bytes(MinEntries/8*sizeof(TimeKey))
+
+  # using fixed size temp on stack possibly
+  # requires multiple iteration to remove
+  # old entries
+  while numRemoved < maxRemove:
+    for v in keys(k.pingPongTime):
+      rc[rci] = v
+      inc rci
+      inc numRemoved
+      if rci >= MaxRC or numRemoved >= maxRemove: break
+
+    for i in 0..<rci:
+      k.pingPongTime.del(rc[i])
+
+    rci = 0
+
+proc updateLastPingReceived(k: KademliaProtocol, n: Node, t: Time) =
+  k.removeTooOldPingPongTime()
+  k.pingPongTime[n.timeKeyPing] = t.toUnix
+
+proc updateLastPongReceived(k: KademliaProtocol, n: Node, t: Time) =
+  k.removeTooOldPingPongTime()
+  k.pingPongTime[n.timeKeyPong] = t.toUnix
+
+when false:
+  # checkBond checks if the given node has a recent enough endpoint proof.
+  proc checkBond(k: KademliaProtocol, n: Node): bool =
+    getTime() - k.lastPongReceived(n) < BOND_EXPIRATION
+
+proc newKBucket(istart, iend: NodeId): KBucket =
+  result.new()
+  result.istart = istart
+  result.iend = iend
+  result.nodes = @[]
+  result.replacementCache = @[]
+
+proc midpoint(k: KBucket): NodeId =
+  k.istart + (k.iend - k.istart) div 2.u256
+
+proc distanceTo(k: KBucket, id: NodeId): UInt256 = k.midpoint xor id
+proc nodesByDistanceTo(k: KBucket, id: NodeId): seq[Node] =
+  sortedByIt(k.nodes, it.distanceTo(id))
+
+proc len(k: KBucket): int = k.nodes.len
+proc head(k: KBucket): Node = k.nodes[0]
+
+proc add(k: KBucket, n: Node): Node =
+  ## Try to add the given node to this bucket.
+
+  ## If the node is already present, it is moved to the tail of the list, and we return None.
+
+  ## If the node is not already present and the bucket has fewer than k entries, it is inserted
+  ## at the tail of the list, and we return None.
+
+  ## If the bucket is full, we add the node to the bucket's replacement cache and return the
+  ## node at the head of the list (i.e. the least recently seen), which should be evicted if it
+  ## fails to respond to a ping.
+  let nodeIdx = k.nodes.find(n)
+  if nodeIdx != -1:
+      k.nodes.delete(nodeIdx)
+      k.nodes.add(n)
+  elif k.len < BUCKET_SIZE:
+      k.nodes.add(n)
+      discv4_routing_table_nodes.inc()
+  else:
+      k.replacementCache.add(n)
+      return k.head
+  return nil
+
+proc removeNode(k: KBucket, n: Node) =
+  let i = k.nodes.find(n)
+  if i != -1:
+    discv4_routing_table_nodes.dec()
+    k.nodes.delete(i)
+
+proc split(k: KBucket): tuple[lower, upper: KBucket] =
+  ## Split at the median id
+  let splitid = k.midpoint
+  result.lower = newKBucket(k.istart, splitid)
+  result.upper = newKBucket(splitid + 1.u256, k.iend)
+  for node in k.nodes:
+    let bucket = if node.id <= splitid: result.lower else: result.upper
+    discard bucket.add(node)
+  for node in k.replacementCache:
+    let bucket = if node.id <= splitid: result.lower else: result.upper
+    bucket.replacementCache.add(node)
+
+proc inRange(k: KBucket, n: Node): bool =
+  k.istart <= n.id and n.id <= k.iend
+
+proc isFull(k: KBucket): bool = k.len == BUCKET_SIZE
+
+proc contains(k: KBucket, n: Node): bool = n in k.nodes
+
+proc binaryGetBucketForNode(buckets: openArray[KBucket], n: Node):
+    KBucket {.raises: [ValueError].} =
+  ## Given a list of ordered buckets, returns the bucket for a given node.
+  let bucketPos = lowerBound(buckets, n.id) do(a: KBucket, b: NodeId) -> int:
+    cmp(a.iend, b)
+  # Prevents edge cases where bisect_left returns an out of range index
+  if bucketPos < buckets.len:
+    let bucket = buckets[bucketPos]
+    if bucket.istart <= n.id and n.id <= bucket.iend:
+      result = bucket
+
+  if result.isNil:
+    raise newException(ValueError, "No bucket found for node with id " & stint.`$`(n.id))
+
+proc computeSharedPrefixBits(nodes: openArray[Node]): int =
+  ## Count the number of prefix bits shared by all nodes.
+  if nodes.len < 2:
+    return ID_SIZE
+
+  var mask = zero(UInt256)
+  let one = one(UInt256)
+
+  for i in 1 .. ID_SIZE:
+    mask = mask or (one shl (ID_SIZE - i))
+    let reference = nodes[0].id and mask
+    for j in 1 .. nodes.high:
+      if (nodes[j].id and mask) != reference: return i - 1
+
+  doAssert(false, "Unable to calculate number of shared prefix bits")
+
+proc init(r: var RoutingTable, thisNode: Node) =
+  r.thisNode = thisNode
+  r.buckets = @[newKBucket(0.u256, high(UInt256))]
+
+proc splitBucket(r: var RoutingTable, index: int) =
+  let bucket = r.buckets[index]
+  let (a, b) = bucket.split()
+  r.buckets[index] = a
+  r.buckets.insert(b, index + 1)
+
+proc bucketForNode(r: RoutingTable, n: Node): KBucket
+    {.raises: [ValueError].} =
+  binaryGetBucketForNode(r.buckets, n)
+
+proc removeNode(r: var RoutingTable, n: Node) {.raises: [ValueError].} =
+  r.bucketForNode(n).removeNode(n)
+
+proc addNode(r: var RoutingTable, n: Node): Node
+    {.raises: [ValueError].} =
+  if n == r.thisNode:
+    warn "Trying to add ourselves to the routing table", node = n
+    return
+  let bucket = r.bucketForNode(n)
+  let evictionCandidate = bucket.add(n)
+  if not evictionCandidate.isNil:
+    # Split if the bucket has the local node in its range or if the depth is not congruent
+    # to 0 mod BITS_PER_HOP
+
+    let depth = computeSharedPrefixBits(bucket.nodes)
+    if bucket.inRange(r.thisNode) or (depth mod BITS_PER_HOP != 0 and depth != ID_SIZE):
+      r.splitBucket(r.buckets.find(bucket))
+      return r.addNode(n) # retry
+
+    # Nothing added, ping evictionCandidate
+    return evictionCandidate
+
+proc contains(r: RoutingTable, n: Node): bool {.raises: [ValueError].} =
+  n in r.bucketForNode(n)
+
+proc bucketsByDistanceTo(r: RoutingTable, id: NodeId): seq[KBucket] =
+  sortedByIt(r.buckets, it.distanceTo(id))
+
+proc notFullBuckets(r: RoutingTable): seq[KBucket] =
+  r.buckets.filterIt(not it.isFull)
+
+proc neighbours(r: RoutingTable, id: NodeId, k: int = BUCKET_SIZE): seq[Node] =
+  ## Return up to k neighbours of the given node.
+  result = newSeqOfCap[Node](k * 2)
+  for bucket in r.bucketsByDistanceTo(id):
+    for n in bucket.nodesByDistanceTo(id):
+      if n.id != id:
+        result.add(n)
+        if result.len == k * 2:
+          break
+  result = sortedByIt(result, it.distanceTo(id))
+  if result.len > k:
+    result.setLen(k)
+
+proc len(r: RoutingTable): int =
+  for b in r.buckets: result += b.len
+
+proc newKademliaProtocol*[Wire](
+    thisNode: Node, wire: Wire, rng = newRng()): KademliaProtocol[Wire] =
+  if rng == nil: raiseAssert "Need an RNG" # doAssert gives compile error on mac
+
+  result.new()
+  result.thisNode = thisNode
+  result.wire = wire
+  result.routing.init(thisNode)
+  result.rng = rng
+
+proc bond(k: KademliaProtocol, n: Node): Future[bool] {.async.}
+proc bondDiscard(k: KademliaProtocol, n: Node) {.async.}
+
+proc updateRoutingTable(k: KademliaProtocol, n: Node)
+    {.raises: [ValueError], gcsafe.} =
+  ## Update the routing table entry for the given node.
+  let evictionCandidate = k.routing.addNode(n)
+  if not evictionCandidate.isNil:
+      # This means we couldn't add the node because its bucket is full, so schedule a bond()
+      # with the least recently seen node on that bucket. If the bonding fails the node will
+      # be removed from the bucket and a new one will be picked from the bucket's
+      # replacement cache.
+      asyncSpawn k.bondDiscard(evictionCandidate)
+
+proc doSleep(p: proc() {.gcsafe, raises: [].}) {.async.} =
+  await sleepAsync(REQUEST_TIMEOUT)
+  p()
+
+template onTimeout(b: untyped) =
+  asyncSpawn doSleep() do():
+    b
+
+proc pingId(n: Node, token: seq[byte]): seq[byte] =
+  result = token & @(n.node.pubkey.toRaw)
+
+proc waitPong(k: KademliaProtocol, n: Node, pingid: seq[byte]): Future[bool] =
+  doAssert(pingid notin k.pongFutures, "Already waiting for pong from " & $n)
+  result = newFuture[bool]("waitPong")
+  let fut = result
+  k.pongFutures[pingid] = result
+  onTimeout:
+    if not fut.finished:
+      k.pongFutures.del(pingid)
+      fut.complete(false)
+
+proc ping(k: KademliaProtocol, n: Node): seq[byte] =
+  doAssert(n != k.thisNode)
+  result = k.wire.sendPing(n)
+
+proc waitPing(k: KademliaProtocol, n: Node): Future[bool] =
+  result = newFuture[bool]("waitPing")
+  doAssert(n notin k.pingFutures)
+  k.pingFutures[n] = result
+  let fut = result
+  onTimeout:
+    if not fut.finished:
+      k.pingFutures.del(n)
+      fut.complete(false)
+
+proc waitNeighbours(k: KademliaProtocol, remote: Node): Future[seq[Node]] =
+  doAssert(remote notin k.neighboursCallbacks)
+  result = newFuture[seq[Node]]("waitNeighbours")
+  let fut = result
+  var neighbours = newSeqOfCap[Node](BUCKET_SIZE)
+  k.neighboursCallbacks[remote] = proc(n: seq[Node]) {.gcsafe, raises: [].} =
+    # This callback is expected to be called multiple times because nodes usually
+    # split the neighbours replies into multiple packets, so we only complete the
+    # future event.set() we've received enough neighbours.
+
+    for i in n:
+      if i != k.thisNode:
+        neighbours.add(i)
+        if neighbours.len == BUCKET_SIZE:
+          k.neighboursCallbacks.del(remote)
+          doAssert(not fut.finished)
+          fut.complete(neighbours)
+
+  onTimeout:
+    if not fut.finished:
+      k.neighboursCallbacks.del(remote)
+      fut.complete(neighbours)
+
+# Exported for test.
+proc findNode*(k: KademliaProtocol, nodesSeen: ref HashSet[Node],
+               nodeId: NodeId, remote: Node): Future[seq[Node]] {.async.} =
+  if remote in k.neighboursCallbacks:
+    # Sometimes findNode is called while another findNode is already in flight.
+    # It's a bug when this happens, and the logic should probably be fixed
+    # elsewhere.  However, this small fix has been tested and proven adequate.
+    debug "Ignoring peer already in k.neighboursCallbacks", peer = remote
+    result = newSeq[Node]()
+    return
+  k.wire.sendFindNode(remote, nodeId)
+  var candidates = await k.waitNeighbours(remote)
+  if candidates.len == 0:
+    trace "Got no candidates from peer, returning", peer = remote
+    result = candidates
+  else:
+    # The following line:
+    # 1. Add new candidates to nodesSeen so that we don't attempt to bond with failing ones
+    # in the future
+    # 2. Removes all previously seen nodes from candidates
+    # 3. Deduplicates candidates
+    candidates.keepItIf(not nodesSeen[].containsOrIncl(it))
+    trace "Got new candidates", count = candidates.len
+
+    var bondedNodes: seq[Future[bool]] = @[]
+    for node in candidates:
+      if node != k.thisNode:
+        bondedNodes.add(k.bond(node))
+
+    await allFutures(bondedNodes)
+
+    for i in 0..<bondedNodes.len:
+      let b = bondedNodes[i]
+      # `bond` will not raise so there should be no failures,
+      # and for cancellation this should be fine to raise for now.
+      doAssert(b.finished() and not(b.failed()))
+      let bonded = b.read()
+      if not bonded: candidates[i] = nil
+
+    candidates.keepItIf(not it.isNil)
+    trace "Bonded with candidates", count = candidates.len
+    result = candidates
+
+proc populateNotFullBuckets(k: KademliaProtocol) =
+  ## Go through all buckets that are not full and try to fill them.
+  ##
+  ## For every node in the replacement cache of every non-full bucket, try to bond.
+  ## When the bonding succeeds the node is automatically added to the bucket.
+  for bucket in k.routing.notFullBuckets:
+    for node in bucket.replacementCache:
+      asyncSpawn k.bondDiscard(node)
+
+proc bond(k: KademliaProtocol, n: Node): Future[bool] {.async.} =
+  ## Bond with the given node.
+  ##
+  ## Bonding consists of pinging the node, waiting for a pong and maybe a ping as well.
+  ## It is necessary to do this at least once before we send findNode requests to a node.
+  trace "Bonding to peer", n
+  if n in k.routing:
+    return true
+
+  let pid = pingId(n, k.ping(n))
+  if pid in k.pongFutures:
+    debug "Bonding failed, already waiting for pong", n
+    return false
+
+  let gotPong = await k.waitPong(n, pid)
+  if not gotPong:
+    trace "Bonding failed, didn't receive pong from", n
+    # Drop the failing node and schedule a populateNotFullBuckets() call to try and
+    # fill its spot.
+    k.routing.removeNode(n)
+    k.populateNotFullBuckets()
+    return false
+
+  # Give the remote node a chance to ping us before we move on and start sending findNode
+  # requests. It is ok for waitPing() to timeout and return false here as that just means
+  # the remote remembers us.
+  if n in k.pingFutures:
+    debug "Bonding failed, already waiting for ping", n
+    return false
+
+  discard await k.waitPing(n)
+
+  trace "Bonding completed successfully", n
+  k.updateRoutingTable(n)
+  return true
+
+proc bondDiscard(k: KademliaProtocol, n: Node) {.async.} =
+  discard (await k.bond(n))
+
+proc sortByDistance(nodes: var seq[Node], nodeId: NodeId, maxResults = 0) =
+  nodes = nodes.sortedByIt(it.distanceTo(nodeId))
+  if maxResults != 0 and nodes.len > maxResults:
+    nodes.setLen(maxResults)
+
+proc lookup*(k: KademliaProtocol, nodeId: NodeId): Future[seq[Node]] {.async.} =
+  ## Lookup performs a network search for nodes close to the given target.
+
+  ## It approaches the target by querying nodes that are closer to it on each iteration.  The
+  ## given target does not need to be an actual node identifier.
+  var nodesAsked = initHashSet[Node]()
+  let nodesSeen = new(HashSet[Node])
+
+  proc excludeIfAsked(nodes: seq[Node]): seq[Node] =
+    result = toSeq(items(nodes.toHashSet() - nodesAsked))
+    sortByDistance(result, nodeId, FIND_CONCURRENCY)
+
+  var closest = k.routing.neighbours(nodeId)
+  trace "Starting lookup; initial neighbours: ", closest
+  var nodesToAsk = excludeIfAsked(closest)
+  while nodesToAsk.len != 0:
+    trace "Node lookup; querying ", nodesToAsk
+    nodesAsked.incl(nodesToAsk.toHashSet())
+
+    var findNodeRequests: seq[Future[seq[Node]]] = @[]
+    for node in nodesToAsk:
+      findNodeRequests.add(k.findNode(nodesSeen, nodeId, node))
+
+    await allFutures(findNodeRequests)
+
+    for candidates in findNodeRequests:
+      # `findNode` will not raise so there should be no failures,
+      # and for cancellation this should be fine to raise for now.
+      doAssert(candidates.finished() and not(candidates.failed()))
+      closest.add(candidates.read())
+
+    sortByDistance(closest, nodeId, BUCKET_SIZE)
+    nodesToAsk = excludeIfAsked(closest)
+
+  trace "Kademlia lookup finished", target = nodeId.toHex, closest
+  result = closest
+
+proc lookupRandom*(k: KademliaProtocol): Future[seq[Node]] =
+  k.lookup(k.rng[].generate(NodeId))
+
+proc resolve*(k: KademliaProtocol, id: NodeId): Future[Node] {.async.} =
+  let closest = await k.lookup(id)
+  for n in closest:
+    if n.id == id: return n
+
+proc bootstrap*(k: KademliaProtocol, bootstrapNodes: seq[Node], retries = 0) {.async.} =
+  ## Bond with bootstrap nodes and do initial lookup. Retry `retries` times
+  ## in case of failure, or indefinitely if `retries` is 0.
+  var retryInterval = chronos.milliseconds(2)
+  var numTries = 0
+  if bootstrapNodes.len != 0:
+    while true:
+      var bondedNodes: seq[Future[bool]] = @[]
+      for node in bootstrapNodes:
+        bondedNodes.add(k.bond(node))
+      await allFutures(bondedNodes)
+
+      # `bond` will not raise so there should be no failures,
+      # and for cancellation this should be fine to raise for now.
+      let bonded = bondedNodes.mapIt(it.read())
+
+      if true notin bonded:
+        inc numTries
+        if retries == 0 or numTries < retries:
+          info "Failed to bond with bootstrap nodes, retrying"
+          retryInterval = min(chronos.seconds(10), retryInterval * 2)
+          await sleepAsync(retryInterval)
+        else:
+          info "Failed to bond with bootstrap nodes"
+          return
+      else:
+        break
+    discard await k.lookupRandom() # Prepopulate the routing table
+  else:
+    info "Skipping discovery bootstrap, no bootnodes provided"
+
+proc recvPong*(k: KademliaProtocol, n: Node, token: seq[byte]) =
+  trace "<<< pong from ", n
+  let pingid = token & @(n.node.pubkey.toRaw)
+  var future: Future[bool]
+  if k.pongFutures.take(pingid, future):
+    future.complete(true)
+  k.updateLastPongReceived(n, getTime())
+
+proc recvPing*(k: KademliaProtocol, n: Node, msgHash: auto)
+    {.raises: [ValueError].} =
+  trace "<<< ping from ", n
+  k.wire.sendPong(n, msgHash)
+
+  if getTime() - k.lastPongReceived(n) > BOND_EXPIRATION:
+    # TODO: It is strange that this would occur, as it means our own node would
+    # have pinged us which should have caused an assert in the first place.
+    if n != k.thisNode:
+      let pingId = pingId(n, k.ping(n))
+
+      let fut = if pingId in k.pongFutures:
+                  k.pongFutures[pingId]
+                else:
+                  k.waitPong(n, pingId)
+
+      let cb = proc(data: pointer) {.gcsafe.} =
+                # fut.read == true if pingid exists
+                try:
+                  if fut.completed and fut.read:
+                    k.updateRoutingTable(n)
+                except CatchableError as ex:
+                  error "recvPing:WaitPong exception", msg=ex.msg
+
+      fut.addCallback cb
+  else:
+    k.updateRoutingTable(n)
+
+  var future: Future[bool]
+  if k.pingFutures.take(n, future):
+    future.complete(true)
+  k.updateLastPingReceived(n, getTime())
+
+proc recvNeighbours*(k: KademliaProtocol, remote: Node, neighbours: seq[Node]) =
+  ## Process a neighbours response.
+  ##
+  ## Neighbours responses should only be received as a reply to a find_node, and that is only
+  ## done as part of node lookup, so the actual processing is left to the callback from
+  ## neighbours_callbacks, which is added (and removed after it's done or timed out) in
+  ## wait_neighbours().
+  trace "Received neighbours", remote, neighbours
+  let cb = k.neighboursCallbacks.getOrDefault(remote)
+  if not cb.isNil:
+    cb(neighbours)
+  else:
+    trace "Unexpected neighbours, probably came too late", remote
+
+proc recvFindNode*(k: KademliaProtocol, remote: Node, nodeId: NodeId)
+    {.raises: [ValueError].} =
+  if remote notin k.routing:
+    # FIXME: This is not correct; a node we've bonded before may have become unavailable
+    # and thus removed from self.routing, but once it's back online we should accept
+    # find_nodes from them.
+    trace "Ignoring find_node request from unknown node ", remote
+    return
+  k.updateRoutingTable(remote)
+  var found = k.routing.neighbours(nodeId)
+  found.sort() do(x, y: Node) -> int: cmp(x.id, y.id)
+  k.wire.sendNeighbours(remote, found)
+
+proc randomNodes*(k: KademliaProtocol, count: int): seq[Node] =
+  var count = count
+  let sz = k.routing.len
+  if count > sz:
+    debug  "Looking for peers", requested = count, present = sz
+    count = sz
+
+  result = newSeqOfCap[Node](count)
+  var seen = initHashSet[Node]()
+
+  # This is a rather inefficient way of randomizing nodes from all buckets, but even if we
+  # iterate over all nodes in the routing table, the time it takes would still be
+  # insignificant compared to the time it takes for the network roundtrips when connecting
+  # to nodes.
+  while len(seen) < count:
+    let bucket = k.rng[].sample(k.routing.buckets)
+    if bucket.nodes.len != 0:
+      let node = k.rng[].sample(bucket.nodes)
+      if node notin seen:
+        result.add(node)
+        seen.incl(node)
+
+proc nodesDiscovered*(k: KademliaProtocol): int = k.routing.len
+
+when isMainModule:
+  proc randomNode(): Node =
+    newNode("enode://aa36fdf33dd030378a0168efe6ed7d5cc587fafa3cdd375854fe735a2e11ea3650ba29644e2db48368c46e1f60e716300ba49396cd63778bf8a818c09bded46f@13.93.211.84:30303")
+
+  var nodes = @[randomNode()]
+  doAssert(computeSharedPrefixBits(nodes) == ID_SIZE)
+  nodes.add(randomNode())
+  nodes[0].id = 0b1.u256
+  nodes[1].id = 0b0.u256
+  doAssert(computeSharedPrefixBits(nodes) == ID_SIZE - 1)
+
+  nodes[0].id = 0b010.u256
+  nodes[1].id = 0b110.u256
+  doAssert(computeSharedPrefixBits(nodes) == ID_SIZE - 3)

--- a/execution_chain/networking/p2p.nim
+++ b/execution_chain/networking/p2p.nim
@@ -1,0 +1,242 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms
+
+{.push raises: [].}
+
+import
+  std/[tables, algorithm, random, typetraits, strutils, net],
+  chronos, chronos/timer, chronicles,
+  eth/common/keys,
+  ./[discoveryv4, peer_pool, rlpx, p2p_types]
+
+export
+  p2p_types, rlpx, enode, kademlia
+
+logScope:
+  topics = "eth p2p"
+
+
+proc addCapability*(node: EthereumNode,
+                    p: ProtocolInfo,
+                    networkState: RootRef = nil) =
+  doAssert node.connectionState == ConnectionState.None
+
+  let pos = lowerBound(node.protocols, p, rlpx.cmp)
+  node.protocols.insert(p, pos)
+  node.capabilities.insert(p.capability, pos)
+
+  if p.networkStateInitializer != nil and networkState.isNil:
+    node.protocolStates[p.index] = p.networkStateInitializer(node)
+
+  if networkState.isNil.not:
+    node.protocolStates[p.index] = networkState
+
+template addCapability*(node: EthereumNode, Protocol: type) =
+  addCapability(node, Protocol.protocolInfo)
+
+template addCapability*(node: EthereumNode,
+                        Protocol: type,
+                        networkState: untyped) =
+  mixin NetworkState
+  type
+    ParamType = type(networkState)
+
+  when ParamType isnot Protocol.NetworkState:
+    const errMsg = "`$1` is not compatible with `$2`" % [
+      name(ParamType), name(Protocol.NetworkState)]
+    {. error: errMsg .}
+
+  addCapability(node, Protocol.protocolInfo,
+    cast[RootRef](networkState))
+
+proc replaceNetworkState*(node: EthereumNode,
+                          p: ProtocolInfo,
+                          networkState: RootRef) =
+  node.protocolStates[p.index] = networkState
+
+template replaceNetworkState*(node: EthereumNode,
+                              Protocol: type,
+                              networkState: untyped) =
+  mixin NetworkState
+  type
+    ParamType = type(networkState)
+
+  when ParamType isnot Protocol.NetworkState:
+    const errMsg = "`$1` is not compatible with `$2`" % [
+      name(ParamType), name(Protocol.NetworkState)]
+    {. error: errMsg .}
+
+  replaceNetworkState(node, Protocol.protocolInfo,
+    cast[RootRef](networkState))
+
+proc newEthereumNode*(
+    keys: KeyPair,
+    address: Address,
+    networkId: NetworkId,
+    clientId = "nim-eth-p2p",
+    addAllCapabilities = true,
+    minPeers = 10,
+    bootstrapNodes: seq[ENode] = @[],
+    bindUdpPort: Port,
+    bindTcpPort: Port,
+    bindIp = IPv6_any(),
+    rng = newRng()): EthereumNode =
+
+  if rng == nil: # newRng could fail
+    raise (ref Defect)(msg: "Cannot initialize RNG")
+
+  new result
+  result.keys = keys
+  result.networkId = networkId
+  result.clientId = clientId
+  result.protocols.newSeq 0
+  result.capabilities.newSeq 0
+  result.address = address
+  result.connectionState = ConnectionState.None
+  result.bindIp = bindIp
+  result.bindPort = bindTcpPort
+
+  result.discovery = newDiscoveryProtocol(
+    keys.seckey, address, bootstrapNodes, bindUdpPort, bindIp, rng)
+
+  result.rng = rng
+  result.protocolStates.newSeq protocolCount()
+
+  result.peerPool = newPeerPool(
+    result, networkId, keys, nil, clientId, minPeers = minPeers)
+
+  result.peerPool.discovery = result.discovery
+
+  if addAllCapabilities:
+    for cap in protocols():
+      result.addCapability(cap)
+
+proc processIncoming(server: StreamServer,
+                     remote: StreamTransport): Future[void] {.async: (raises: []).} =
+  try:
+    var node = getUserData[EthereumNode](server)
+    let peer = await node.rlpxAccept(remote)
+    if not peer.isNil:
+      trace "Connection established (incoming)", peer
+      if node.peerPool != nil:
+        node.peerPool.connectingNodes.excl(peer.remote)
+        node.peerPool.addPeer(peer)
+  except CatchableError as exc:
+    error "processIncoming", msg=exc.msg
+
+proc listeningAddress*(node: EthereumNode): ENode =
+  node.toENode()
+
+proc startListening*(node: EthereumNode) {.raises: [CatchableError].} =
+  # TODO: allow binding to both IPv4 & IPv6
+  let ta = initTAddress(node.bindIp, node.bindPort)
+  if node.listeningServer == nil:
+    node.listeningServer = createStreamServer(ta, processIncoming,
+                                              {ReuseAddr},
+                                              udata = cast[pointer](node))
+  node.listeningServer.start()
+  info "RLPx listener up", self = node.listeningAddress
+
+proc connectToNetwork*(
+    node: EthereumNode, startListening = true,
+    enableDiscovery = true, waitForPeers = true) {.async.} =
+  doAssert node.connectionState == ConnectionState.None
+
+  node.connectionState = Connecting
+
+  if startListening:
+    p2p.startListening(node)
+
+  if enableDiscovery:
+    node.discovery.open()
+    await node.discovery.bootstrap()
+    node.peerPool.start()
+  else:
+    info "Discovery disabled"
+
+  while node.peerPool.connectedNodes.len == 0 and waitForPeers:
+    trace "Waiting for more peers", peers = node.peerPool.connectedNodes.len
+    await sleepAsync(500.milliseconds)
+
+proc stopListening*(node: EthereumNode) {.raises: [CatchableError].} =
+  node.listeningServer.stop()
+
+iterator peers*(node: EthereumNode): Peer =
+  for peer in node.peerPool.peers:
+    yield peer
+
+iterator peers*(node: EthereumNode, Protocol: type): Peer =
+  for peer in node.peerPool.peers(Protocol):
+    yield peer
+
+iterator protocolPeers*(node: EthereumNode, Protocol: type): auto =
+  mixin state
+  for peer in node.peerPool.peers(Protocol):
+    yield peer.state(Protocol)
+
+iterator randomPeers*(node: EthereumNode, maxPeers: int): Peer =
+  # TODO: this can be implemented more efficiently
+
+  # XXX: this doesn't compile, why?
+  # var peer = toSeq node.peers
+  var peers = newSeqOfCap[Peer](node.peerPool.connectedNodes.len)
+  for peer in node.peers: peers.add(peer)
+
+  shuffle(peers)
+  for i in 0 ..< min(maxPeers, peers.len):
+    yield peers[i]
+
+proc randomPeer*(node: EthereumNode): Peer =
+  let peerIdx = rand(node.peerPool.connectedNodes.len)
+  var i = 0
+  for peer in node.peers:
+    if i == peerIdx: return peer
+    inc i
+
+iterator randomPeers*(node: EthereumNode, maxPeers: int, Protocol: type): Peer =
+  var peers = newSeqOfCap[Peer](node.peerPool.connectedNodes.len)
+  for peer in node.peers(Protocol):
+    peers.add(peer)
+  shuffle(peers)
+  if peers.len > maxPeers: peers.setLen(maxPeers)
+  for p in peers: yield p
+
+proc randomPeerWith*(node: EthereumNode, Protocol: type): Peer =
+  var candidates = newSeq[Peer]()
+  for p in node.peers(Protocol):
+    candidates.add(p)
+  if candidates.len > 0:
+    return candidates.rand()
+
+proc getPeer*(node: EthereumNode, peerId: NodeId, Protocol: type): Option[Peer] =
+  for peer in node.peers(Protocol):
+    if peer.remote.id == peerId:
+      return some(peer)
+
+proc connectToNode*(node: EthereumNode, n: Node) {.async.} =
+  await node.peerPool.connectToNode(n)
+
+proc connectToNode*(node: EthereumNode, n: ENode) {.async.} =
+  await node.peerPool.connectToNode(n)
+
+func numPeers*(node: EthereumNode): int =
+  node.peerPool.numPeers
+
+func hasPeer*(node: EthereumNode, n: ENode): bool =
+  n in node.peerPool
+
+func hasPeer*(node: EthereumNode, n: Node): bool =
+  n in node.peerPool
+
+func hasPeer*(node: EthereumNode, n: Peer): bool =
+  n in node.peerPool
+
+proc closeWait*(node: EthereumNode) {.async.} =
+  node.stopListening()
+  await node.listeningServer.closeWait()

--- a/execution_chain/networking/p2p_backends_helpers.nim
+++ b/execution_chain/networking/p2p_backends_helpers.nim
@@ -1,0 +1,79 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [].}
+
+let protocolManager = ProtocolManager()
+
+# The variables above are immutable RTTI information. We need to tell
+# Nim to not consider them GcSafe violations:
+proc registerProtocol*(proto: ProtocolInfo) {.gcsafe.} =
+  {.gcsafe.}:
+    proto.index = protocolManager.protocols.len
+    if proto.capability.name == "p2p":
+      doAssert(proto.index == 0)
+    protocolManager.protocols.add proto
+
+proc protocolCount*(): int {.gcsafe.} =
+  {.gcsafe.}:
+    protocolManager.protocols.len
+
+proc getProtocol*(index: int): ProtocolInfo {.gcsafe.} =
+  {.gcsafe.}:
+    protocolManager.protocols[index]
+
+iterator protocols*(): ProtocolInfo {.gcsafe.} =
+  {.gcsafe.}:
+    for x in protocolManager.protocols:
+      yield x
+
+template getProtocol*(Protocol: type): ProtocolInfo =
+  getProtocol(Protocol.index)
+
+template devp2pInfo*(): ProtocolInfo =
+  getProtocol(0)
+
+proc getState*(peer: Peer, proto: ProtocolInfo): RootRef =
+  peer.protocolStates[proto.index]
+
+template state*(peer: Peer, Protocol: type): untyped =
+  ## Returns the state object of a particular protocol for a
+  ## particular connection.
+  mixin State
+  bind getState
+  cast[Protocol.State](getState(peer, Protocol.protocolInfo))
+
+proc getNetworkState*(node: EthereumNode, proto: ProtocolInfo): RootRef =
+  node.protocolStates[proto.index]
+
+template protocolState*(node: EthereumNode, Protocol: type): untyped =
+  mixin NetworkState
+  bind getNetworkState
+  cast[Protocol.NetworkState](getNetworkState(node, Protocol.protocolInfo))
+
+template networkState*(connection: Peer, Protocol: type): untyped =
+  ## Returns the network state object of a particular protocol for a
+  ## particular connection.
+  protocolState(connection.network, Protocol)
+
+proc initProtocolState*[T](state: T, x: Peer|EthereumNode)
+    {.gcsafe, raises: [].} =
+  discard
+
+proc initProtocolStates(peer: Peer, protocols: openArray[ProtocolInfo])
+    {.raises: [].} =
+  # Initialize all the active protocol states
+  newSeq(peer.protocolStates, protocolCount())
+  for protocol in protocols:
+    let peerStateInit = protocol.peerStateInitializer
+    if peerStateInit != nil:
+      peer.protocolStates[protocol.index] = peerStateInit(peer)
+
+{.pop.}
+

--- a/execution_chain/networking/p2p_protocol_dsl.nim
+++ b/execution_chain/networking/p2p_protocol_dsl.nim
@@ -1,0 +1,997 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+## This module defines a DSL for constructing communication message packet
+## drivers to support the ones as defined with the Ethereum p2p protocols
+## (see `devp2p <https://github.com/ethereum/devp2p/tree/master>`_.)
+##
+## Particular restictions apply to intrinsic message entities as message
+## ID and request/response ID. Both must be unsigned. This is a consequence
+## of message packets being serialised using RLP which is defined for
+## non-negative scalar values only, see
+## `Yellow Paper <https://ethereum.github.io/yellowpaper/paper.pdf#appendix.B>`_,
+## Appx B, clauses (195) ff. and (199).)
+
+
+{.push raises: [].}
+
+import
+  std/[options, sequtils, macrocache],
+  results,
+  stew/shims/macros, chronos
+
+type
+  MessageKind* = enum
+    msgHandshake
+    msgNotification
+    msgRequest
+    msgResponse
+
+  Message* = ref object
+    id*: uint64
+    ident*: NimNode
+    kind*: MessageKind
+    procDef*: NimNode
+    timeoutParam*: NimNode
+    recName*: NimNode
+    strongRecName*: NimNode
+    recBody*: NimNode
+    protocol*: P2PProtocol
+    response*: Message
+    userHandler*: NimNode
+    initResponderCall*: NimNode
+    outputParamDef*: NimNode
+
+  Request* = ref object
+    queries*: seq[Message]
+    response*: Message
+
+  SendProc* = object
+    ## A `SendProc` is a proc used to send a single P2P message.
+    ## If it's a Request, then the return type will be a Future
+    ## of the respective Response type. All send procs also have
+    ## an automatically inserted `timeout` parameter.
+
+    msg*: Message
+      ## The message being implemented
+
+    def*: NimNode
+      ## The definition of the proc
+
+    peerParam*: NimNode
+      ## Cached ident for the peer param
+
+    msgParams*: seq[NimNode]
+      ## Cached param ident for all values that must be written
+      ## on the wire. The automatically inserted `timeout` is not
+      ## included.
+
+    timeoutParam*: NimNode
+      ## Cached ident for the timeout parameter
+
+    extraDefs*: NimNode
+      ## The response procs have extra templates that must become
+      ## part of the generated code
+
+  P2PProtocol* = ref object
+    # Settings
+    name*: string
+    version*: uint64
+    timeouts*: int64
+    useRequestIds*: bool
+    useSingleRecordInlining*: bool
+    rlpxName*: string
+    outgoingRequestDecorator*: NimNode
+    incomingRequestDecorator*: NimNode
+    incomingRequestThunkDecorator*: NimNode
+    incomingResponseDecorator*: NimNode
+    incomingResponseThunkDecorator*: NimNode
+    PeerStateType*: NimNode
+    NetworkStateType*: NimNode
+    backend*: Backend
+
+    # Cached properties
+    nameIdent*: NimNode
+    protocolInfo*: NimNode
+
+    # All messages
+    messages*: seq[Message]
+
+    # Messages by type:
+    handshake*: Message
+    notifications*: seq[Message]
+    requests*: seq[Request]
+
+    # Output procs
+    outSendProcs*: NimNode
+    outRecvProcs*: NimNode
+    outProcRegistrations*: NimNode
+
+    # Event handlers
+    onPeerConnected*: NimNode
+    onPeerDisconnected*: NimNode
+
+  Backend* = ref object
+    # Code generators
+    implementMsg*: proc (msg: Message)
+    implementProtocolInit*: proc (protocol: P2PProtocol): NimNode
+
+    afterProtocolInit*: proc (protocol: P2PProtocol)
+
+    # Bound symbols to the back-end run-time types and procs
+    PeerType*: NimNode
+    NetworkType*: NimNode
+    SerializationFormat*: NimNode
+    ResponderType*: NimNode
+    RequestResultsWrapper*: NimNode
+    ReqIdType*: NimNode
+
+    registerProtocol*: NimNode
+    setEventHandlers*: NimNode
+
+  BackendFactory* = proc (p: P2PProtocol): Backend
+
+  P2PBackendError* = object of CatchableError
+  InvalidMsgError* = object of P2PBackendError
+
+const
+  defaultReqTimeout = 10.seconds
+  tracingEnabled = defined(p2pdump)
+
+let
+  # Variable names affecting the public interface of the library:
+  reqIdVar*             {.compileTime.} = ident "reqId"
+  ReqIdType*            {.compileTime.} = ident "uint64"
+  peerVar*              {.compileTime.} = ident "peer"
+  responseVar*          {.compileTime.} = ident "response"
+  streamVar*            {.compileTime.} = ident "stream"
+  protocolVar*          {.compileTime.} = ident "protocol"
+  timeoutVar*           {.compileTime.} = ident "timeout"
+  perProtocolMsgIdVar*  {.compileTime.} = ident "perProtocolMsgId"
+  currentProtocolSym*   {.compileTime.} = ident "CurrentProtocol"
+  resultIdent*          {.compileTime.} = ident "result"
+
+  # Locally used symbols:
+  Option                {.compileTime.} = ident "Option"
+  Future                {.compileTime.} = ident "Future"
+  Void                  {.compileTime.} = ident "void"
+  writeField            {.compileTime.} = ident "writeField"
+
+  PROTO                 {.compileTime.} = ident "PROTO"
+  MSG                   {.compileTime.} = ident "MSG"
+
+const
+  protocolCounter = CacheCounter"protocolCounter"
+
+template Fut(T): auto = newTree(nnkBracketExpr, Future, T)
+
+proc initFuture*[T](loc: var Future[T]) =
+  loc = newFuture[T]()
+
+proc isRlpx*(p: P2PProtocol): bool =
+  p.rlpxName.len > 0
+
+template applyDecorator(p: NimNode, decorator: NimNode) =
+  if decorator.kind != nnkNilLit:
+    p.pragma.insert(0, decorator)
+
+when tracingEnabled:
+  proc logSentMsgFields(peer: NimNode,
+                        protocolInfo: NimNode,
+                        msgName: string,
+                        fields: openArray[NimNode]): NimNode =
+    ## This generates the tracing code inserted in the message sending procs
+    ## `fields` contains all the params that were serialized in the message
+    let
+      tracer = ident "tracer"
+      tracerStream = ident "tracerStream"
+      logMsgEventImpl = ident "logMsgEventImpl"
+
+    result = quote do:
+      var `tracerStream` = memoryOutput()
+      var `tracer` = JsonWriter.init(`tracerStream`)
+      beginRecord(`tracer`)
+
+    for f in fields:
+      result.add newCall(writeField, tracer, newLit($f), f)
+
+    result.add quote do:
+      endRecord(`tracer`)
+      `logMsgEventImpl`("outgoing_msg", `peer`,
+                        `protocolInfo`, `msgName`,
+                        getOutput(`tracerStream`, string))
+
+proc createPeerState[Peer, ProtocolState](peer: Peer): RootRef =
+  var res = new ProtocolState
+  mixin initProtocolState
+  initProtocolState(res, peer)
+  return cast[RootRef](res)
+
+proc createNetworkState[NetworkNode, NetworkState](network: NetworkNode): RootRef {.gcsafe.} =
+  var res = new NetworkState
+  mixin initProtocolState
+  initProtocolState(res, network)
+  return cast[RootRef](res)
+
+proc expectBlockWithProcs*(n: NimNode): seq[NimNode] =
+  template helperName: auto = $n[0]
+
+  if n.len != 2 or n[1].kind != nnkStmtList:
+    error(helperName & " expects a block", n)
+
+  for p in n[1]:
+    if p.kind == nnkProcDef:
+      result.add p
+    elif p.kind == nnkCommentStmt:
+      continue
+    else:
+      error(helperName & " expects a proc definition.", p)
+
+proc nameOrNil*(procDef: NimNode): NimNode =
+  if procDef != nil:
+    procDef.name
+  else:
+    newNilLit()
+
+proc isOutputParamName(paramName: NimNode): bool =
+  eqIdent(paramName, "output") or eqIdent(paramName, "response")
+
+proc isOutputParam(param: NimNode): bool =
+  param.len > 0 and param[0].skipPragma.isOutputParamName
+
+proc getOutputParam(procDef: NimNode): NimNode =
+  let params = procDef.params
+  for i in countdown(params.len - 1, 1):
+    let param = params[i]
+    if isOutputParam(param):
+      return param
+
+proc outputParam*(msg: Message): NimNode =
+  case msg.kind
+  of msgRequest:
+    outputParam(msg.response)
+  of msgResponse:
+    msg.outputParamDef
+  else:
+    raiseAssert "Only requests (and the attached responses) can have output parameters"
+
+proc outputParamIdent*(msg: Message): NimNode =
+  let outputParam = msg.outputParam
+  if outputParam != nil:
+    return outputParam[0].skipPragma
+
+proc outputParamType*(msg: Message): NimNode =
+  let outputParam = msg.outputParam
+  if outputParam != nil:
+    return outputParam[1]
+
+proc refreshParam(n: NimNode): NimNode =
+  result = copyNimTree(n)
+  if n.kind == nnkIdentDefs:
+    for i in 0..<n.len-2:
+      if n[i].kind == nnkSym:
+        result[i] = genSym(symKind(n[i]), $n[i])
+
+iterator typedInputParams(procDef: NimNode, skip = 0): (NimNode, NimNode) =
+  for paramName, paramType in typedParams(procDef, skip):
+    if not isOutputParamName(paramName):
+      yield (paramName, paramType)
+
+proc copyInputParams(params: NimNode): NimNode =
+  result = newTree(params.kind)
+  for param in params:
+    if not isOutputParam(param):
+      result.add param.refreshParam
+
+proc chooseFieldType(n: NimNode): NimNode =
+  ## Examines the parameter types used in the message signature
+  ## and selects the corresponding field type for use in the
+  ## message object type (i.e. `p2p.hello`).
+  ##
+  ## For now, only openArray types are remapped to sequences.
+  result = n
+  if n.kind == nnkBracketExpr and eqIdent(n[0], "openArray"):
+    result = n.copyNimTree
+    result[0] = ident("seq")
+
+proc verifyStateType(t: NimNode): NimNode =
+  result = t[1]
+  if result.kind == nnkSym and $result == "nil":
+    return nil
+  if result.kind != nnkBracketExpr or $result[0] != "ref":
+    error $result & " must be a ref type"
+
+proc processProtocolBody*(p: P2PProtocol, protocolBody: NimNode)
+
+proc init*(T: type P2PProtocol, backendFactory: BackendFactory,
+           name: string, version: uint64, body: NimNode,
+           timeouts: int64, useRequestIds: bool, rlpxName: string,
+           outgoingRequestDecorator: NimNode,
+           incomingRequestDecorator: NimNode,
+           incomingRequestThunkDecorator: NimNode,
+           incomingResponseDecorator: NimNode,
+           incomingResponseThunkDecorator: NimNode,
+           peerState, networkState: NimNode): P2PProtocol =
+
+  result = P2PProtocol(
+    name: name,
+    version: version,
+    timeouts: timeouts,
+    useRequestIds: useRequestIds,
+    rlpxName: rlpxName,
+    outgoingRequestDecorator: outgoingRequestDecorator,
+    incomingRequestDecorator: incomingRequestDecorator,
+    incomingRequestThunkDecorator: incomingRequestThunkDecorator,
+    incomingResponseDecorator: incomingResponseDecorator,
+    incomingResponseThunkDecorator: incomingResponseThunkDecorator,
+    PeerStateType: verifyStateType peerState,
+    NetworkStateType: verifyStateType networkState,
+    nameIdent: ident(name),
+    protocolInfo: newCall(ident("protocolInfo"), ident(name)),
+    outSendProcs: newStmtList(),
+    outRecvProcs: newStmtList(),
+    outProcRegistrations: newStmtList())
+
+  result.backend = backendFactory(result)
+  assert(not result.backend.implementProtocolInit.isNil)
+
+  if result.backend.ReqIdType.isNil:
+    result.backend.ReqIdType = ident "uint64"
+
+  result.processProtocolBody body
+
+  if not result.backend.afterProtocolInit.isNil:
+    result.backend.afterProtocolInit(result)
+
+proc augmentUserHandler(p: P2PProtocol, userHandlerProc: NimNode, canRaise: bool, msgId = Opt.none(uint64)) =
+  ## This procs adds a set of common helpers available in all messages handlers
+  ## (e.g. `perProtocolMsgId`, `peer.state`, etc).
+
+  # we only take the pragma
+  let dummy = if canRaise:
+    quote do:
+      proc dummy(): Future[void] {.async: (raises: [CancelledError, EthP2PError]).}
+  else:
+    quote do:
+      proc dummy(): Future[void] {.async: (raises: []).}
+
+  if p.isRlpx:
+    userHandlerProc.addPragma dummy.pragma[0]
+
+  var
+    getState = ident"getState"
+    getNetworkState = ident"getNetworkState"
+    protocolInfo = p.protocolInfo
+    protocolNameIdent = p.nameIdent
+    PeerType = p.backend.PeerType
+    PeerStateType = p.PeerStateType
+    NetworkStateType = p.NetworkStateType
+    prelude = newStmtList()
+
+  userHandlerProc.body.insert 0, prelude
+
+  # We allow the user handler to use `openArray` params, but we turn
+  # those into sequences to make the `async` pragma happy.
+  for i in 1 ..< userHandlerProc.params.len:
+    var param = userHandlerProc.params[i]
+    param[^2] = chooseFieldType(param[^2])
+
+  prelude.add quote do:
+    type `currentProtocolSym` {.used.} = `protocolNameIdent`
+
+  if msgId.isSome and p.isRlpx:
+    let msgId = msgId.value
+    prelude.add quote do:
+      const `perProtocolMsgIdVar` {.used.} = `msgId`
+
+  # Define local accessors for the peer and the network protocol states
+  # inside each user message handler proc (e.g. peer.state.foo = bar)
+  if PeerStateType != nil:
+    prelude.add quote do:
+      template state(`peerVar`: `PeerType`): `PeerStateType` {.used.} =
+        `PeerStateType`(`getState`(`peerVar`, `protocolInfo`))
+
+  if NetworkStateType != nil:
+    prelude.add quote do:
+      template networkState(`peerVar`: `PeerType`): `NetworkStateType` {.used.} =
+        `NetworkStateType`(`getNetworkState`(`peerVar`.network, `protocolInfo`))
+
+proc addPreludeDefs(userHandlerProc: NimNode, definitions: NimNode) =
+  userHandlerProc.body[0].add definitions
+
+proc eventHandlerToProc(p: P2PProtocol, doBlock: NimNode, handlerName: string, canRaise: bool): NimNode =
+  ## Turns a "named" do block to a regular async proc
+  ## (e.g. onPeerConnected do ...)
+  result = newTree(nnkProcDef)
+  doBlock.copyChildrenTo(result)
+  result.name = ident(p.name & handlerName) # genSym(nskProc, p.name & handlerName)
+  p.augmentUserHandler result, canRaise
+
+proc addTimeoutParam(procDef: NimNode, defaultValue: int64) =
+  var
+    Duration = bindSym"Duration"
+    milliseconds = bindSym"milliseconds"
+
+  procDef.params.add newTree(nnkIdentDefs,
+                             timeoutVar,
+                             Duration,
+                             newCall(milliseconds, newLit(defaultValue)))
+
+proc hasReqId*(msg: Message): bool =
+  msg.protocol.useRequestIds and msg.kind in {msgRequest, msgResponse}
+
+proc ResponderType(msg: Message): NimNode =
+  var resp = if msg.kind == msgRequest: msg.response else: msg
+  newTree(nnkBracketExpr,
+          msg.protocol.backend.ResponderType, resp.strongRecName)
+
+proc needsSingleParamInlining(msg: Message): bool =
+  msg.recBody.kind == nnkDistinctTy
+
+proc newMsg(protocol: P2PProtocol, kind: MessageKind, msgId: uint64,
+            procDef: NimNode, response: Message = nil): Message =
+
+  if procDef[0].kind == nnkPostfix:
+    error("p2pProtocol procs are public by default. " &
+          "Please remove the postfix `*`.", procDef)
+
+  var
+    msgIdent = procDef.name
+    msgName = $msgIdent
+    recFields = newTree(nnkRecList)
+    recBody = newTree(nnkObjectTy, newEmptyNode(), newEmptyNode(), recFields)
+    strongRecName = ident(msgName & "Obj")
+    recName = strongRecName
+
+  for param, paramType in procDef.typedInputParams(skip = 1):
+    recFields.add newTree(nnkIdentDefs,
+      newTree(nnkPostfix, ident("*"), param), # The fields are public
+      chooseFieldType(paramType),             # some types such as openArray
+      newEmptyNode())                         # are automatically remapped
+
+  if recFields.len == 1 and protocol.useSingleRecordInlining:
+    # When we have a single parameter, it's treated as the transferred message
+    # type. `recName` will be resolved to the message type that's intended
+    # for serialization while `strongRecName` will be a distinct type over
+    # which overloads such as `msgId` can be defined. We must use a distinct
+    # type because otherwise Nim may see multiple overloads defined over the
+    # same request parameter type and this will be an ambiguity error.
+    recName = recFields[0][1]
+    recBody = newTree(nnkDistinctTy, recName)
+
+  result = Message(protocol: protocol,
+                   id: msgId,
+                   ident: msgIdent,
+                   kind: kind,
+                   procDef: procDef,
+                   recName: recName,
+                   strongRecName: strongRecName,
+                   recBody: recBody,
+                   response: response)
+
+  if procDef.body.kind != nnkEmpty:
+    var userHandler = copy procDef
+
+    protocol.augmentUserHandler userHandler, true, Opt.some(msgId)
+    userHandler.name = ident(msgName & "UserHandler")
+
+    # Request and Response handlers get an extra `reqId` parameter if the
+    # protocol uses them:
+    if result.hasReqId:
+      userHandler.params.insert(2, newIdentDefs(reqIdVar, protocol.backend.ReqIdType))
+
+    # All request handlers get an automatically inserter `response` variable:
+    if kind == msgRequest and protocol.isRlpx:
+      assert response != nil
+      let
+        peerParam = userHandler.params[1][0]
+        ResponderType = result.ResponderType
+        initResponderCall = newCall(ident"init", ResponderType, peerParam)
+
+      if protocol.useRequestIds:
+        initResponderCall.add reqIdVar
+
+      userHandler.addPreludeDefs quote do:
+        var `responseVar` {.used.} = `initResponderCall`
+
+      result.initResponderCall = initResponderCall
+
+    case kind
+    of msgRequest:  userHandler.applyDecorator protocol.incomingRequestDecorator
+    of msgResponse: userHandler.applyDecorator protocol.incomingResponseDecorator
+    else: discard
+
+    result.userHandler = userHandler
+    protocol.outRecvProcs.add result.userHandler
+
+  protocol.messages.add result
+
+proc isVoid(t: NimNode): bool =
+  t.kind == nnkEmpty or eqIdent(t, "void")
+
+proc addMsg(p: P2PProtocol, msgId: uint64, procDef: NimNode) =
+  var
+    returnType = procDef.params[0]
+    hasReturnValue = not isVoid(returnType)
+    outputParam = procDef.getOutputParam()
+
+  if outputParam != nil:
+    if hasReturnValue:
+      error "A request proc should either use a return value or an output parameter"
+    returnType = outputParam[1]
+    hasReturnValue = true
+
+  if hasReturnValue:
+    let
+      responseIdent = ident($procDef.name & "Response")
+      response = Message(protocol: p,
+                         id: msgId,
+                         ident: responseIdent,
+                         kind: msgResponse,
+                         recName: returnType,
+                         strongRecName: returnType,
+                         recBody: returnType,
+                         outputParamDef: outputParam)
+
+    p.messages.add response
+    let msg = p.newMsg(msgRequest, msgId, procDef, response = response)
+    p.requests.add Request(queries: @[msg], response: response)
+  else:
+    p.notifications.add p.newMsg(msgNotification, msgId, procDef)
+
+proc identWithExportMarker*(msg: Message): NimNode =
+  newTree(nnkPostfix, ident("*"), msg.ident)
+
+proc requestResultType*(msg: Message): NimNode =
+  let
+    protocol = msg.protocol
+    backend = protocol.backend
+    responseRec = msg.response.recName
+
+  var wrapperType = backend.RequestResultsWrapper
+  if wrapperType != nil:
+    if eqIdent(wrapperType, "void"):
+      return responseRec
+    else:
+      return newTree(nnkBracketExpr, wrapperType, responseRec)
+  else:
+    return newTree(nnkBracketExpr, Option, responseRec)
+
+proc createSendProc*(msg: Message,
+                     procType = nnkProcDef,
+                     isRawSender = false,
+                     nameSuffix = ""): SendProc =
+  # TODO: file an issue:
+  # macros.newProc and macros.params doesn't work with nnkMacroDef
+
+  let
+    nameSuffix = if nameSuffix.len == 0: (if isRawSender: "RawSender" else: "")
+                 else: nameSuffix
+
+    name = if nameSuffix.len == 0: msg.identWithExportMarker
+           else: ident($msg.ident & nameSuffix)
+
+    dummy = quote do:
+      proc dummy(): Future[void] {.async: (raises: [CancelledError, EthP2PError], raw: true).}
+
+    pragmas = if procType == nnkProcDef: dummy.pragma
+              else: newEmptyNode()
+
+  var def = newNimNode(procType).add(
+    name,
+    newEmptyNode(),
+    newEmptyNode(),
+    copyInputParams msg.procDef.params,
+    pragmas,
+    newEmptyNode(),
+    newStmtList()) ## body
+
+  if procType == nnkProcDef:
+    for p in msg.procDef.pragma:
+      if not eqIdent(p, "async"):
+        def.addPragma p
+
+  result.msg = msg
+  result.def = def
+
+  for param, paramType in def.typedInputParams():
+    if result.peerParam.isNil:
+      result.peerParam = param
+    else:
+      result.msgParams.add param
+
+  case msg.kind
+  of msgHandshake, msgRequest:
+    # Add a timeout parameter for all request procs
+    def.addTimeoutParam(msg.protocol.timeouts)
+
+  of msgResponse:
+    if msg.ResponderType != nil:
+      # A response proc must be called with a response object that originates
+      # from a certain request. Here we change the Peer parameter at position
+      # 1 to the correct strongly-typed ResponderType. The incoming procs still
+      # gets the normal Peer parameter.
+      let
+        ResponderType = msg.ResponderType
+        sendProcName = msg.ident
+
+      def[3][1][1] = ResponderType
+
+      # We create a helper that enables the `response.send()` syntax
+      # inside the user handler of the request proc:
+      result.extraDefs = quote do:
+        template send*(r: `ResponderType`, args: varargs[untyped]): auto =
+          `sendProcName`(r, args)
+
+  of msgNotification:
+    discard
+
+  def[3][0] = if procType in [nnkMacroDef, nnkTemplateDef]:
+                ident "untyped"
+              elif msg.kind == msgRequest and not isRawSender:
+                Fut(msg.requestResultType)
+              elif msg.kind == msgHandshake and not isRawSender:
+                Fut(msg.recName)
+              else:
+                Fut(Void)
+
+proc setBody*(sendProc: SendProc, body: NimNode) =
+  var
+    msg = sendProc.msg
+    protocol = msg.protocol
+    def = sendProc.def
+
+  # TODO: macros.body triggers an assertion error when the proc type is nnkMacroDef
+  def[6] = body
+
+  if msg.kind == msgRequest:
+    def.applyDecorator protocol.outgoingRequestDecorator
+
+  msg.protocol.outSendProcs.add def
+
+  if sendProc.extraDefs != nil:
+    msg.protocol.outSendProcs.add sendProc.extraDefs
+
+proc writeParamsAsRecord*(params: openArray[NimNode],
+                          outputStream, Format, RecordType: NimNode): NimNode =
+  if params.len == 0:
+    return newStmtList()
+
+  var
+    appendParams = newStmtList()
+    recordWriterCtx = ident "recordWriterCtx"
+    writer = ident "writer"
+
+  for param in params:
+    appendParams.add newCall(writeField,
+                             writer, recordWriterCtx,
+                             newLit($param), param)
+
+  # TODO: this doesn't respect the `useSingleRecordInlining` option.
+  # Right now, it's not a problem because it's used only in the libp2p back-end
+  if params.len > 1:
+    result = quote do:
+      mixin init, writerType, beginRecord, endRecord
+
+      var `writer` = init(WriterType(`Format`), `outputStream`)
+      var `recordWriterCtx` = beginRecord(`writer`, `RecordType`)
+      `appendParams`
+      endRecord(`writer`, `recordWriterCtx`)
+  else:
+    let param = params[0]
+
+    result = quote do:
+      var `writer` = init(WriterType(`Format`), `outputStream`)
+      writeValue(`writer`, `param`)
+
+proc defineThunk*(msg: Message, thunk: NimNode) =
+  let protocol = msg.protocol
+
+  case msg.kind
+  of msgRequest:  thunk.applyDecorator protocol.incomingRequestThunkDecorator
+  of msgResponse: thunk.applyDecorator protocol.incomingResponseThunkDecorator
+  else: discard
+
+  protocol.outRecvProcs.add thunk
+
+proc genUserHandlerCall*(msg: Message, receivedMsg: NimNode,
+                         leadingParams: openArray[NimNode],
+                         outputParam: NimNode = nil): NimNode =
+  if msg.userHandler == nil:
+    return newStmtList()
+
+  result = newCall(msg.userHandler.name, leadingParams)
+
+  if msg.needsSingleParamInlining:
+    result.add receivedMsg
+  else:
+    var params = toSeq(msg.procDef.typedInputParams(skip = 1))
+    for p in params:
+      result.add newDotExpr(receivedMsg, p[0])
+
+  if outputParam != nil:
+    result.add outputParam
+
+proc genAwaitUserHandler*(msg: Message, receivedMsg: NimNode,
+                          leadingParams: openArray[NimNode],
+                          outputParam: NimNode = nil): NimNode =
+  result = msg.genUserHandlerCall(receivedMsg, leadingParams, outputParam)
+  if result.len > 0: result = newCall("await", result)
+
+proc appendAllInputParams*(node: NimNode, procDef: NimNode): NimNode =
+  result = node
+  for p, _ in procDef.typedInputParams():
+    result.add p
+
+proc paramNames*(procDef: NimNode, skipFirst = 0): seq[NimNode] =
+  result = newSeq[NimNode]()
+  for name, _ in procDef.typedParams(skip = skipFirst):
+    result.add name
+
+proc netInit*(p: P2PProtocol): NimNode =
+  if p.NetworkStateType == nil:
+    newNilLit()
+  else:
+    newTree(nnkBracketExpr, bindSym"createNetworkState",
+                            p.backend.NetworkType,
+                            p.NetworkStateType)
+
+proc createHandshakeTemplate*(
+    msg: Message, rawSendProc, handshakeImpl, nextMsg: NimNode
+): SendProc =
+  let
+    handshakeExchanger = msg.createSendProc(procType = nnkTemplateDef)
+    forwardCall = newCall(rawSendProc).appendAllInputParams(handshakeExchanger.def)
+    peerValue = forwardCall[1]
+    msgRecName = msg.recName
+
+  forwardCall[1] = peerVar
+  forwardCall.del(forwardCall.len - 1)
+
+  let peerVar = genSym(nskLet, "peer")
+  handshakeExchanger.setBody quote do:
+    let `peerVar` = `peerValue`
+    let sendingFuture = `forwardCall`
+    `handshakeImpl`[`msgRecName`](
+      `peerVar`, sendingFuture, `nextMsg`(`peerVar`, `msgRecName`), `timeoutVar`
+    )
+
+  return handshakeExchanger
+
+proc peerInit*(p: P2PProtocol): NimNode =
+  if p.PeerStateType == nil:
+    newNilLit()
+  else:
+    newTree(nnkBracketExpr, bindSym"createPeerState",
+                            p.backend.PeerType,
+                            p.PeerStateType)
+
+proc processProtocolBody*(p: P2PProtocol, protocolBody: NimNode) =
+  ## This procs handles all DSL statements valid inside a p2pProtocol.
+  ##
+  ## It will populate the protocol's fields such as:
+  ##   * handshake
+  ##   * requests
+  ##   * notifications
+  ##   * onPeerConnected
+  ##   * onPeerDisconnected
+  ##
+  ## All messages will have properly computed numeric IDs
+  ##
+  var nextId = 0u64
+
+  for n in protocolBody:
+    case n.kind
+    of {nnkCall, nnkCommand}:
+      if eqIdent(n[0], "nextID"):
+        # By default message IDs are assigned in increasing order
+        # `nextID` can be used to skip some of the numeric slots
+        if n.len == 2 and n[1].kind == nnkIntLit:
+          nextId = n[1].intVal.uint64
+        else:
+          error("nextID expects a single int value", n)
+
+      elif eqIdent(n[0], "requestResponse"):
+        # `requestResponse` can be given a block of 2 or more procs.
+        # The last one is considered to be a response message, while
+        # all preceding ones are requests triggering the response.
+        # The system makes sure to automatically insert a hidden `reqId`
+        # parameter used to discriminate the individual messages.
+        let procs = expectBlockWithProcs(n)
+        if procs.len < 2:
+          error "requestResponse expects a block with at least two proc definitions"
+
+        var queries = newSeq[Message]()
+        let responseMsg = p.newMsg(msgResponse, nextId + procs.len.uint64 - 1, procs[^1])
+
+        for i in 0 .. procs.len - 2:
+          queries.add p.newMsg(msgRequest, nextId + i.uint64, procs[i], response = responseMsg)
+
+        p.requests.add Request(queries: queries, response: responseMsg)
+
+        inc nextId, procs.len
+
+      elif eqIdent(n[0], "handshake"):
+        let procs = expectBlockWithProcs(n)
+        if procs.len != 1:
+          error "handshake expects a block with a single proc definition", n
+
+        if p.handshake != nil:
+          error "The handshake for the protocol is already defined", n
+
+        p.handshake = p.newMsg(msgHandshake, nextId, procs[0])
+        inc nextId
+
+      elif eqIdent(n[0], "onPeerConnected"):
+        p.onPeerConnected = p.eventHandlerToProc(n[1], "PeerConnected", true)
+
+      elif eqIdent(n[0], "onPeerDisconnected"):
+        p.onPeerDisconnected = p.eventHandlerToProc(n[1], "PeerDisconnected", false)
+
+      else:
+        error(repr(n) & " is not a recognized call in P2P protocol definitions", n)
+
+    of nnkProcDef, nnkIteratorDef:
+      p.addMsg(nextId, n)
+      inc nextId
+
+    of nnkCommentStmt:
+      discard
+
+    else:
+      error "Illegal syntax in a P2P protocol definition", n
+
+proc genTypeSection*(p: P2PProtocol): NimNode =
+  var
+    protocolIdx = protocolCounter.value
+    protocolName = p.nameIdent
+    peerState = p.PeerStateType
+    networkState= p.NetworkStateType
+
+  protocolCounter.inc
+  result = newStmtList()
+  result.add quote do:
+    # Create a type acting as a pseudo-object representing the protocol
+    # (e.g. p2p)
+    type `protocolName`* = object
+
+    # The protocol run-time index is available as a pseudo-field
+    # (e.g. `p2p.index`)
+    template index*(`PROTO`: type `protocolName`): auto = `protocolIdx`
+    template protocolInfo*(`PROTO`: type `protocolName`): auto =
+      getProtocol(`protocolIdx`)
+
+  if peerState != nil:
+    result.add quote do:
+      template State*(`PROTO`: type `protocolName`): type = `peerState`
+
+  if networkState != nil:
+    result.add quote do:
+      template NetworkState*(`PROTO`: type `protocolName`): type = `networkState`
+
+  for msg in p.messages:
+    if msg.procDef == nil:
+      continue
+
+    let
+      msgId = msg.id
+      msgName = msg.ident
+      msgRecName = msg.recName
+      msgStrongRecName = msg.strongRecName
+      msgRecBody = msg.recBody
+
+    result.add quote do:
+      # This is a type featuring a single field for each message param:
+      type `msgStrongRecName`* = `msgRecBody`
+
+      # Add a helper template for accessing the message type:
+      # e.g. p2p.hello:
+      template `msgName`*(`PROTO`: type `protocolName`): type = `msgRecName`
+
+      # Add a helper template for obtaining the message Id for
+      # a particular message type:
+      template msgProtocol*(`MSG`: type `msgStrongRecName`): type = `protocolName`
+      template RecType*(`MSG`: type `msgStrongRecName`): untyped = `msgRecName`
+
+    if p.isRlpx:
+      result.add quote do:
+        template msgId*(`MSG`: type `msgStrongRecName`): uint64 = `msgId`
+
+proc genCode*(p: P2PProtocol): NimNode =
+  for msg in p.messages:
+    p.backend.implementMsg msg
+
+  result = newStmtList()
+  result.add p.genTypeSection()
+
+  let
+    protocolInit = p.backend.implementProtocolInit(p)
+    protocolReg  = ident($p.nameIdent & "Registration")
+    regBody      = newStmtList()
+
+  result.add p.outSendProcs,
+             p.outRecvProcs
+
+  if p.onPeerConnected != nil: result.add p.onPeerConnected
+  if p.onPeerDisconnected != nil: result.add p.onPeerDisconnected
+
+  regBody.add newCall(p.backend.setEventHandlers,
+                      protocolVar,
+                      nameOrNil p.onPeerConnected,
+                      nameOrNil p.onPeerDisconnected)
+
+  regBody.add p.outProcRegistrations
+  regBody.add newCall(p.backend.registerProtocol, protocolVar)
+
+  result.add quote do:
+    proc `protocolReg`() =
+      let `protocolVar` = `protocolInit`
+      `regBody`
+    `protocolReg`()
+
+macro emitForSingleBackend(
+    name: static[string],
+    version: static[uint64],
+    backend: static[BackendFactory],
+    body: untyped,
+    # TODO Nim can't handle a proper duration parameter here
+    timeouts: static[int64] = defaultReqTimeout.milliseconds,
+    useRequestIds: static[bool] = true,
+    rlpxName: static[string] = "",
+    outgoingRequestDecorator: untyped = nil,
+    incomingRequestDecorator: untyped = nil,
+    incomingRequestThunkDecorator: untyped = nil,
+    incomingResponseDecorator: untyped = nil,
+    incomingResponseThunkDecorator: untyped = nil,
+    peerState = type(nil),
+    networkState = type(nil)): untyped =
+
+  var p = P2PProtocol.init(
+    backend,
+    name, version, body, timeouts,
+    useRequestIds, rlpxName,
+    outgoingRequestDecorator,
+    incomingRequestDecorator,
+    incomingRequestThunkDecorator,
+    incomingResponseDecorator,
+    incomingResponseThunkDecorator,
+    peerState.getType, networkState.getType)
+
+  result = p.genCode()
+
+  try:
+    result.storeMacroResult true
+  except IOError:
+    # IO error so the generated nim code might not be stored, don't sweat it.
+    discard
+
+macro emitForAllBackends(backendSyms: typed, options: untyped, body: untyped): untyped =
+  let name = $(options[0])
+
+  var backends = newSeq[NimNode]()
+  if backendSyms.kind == nnkSym:
+    backends.add backendSyms
+  else:
+    for backend in backendSyms:
+      backends.add backend
+
+  result = newStmtList()
+
+  for backend in backends:
+    let call = copy options
+    call[0] = bindSym"emitForSingleBackend"
+    call.add newTree(nnkExprEqExpr, ident("name"), newLit(name))
+    call.add newTree(nnkExprEqExpr, ident("backend"), backend)
+    call.add newTree(nnkExprEqExpr, ident("body"), body)
+    result.add call
+
+template p2pProtocol*(options: untyped, body: untyped) {.dirty.} =
+  bind emitForAllBackends
+  emitForAllBackends(p2pProtocolBackendImpl, options, body)
+

--- a/execution_chain/networking/p2p_tracing.nim
+++ b/execution_chain/networking/p2p_tracing.nim
@@ -1,0 +1,113 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+const tracingEnabled = defined(p2pdump)
+
+when tracingEnabled:
+  import
+    std/typetraits,
+    json_serialization, chronicles #, chronicles_tail/configuration
+
+  export
+    # XXX: Nim visibility rules get in the way here.
+    # It would be nice if the users of this module don't have to
+    # import json_serializer, but this won't work at the moment,
+    # because the `encode` call inside `logMsgEvent` has its symbols
+    # mixed in from the module where `logMsgEvent` is called
+    # (instead of from this module, which will be more logical).
+    init, writeValue, getOutput
+    # TODO: File this as an issue
+
+  logStream p2pMessages[json[file(p2p_messages.json,truncate)]]
+  # p2pMessages.useTailPlugin "p2p_tracing_ctail_plugin.nim"
+
+  template logRecord(eventName: static[string], args: varargs[untyped]) =
+    p2pMessages.log LogLevel.NONE, eventName, topics = "p2pdump", args
+
+  proc initTracing*(baseProtocol: ProtocolInfo,
+                    userProtocols: seq[ProtocolInfo]) =
+    once:
+      var s = init OutputStream
+      var w = JsonWriter.init(s)
+
+      proc addProtocol(p: ProtocolInfo) =
+        w.writeFieldName p.name
+        w.beginRecord()
+        var i = 0
+        for msg in p.messages:
+          let msgId = i # msg.id
+          w.writeField $msgId, msg.name
+          inc i
+        w.endRecordField()
+
+      w.beginRecord()
+      addProtocol baseProtocol
+      for userProtocol in userProtocols:
+        addProtocol userProtocol
+      w.endRecord()
+
+      logRecord "p2p_protocols", data = JsonString(s.getOutput(string))
+
+  proc logMsgEventImpl*(eventName: static[string],
+                       peer: Peer,
+                       protocol: ProtocolInfo,
+                       msgName: string,
+                       json: string) =
+    # this is kept as a separate proc to reduce the code bloat
+    logRecord eventName, peer = $peer.remote,
+                         protocol = protocol.name,
+                         msg = msgName,
+                         data = JsonString(json)
+
+  template logMsgEventImpl*(eventName: static[string],
+                            responder: Responder,
+                            protocol: ProtocolInfo,
+                            msgName: string,
+                            json: string) =
+    logMsgEventImpl(eventName, UntypedResponder(responder).peer,
+                    protocol, msgName, json)
+
+  proc logMsgEvent[Msg](eventName: static[string], peer: Peer, msg: Msg) =
+    mixin msgProtocol, protocolInfo, msgId, RecType
+    type R = RecType(Msg)
+    logMsgEventImpl(eventName, peer,
+                    Msg.msgProtocol.protocolInfo,
+                    Msg.type.name,
+                    Json.encode(R msg))
+
+  template logSentMsg*(peer: Peer, msg: auto) =
+    logMsgEvent("outgoing_msg", peer, msg)
+
+  template logReceivedMsg*(peer: Peer, msg: auto) =
+    logMsgEvent("incoming_msg", peer, msg)
+
+  template logConnectedPeer*(p: Peer) =
+    logRecord "peer_connected",
+              port = int(p.network.address.tcpPort),
+              peer = $p.remote
+
+  template logAcceptedPeer*(p: Peer) =
+    logRecord "peer_accepted",
+              port = int(p.network.address.tcpPort),
+              peer = $p.remote
+
+  template logDisconnectedPeer*(p: Peer) =
+    logRecord "peer_disconnected",
+              port = int(p.network.address.tcpPort),
+              peer = $p.remote
+
+else:
+  template initTracing*(baseProtocol: ProtocolInfo,
+                       userProtocols: seq[ProtocolInfo])= discard
+  template logSentMsg*(peer: Peer, msg: auto) = discard
+  template logReceivedMsg*(peer: Peer, msg: auto) = discard
+  template logConnectedPeer*(peer: Peer) = discard
+  template logAcceptedPeer*(peer: Peer) = discard
+  template logDisconnectedPeer*(peer: Peer) = discard
+

--- a/execution_chain/networking/p2p_tracing_ctail_plugin.nim
+++ b/execution_chain/networking/p2p_tracing_ctail_plugin.nim
@@ -1,0 +1,21 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  karax/[karaxdsl, vdom]
+
+import
+  chronicles_tail/jsplugins
+
+proc networkSectionContent: VNode =
+  result = buildHtml(tdiv):
+    text "Networking"
+
+addSection("Network", networkSectionContent)
+

--- a/execution_chain/networking/p2p_types.nim
+++ b/execution_chain/networking/p2p_types.nim
@@ -1,0 +1,221 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [].}
+
+import
+  std/[deques, tables],
+  chronos,
+  results,
+  eth/rlp,
+  eth/common/[base, keys],
+  ./discoveryv4,
+  ./rlpx/rlpxtransport,
+  ./discoveryv4/[enode, kademlia]
+
+export base.NetworkId, rlpxtransport, kademlia
+
+type
+  EthereumNode* = ref object
+    networkId*: NetworkId
+    clientId*: string
+    connectionState*: ConnectionState
+    keys*: KeyPair
+    address*: Address # The external address that the node will be advertising
+    peerPool*: PeerPool
+    bindIp*: IpAddress
+    bindPort*: Port
+
+    # Private fields:
+    capabilities*: seq[Capability]
+    protocols*: seq[ProtocolInfo]
+    listeningServer*: StreamServer
+    protocolStates*: seq[RootRef]
+    discovery*: DiscoveryProtocol
+    rng*: ref HmacDrbgContext
+
+  Peer* = ref object
+    remote*: Node
+    network*: EthereumNode
+
+    # Private fields:
+    transport*: RlpxTransport
+    dispatcher*: Dispatcher
+    lastReqId*: Opt[uint64]
+    connectionState*: ConnectionState
+    protocolStates*: seq[RootRef]
+    outstandingRequests*: seq[Deque[OutstandingRequest]] # per `msgId` table
+    awaitedMessages*: seq[FutureBase] # per `msgId` table
+    snappyEnabled*: bool
+    clientId*: string
+
+  SeenNode* = object
+    nodeId*: NodeId
+    stamp*: chronos.Moment
+
+  PeerPool* = ref object
+    # Private fields:
+    network*: EthereumNode
+    keyPair*: KeyPair
+    networkId*: NetworkId
+    minPeers*: int
+    clientId*: string
+    discovery*: DiscoveryProtocol
+    lastLookupTime*: float
+    connQueue*: AsyncQueue[Node]
+    seenTable*: Table[NodeId, SeenNode]
+    connectedNodes*: Table[Node, Peer]
+    connectingNodes*: HashSet[Node]
+    running*: bool
+    observers*: Table[int, PeerObserver]
+
+  PeerObserver* = object
+    onPeerConnected*: proc(p: Peer) {.gcsafe, raises: [].}
+    onPeerDisconnected*: proc(p: Peer) {.gcsafe, raises: [].}
+    protocol*: ProtocolInfo
+
+  Capability* = object
+    name*: string
+    version*: uint64
+
+  EthP2PError* = object of CatchableError
+
+  UnsupportedProtocol* = object of EthP2PError
+    # This is raised when you attempt to send a message from a particular
+    # protocol to a peer that doesn't support the protocol.
+
+  MalformedMessageError* = object of EthP2PError
+  UnsupportedMessageError* = object of EthP2PError
+
+  PeerDisconnected* = object of EthP2PError
+    reason*: DisconnectionReason
+
+  UselessPeerError* = object of EthP2PError
+
+  P2PInternalError* = object of EthP2PError
+
+  ##
+  ## Quasy-private types. Use at your own risk.
+  ##
+  ProtocolManager* = ref object
+    protocols*: seq[ProtocolInfo]
+
+  ProtocolInfo* = ref object
+    capability*: Capability
+    messages*: seq[MessageInfo]
+    index*: int # the position of the protocol in the
+                # ordered list of supported protocols
+
+    # Private fields:
+    peerStateInitializer*: PeerStateInitializer
+    networkStateInitializer*: NetworkStateInitializer
+
+    onPeerConnected*: OnPeerConnectedHandler
+    onPeerDisconnected*: OnPeerDisconnectedHandler
+
+  MessageInfo* = ref object
+    id*: uint64 # this is a `msgId` (as opposed to a `reqId`)
+    name*: string
+
+    # Private fields:
+    thunk*: ThunkProc
+    printer*: MessageContentPrinter
+    requestResolver*: RequestResolver
+    nextMsgResolver*: NextMsgResolver
+    failResolver*: FailResolver
+
+  Dispatcher* = ref object # private
+    # The dispatcher stores the mapping of negotiated message IDs between
+    # two connected peers. The dispatcher may be shared between connections
+    # running with the same set of supported protocols.
+    #
+    # `protocolOffsets` will hold one slot of each locally supported
+    # protocol. If the other peer also supports the protocol, the stored
+    # offset indicates the numeric value of the first message of the protocol
+    # (for this particular connection). If the other peer doesn't support the
+    # particular protocol, the stored offset is `Opt.none(uint64)`.
+    #
+    # `messages` holds a mapping from valid message IDs to their handler procs.
+    #
+    protocolOffsets*: seq[Opt[uint64]]
+    messages*: seq[MessageInfo] # per `msgId` table (se above)
+    activeProtocols*: seq[ProtocolInfo]
+
+  ##
+  ## Private types:
+  ##
+
+  OutstandingRequest* = object
+    id*: uint64 # a `reqId` that may be used for response
+    future*: FutureBase
+
+  # Private types:
+  MessageHandlerDecorator* = proc(msgId: uint64, n: NimNode): NimNode
+
+  ThunkProc* = proc(x: Peer, data: Rlp): Future[void]
+    {.async: (raises: [CancelledError, EthP2PError]).}
+
+  MessageContentPrinter* = proc(msg: pointer): string
+    {.gcsafe, raises: [].}
+
+  RequestResolver* = proc(msg: pointer, future: FutureBase)
+    {.gcsafe, raises: [].}
+
+  NextMsgResolver* = proc(msgData: Rlp, future: FutureBase)
+    {.gcsafe, raises: [RlpError].}
+
+  FailResolver* = proc(reason: DisconnectionReason, future: FutureBase)
+    {.gcsafe, raises: [].}
+
+  PeerStateInitializer* = proc(peer: Peer): RootRef
+    {.gcsafe, raises: [].}
+
+  NetworkStateInitializer* = proc(network: EthereumNode): RootRef
+    {.gcsafe, raises: [].}
+
+  OnPeerConnectedHandler* = proc(peer: Peer): Future[void]
+    {.async: (raises: [CancelledError, EthP2PError]).}
+
+  OnPeerDisconnectedHandler* = proc(peer: Peer, reason: DisconnectionReason):
+    Future[void] {.async: (raises: []).}
+
+  ConnectionState* = enum
+    None,
+    Connecting,
+    Connected,
+    Disconnecting,
+    Disconnected
+
+  # Disconnect message reasons as specified:
+  # https://github.com/ethereum/devp2p/blob/master/rlpx.md#disconnect-0x01
+  # Receiving values that are too large or that are in the enum hole will
+  # trigger `RlpTypeMismatch` error on deserialization.
+  DisconnectionReason* = enum
+    DisconnectRequested = 0x00,
+    TcpError = 0x01,
+    BreachOfProtocol = 0x02,
+    UselessPeer = 0x03,
+    TooManyPeers = 0x04,
+    AlreadyConnected = 0x05,
+    IncompatibleProtocolVersion = 0x06,
+    NullNodeIdentityReceived = 0x07,
+    ClientQuitting = 0x08,
+    UnexpectedIdentity = 0x09,
+    SelfConnection = 0x0A,
+    PingTimeout = 0x0B,
+    SubprotocolReason = 0x10
+
+  Address = enode.Address
+
+proc `$`*(peer: Peer): string = $peer.remote
+
+proc `$`*(v: Capability): string = v.name & "/" & $v.version
+
+proc toENode*(v: EthereumNode): ENode =
+  ENode(pubkey: v.keys.pubkey, address: v.address)

--- a/execution_chain/networking/peer_pool.nim
+++ b/execution_chain/networking/peer_pool.nim
@@ -1,0 +1,309 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+# PeerPool attempts to keep connections to at least min_peers
+# on the given network.
+
+{.push raises: [].}
+
+import
+  std/[os, tables, times, random, sequtils, options],
+  chronos, chronicles,
+  ./[discoveryv4, rlpx, p2p_types]
+
+logScope:
+  topics = "eth p2p peer_pool"
+
+
+const
+  lookupInterval = 5
+  connectLoopSleep = chronos.milliseconds(2000)
+  maxConcurrentConnectionRequests = 40
+  sleepBeforeTryingARandomBootnode = chronos.milliseconds(3000)
+
+  ## Period of time for dead / unreachable peers.
+  SeenTableTimeDeadPeer = chronos.minutes(10)
+  ## Period of time for Useless peers, either because of no matching
+  ## capabilities or on an irrelevant network.
+  SeenTableTimeUselessPeer = chronos.hours(24)
+  ## Period of time for peers with a protocol error.
+  SeenTableTimeProtocolError = chronos.minutes(30)
+  ## Period of time for peers with general disconnections / transport errors.
+  SeenTableTimeReconnect = chronos.minutes(5)
+
+proc isSeen(p: PeerPool, nodeId: NodeId): bool =
+  ## Returns ``true`` if ``nodeId`` present in SeenTable and time period is not
+  ## yet expired.
+  let currentTime = now(chronos.Moment)
+  if nodeId notin p.seenTable:
+    false
+  else:
+    let item = try: p.seenTable[nodeId]
+    except KeyError: raiseAssert "checked with notin"
+    if currentTime >= item.stamp:
+      # Peer is in SeenTable, but the time period has expired.
+      p.seenTable.del(nodeId)
+      false
+    else:
+      true
+
+proc addSeen(
+    p: PeerPool, nodeId: NodeId, period: chronos.Duration) =
+  ## Adds peer with NodeId ``nodeId`` to SeenTable and timeout ``period``.
+  let item = SeenNode(nodeId: nodeId, stamp: now(chronos.Moment) + period)
+  withValue(p.seenTable, nodeId, entry) do:
+    if entry.stamp < item.stamp:
+      entry.stamp = item.stamp
+  do:
+    p.seenTable[nodeId] = item
+
+proc newPeerPool*(
+    network: EthereumNode, networkId: NetworkId, keyPair: KeyPair,
+    discovery: DiscoveryProtocol, clientId: string, minPeers = 10): PeerPool =
+  new result
+  result.network = network
+  result.keyPair = keyPair
+  result.minPeers = minPeers
+  result.networkId = networkId
+  result.discovery = discovery
+  result.connQueue = newAsyncQueue[Node](maxConcurrentConnectionRequests)
+  result.connectedNodes = initTable[Node, Peer]()
+  result.connectingNodes = initHashSet[Node]()
+  result.observers = initTable[int, PeerObserver]()
+
+proc nodesToConnect(p: PeerPool): seq[Node] =
+  p.discovery.randomNodes(p.minPeers).filterIt(it notin p.discovery.bootstrapNodes)
+
+proc addObserver*(p: PeerPool, observerId: int, observer: PeerObserver) =
+  doAssert(observerId notin p.observers)
+  p.observers[observerId] = observer
+  if not observer.onPeerConnected.isNil:
+    for peer in p.connectedNodes.values:
+      if observer.protocol.isNil or peer.supports(observer.protocol):
+        observer.onPeerConnected(peer)
+
+proc delObserver*(p: PeerPool, observerId: int) =
+  p.observers.del(observerId)
+
+proc addObserver*(p: PeerPool, observerId: ref, observer: PeerObserver) =
+  p.addObserver(cast[int](observerId), observer)
+
+proc delObserver*(p: PeerPool, observerId: ref) =
+  p.delObserver(cast[int](observerId))
+
+template setProtocol*(observer: PeerObserver, Protocol: type) =
+  observer.protocol = Protocol.protocolInfo
+
+proc stopAllPeers(p: PeerPool) {.async.} =
+  debug "Stopping all peers ..."
+  # TODO: ...
+  # await asyncio.gather(
+  #   *[peer.stop() for peer in self.connected_nodes.values()])
+
+# async def stop(self) -> None:
+#   self.cancel_token.trigger()
+#   await self.stop_all_peers()
+
+proc connect(p: PeerPool, remote: Node): Future[Peer] {.async.} =
+  ## Connect to the given remote and return a Peer instance when successful.
+  ## Returns nil if the remote is unreachable, times out or is useless.
+  if remote in p.connectedNodes:
+    trace "skipping_connection_to_already_connected_peer", remote
+    return nil
+
+  if remote in p.connectingNodes:
+    # debug "skipping connection"
+    return nil
+
+  if p.isSeen(remote.id):
+    return nil
+
+  trace "Connecting to node", remote
+  p.connectingNodes.incl(remote)
+  let res = await p.network.rlpxConnect(remote)
+  p.connectingNodes.excl(remote)
+
+  # TODO: Probably should move all this logic to rlpx.nim
+  if res.isOk():
+    rlpx_connect_success.inc()
+    return res.get()
+  else:
+    rlpx_connect_failure.inc()
+    rlpx_connect_failure.inc(labelValues = [$res.error])
+    case res.error():
+    of UselessRlpxPeerError:
+      p.addSeen(remote.id, SeenTableTimeUselessPeer)
+    of TransportConnectError:
+      p.addSeen(remote.id, SeenTableTimeDeadPeer)
+    of RlpxHandshakeError, ProtocolError, InvalidIdentityError:
+      p.addSeen(remote.id, SeenTableTimeProtocolError)
+    of RlpxHandshakeTransportError,
+        P2PHandshakeError,
+        P2PTransportError,
+        PeerDisconnectedError,
+        TooManyPeersError:
+      p.addSeen(remote.id, SeenTableTimeReconnect)
+
+    return nil
+
+proc lookupRandomNode(p: PeerPool) {.async.} =
+  discard await p.discovery.lookupRandom()
+  p.lastLookupTime = epochTime()
+
+proc getRandomBootnode(p: PeerPool): Option[Node] =
+  if p.discovery.bootstrapNodes.len != 0:
+    result = option(p.discovery.bootstrapNodes.sample())
+
+proc addPeer*(pool: PeerPool, peer: Peer) {.gcsafe.} =
+  doAssert(peer.remote notin pool.connectedNodes)
+  pool.connectedNodes[peer.remote] = peer
+  rlpx_connected_peers.inc()
+  for o in pool.observers.values:
+    if not o.onPeerConnected.isNil:
+      if o.protocol.isNil or peer.supports(o.protocol):
+        o.onPeerConnected(peer)
+
+proc connectToNode*(p: PeerPool, n: Node) {.async.} =
+  let peer = await p.connect(n)
+  if not peer.isNil:
+    trace "Connection established (outgoing)", peer
+    p.addPeer(peer)
+
+proc connectToNode*(p: PeerPool, n: ENode) {.async.} =
+  await p.connectToNode(newNode(n))
+
+
+# This code is loosely based on code from nimbus-eth2;
+# see eth2_network.nim and search for connQueue.
+proc createConnectionWorker(p: PeerPool, workerId: int): Future[void] {.async.} =
+  trace "Connection worker started", workerId = workerId
+  while true:
+    let n = await p.connQueue.popFirst()
+    await connectToNode(p, n)
+
+    # # TODO: Consider changing connect() to raise an exception instead of
+    # # returning None, as discussed in
+    # # https://github.com/ethereum/py-evm/pull/139#discussion_r152067425
+    # echo "Connecting to node: ", node
+    # let peer = await p.connect(node)
+    # if not peer.isNil:
+    #   info "Successfully connected to ", peer
+    #   ensureFuture peer.run(p)
+
+    #   p.connectedNodes[peer.remote] = peer
+    #   # for subscriber in self._subscribers:
+    #   #   subscriber.register_peer(peer)
+    #   if p.connectedNodes.len >= p.minPeers:
+    #     return
+
+proc startConnectionWorkerPool(p: PeerPool, workerCount: int) =
+  for i in 0 ..< workerCount:
+    asyncSpawn createConnectionWorker(p, i)
+
+proc maybeConnectToMorePeers(p: PeerPool) {.async.} =
+  ## Connect to more peers if we're not yet connected to at least self.minPeers.
+  if p.connectedNodes.len >= p.minPeers:
+    # debug "pool already connected to enough peers (sleeping)", count = p.connectedNodes
+    return
+
+  if p.lastLookupTime + lookupInterval < epochTime():
+    asyncSpawn p.lookupRandomNode()
+
+  let debugEnode = getEnv("ETH_DEBUG_ENODE")
+  if debugEnode.len != 0:
+    await p.connectToNode(newNode(debugEnode))
+  else:
+    for n in p.nodesToConnect():
+      await p.connQueue.addLast(n)
+
+    # The old version of the code (which did all the connection
+    # attempts in serial, not parallel) actually *awaited* all
+    # the connection attempts before reaching the code at the
+    # end of this proc that tries a random bootnode. Should
+    # that still be what happens? I don't think so; one of the
+    # reasons we're doing the connection attempts concurrently
+    # is because sometimes the attempt takes a long time. Still,
+    # it seems like we should give the many connection attempts
+    # a *chance* to complete before moving on to trying a random
+    # bootnode. So let's try just waiting a few seconds. (I am
+    # really not sure this makes sense.)
+    #
+    # --Adam, Dec. 2022
+    await sleepAsync(sleepBeforeTryingARandomBootnode)
+
+  # In some cases (e.g ROPSTEN or private testnets), the discovery table might
+  # be full of bad peers, so if we can't connect to any peers we try a random
+  # bootstrap node as well.
+  if p.connectedNodes.len == 0 and (let n = p.getRandomBootnode(); n.isSome):
+    await p.connectToNode(n.get())
+
+proc run(p: PeerPool) {.async.} =
+  trace "Running PeerPool..."
+  p.running = true
+  p.startConnectionWorkerPool(maxConcurrentConnectionRequests)
+  while p.running:
+
+    debug "Amount of peers", amount = p.connectedNodes.len()
+    var dropConnections = false
+    try:
+      await p.maybeConnectToMorePeers()
+    except CatchableError as e:
+      # Most unexpected errors should be transient, so we log and restart from
+      # scratch.
+      error "Unexpected PeerPool error, restarting",
+        err = e.msg, stackTrace = e.getStackTrace()
+      dropConnections = true
+
+    if dropConnections:
+      await p.stopAllPeers()
+
+    await sleepAsync(connectLoopSleep)
+
+proc start*(p: PeerPool) =
+  if not p.running:
+    asyncSpawn p.run()
+
+proc len*(p: PeerPool): int = p.connectedNodes.len
+# @property
+# def peers(self) -> List[BasePeer]:
+#   peers = list(self.connected_nodes.values())
+#   # Shuffle the list of peers so that dumb callsites are less likely to send
+#   # all requests to
+#   # a single peer even if they always pick the first one from the list.
+#   random.shuffle(peers)
+#   return peers
+
+# async def get_random_peer(self) -> BasePeer:
+#   while not self.peers:
+#     self.logger.debug("No connected peers, sleeping a bit")
+#     await asyncio.sleep(0.5)
+#   return random.choice(self.peers)
+
+iterator peers*(p: PeerPool): Peer =
+  for remote, peer in p.connectedNodes:
+    yield peer
+
+iterator peers*(p: PeerPool, Protocol: type): Peer =
+  for peer in p.peers:
+    if peer.supports(Protocol):
+      yield peer
+
+func numPeers*(p: PeerPool): int =
+  p.connectedNodes.len
+
+func contains*(p: PeerPool, n: ENode): bool =
+  for remote, _ in p.connectedNodes:
+    if remote.node == n:
+      return true
+
+func contains*(p: PeerPool, n: Node): bool =
+  n in p.connectedNodes
+
+func contains*(p: PeerPool, n: Peer): bool =
+  n.remote in p.connectedNodes

--- a/execution_chain/networking/rlpx.nim
+++ b/execution_chain/networking/rlpx.nim
@@ -1,0 +1,1404 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+## This module implements the `RLPx` Transport Protocol defined at
+## `RLPx <https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/rlpx.md>`_
+## in its EIP-8 version.
+##
+## This modules implements version 5 of the p2p protocol as defined by EIP-706 -
+## earlier versions are not supported.
+##
+## Both, the message ID and the request/response ID are now unsigned. This goes
+## along with the RLPx specs (see above) and the sub-protocol specs at
+## `sub-proto <https://github.com/ethereum/devp2p/tree/master/caps>`_ plus the
+## fact that RLP is defined for non-negative integers smaller than 2^64 only at
+## `Yellow Paper <https://ethereum.github.io/yellowpaper/paper.pdf#appendix.B>`_,
+## Appx B, clauses (195) ff and (199).
+##
+
+{.push raises: [].}
+
+import
+  std/[algorithm, deques, options, os, sequtils, strutils, typetraits],
+  stew/byteutils,
+  stew/shims/macros,
+  chronicles,
+  chronos,
+  metrics,
+  snappy,
+  eth/rlp,
+  ./p2p_types,
+  ./p2p_protocol_dsl,
+  ./rlpx/[auth, rlpxcrypt],
+  ./discoveryv4/[kademlia, enode]
+
+const
+  devp2pSnappyVersion* = 5
+    ## EIP-706 version of devp2p, with snappy compression - no support offered
+    ## for earlier versions
+  maxMsgSize = 1024 * 1024 * 16
+    ## The maximum message size is normally limited by the 24-bit length field in
+    ## the message header but in the case of snappy, we need to protect against
+    ## decompression bombs:
+    ## https://eips.ethereum.org/EIPS/eip-706#avoiding-dos-attacks
+
+  connectionTimeout = 10.seconds
+
+  msgIdHello = byte 0
+  msgIdDisconnect = byte 1
+  msgIdPing = byte 2
+  msgIdPong = byte 3
+
+# TODO: chronicles re-export here is added for the error
+# "undeclared identifier: 'activeChroniclesStream'", when the code using p2p
+# does not import chronicles. Need to resolve this properly.
+export options, p2pProtocol, rlp, chronicles, metrics
+
+declarePublicGauge rlpx_connected_peers, "Number of connected peers in the pool"
+
+declarePublicCounter rlpx_connect_success, "Number of successfull rlpx connects"
+
+declarePublicCounter rlpx_connect_failure,
+  "Number of rlpx connects that failed", labels = ["reason"]
+
+declarePublicCounter rlpx_accept_success, "Number of successful rlpx accepted peers"
+
+declarePublicCounter rlpx_accept_failure,
+  "Number of rlpx accept attempts that failed", labels = ["reason"]
+
+logScope:
+  topics = "eth p2p rlpx"
+
+type
+  ResponderWithId*[MsgType] = object
+    peer*: Peer
+    reqId*: uint64
+
+  ResponderWithoutId*[MsgType] = distinct Peer
+
+  # We need these two types in rlpx/devp2p as no parameters or single parameters
+  # are not getting encoded in an rlp list.
+  # TODO: we could generalize this in the protocol dsl but it would need an
+  # `alwaysList` flag as not every protocol expects lists in these cases.
+  EmptyList = object
+  DisconnectionReasonList = object
+    value: DisconnectionReason
+
+proc read(
+    rlp: var Rlp, T: type DisconnectionReasonList
+): T {.gcsafe, raises: [RlpError].} =
+  ## Rlp mixin: `DisconnectionReasonList` parser
+
+  if rlp.isList:
+    # Be strict here: The expression `rlp.read(DisconnectionReasonList)`
+    # accepts lists with at least one item. The array expression wants
+    # exactly one item.
+    if rlp.rawData.len < 3:
+      # avoids looping through all items when parsing for an overlarge array
+      return DisconnectionReasonList(value: rlp.read(array[1, DisconnectionReason])[0])
+
+  # Also accepted: a single byte reason code. Is is typically used
+  # by variants of the reference implementation `Geth`
+  elif rlp.blobLen <= 1:
+    return DisconnectionReasonList(value: rlp.read(DisconnectionReason))
+
+  # Also accepted: a blob of a list (aka object) of reason code. It is
+  # used by `bor`, a `geth` fork
+  elif rlp.blobLen < 4:
+    var subList = rlp.toBytes.rlpFromBytes
+    if subList.isList:
+      # Ditto, see above.
+      return
+        DisconnectionReasonList(value: subList.read(array[1, DisconnectionReason])[0])
+
+  raise newException(RlpTypeMismatch, "Single entry list expected")
+
+include p2p_tracing
+
+when tracingEnabled:
+  import eth/common/eth_types_json_serialization
+
+  export
+    # XXX: This is a work-around for a Nim issue.
+    # See a more detailed comment in p2p_tracing.nim
+    init,
+    writeValue,
+    getOutput
+
+proc init*[MsgName](T: type ResponderWithId[MsgName], peer: Peer, reqId: uint64): T =
+  T(peer: peer, reqId: reqId)
+
+proc init*[MsgName](T: type ResponderWithoutId[MsgName], peer: Peer): T =
+  T(peer)
+
+chronicles.formatIt(Peer):
+  $(it.remote)
+chronicles.formatIt(Opt[uint64]):
+  (if it.isSome(): $it.value else: "-1")
+
+include p2p_backends_helpers
+
+proc requestResolver[MsgType](msg: pointer, future: FutureBase) {.gcsafe.} =
+  var f = Future[Option[MsgType]](future)
+  if not f.finished:
+    if msg != nil:
+      f.complete some(cast[ptr MsgType](msg)[])
+    else:
+      f.complete none(MsgType)
+
+proc linkSendFailureToReqFuture[S, R](sendFut: Future[S], resFut: Future[R]) =
+  sendFut.addCallback do(arg: pointer):
+    # Avoiding potentially double future completions
+    if not resFut.finished:
+      if sendFut.failed:
+        resFut.fail(sendFut.error)
+
+proc messagePrinter[MsgType](msg: pointer): string {.gcsafe.} =
+  result = ""
+  # TODO: uncommenting the line below increases the compile-time
+  # tremendously (for reasons not yet known)
+  # result = $(cast[ptr MsgType](msg)[])
+
+proc disconnect*(
+  peer: Peer, reason: DisconnectionReason, notifyOtherPeer = false
+) {.async: (raises: []).}
+
+# TODO Rework the disconnect-and-raise flow to not do both raising
+#      and disconnection - this results in convoluted control flow and redundant
+#      disconnect calls
+template raisePeerDisconnected(msg: string, r: DisconnectionReason) =
+  var e = newException(PeerDisconnected, msg)
+  e.reason = r
+  raise e
+
+proc disconnectAndRaise(
+    peer: Peer, reason: DisconnectionReason, msg: string
+) {.async: (raises: [PeerDisconnected]).} =
+  if reason == BreachOfProtocol:
+    warn "TODO Raising protocol breach",
+      remote = peer.remote, clientId = peer.clientId, msg
+  await peer.disconnect(reason)
+  raisePeerDisconnected(msg, reason)
+
+proc handshakeImpl[T](
+    peer: Peer,
+    sendFut: Future[void],
+    responseFut: auto, # Future[T].Raising([CancelledError, EthP2PError]),
+    timeout: Duration,
+): Future[T] {.async: (raises: [CancelledError, EthP2PError]).} =
+  sendFut.addCallback do(arg: pointer) {.gcsafe.}:
+    if sendFut.failed:
+      debug "Handshake message not delivered", peer
+
+  doAssert timeout.milliseconds > 0
+
+  try:
+    let res = await responseFut.wait(timeout)
+    return res
+  except AsyncTimeoutError:
+    # TODO: Really shouldn't disconnect and raise everywhere. In order to avoid
+    # understanding what error occured where.
+    # And also, incoming and outgoing disconnect errors should be seperated,
+    # probably by seperating the actual disconnect call to begin with.
+    await disconnectAndRaise(peer, TcpError, T.name() & " was not received in time.")
+
+# Dispatcher
+#
+
+proc describeProtocols(d: Dispatcher): string =
+  d.activeProtocols.mapIt($it.capability).join(",")
+
+proc numProtocols(d: Dispatcher): int =
+  d.activeProtocols.len
+
+proc getDispatcher(
+    node: EthereumNode, otherPeerCapabilities: openArray[Capability]
+): Opt[Dispatcher] =
+  let dispatcher = Dispatcher()
+  newSeq(dispatcher.protocolOffsets, protocolCount())
+  dispatcher.protocolOffsets.fill Opt.none(uint64)
+
+  var nextUserMsgId = 0x10u64
+
+  for localProtocol in node.protocols:
+    let idx = localProtocol.index
+    block findMatchingProtocol:
+      for remoteCapability in otherPeerCapabilities:
+        if localProtocol.capability == remoteCapability:
+          dispatcher.protocolOffsets[idx] = Opt.some(nextUserMsgId)
+          nextUserMsgId += localProtocol.messages.len.uint64
+          break findMatchingProtocol
+
+  template copyTo(src, dest; index: int) =
+    for i in 0 ..< src.len:
+      dest[index + i] = src[i]
+
+  dispatcher.messages = newSeq[MessageInfo](nextUserMsgId)
+  devp2pInfo.messages.copyTo(dispatcher.messages, 0)
+
+  for localProtocol in node.protocols:
+    let idx = localProtocol.index
+    if dispatcher.protocolOffsets[idx].isSome:
+      dispatcher.activeProtocols.add localProtocol
+      localProtocol.messages.copyTo(
+        dispatcher.messages, dispatcher.protocolOffsets[idx].value.int
+      )
+
+  if dispatcher.numProtocols == 0:
+    Opt.none(Dispatcher)
+  else:
+    Opt.some(dispatcher)
+
+proc getMsgName*(peer: Peer, msgId: uint64): string =
+  if not peer.dispatcher.isNil and msgId < peer.dispatcher.messages.len.uint64 and
+      not peer.dispatcher.messages[msgId].isNil:
+    return peer.dispatcher.messages[msgId].name
+  else:
+    return
+      case msgId
+      of msgIdHello:
+        "hello"
+      of msgIdDisconnect:
+        "disconnect"
+      of msgIdPing:
+        "ping"
+      of msgIdPong:
+        "pong"
+      else:
+        $msgId
+
+# Protocol info objects
+#
+
+proc initProtocol(
+    name: string,
+    version: uint64,
+    peerInit: PeerStateInitializer,
+    networkInit: NetworkStateInitializer,
+): ProtocolInfo =
+  ProtocolInfo(
+    capability: Capability(name: name, version: version),
+    messages: @[],
+    peerStateInitializer: peerInit,
+    networkStateInitializer: networkInit,
+  )
+
+proc setEventHandlers(
+    p: ProtocolInfo,
+    onPeerConnected: OnPeerConnectedHandler,
+    onPeerDisconnected: OnPeerDisconnectedHandler,
+) =
+  p.onPeerConnected = onPeerConnected
+  p.onPeerDisconnected = onPeerDisconnected
+
+proc cmp*(lhs, rhs: ProtocolInfo): int =
+  let c = cmp(lhs.capability.name, rhs.capability.name)
+  if c == 0:
+    # Highest version first!
+    -cmp(lhs.capability.version, rhs.capability.version)
+  else:
+    c
+
+proc nextMsgResolver[MsgType](
+    msgData: Rlp, future: FutureBase
+) {.gcsafe, raises: [RlpError].} =
+  var reader = msgData
+  Future[MsgType](future).complete reader.readRecordType(
+    MsgType, MsgType.rlpFieldsCount > 1
+  )
+
+proc failResolver[MsgType](reason: DisconnectionReason, future: FutureBase) =
+  Future[MsgType](future).fail(
+    (ref PeerDisconnected)(msg: "Peer disconnected during handshake", reason: reason),
+    warn = false,
+  )
+
+proc registerMsg(
+    protocol: ProtocolInfo,
+    msgId: uint64,
+    name: string,
+    thunk: ThunkProc,
+    printer: MessageContentPrinter,
+    requestResolver: RequestResolver,
+    nextMsgResolver: NextMsgResolver,
+    failResolver: FailResolver,
+) =
+  if protocol.messages.len.uint64 <= msgId:
+    protocol.messages.setLen(msgId + 1)
+  protocol.messages[msgId] = MessageInfo(
+    id: msgId,
+    name: name,
+    thunk: thunk,
+    printer: printer,
+    requestResolver: requestResolver,
+    nextMsgResolver: nextMsgResolver,
+    failResolver: failResolver,
+  )
+
+# Message composition and encryption
+#
+
+proc perPeerMsgIdImpl(peer: Peer, proto: ProtocolInfo, msgId: uint64): uint64 =
+  result = msgId
+  if not peer.dispatcher.isNil:
+    result += peer.dispatcher.protocolOffsets[proto.index].value
+
+template getPeer(peer: Peer): auto =
+  peer
+
+template getPeer(responder: ResponderWithId): auto =
+  responder.peer
+
+template getPeer(responder: ResponderWithoutId): auto =
+  Peer(responder)
+
+proc supports*(peer: Peer, proto: ProtocolInfo): bool =
+  peer.dispatcher.protocolOffsets[proto.index].isSome
+
+proc supports*(peer: Peer, Protocol: type): bool =
+  ## Checks whether a Peer supports a particular protocol
+  peer.supports(Protocol.protocolInfo)
+
+template perPeerMsgId(peer: Peer, MsgType: type): uint64 =
+  perPeerMsgIdImpl(peer, MsgType.msgProtocol.protocolInfo, MsgType.msgId)
+
+proc invokeThunk*(
+    peer: Peer, msgId: uint64, msgData: Rlp
+): Future[void] {.async: (raises: [CancelledError, EthP2PError]).} =
+  template invalidIdError(): untyped =
+    raise newException(
+      UnsupportedMessageError,
+      "RLPx message with an invalid id " & $msgId & " on a connection supporting " &
+        peer.dispatcher.describeProtocols,
+    )
+
+  if msgId >= peer.dispatcher.messages.len.uint64 or
+      peer.dispatcher.messages[msgId].isNil:
+    invalidIdError()
+  let msgInfo = peer.dispatcher.messages[msgId]
+
+  doAssert peer.dispatcher.messages.len == peer.awaitedMessages.len,
+    "Should have been set up in peer constructor"
+
+  # Check if the peer is "expecting" this message as part of a handshake
+  if peer.awaitedMessages[msgId] != nil:
+    let awaited = move(peer.awaitedMessages[msgId])
+    peer.awaitedMessages[msgId] = nil
+
+    try:
+      msgInfo.nextMsgResolver(msgData, awaited)
+    except rlp.RlpError:
+      await peer.disconnectAndRaise(
+        BreachOfProtocol, "Could not decode rlp for " & $msgId
+      )
+  else:
+    await msgInfo.thunk(peer, msgData)
+
+template compressMsg(peer: Peer, data: seq[byte]): seq[byte] =
+  if peer.snappyEnabled:
+    snappy.encode(data)
+  else:
+    data
+
+proc recvMsg(
+    peer: Peer
+): Future[tuple[msgId: uint64, msgRlp: Rlp]] {.
+    async: (raises: [CancelledError, EthP2PError])
+.} =
+  var msgBody: seq[byte]
+  try:
+    msgBody = await peer.transport.recvMsg()
+
+    trace "Received message",
+      remote = peer.remote,
+      clientId = peer.clientId,
+      data = toHex(msgBody.toOpenArray(0, min(255, msgBody.high)))
+
+    # TODO we _really_ need an rlp decoder that doesn't require this many
+    #      copies of each message...
+    var tmp = rlpFromBytes(msgBody)
+    let msgId = tmp.read(uint64)
+
+    if peer.snappyEnabled and tmp.hasData():
+      let decoded =
+        snappy.decode(msgBody.toOpenArray(tmp.position, msgBody.high), maxMsgSize)
+      if decoded.len == 0:
+        if msgId == 0x01 and msgBody.len > 1 and msgBody.len < 16 and msgBody[1] == 0xc1:
+          # Nethermind sends its TooManyPeers uncompressed but we want to be nice!
+          # https://github.com/NethermindEth/nethermind/issues/7726
+          debug "Trying to decode disconnect uncompressed",
+            remote = peer.remote, clientId = peer.clientId, data = toHex(msgBody)
+        else:
+          await peer.disconnectAndRaise(
+            BreachOfProtocol, "Could not decompress snappy data"
+          )
+      else:
+        trace "Decoded message",
+          remote = peer.remote,
+          clientId = peer.clientId,
+          decoded = toHex(decoded.toOpenArray(0, min(255, decoded.high)))
+        tmp = rlpFromBytes(decoded)
+
+    return (msgId, tmp)
+  except TransportError as exc:
+    await peer.disconnectAndRaise(TcpError, exc.msg)
+  except RlpxTransportError as exc:
+    await peer.disconnectAndRaise(BreachOfProtocol, exc.msg)
+  except RlpError as exc:
+    # TODO remove this warning before using in production
+    warn "TODO: RLP decoding failed for msgId",
+      remote = peer.remote,
+      clientId = peer.clientId,
+      err = exc.msg,
+      rawData = toHex(msgBody)
+
+    await peer.disconnectAndRaise(BreachOfProtocol, "Could not decode msgId")
+
+proc encodeMsg(msg: auto): seq[byte] =
+  var rlpWriter = initRlpWriter()
+  rlpWriter.appendRecordType(msg, typeof(msg).rlpFieldsCount > 1)
+  rlpWriter.finish
+
+proc sendMsg(
+    peer: Peer, msgId: uint64, payload: seq[byte]
+): Future[void] {.async: (raises: [CancelledError, EthP2PError]).} =
+  try:
+    let
+      msgIdBytes = rlp.encodeInt(msgId)
+      payloadBytes = peer.compressMsg(payload)
+
+    var msg = newSeqOfCap[byte](msgIdBytes.data.len + payloadBytes.len)
+    msg.add msgIdBytes.data()
+    msg.add payloadBytes
+
+    trace "Sending message",
+      remote = peer.remote,
+      clientId = peer.clientId,
+      msgId,
+      data = toHex(msg.toOpenArray(0, min(255, msg.high))),
+      payload = toHex(payload.toOpenArray(0, min(255, payload.high)))
+
+    await peer.transport.sendMsg(msg)
+  except TransportError as exc:
+    await peer.disconnectAndRaise(TcpError, exc.msg)
+  except RlpxTransportError as exc:
+    await peer.disconnectAndRaise(BreachOfProtocol, exc.msg)
+
+proc send*[Msg](
+    peer: Peer, msg: Msg
+): Future[void] {.async: (raises: [CancelledError, EthP2PError], raw: true).} =
+  logSentMsg(peer, msg)
+
+  peer.sendMsg perPeerMsgId(peer, Msg), encodeMsg(msg)
+
+proc registerRequest(
+    peer: Peer, timeout: Duration, responseFuture: FutureBase, responseMsgId: uint64
+): uint64 =
+  result =
+    if peer.lastReqId.isNone:
+      0u64
+    else:
+      peer.lastReqId.value + 1u64
+  peer.lastReqId = Opt.some(result)
+
+  let timeoutAt = Moment.fromNow(timeout)
+  let req = OutstandingRequest(id: result, future: responseFuture)
+  peer.outstandingRequests[responseMsgId].addLast req
+
+  doAssert(not peer.dispatcher.isNil)
+  let requestResolver = peer.dispatcher.messages[responseMsgId].requestResolver
+  proc timeoutExpired(udata: pointer) {.gcsafe.} =
+    requestResolver(nil, responseFuture)
+
+  discard setTimer(timeoutAt, timeoutExpired, nil)
+
+proc resolveResponseFuture(peer: Peer, msgId: uint64, msg: pointer) =
+  ## This function is a split off from the previously combined version with
+  ## the same name using optional request ID arguments. This here is the
+  ## version without a request ID (there is the other part below.).
+  ##
+  ## Optional arguments for macro helpers seem easier to handle with
+  ## polymorphic functions (than a `Opt[]` prototype argument.)
+  ##
+  let msgInfo = peer.dispatcher.messages[msgId]
+
+  logScope:
+    msg = msgInfo.name
+    msgContents = msgInfo.printer(msg)
+    receivedReqId = -1
+    remotePeer = peer.remote
+
+  template outstandingReqs(): auto =
+    peer.outstandingRequests[msgId]
+
+  block: # no request ID
+    # XXX: This is a response from an ETH-like protocol that doesn't feature
+    # request IDs. Handling the response is quite tricky here because this may
+    # be a late response to an already timed out request or a valid response
+    # from a more recent one.
+    #
+    # We can increase the robustness by recording enough features of the
+    # request so we can recognize the matching response, but this is not very
+    # easy to do because our peers are allowed to send partial responses.
+    #
+    # A more generally robust approach is to maintain a set of the wanted
+    # data items and then to periodically look for items that have been
+    # requested long time ago, but are still missing. New requests can be
+    # issues for such items potentially from another random peer.
+    var expiredRequests = 0
+    for req in outstandingReqs:
+      if not req.future.finished:
+        break
+      inc expiredRequests
+    outstandingReqs.shrink(fromFirst = expiredRequests)
+    if outstandingReqs.len > 0:
+      let oldestReq = outstandingReqs.popFirst
+      msgInfo.requestResolver(msg, oldestReq.future)
+    else:
+      trace "late or dup RPLx reply ignored", msgId
+
+proc resolveResponseFuture(peer: Peer, msgId: uint64, msg: pointer, reqId: uint64) =
+  ## Variant of `resolveResponseFuture()` for request ID argument.
+  let msgInfo = peer.dispatcher.messages[msgId]
+  logScope:
+    msg = msgInfo.name
+    msgContents = msgInfo.printer(msg)
+    receivedReqId = reqId
+    remotePeer = peer.remote
+
+  template outstandingReqs(): auto =
+    peer.outstandingRequests[msgId]
+
+  block: # have request ID
+    # TODO: This is not completely sound because we are still using a global
+    # `reqId` sequence (the problem is that we might get a response ID that
+    # matches a request ID for a different type of request). To make the code
+    # correct, we can use a separate sequence per response type, but we have
+    # to first verify that the other Ethereum clients are supporting this
+    # correctly (because then, we'll be reusing the same reqIds for different
+    # types of requests). Alternatively, we can assign a separate interval in
+    # the `reqId` space for each type of response.
+    if peer.lastReqId.isNone or reqId > peer.lastReqId.value:
+      debug "RLPx response without matching request", msgId, reqId
+      return
+
+    var idx = 0
+    while idx < outstandingReqs.len:
+      template req(): auto =
+        outstandingReqs()[idx]
+
+      if req.future.finished:
+        # Here we'll remove the expired request by swapping
+        # it with the last one in the deque (if necessary):
+        if idx != outstandingReqs.len - 1:
+          req = outstandingReqs.popLast
+          continue
+        else:
+          outstandingReqs.shrink(fromLast = 1)
+          # This was the last item, so we don't have any
+          # more work to do:
+          return
+
+      if req.id == reqId:
+        msgInfo.requestResolver msg, req.future
+        # Here we'll remove the found request by swapping
+        # it with the last one in the deque (if necessary):
+        if idx != outstandingReqs.len - 1:
+          req = outstandingReqs.popLast
+        else:
+          outstandingReqs.shrink(fromLast = 1)
+        return
+
+      inc idx
+
+    trace "late or dup RPLx reply ignored"
+
+proc checkedRlpRead(
+    peer: Peer, r: var Rlp, MsgType: type
+): auto {.raises: [RlpError].} =
+  when defined(release):
+    return r.read(MsgType)
+  else:
+    try:
+      return r.read(MsgType)
+    except rlp.RlpError as e:
+      debug "Failed rlp.read",
+        peer = peer, dataType = MsgType.name, err = e.msg, errName = e.name
+        #, rlpData = r.inspect -- don't use (might crash)
+
+      raise e
+
+proc nextMsg*(
+    peer: Peer, MsgType: type
+): Future[MsgType] {.async: (raises: [CancelledError, EthP2PError], raw: true).} =
+  ## This procs awaits a specific RLPx message.
+  ## Any messages received while waiting will be dispatched to their
+  ## respective handlers. The designated message handler will also run
+  ## to completion before the future returned by `nextMsg` is resolved.
+  let wantedId = peer.perPeerMsgId(MsgType)
+  let f = peer.awaitedMessages[wantedId]
+  if not f.isNil:
+    return Future[MsgType].Raising([CancelledError, EthP2PError])(f)
+
+  initFuture result
+  peer.awaitedMessages[wantedId] = result
+
+proc dispatchMessages*(peer: Peer) {.async: (raises: []).} =
+  try:
+    while peer.connectionState notin {Disconnecting, Disconnected}:
+      var (msgId, msgData) = await peer.recvMsg()
+
+      await peer.invokeThunk(msgId, msgData)
+  except EthP2PError:
+    # TODO Is this needed? Most such exceptions are raised with an accompanying
+    #      disconnect already .. ClientQuitting isn't a great error but as good
+    #      as any since it will have no effect if the disconnect already happened
+    await peer.disconnect(ClientQuitting)
+  except CancelledError:
+    await peer.disconnect(ClientQuitting)
+
+proc p2pProtocolBackendImpl*(protocol: P2PProtocol): Backend =
+  let
+    resultIdent = ident "result"
+    Peer = bindSym "Peer"
+    EthereumNode = bindSym "EthereumNode"
+
+    initRlpWriter = bindSym "initRlpWriter"
+    append = bindSym("append", brForceOpen)
+    read = bindSym("read", brForceOpen)
+    checkedRlpRead = bindSym "checkedRlpRead"
+    startList = bindSym "startList"
+    tryEnterList = bindSym "tryEnterList"
+    finish = bindSym "finish"
+
+    messagePrinter = bindSym "messagePrinter"
+    nextMsgResolver = bindSym "nextMsgResolver"
+    failResolver = bindSym "failResolver"
+    registerRequest = bindSym "registerRequest"
+    requestResolver = bindSym "requestResolver"
+    resolveResponseFuture = bindSym "resolveResponseFuture"
+    sendMsg = bindSym "sendMsg"
+    nextMsg = bindSym "nextMsg"
+    initProtocol = bindSym"initProtocol"
+    registerMsg = bindSym "registerMsg"
+    perPeerMsgId = bindSym "perPeerMsgId"
+    perPeerMsgIdImpl = bindSym "perPeerMsgIdImpl"
+    linkSendFailureToReqFuture = bindSym "linkSendFailureToReqFuture"
+    handshakeImpl = bindSym "handshakeImpl"
+
+    ResponderWithId = bindSym "ResponderWithId"
+    ResponderWithoutId = bindSym "ResponderWithoutId"
+
+    isSubprotocol = protocol.rlpxName != "p2p"
+
+  if protocol.rlpxName.len == 0:
+    protocol.rlpxName = protocol.name
+  # By convention, all Ethereum protocol names have at least 3 characters.
+  doAssert protocol.rlpxName.len >= 3
+
+  new result
+
+  result.registerProtocol = bindSym "registerProtocol"
+  result.setEventHandlers = bindSym "setEventHandlers"
+  result.PeerType = Peer
+  result.NetworkType = EthereumNode
+  result.ResponderType =
+    if protocol.useRequestIds: ResponderWithId else: ResponderWithoutId
+
+  result.implementMsg = proc(msg: Message) =
+    var
+      msgIdValue = msg.id
+      msgIdent = msg.ident
+      msgName = $msgIdent
+      msgRecName = msg.recName
+      responseMsgId =
+        if msg.response.isNil:
+          Opt.none(uint64)
+        else:
+          Opt.some(msg.response.id)
+      hasReqId = msg.hasReqId
+      protocol = msg.protocol
+
+      # variables used in the sending procs
+      peerOrResponder = ident"peerOrResponder"
+      rlpWriter = ident"writer"
+      perPeerMsgIdVar = ident"perPeerMsgId"
+
+      # variables used in the receiving procs
+      receivedRlp = ident"rlp"
+      receivedMsg = ident"msg"
+
+    var
+      readParams = newNimNode(nnkStmtList)
+      paramsToWrite = newSeq[NimNode](0)
+      appendParams = newNimNode(nnkStmtList)
+
+    if hasReqId:
+      # Messages using request Ids
+      readParams.add quote do:
+        let `reqIdVar` = `read`(`receivedRlp`, uint64)
+
+    case msg.kind
+    of msgRequest:
+      doAssert responseMsgId.isSome
+
+      let reqToResponseOffset = responseMsgId.value - msgIdValue
+      let responseMsgId = quote:
+        `perPeerMsgIdVar` + `reqToResponseOffset`
+
+      # Each request is registered so we can resolve it when the response
+      # arrives. There are two types of protocols: newer protocols use
+      # explicit `reqId` sent over the wire, while old versions of the ETH wire
+      # protocol assume response order matches requests.
+      let registerRequestCall =
+        newCall(registerRequest, peerVar, timeoutVar, resultIdent, responseMsgId)
+      if hasReqId:
+        appendParams.add quote do:
+          initFuture `resultIdent`
+          let `reqIdVar` = `registerRequestCall`
+        paramsToWrite.add reqIdVar
+      else:
+        appendParams.add quote do:
+          initFuture `resultIdent`
+          discard `registerRequestCall`
+    of msgResponse:
+      if hasReqId:
+        paramsToWrite.add newDotExpr(peerOrResponder, reqIdVar)
+    of msgHandshake, msgNotification:
+      discard
+
+    for param, paramType in msg.procDef.typedParams(skip = 1):
+      # This is a fragment of the sending proc that
+      # serializes each of the passed parameters:
+      paramsToWrite.add param
+
+      # The received RLP data is deserialized to a local variable of
+      # the message-specific type. This is done field by field here:
+      readParams.add quote do:
+        `receivedMsg`.`param` = `checkedRlpRead`(`peerVar`, `receivedRlp`, `paramType`)
+
+    let
+      paramCount = paramsToWrite.len
+      readParamsPrelude =
+        if paramCount > 1:
+          newCall(tryEnterList, receivedRlp)
+        else:
+          newStmtList()
+
+    when tracingEnabled:
+      readParams.add newCall(bindSym"logReceivedMsg", peerVar, receivedMsg)
+
+    let callResolvedResponseFuture =
+      if msg.kind != msgResponse:
+        newStmtList()
+      elif hasReqId:
+        newCall(
+          resolveResponseFuture,
+          peerVar,
+          newCall(perPeerMsgId, peerVar, msgRecName),
+          newCall("addr", receivedMsg),
+          reqIdVar,
+        )
+      else:
+        newCall(
+          resolveResponseFuture,
+          peerVar,
+          newCall(perPeerMsgId, peerVar, msgRecName),
+          newCall("addr", receivedMsg),
+        )
+
+    var userHandlerParams = @[peerVar]
+    if hasReqId:
+      userHandlerParams.add reqIdVar
+
+    let
+      awaitUserHandler = msg.genAwaitUserHandler(receivedMsg, userHandlerParams)
+      thunkName = ident(msgName & "Thunk")
+
+    msg.defineThunk quote do:
+      proc `thunkName`(
+          `peerVar`: `Peer`, data: Rlp
+      ) {.async: (raises: [CancelledError, EthP2PError]).} =
+        var `receivedRlp` = data
+        var `receivedMsg`: `msgRecName`
+        try:
+          `readParamsPrelude`
+          `readParams`
+          `awaitUserHandler`
+          `callResolvedResponseFuture`
+        except rlp.RlpError as exc:
+          # TODO this is a pre-release warning - we should turn this into an
+          #      actual BreachOfProtocol disconnect down the line
+          warn "TODO: RLP decoding failed for incoming message",
+            msg = name(`msgRecName`),
+            remote = `peerVar`.remote,
+            clientId = `peerVar`.clientId,
+            err = exc.msg
+
+          await `peerVar`.disconnectAndRaise(
+            BreachOfProtocol, "Invalid RLP in parameter list for " & $(`msgRecName`)
+          )
+
+    var sendProc = msg.createSendProc(isRawSender = (msg.kind == msgHandshake))
+    sendProc.def.params[1][0] = peerOrResponder
+
+    let
+      msgBytes = ident"msgBytes"
+      finalizeRequest = quote:
+        let `msgBytes` = `finish`(`rlpWriter`)
+
+      perPeerMsgIdValue =
+        if isSubprotocol:
+          newCall(perPeerMsgIdImpl, peerVar, protocol.protocolInfo, newLit(msgIdValue))
+        else:
+          newLit(msgIdValue)
+
+    var sendCall = newCall(sendMsg, peerVar, perPeerMsgIdVar, msgBytes)
+    let senderEpilogue =
+      if msg.kind == msgRequest:
+        # In RLPx requests, the returned future was allocated here and passed
+        # to `registerRequest`. It's already assigned to the result variable
+        # of the proc, so we just wait for the sending operation to complete
+        # and we return in a normal way. (the waiting is done, so we can catch
+        # any possible errors).
+        quote:
+          `linkSendFailureToReqFuture`(`sendCall`, `resultIdent`)
+      else:
+        # In normal RLPx messages, we are returning the future returned by the
+        # `sendMsg` call.
+        quote:
+          return `sendCall`
+
+    if paramCount > 1:
+      # In case there are more than 1 parameter,
+      # the params must be wrapped in a list:
+      appendParams =
+        newStmtList(newCall(startList, rlpWriter, newLit(paramCount)), appendParams)
+
+    for param in paramsToWrite:
+      appendParams.add newCall(append, rlpWriter, param)
+
+    let initWriter = quote:
+      var `rlpWriter` = `initRlpWriter`()
+      let `perPeerMsgIdVar` = `perPeerMsgIdValue`
+
+    when tracingEnabled:
+      appendParams.add logSentMsgFields(peerVar, protocol, msgId, paramsToWrite)
+
+    # let paramCountNode = newLit(paramCount)
+    sendProc.setBody quote do:
+      let `peerVar` = getPeer(`peerOrResponder`)
+      `initWriter`
+      `appendParams`
+      `finalizeRequest`
+      `senderEpilogue`
+
+    if msg.kind == msgHandshake:
+      discard msg.createHandshakeTemplate(sendProc.def.name, handshakeImpl, nextMsg)
+
+    protocol.outProcRegistrations.add(
+      newCall(
+        registerMsg,
+        protocolVar,
+        newLit(msgIdValue),
+        newLit(msgName),
+        thunkName,
+        newTree(nnkBracketExpr, messagePrinter, msgRecName),
+        newTree(nnkBracketExpr, requestResolver, msgRecName),
+        newTree(nnkBracketExpr, nextMsgResolver, msgRecName),
+        newTree(nnkBracketExpr, failResolver, msgRecName),
+      )
+    )
+
+  result.implementProtocolInit = proc(protocol: P2PProtocol): NimNode =
+    return newCall(
+      initProtocol,
+      newLit(protocol.rlpxName),
+      newLit(protocol.version),
+      protocol.peerInit,
+      protocol.netInit,
+    )
+
+p2pProtocol DevP2P(version = devp2pSnappyVersion, rlpxName = "p2p"):
+  proc hello(
+      peer: Peer,
+      version: uint64,
+      clientId: string,
+      capabilities: seq[Capability],
+      listenPort: uint,
+      nodeId: array[RawPublicKeySize, byte],
+  ) =
+    # The first hello message gets processed during the initial handshake - this
+    # version is used for any subsequent messages
+
+    # TODO investigate and turn warning into protocol breach
+    warn "TODO Multiple hello messages received",
+      remote = peer.remote, clientId = clientId
+    # await peer.disconnectAndRaise(BreachOfProtocol, "Multiple hello messages")
+
+  proc sendDisconnectMsg(peer: Peer, reason: DisconnectionReasonList) =
+    ## Notify other peer that we're about to disconnect them for the given
+    ## reason
+    if reason.value == BreachOfProtocol:
+      # TODO This is a temporary log message at warning level to aid in
+      #      debugging in pre-release versions - it should be removed before
+      #      release
+      # TODO Nethermind sends BreachOfProtocol on network id mismatch:
+      #      https://github.com/NethermindEth/nethermind/issues/7727
+      if not peer.clientId.startsWith("Nethermind"):
+        warn "TODO Peer sent BreachOfProtocol error!",
+          remote = peer.remote, clientId = peer.clientId
+    else:
+      trace "disconnect message received", reason = reason.value, peer
+    await peer.disconnect(reason.value, false)
+
+  # Adding an empty RLP list as the spec defines.
+  # The parity client specifically checks if there is rlp data.
+  proc ping(peer: Peer, emptyList: EmptyList) =
+    discard peer.pong(EmptyList())
+
+  proc pong(peer: Peer, emptyList: EmptyList) =
+    discard
+
+proc removePeer(network: EthereumNode, peer: Peer) =
+  # It is necessary to check if peer.remote still exists. The connection might
+  # have been dropped already from the peers side.
+  # E.g. when receiving a p2p.disconnect message from a peer, a race will happen
+  # between which side disconnects first.
+  if network.peerPool != nil and not peer.remote.isNil and
+      peer.remote in network.peerPool.connectedNodes:
+    network.peerPool.connectedNodes.del(peer.remote)
+    rlpx_connected_peers.dec()
+
+    # Note: we need to do this check as disconnect (and thus removePeer)
+    # currently can get called before the dispatcher is initialized.
+    if not peer.dispatcher.isNil:
+      for observer in network.peerPool.observers.values:
+        if not observer.onPeerDisconnected.isNil:
+          if observer.protocol.isNil or peer.supports(observer.protocol):
+            observer.onPeerDisconnected(peer)
+
+proc callDisconnectHandlers(
+    peer: Peer, reason: DisconnectionReason
+): Future[void] {.async: (raises: []).} =
+  let futures = peer.dispatcher.activeProtocols
+    .filterIt(it.onPeerDisconnected != nil)
+    .mapIt(it.onPeerDisconnected(peer, reason))
+
+  await noCancel allFutures(futures)
+
+proc disconnect*(
+    peer: Peer, reason: DisconnectionReason, notifyOtherPeer = false
+) {.async: (raises: []).} =
+  if reason == BreachOfProtocol:
+    # TODO remove warning after all protocol breaches have been investigated
+    # TODO https://github.com/NethermindEth/nethermind/issues/7727
+    if not peer.clientId.startsWith("Nethermind"):
+      warn "TODO disconnecting peer because of protocol breach",
+        remote = peer.remote, clientId = peer.clientId
+  if peer.connectionState notin {Disconnecting, Disconnected}:
+    if peer.connectionState == Connected:
+      # Only log peers that successfully completed the full connection setup -
+      # the others should have been logged already
+      debug "Peer disconnected", remote = peer.remote, clientId = peer.clientId, reason
+
+    peer.connectionState = Disconnecting
+
+    # Do this first so sub-protocols have time to clean up and stop sending
+    # before this node closes transport to remote peer
+    if not peer.dispatcher.isNil:
+      # Notify all pending handshake handlers that a disconnection happened
+      for msgId, fut in peer.awaitedMessages.mpairs:
+        if fut != nil:
+          var tmp = fut
+          fut = nil
+          peer.dispatcher.messages[msgId].failResolver(reason, tmp)
+
+      for msgId, reqs in peer.outstandingRequests.mpairs():
+        while reqs.len > 0:
+          let req = reqs.popFirst()
+          # Same as when they timeout
+          peer.dispatcher.messages[msgId].requestResolver(nil, req.future)
+
+      # In case of `CatchableError` in any of the handlers, this will be logged.
+      # Other handlers will still execute.
+      # In case of `Defect` in any of the handlers, program will quit.
+      await callDisconnectHandlers(peer, reason)
+
+    if notifyOtherPeer and not peer.transport.closed:
+      proc waitAndClose(
+          transport: RlpxTransport, time: Duration
+      ) {.async: (raises: []).} =
+        await noCancel sleepAsync(time)
+        await noCancel peer.transport.closeWait()
+
+      try:
+        await peer.sendDisconnectMsg(DisconnectionReasonList(value: reason))
+      except CatchableError as e:
+        trace "Failed to deliver disconnect message",
+          peer, err = e.msg, errName = e.name
+
+      # Give the peer a chance to disconnect
+      asyncSpawn peer.transport.waitAndClose(2.seconds)
+    elif not peer.transport.closed:
+      peer.transport.close()
+
+    logDisconnectedPeer peer
+    peer.connectionState = Disconnected
+    removePeer(peer.network, peer)
+
+proc initPeerState*(
+    peer: Peer, capabilities: openArray[Capability]
+) {.raises: [UselessPeerError].} =
+  peer.dispatcher = getDispatcher(peer.network, capabilities).valueOr:
+    raise (ref UselessPeerError)(
+      msg: "No capabilities in common: " & capabilities.mapIt($it).join(",")
+    )
+
+  # The dispatcher has determined our message ID sequence.
+  # For each message ID, we allocate a potential slot for
+  # tracking responses to requests.
+  # (yes, some of the slots won't be used).
+  peer.outstandingRequests.newSeq(peer.dispatcher.messages.len)
+  for d in mitems(peer.outstandingRequests):
+    d = initDeque[OutstandingRequest]()
+
+  # Similarly, we need a bit of book-keeping data to keep track
+  # of the potentially concurrent calls to `nextMsg`.
+  peer.awaitedMessages.newSeq(peer.dispatcher.messages.len)
+  peer.lastReqId = Opt.some(0u64)
+  peer.initProtocolStates peer.dispatcher.activeProtocols
+
+proc postHelloSteps(
+    peer: Peer, h: DevP2P.hello
+) {.async: (raises: [CancelledError, EthP2PError]).} =
+  peer.clientId = h.clientId
+  initPeerState(peer, h.capabilities)
+
+  # Please note that the ordering of operations here is important!
+  #
+  # We must first start all handshake procedures and give them a
+  # chance to send any initial packages they might require over
+  # the network and to yield on their `nextMsg` waits.
+  #
+
+  let handshakes = peer.dispatcher.activeProtocols
+    .filterIt(it.onPeerConnected != nil)
+    .mapIt(it.onPeerConnected(peer))
+
+  # The `dispatchMessages` loop must be started after this.
+  # Otherwise, we risk that some of the handshake packets sent by
+  # the other peer may arrive too early and be processed before
+  # the handshake code got a change to wait for them.
+  #
+  let messageProcessingLoop = peer.dispatchMessages()
+
+  # The handshake may involve multiple async steps, so we wait
+  # here for all of them to finish.
+  #
+  await allFutures(handshakes)
+
+  for handshake in handshakes:
+    if not handshake.completed():
+      await handshake # raises correct error without actually waiting
+
+  # This is needed as a peer might have already disconnected. In this case
+  # we need to raise so that rlpxConnect/rlpxAccept fails.
+  # Disconnect is done only to run the disconnect handlers. TODO: improve this
+  # also TODO: Should we discern the type of error?
+  if messageProcessingLoop.finished:
+    await peer.disconnectAndRaise(
+      ClientQuitting, "messageProcessingLoop ended while connecting"
+    )
+  peer.connectionState = Connected
+
+template setSnappySupport(peer: Peer, hello: DevP2P.hello) =
+  peer.snappyEnabled = hello.version >= devp2pSnappyVersion.uint64
+
+type RlpxError* = enum
+  TransportConnectError
+  RlpxHandshakeTransportError
+  RlpxHandshakeError
+  ProtocolError
+  P2PHandshakeError
+  P2PTransportError
+  InvalidIdentityError
+  UselessRlpxPeerError
+  PeerDisconnectedError
+  TooManyPeersError
+
+proc helloHandshake(
+    node: EthereumNode, peer: Peer
+): Future[DevP2P.hello] {.async: (raises: [CancelledError, EthP2PError]).} =
+  ## Negotiate common capabilities using the p2p `hello` message
+
+  # https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/rlpx.md#hello-0x00
+
+  await peer.send(
+    DevP2P.hello(
+      version: devp2pSnappyVersion,
+      clientId: node.clientId,
+      capabilities: node.capabilities,
+      listenPort: 0, # obsolete
+      nodeId: node.keys.pubkey.toRaw(),
+    )
+  )
+
+  # The first message received must be a hello or a disconnect
+  var (msgId, msgData) = await peer.recvMsg()
+
+  try:
+    case msgId
+    of msgIdHello:
+      # Implementations must ignore any additional list elements in Hello
+      # because they may be used by a future version.
+      let response = msgData.read(DevP2P.hello)
+      trace "Received Hello", version = response.version, id = response.clientId
+
+      if response.nodeId != peer.transport.pubkey.toRaw:
+        await peer.disconnectAndRaise(
+          BreachOfProtocol, "nodeId in hello does not match RLPx transport identity"
+        )
+
+      return response
+    of msgIdDisconnect: # Disconnection requested by peer
+      # TODO distinguish their reason from ours
+      let reason = msgData.read(DisconnectionReasonList).value
+      await peer.disconnectAndRaise(
+        reason, "Peer disconnecting during hello: " & $reason
+      )
+    else:
+      # No other messages may be sent until a Hello is received.
+      await peer.disconnectAndRaise(BreachOfProtocol, "Expected hello, got " & $msgId)
+  except RlpError:
+    await peer.disconnectAndRaise(BreachOfProtocol, "Could not decode hello RLP")
+
+proc rlpxConnect*(
+    node: EthereumNode, remote: Node
+): Future[Result[Peer, RlpxError]] {.async: (raises: [CancelledError]).} =
+  # TODO move logging elsewhere - the aim is to have exactly _one_ debug log per
+  #      connection attempt (success or failure) to not spam the logs
+  initTracing(devp2pInfo, node.protocols)
+  logScope:
+    remote
+  trace "Connecting to peer"
+
+  let
+    peer = Peer(remote: remote, network: node)
+    deadline = sleepAsync(connectionTimeout)
+
+  var error = true
+
+  defer:
+    deadline.cancelSoon() # Harmless if finished
+
+    if error: # TODO: Not sure if I like this much
+      if peer.transport != nil:
+        peer.transport.close()
+
+  peer.transport =
+    try:
+      let ta = initTAddress(remote.node.address.ip, remote.node.address.tcpPort)
+      await RlpxTransport.connect(node.rng, node.keys, ta, remote.node.pubkey).wait(
+        deadline
+      )
+    except AsyncTimeoutError:
+      debug "Connect timeout"
+      return err(TransportConnectError)
+    except RlpxTransportError as exc:
+      debug "Connect RlpxTransport error", err = exc.msg
+      return err(ProtocolError)
+    except TransportError as exc:
+      debug "Connect transport error", err = exc.msg
+      return err(TransportConnectError)
+
+  logConnectedPeer peer
+
+  # RLPx p2p capability handshake: After the initial handshake, both sides of
+  # the connection must send either Hello or a Disconnect message.
+  let response =
+    try:
+      await node.helloHandshake(peer).wait(deadline)
+    except AsyncTimeoutError:
+      debug "Connect handshake timeout"
+      return err(P2PHandshakeError)
+    except PeerDisconnected as exc:
+      debug "Connect handshake disconnection", err = exc.msg, reason = exc.reason
+      case exc.reason
+      of TooManyPeers:
+        return err(TooManyPeersError)
+      else:
+        return err(PeerDisconnectedError)
+    except UselessPeerError as exc:
+      debug "Useless peer during handshake", err = exc.msg
+      return err(UselessRlpxPeerError)
+    except EthP2PError as exc:
+      debug "Connect handshake error", err = exc.msg
+      return err(PeerDisconnectedError)
+
+  if response.version < devp2pSnappyVersion:
+    await peer.disconnect(IncompatibleProtocolVersion, notifyOtherPeer = true)
+    debug "Peer using obsolete devp2p version",
+      version = response.version, clientId = response.clientId
+    return err(UselessRlpxPeerError)
+
+  peer.setSnappySupport(response)
+
+  logScope:
+    clientId = response.clientId
+
+  trace "DevP2P handshake completed"
+
+  try:
+    await postHelloSteps(peer, response)
+  except PeerDisconnected as exc:
+    debug "Disconnect finishing hello",
+      remote, clientId = response.clientId, err = exc.msg, reason = exc.reason
+    case exc.reason
+    of TooManyPeers:
+      return err(TooManyPeersError)
+    else:
+      return err(PeerDisconnectedError)
+  except UselessPeerError as exc:
+    debug "Useless peer finishing hello", err = exc.msg
+    return err(UselessRlpxPeerError)
+  except EthP2PError as exc:
+    debug "P2P error finishing hello", err = exc.msg
+    return err(ProtocolError)
+
+  debug "Peer connected", capabilities = response.capabilities
+
+  error = false
+
+  return ok(peer)
+
+# TODO: rework rlpxAccept similar to rlpxConnect.
+proc rlpxAccept*(
+    node: EthereumNode, stream: StreamTransport
+): Future[Peer] {.async: (raises: [CancelledError, EthP2PError]).} =
+  # TODO move logging elsewhere - the aim is to have exactly _one_ debug log per
+  #      connection attempt (success or failure) to not spam the logs
+  initTracing(devp2pInfo, node.protocols)
+
+  let
+    peer = Peer(network: node)
+    deadline = sleepAsync(connectionTimeout)
+
+  var error = true
+  defer:
+    deadline.cancelSoon()
+
+    if error:
+      stream.close()
+
+  let remoteAddress =
+    try:
+      stream.remoteAddress()
+    except TransportError as exc:
+      debug "Could not get remote address", err = exc.msg
+      return nil
+
+  trace "Incoming connection", remoteAddress = $remoteAddress
+
+  peer.transport =
+    try:
+      await RlpxTransport.accept(node.rng, node.keys, stream).wait(deadline)
+    except AsyncTimeoutError:
+      debug "Accept timeout", remoteAddress = $remoteAddress
+      rlpx_accept_failure.inc(labelValues = ["timeout"])
+      return nil
+    except RlpxTransportError as exc:
+      debug "Accept RlpxTransport error", remoteAddress = $remoteAddress, err = exc.msg
+      rlpx_accept_failure.inc(labelValues = [$BreachOfProtocol])
+      return nil
+    except TransportError as exc:
+      debug "Accept transport error", remoteAddress = $remoteAddress, err = exc.msg
+      rlpx_accept_failure.inc(labelValues = [$TcpError])
+      return nil
+
+  let
+    # The ports in this address are not necessarily the ports that the peer is
+    # actually listening on, so we cannot use this information to connect to
+    # the peer in the future!
+    ip =
+      try:
+        remoteAddress.address
+      except ValueError:
+        raiseAssert "only tcp sockets supported"
+    address = Address(ip: ip, tcpPort: remoteAddress.port, udpPort: remoteAddress.port)
+
+  peer.remote = newNode(ENode(pubkey: peer.transport.pubkey, address: address))
+
+  logAcceptedPeer peer
+
+  logScope:
+    remote = peer.remote
+
+  let response =
+    try:
+      await node.helloHandshake(peer).wait(deadline)
+    except AsyncTimeoutError:
+      debug "Accept handshake timeout"
+      rlpx_accept_failure.inc(labelValues = ["timeout"])
+      return nil
+    except PeerDisconnected as exc:
+      debug "Accped handshake disconnection", err = exc.msg, reason = exc.reason
+      rlpx_accept_failure.inc(labelValues = [$exc.reason])
+      return nil
+    except EthP2PError as exc:
+      debug "Accped handshake error", err = exc.msg
+      rlpx_accept_failure.inc(labelValues = ["error"])
+      return nil
+
+  if response.version < devp2pSnappyVersion:
+    await peer.disconnect(IncompatibleProtocolVersion, notifyOtherPeer = true)
+    debug "Peer using obsolete devp2p version",
+      version = response.version, clientId = response.clientId
+    rlpx_accept_failure.inc(labelValues = [$IncompatibleProtocolVersion])
+    return nil
+
+  peer.setSnappySupport(response)
+
+  logScope:
+    clientId = response.clientId
+
+  trace "DevP2P handshake completed", response
+
+  # In case there is an outgoing connection started with this peer we give
+  # precedence to that one and we disconnect here with `AlreadyConnected`
+  if peer.remote in node.peerPool.connectedNodes or
+      peer.remote in node.peerPool.connectingNodes:
+    trace "Duplicate connection in rlpxAccept"
+    rlpx_accept_failure.inc(labelValues = [$AlreadyConnected])
+    return nil
+
+  node.peerPool.connectingNodes.incl(peer.remote)
+
+  try:
+    await postHelloSteps(peer, response)
+  except PeerDisconnected as exc:
+    debug "Disconnect while accepting", reason = exc.reason, err = exc.msg
+    rlpx_accept_failure.inc(labelValues = [$exc.reason])
+    return nil
+  except UselessPeerError as exc:
+    debug "Useless peer while accepting", err = exc.msg
+
+    rlpx_accept_failure.inc(labelValues = [$UselessPeer])
+    return nil
+  except EthP2PError as exc:
+    trace "P2P error during accept", err = exc.msg
+    rlpx_accept_failure.inc(labelValues = [$exc.name])
+    return nil
+
+  debug "Peer accepted", capabilities = response.capabilities
+
+  error = false
+  rlpx_accept_success.inc()
+
+  return peer

--- a/execution_chain/networking/rlpx/auth.nim
+++ b/execution_chain/networking/rlpx/auth.nim
@@ -1,0 +1,406 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+## This module implements Ethereum EIP-8 RLPx authentication - pre-EIP-8
+## messages are not supported
+## https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/rlpx.md#initial-handshake
+## https://github.com/ethereum/EIPs/blob/b479473414cf94445b450c266a9dedc079a12158/EIPS/eip-8.md
+
+{.push raises: [].}
+
+import
+  nimcrypto/[rijndael, keccak, utils],
+  stew/[arrayops, byteutils, endians2, objects],
+  results,
+  eth/rlp,
+  eth/common/keys,
+  ./ecies
+
+export results
+
+type keccak256 = keccak.keccak256
+
+const
+  # Auth message sizes
+  MsgLenLenEIP8* = 2
+    ## auth-size = size of enc-auth-body, encoded as a big-endian 16-bit integer
+    ## ack-size = size of enc-ack-body, encoded as a big-endian 16-bit integer
+
+  MinPadLenEIP8* = 100
+  MaxPadLenEIP8* = 300
+    ## Padding makes message length unpredictable which makes packet filtering
+    ## a tiny bit harder - although not necessary any more, we always add at
+    ## least 100 bytes of padding to make the message distinguishable from
+    ## pre-EIP8 and at most 200 to stay within recommendation
+
+  # signature + pubkey + nonce + version + rlp encoding overhead
+  # 65 + 64 + 32 + 1 + 7 = 169
+  PlainAuthMessageEIP8Length = 169
+  PlainAuthMessageMaxEIP8 = PlainAuthMessageEIP8Length + MaxPadLenEIP8
+  # Min. encrypted message + size prefix = 284
+  AuthMessageEIP8Length* =
+    eciesEncryptedLength(PlainAuthMessageEIP8Length) + MsgLenLenEIP8
+  AuthMessageMaxEIP8* = AuthMessageEIP8Length + MaxPadLenEIP8
+    ## Minimal output buffer size to pass into `authMessage`
+
+  # Ack message sizes
+
+  # pubkey + nounce + version + rlp encoding overhead
+  # 64 + 32 + 1 + 5 = 102
+  PlainAckMessageEIP8Length = 102
+  PlainAckMessageMaxEIP8 = PlainAckMessageEIP8Length + MaxPadLenEIP8
+  # Min. encrypted message + size prefix = 217
+  AckMessageEIP8Length* =
+    eciesEncryptedLength(PlainAckMessageEIP8Length) + MsgLenLenEIP8
+  AckMessageMaxEIP8* = AckMessageEIP8Length + MaxPadLenEIP8
+    ## Minimal output buffer size to pass into `ackMessage`
+
+  Vsn = [byte 4]
+    ## auth-vsn = 4
+    ## ack-vsn = 4
+
+type
+  Nonce* = array[KeyLength, byte]
+
+  HandshakeFlag* = enum
+    Initiator ## `Handshake` owner is connection initiator
+    Responder ## `Handshake` owner is connection responder
+
+  AuthError* = enum
+    EcdhError = "auth: ECDH shared secret could not be calculated"
+    BufferOverrun = "auth: buffer overrun"
+    SignatureError = "auth: signature could not be obtained"
+    EciesError = "auth: ECIES encryption/decryption error"
+    InvalidPubKey = "auth: invalid public key"
+    InvalidAuth = "auth: invalid Authentication message"
+    InvalidAck = "auth: invalid Authentication ACK message"
+    RlpError = "auth: error while decoding RLP stream"
+    IncompleteError = "auth: data incomplete"
+
+  Handshake* = object
+    flags*: set[HandshakeFlag] ## handshake flags
+    host*: KeyPair ## host keypair
+    ephemeral*: KeyPair ## ephemeral host keypair
+    remoteHPubkey*: PublicKey ## remote host public key
+    remoteEPubkey*: PublicKey ## remote host ephemeral public key
+    initiatorNonce*: Nonce ## initiator nonce
+    responderNonce*: Nonce ## responder nonce
+
+  ConnectionSecret* = object
+    aesKey*: array[aes256.sizeKey, byte]
+    macKey*: array[KeyLength, byte]
+    egressMac*: keccak256
+    ingressMac*: keccak256
+
+  AuthResult*[T] = Result[T, AuthError]
+
+template toa(a, b, c: untyped): untyped =
+  toOpenArray((a), (b), (b) + (c) - 1)
+
+proc mapErrTo[T, E](r: Result[T, E], v: static AuthError): AuthResult[T] =
+  r.mapErr(
+    proc(e: E): AuthError =
+      v
+  )
+
+proc init*(
+    T: type Handshake,
+    rng: var HmacDrbgContext,
+    host: KeyPair,
+    flags: set[HandshakeFlag],
+): T =
+  ## Create new `Handshake` object.
+  var
+    initiatorNonce: Nonce
+    responderNonce: Nonce
+    ephemeral = KeyPair.random(rng)
+
+  if Initiator in flags:
+    rng.generate(initiatorNonce)
+  else:
+    rng.generate(responderNonce)
+
+  return T(
+    flags: flags,
+    host: host,
+    ephemeral: ephemeral,
+    initiatorNonce: initiatorNonce,
+    responderNonce: responderNonce,
+  )
+
+proc authMessage*(
+    h: var Handshake,
+    rng: var HmacDrbgContext,
+    pubkey: PublicKey,
+    output: var openArray[byte],
+): AuthResult[int] =
+  ## Create EIP8 authentication message - returns length of encoded message
+  ## The output should be a buffer of AuthMessageMaxEIP8 bytes at least.
+  if len(output) < AuthMessageMaxEIP8:
+    return err(AuthError.BufferOverrun)
+
+  var padsize = int(rng.generate(byte))
+  while padsize > (MaxPadLenEIP8 - MinPadLenEIP8):
+    padsize = int(rng.generate(byte))
+  padsize += MinPadLenEIP8
+
+  let
+    pencsize = eciesEncryptedLength(PlainAuthMessageEIP8Length)
+    wosize = pencsize + padsize
+    fullsize = wosize + 2
+
+  doAssert fullsize <= len(output), "We checked against max possible length above"
+
+  var secret = ecdhSharedSecret(h.host.seckey, pubkey)
+  secret.data = secret.data xor h.initiatorNonce
+
+  let signature = sign(h.ephemeral.seckey, SkMessage(secret.data))
+  secret.clear()
+
+  h.remoteHPubkey = pubkey
+  var payload =
+    rlp.encodeList(signature.toRaw(), h.host.pubkey.toRaw(), h.initiatorNonce, Vsn)
+  doAssert(len(payload) == PlainAuthMessageEIP8Length)
+
+  var buffer {.noinit.}: array[PlainAuthMessageMaxEIP8, byte]
+  copyMem(addr buffer[0], addr payload[0], len(payload))
+  rng.generate(toa(buffer, PlainAuthMessageEIP8Length, padsize))
+
+  let wosizeBE = uint16(wosize).toBytesBE()
+  output[0 ..< 2] = wosizeBE
+  if eciesEncrypt(
+    rng,
+    toa(buffer, 0, len(payload) + padsize),
+    toa(output, 2, wosize),
+    pubkey,
+    toa(output, 0, 2),
+  ).isErr:
+    return err(AuthError.EciesError)
+
+  ok(fullsize)
+
+proc ackMessage*(
+    h: var Handshake, rng: var HmacDrbgContext, output: var openArray[byte]
+): AuthResult[int] =
+  ## Create EIP8 authentication ack message - returns length of encoded message
+  ## The output should be a buffer of AckMessageMaxEIP8 bytes at least.
+  if len(output) < AckMessageMaxEIP8:
+    return err(AuthError.BufferOverrun)
+
+  var padsize = int(rng.generate(byte))
+  while padsize > (MaxPadLenEIP8 - MinPadLenEIP8):
+    padsize = int(rng.generate(byte))
+  padsize += MinPadLenEIP8
+
+  let
+    pencsize = eciesEncryptedLength(PlainAckMessageEIP8Length)
+    wosize = pencsize + padsize
+    fullsize = wosize + 2
+
+  doAssert fullsize <= len(output), "We checked against max possible length above"
+
+  var
+    buffer: array[PlainAckMessageMaxEIP8, byte]
+    payload = rlp.encodeList(h.ephemeral.pubkey.toRaw(), h.responderNonce, Vsn)
+  doAssert(len(payload) == PlainAckMessageEIP8Length)
+
+  copyMem(addr buffer[0], addr payload[0], PlainAckMessageEIP8Length)
+  rng.generate(toa(buffer, PlainAckMessageEIP8Length, padsize))
+
+  output[0 ..< MsgLenLenEIP8] = uint16(wosize).toBytesBE()
+
+  if eciesEncrypt(
+    rng,
+    toa(buffer, 0, PlainAckMessageEIP8Length + padsize),
+    toa(output, MsgLenLenEIP8, wosize),
+    h.remoteHPubkey,
+    toa(output, 0, MsgLenLenEIP8),
+  ).isErr:
+    return err(AuthError.EciesError)
+  ok(fullsize)
+
+func decodeMsgLen(input: openArray[byte]): AuthResult[int] =
+  if input.len < 2:
+    return err(AuthError.IncompleteError)
+  ok(int(uint16.fromBytesBE(input)) + 2)
+
+func decodeAuthMsgLen*(h: Handshake, input: openArray[byte]): AuthResult[int] =
+  let len = ?decodeMsgLen(input)
+  if len < AuthMessageEIP8Length:
+    return err(AuthError.IncompleteError)
+  ok(len)
+
+func decodeAckMsgLen*(h: Handshake, input: openArray[byte]): AuthResult[int] =
+  let len = ?decodeMsgLen(input)
+  if len < AckMessageEIP8Length:
+    return err(AuthError.IncompleteError)
+  ok(len)
+
+proc decodeAuthMessage*(h: var Handshake, m: openArray[byte]): AuthResult[void] =
+  ## Decodes EIP-8 AuthMessage.
+  let
+    expectedLength = ?h.decodeAuthMsgLen(m)
+    size = expectedLength - MsgLenLenEIP8
+
+  # Check if the prefixed size is => than the minimum
+  if expectedLength < AuthMessageEIP8Length:
+    return err(AuthError.IncompleteError)
+
+  if expectedLength > len(m):
+    return err(AuthError.IncompleteError)
+
+  let plainLen = eciesDecryptedLength(size).valueOr:
+    return err(AuthError.IncompleteError)
+
+  var buffer = newSeq[byte](plainLen)
+  if eciesDecrypt(
+    toa(m, MsgLenLenEIP8, int(size)), buffer, h.host.seckey, toa(m, 0, MsgLenLenEIP8)
+  ).isErr:
+    return err(AuthError.EciesError)
+
+  try:
+    var reader = rlpFromBytes(buffer)
+    if not reader.isList() or reader.listLen() < 4:
+      return err(AuthError.InvalidAuth)
+    if reader.listElem(0).blobLen != RawSignatureSize:
+      return err(AuthError.InvalidAuth)
+    if reader.listElem(1).blobLen != RawPublicKeySize:
+      return err(AuthError.InvalidAuth)
+    if reader.listElem(2).blobLen != KeyLength:
+      return err(AuthError.InvalidAuth)
+    if reader.listElem(3).blobLen != 1:
+      return err(AuthError.InvalidAuth)
+    let
+      signatureBr = reader.listElem(0).toBytes()
+      pubkeyBr = reader.listElem(1).toBytes()
+      nonceBr = reader.listElem(2).toBytes()
+
+      signature = ?Signature.fromRaw(signatureBr).mapErrTo(SignatureError)
+      pubkey = ?PublicKey.fromRaw(pubkeyBr).mapErrTo(InvalidPubKey)
+      nonce = toArray(KeyLength, nonceBr)
+
+    var secret = ecdhSharedSecret(h.host.seckey, pubkey)
+    secret.data = secret.data xor nonce
+
+    let recovered = recover(signature, SkMessage(secret.data))
+    secret.clear()
+
+    h.remoteEPubkey = ?recovered.mapErrTo(SignatureError)
+    h.initiatorNonce = nonce
+    h.remoteHPubkey = pubkey
+    ok()
+  except RlpError:
+    err(AuthError.RlpError)
+
+proc decodeAckMessage*(h: var Handshake, m: openArray[byte]): AuthResult[void] =
+  ## Decodes EIP-8 AckMessage.
+  let
+    expectedLength = ?h.decodeAckMsgLen(m)
+    size = expectedLength - MsgLenLenEIP8
+
+  # Check if the prefixed size is => than the minimum
+  if expectedLength > len(m):
+    return err(AuthError.IncompleteError)
+
+  let plainLen = eciesDecryptedLength(size).valueOr:
+    return err(AuthError.IncompleteError)
+
+  var buffer = newSeq[byte](plainLen)
+  if eciesDecrypt(
+    toa(m, MsgLenLenEIP8, size), buffer, h.host.seckey, toa(m, 0, MsgLenLenEIP8)
+  ).isErr:
+    return err(AuthError.EciesError)
+  try:
+    var reader = rlpFromBytes(buffer)
+    # The last element, the version, is ignored
+    if not reader.isList() or reader.listLen() < 3:
+      return err(AuthError.InvalidAck)
+    if reader.listElem(0).blobLen != RawPublicKeySize:
+      return err(AuthError.InvalidAck)
+    if reader.listElem(1).blobLen != KeyLength:
+      return err(AuthError.InvalidAck)
+
+    let
+      pubkeyBr = reader.listElem(0).toBytes()
+      nonceBr = reader.listElem(1).toBytes()
+
+    h.remoteEPubkey = ?PublicKey.fromRaw(pubkeyBr).mapErrTo(InvalidPubKey)
+    h.responderNonce = toArray(KeyLength, nonceBr)
+
+    ok()
+  except RlpError:
+    err(AuthError.RlpError)
+
+proc getSecrets*(
+    h: Handshake, authmsg: openArray[byte], ackmsg: openArray[byte]
+): ConnectionSecret =
+  ## Derive secrets from handshake `h` using encrypted AuthMessage `authmsg` and
+  ## encrypted AckMessage `ackmsg`.
+  var
+    ctx0: keccak256
+    ctx1: keccak256
+    mac1: MDigest[256]
+    secret: ConnectionSecret
+
+  # ecdhe-secret = ecdh.agree(ephemeral-privkey, remote-ephemeral-pubk)
+  var shsec = ecdhSharedSecret(h.ephemeral.seckey, h.remoteEPubkey)
+
+  # shared-secret = keccak(ecdhe-secret || keccak(nonce || initiator-nonce))
+  ctx0.init()
+  ctx1.init()
+  ctx1.update(h.responderNonce)
+  ctx1.update(h.initiatorNonce)
+  mac1 = ctx1.finish()
+  ctx1.clear()
+  ctx0.update(shsec.data)
+  ctx0.update(mac1.data)
+  mac1 = ctx0.finish()
+
+  # aes-secret = keccak(ecdhe-secret || shared-secret)
+  ctx0.init()
+  ctx0.update(shsec.data)
+  ctx0.update(mac1.data)
+  mac1 = ctx0.finish()
+
+  # mac-secret = keccak(ecdhe-secret || aes-secret)
+  ctx0.init()
+  ctx0.update(shsec.data)
+  ctx0.update(mac1.data)
+  secret.aesKey = mac1.data
+  mac1 = ctx0.finish()
+  secret.macKey = mac1.data
+
+  clear(shsec)
+
+  # egress-mac = keccak256(mac-secret ^ recipient-nonce || auth-sent-init)
+
+  var xornonce = mac1.data xor h.responderNonce
+  ctx0.init()
+  ctx0.update(xornonce)
+  ctx0.update(authmsg)
+
+  # ingress-mac = keccak256(mac-secret ^ initiator-nonce || auth-recvd-ack)
+  xornonce = secret.macKey xor h.initiatorNonce
+
+  ctx1.init()
+  ctx1.update(xornonce)
+  ctx1.update(ackmsg)
+  burnMem(xornonce)
+
+  if Initiator in h.flags:
+    secret.egressMac = ctx0
+    secret.ingressMac = ctx1
+  else:
+    secret.ingressMac = ctx0
+    secret.egressMac = ctx1
+
+  ctx0.clear()
+  ctx1.clear()
+
+  secret

--- a/execution_chain/networking/rlpx/ecies.nim
+++ b/execution_chain/networking/rlpx/ecies.nim
@@ -1,0 +1,218 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+## This module implements ECIES method encryption/decryption.
+## https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/rlpx.md?plain=1#L31
+
+{.push raises: [].}
+
+import
+  stew/[assign2, endians2],
+  results,
+  nimcrypto/[rijndael, bcmode, hash, hmac, sha2, utils],
+  eth/common/keys
+
+export results, keys
+
+const
+  ivLen = aes128.sizeBlock
+  tagLen = sha256.sizeDigest
+
+  eciesOverheadLength* =
+    # Data overhead size for ECIES encrypted message
+    # pubkey + IV + MAC = 65 + 16 + 32 = 113
+    1 + sizeof(PublicKey) + ivLen + tagLen
+
+type
+  EciesError* = enum
+    BufferOverrun = "ecies: output buffer size is too small"
+    EcdhError = "ecies: ECDH shared secret could not be calculated"
+    WrongHeader = "ecies: header is incorrect"
+    IncorrectKey = "ecies: recovered public key is invalid"
+    IncorrectTag = "ecies: tag verification failed"
+    IncompleteError = "ecies: decryption needs more data"
+
+  EciesResult*[T] = Result[T, EciesError]
+
+template eciesEncryptedLength*(size: int): int =
+  ## Return size of encrypted message for message with size `size`.
+  size + eciesOverheadLength
+
+func eciesDecryptedLength*(size: int): Result[int, EciesError] =
+  ## Return size of decrypted message for encrypted message with size `size`.
+  if size >= eciesOverheadLength:
+    ok size - eciesOverheadLength
+  else:
+    err IncompleteError
+
+template version(v: openArray[byte]): untyped =
+  v[0]
+
+template pubkey(v: openArray[byte]): untyped =
+  v.toOpenArray(1, 1 + sizeof(PublicKey) - 1)
+
+template iv(v: openArray[byte]): untyped =
+  v.toOpenArray(1 + sizeof(PublicKey), 1 + sizeof(PublicKey) + ivLen - 1)
+
+template data(v: openArray[byte], inputLen): untyped =
+  v.toOpenArray(
+    1 + sizeof(PublicKey) + ivLen, 1 + sizeof(PublicKey) + ivLen + inputLen - 1
+  )
+
+template ivdata(v: openArray[byte], inputLen): untyped =
+  v.toOpenArray(1 + sizeof(PublicKey), 1 + sizeof(PublicKey) + ivLen + inputLen - 1)
+
+template tag(v: openArray[byte], inputLen: int): untyped =
+  v.toOpenArray(
+    1 + sizeof(PublicKey) + ivLen + inputLen,
+    1 + sizeof(PublicKey) + ivLen + inputLen + tagLen - 1,
+  )
+
+template enckey(material: openArray[byte]): untyped =
+  material.toOpenArray(0, aes128.sizeKey - 1)
+
+template mackey(material: openArray[byte]): untyped =
+  sha256.digest(material.toOpenArray(aes128.sizeKey, material.len - 1))
+
+func kdf*(data: openArray[byte]): array[KeyLength, byte] {.noinit.} =
+  ## NIST SP 800-56a Concatenation Key Derivation Function (see section 5.8.1)
+  var
+    ctx: sha256
+    counter = 1'u32
+    offset = 0
+    hash: MDigest[256]
+
+  while offset < result.len:
+    ctx.init()
+    ctx.update(toBytesBE(counter))
+    ctx.update(data)
+    hash = ctx.finish()
+    let bytes = min(hash.data.len, result.len - offset)
+    assign(
+      result.toOpenArray(offset, offset + bytes - 1),
+      hash.data.toOpenArray(0, bytes - 1),
+    )
+
+    offset += bytes
+    counter += 1
+
+  hash.burnMem()
+  ctx.clear() # clean ctx
+
+proc eciesEncrypt*(
+    rng: var HmacDrbgContext,
+    input: openArray[byte],
+    output: var openArray[byte],
+    pubkey: PublicKey,
+    sharedmac: openArray[byte] = [],
+): EciesResult[void] =
+  ## Encrypt data with ECIES method using given public key `pubkey`.
+  ## ``input``     - input data
+  ## ``output``    - output data
+  ## ``pubkey``    - ECC public key
+  ## ``sharedmac`` - additional data used to calculate encrypted message MAC
+  ## Length of output data can be calculated using ``eciesEncryptedLength()``
+  ## template.
+  if len(output) < eciesEncryptedLength(len(input)):
+    return err(BufferOverrun)
+
+  var
+    ephemeral = KeyPair.random(rng)
+    secret = ecdhSharedSecret(ephemeral.seckey, pubkey)
+    material = kdf(secret.data)
+
+  clear(secret)
+
+  output.version() = 0x04
+
+  block: # pubkey
+    assign(output.pubkey, ephemeral.pubkey.toRaw())
+    ephemeral.clear()
+
+  block: # iv
+    rng.generate(output.iv())
+
+  block: # ciphertext
+    var cipher: CTR[aes128]
+    cipher.init(material.enckey(), output.iv())
+    cipher.encrypt(input, output.data(input.len))
+    cipher.clear()
+
+  block: # mac
+    var mackey = material.mackey()
+    burnMem(material)
+
+    var ctx: HMAC[sha256]
+    ctx.init(mackey.data)
+    mackey.burnMem()
+
+    ctx.update(output.ivdata(input.len))
+    ctx.update(sharedmac)
+
+    let tag = ctx.finish()
+    assign(output.tag(input.len), tag.data)
+    ctx.clear()
+
+  ok()
+
+func eciesDecrypt*(
+    input: openArray[byte],
+    output: var openArray[byte],
+    seckey: PrivateKey,
+    sharedmac: openArray[byte] = [],
+): EciesResult[void] =
+  ## Decrypt data with ECIES method using given private key `seckey`.
+  ## ``input``     - input data
+  ## ``output``    - output data
+  ## ``pubkey``    - ECC private key
+  ## ``sharedmac`` - additional data used to calculate encrypted message MAC
+  ## Length of output data can be calculated using ``eciesDecryptedLength()``
+  ## template.
+
+  let plainLen = ?eciesDecryptedLength(input.len)
+  if plainLen > len(output):
+    return err(BufferOverrun)
+
+  if input.version() != byte 0x04:
+    return err(WrongHeader)
+
+  var
+    pubkey = PublicKey.fromRaw(input.pubkey).valueOr:
+      return err(IncorrectKey)
+    secret = ecdhSharedSecret(seckey, pubkey)
+    material = kdf(secret.data)
+
+  secret.clear()
+
+  block: # mac
+    var mackey = material.mackey()
+
+    var ctx: HMAC[sha256]
+    ctx.init(mackey.data)
+    burnMem(mackey)
+
+    ctx.update(input.ivdata(plainLen))
+    ctx.update(sharedmac)
+
+    let tag = ctx.finish()
+    ctx.clear()
+
+    if tag.data != input.tag(plainLen):
+      burnMem(material)
+      return err(IncorrectTag)
+
+  block: # ciphertext
+    var cipher: CTR[aes128]
+    cipher.init(material.enckey(), input.iv())
+    burnMem(material)
+
+    cipher.decrypt(input.data(plainLen), output)
+    cipher.clear()
+
+  ok()

--- a/execution_chain/networking/rlpx/rlpxcrypt.nim
+++ b/execution_chain/networking/rlpx/rlpxcrypt.nim
@@ -1,0 +1,232 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+## This module implements RLPx cryptography
+
+{.push raises: [].}
+
+import
+  nimcrypto/[bcmode, keccak, rijndael, utils], results
+from auth import ConnectionSecret
+
+export results
+
+const
+  RlpHeaderLength* = 16
+  RlpMacLength* = 16
+  maxUInt24 = (not uint32(0)) shl 8
+
+type
+  SecretState* = object
+    ## Object represents current encryption/decryption context.
+    aesenc*: CTR[aes256]
+    aesdec*: CTR[aes256]
+    macenc*: ECB[aes256]
+    emac*: keccak256
+    imac*: keccak256
+
+  RlpxError* = enum
+    IncorrectMac = "rlpx: MAC verification failed"
+    BufferOverrun = "rlpx: buffer overrun"
+    IncompleteError = "rlpx: data incomplete"
+    IncorrectArgs = "rlpx: incorrect arguments"
+
+  RlpxEncryptedHeader* = array[RlpHeaderLength + RlpMacLength, byte]
+  RlpxHeader* = array[RlpHeaderLength, byte]
+
+  RlpxResult*[T] = Result[T, RlpxError]
+
+proc roundup16*(x: int): int {.inline.} =
+  ## Procedure aligns `x` to
+  let rem = x and 15
+  if rem != 0:
+    result = x + 16 - rem
+  else:
+    result = x
+
+template toa(a, b, c: untyped): untyped =
+  toOpenArray((a), (b), (b) + (c) - 1)
+
+proc sxor[T](a: var openArray[T], b: openArray[T]) {.inline.} =
+  doAssert(len(a) == len(b))
+  for i in 0 ..< len(a):
+    a[i] = a[i] xor b[i]
+
+proc initSecretState*(secrets: ConnectionSecret, context: var SecretState) =
+  ## Initialized `context` with values from `secrets`.
+
+  # This scheme is insecure, see:
+  # https://github.com/ethereum/devp2p/issues/32
+  # https://github.com/ethereum/py-evm/blob/master/p2p/peer.py#L159-L160
+  var iv: array[context.aesenc.sizeBlock, byte]
+  context.aesenc.init(secrets.aesKey, iv)
+  context.aesdec = context.aesenc
+  context.macenc.init(secrets.macKey)
+  context.emac = secrets.egressMac
+  context.imac = secrets.ingressMac
+
+template encryptedLength*(size: int): int =
+  ## Returns the number of bytes used by the entire frame of a
+  ## message with size `size`:
+  RlpHeaderLength + roundup16(size) + 2 * RlpMacLength
+
+template decryptedLength*(size: int): int =
+  ## Returns size of decrypted message for body with length `size`.
+  roundup16(size)
+
+proc encrypt*(c: var SecretState, header: openArray[byte],
+              frame: openArray[byte],
+              output: var openArray[byte]): RlpxResult[void] =
+  ## Encrypts `header` and `frame` using SecretState `c` context and store
+  ## result into `output`.
+  ##
+  ## `header` must be exactly `RlpHeaderLength` length.
+  ## `frame` must not be zero length.
+  ## `output` must be at least `encryptedLength(len(frame))` length.
+  var
+    tmpmac: keccak256
+    aes: array[RlpHeaderLength, byte]
+  let length = encryptedLength(len(frame))
+  let frameLength = roundup16(len(frame))
+  let headerMacPos = RlpHeaderLength
+  let framePos = RlpHeaderLength + RlpMacLength
+  let frameMacPos = RlpHeaderLength * 2 + frameLength
+  if len(header) != RlpHeaderLength or len(frame) == 0 or length != len(output):
+    return err(IncorrectArgs)
+  # header_ciphertext = self.aes_enc.update(header)
+  c.aesenc.encrypt(header, toa(output, 0, RlpHeaderLength))
+  # mac_secret = self.egress_mac.digest()[:HEADER_LEN]
+  tmpmac = c.emac
+  var macsec = tmpmac.finish()
+  # self.egress_mac.update(sxor(self.mac_enc(mac_secret), header_ciphertext))
+  c.macenc.encrypt(toa(macsec.data, 0, RlpHeaderLength), aes)
+  sxor(aes, toa(output, 0, RlpHeaderLength))
+  c.emac.update(aes)
+  burnMem(aes)
+  # header_mac = self.egress_mac.digest()[:HEADER_LEN]
+  tmpmac = c.emac
+  var headerMac = tmpmac.finish()
+  # frame_ciphertext = self.aes_enc.update(frame)
+  copyMem(addr output[framePos], unsafeAddr frame[0], len(frame))
+  c.aesenc.encrypt(toa(output, 32, frameLength), toa(output, 32, frameLength))
+  # self.egress_mac.update(frame_ciphertext)
+  c.emac.update(toa(output, 32, frameLength))
+  # fmac_seed = self.egress_mac.digest()[:HEADER_LEN]
+  tmpmac = c.emac
+  var seed = tmpmac.finish()
+  # mac_secret = self.egress_mac.digest()[:HEADER_LEN]
+  macsec = seed
+  # self.egress_mac.update(sxor(self.mac_enc(mac_secret), fmac_seed))
+  c.macenc.encrypt(toa(macsec.data, 0, RlpHeaderLength), aes)
+  sxor(aes, toa(seed.data, 0, RlpHeaderLength))
+  c.emac.update(aes)
+  burnMem(aes)
+  # frame_mac = self.egress_mac.digest()[:HEADER_LEN]
+  tmpmac = c.emac
+  var frameMac = tmpmac.finish()
+  tmpmac.clear()
+  # return header_ciphertext + header_mac + frame_ciphertext + frame_mac
+  copyMem(addr output[headerMacPos], addr headerMac.data[0], RlpMacLength)
+  copyMem(addr output[frameMacPos], addr frameMac.data[0], RlpMacLength)
+  ok()
+
+proc encryptMsg*(msg: openArray[byte], secrets: var SecretState): seq[byte] =
+  doAssert(uint32(msg.len) <= maxUInt24, "RLPx message size exceeds limit")
+
+  var header: RlpxHeader
+  # write the frame size in the first 3 bytes of the header
+  header[0] = byte((msg.len shr 16) and 0xFF)
+  header[1] = byte((msg.len shr 8) and 0xFF)
+  header[2] = byte(msg.len and 0xFF)
+  # This is the  [capability-id, context-id] in header-data
+  # While not really used, this is checked in the Parity client.
+  # Same as rlp.encode((0, 0))
+  header[3] = 0xc2
+  header[4] = 0x80
+  header[5] = 0x80
+
+  var res = newSeq[byte](encryptedLength(msg.len))
+  encrypt(secrets, header, msg, res).expect(
+    "always succeeds because we call with correct buffer")
+  res
+
+proc getBodySize*(a: RlpxHeader): int =
+  (int(a[0]) shl 16) or (int(a[1]) shl 8) or int(a[2])
+
+proc decryptHeader*(c: var SecretState, data: openArray[byte]): RlpxResult[RlpxHeader] =
+  ## Decrypts header `data` using SecretState `c` context and store
+  ## result into `output`.
+  ##
+  ## `header` must be at least `RlpHeaderLength + RlpMacLength` length.
+
+  var
+    tmpmac: keccak256
+    aes: array[RlpHeaderLength, byte]
+
+  if len(data) < RlpHeaderLength + RlpMacLength:
+    return err(IncompleteError)
+
+  # mac_secret = self.ingress_mac.digest()[:HEADER_LEN]
+  tmpmac = c.imac
+  var macsec = tmpmac.finish()
+  # aes = self.mac_enc(mac_secret)[:HEADER_LEN]
+  c.macenc.encrypt(toa(macsec.data, 0, RlpHeaderLength), aes)
+  # self.ingress_mac.update(sxor(aes, header_ciphertext))
+  sxor(aes, toa(data, 0, RlpHeaderLength))
+  c.imac.update(aes)
+  burnMem(aes)
+  # expected_header_mac = self.ingress_mac.digest()[:HEADER_LEN]
+  tmpmac = c.imac
+  var expectMac = tmpmac.finish()
+  # if not bytes_eq(expected_header_mac, header_mac):
+  if not equalMem(unsafeAddr data[RlpHeaderLength],
+                  addr expectMac.data[0], RlpMacLength):
+    return err(IncorrectMac)
+
+  # return self.aes_dec.update(header_ciphertext)
+  var output: RlpxHeader
+  c.aesdec.decrypt(toa(data, 0, RlpHeaderLength), output)
+  ok(output)
+
+proc decryptBody*(c: var SecretState, data: openArray[byte], bodysize: int,
+                  output: var openArray[byte]): RlpxResult[void] =
+  ## Decrypts body `data` using SecretState `c` context and store
+  ## result into `output`.
+  ##
+  ## `data` must be at least `roundup16(bodysize) + RlpMacLength` length.
+  ## `output` must be at least `roundup16(bodysize)` length.
+  ##
+  ## On success completion `outlen` will hold actual size of decrypted body.
+  var
+    tmpmac: keccak256
+    aes: array[RlpHeaderLength, byte]
+  let rsize = roundup16(bodysize)
+  if len(data) < rsize + RlpMacLength:
+    return err(IncompleteError)
+  if len(output) < rsize:
+    return err(IncorrectArgs)
+  # self.ingress_mac.update(frame_ciphertext)
+  c.imac.update(toa(data, 0, rsize))
+  tmpmac = c.imac
+  # fmac_seed = self.ingress_mac.digest()[:MAC_LEN]
+  var seed = tmpmac.finish()
+  # self.ingress_mac.update(sxor(self.mac_enc(fmac_seed), fmac_seed))
+  c.macenc.encrypt(toa(seed.data, 0, RlpHeaderLength), aes)
+  sxor(aes, toa(seed.data, 0, RlpHeaderLength))
+  c.imac.update(aes)
+  # expected_frame_mac = self.ingress_mac.digest()[:MAC_LEN]
+  tmpmac = c.imac
+  var expectMac = tmpmac.finish()
+  let bodyMacPos = rsize
+  if not equalMem(cast[pointer](unsafeAddr data[bodyMacPos]),
+                  cast[pointer](addr expectMac.data[0]), RlpMacLength):
+    err(IncorrectMac)
+  else:
+    c.aesdec.decrypt(toa(data, 0, rsize), output)
+    ok()

--- a/execution_chain/networking/rlpx/rlpxtransport.nim
+++ b/execution_chain/networking/rlpx/rlpxtransport.nim
@@ -1,0 +1,242 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [], gcsafe.}
+
+import results, chronos, eth/common/keys, ./[auth, rlpxcrypt]
+
+export results, keys
+
+type
+  RlpxTransport* = ref object
+    stream: StreamTransport
+    state: SecretState
+    pubkey*: PublicKey
+
+  RlpxTransportError* = object of CatchableError
+
+template `^`(arr): auto =
+  # passes a stack array with a matching `arrLen` variable as an open array
+  arr.toOpenArray(0, `arr Len` - 1)
+
+proc initiatorHandshake(
+    rng: ref HmacDrbgContext,
+    keys: KeyPair,
+    stream: StreamTransport,
+    remotePubkey: PublicKey,
+): Future[ConnectionSecret] {.
+    async: (raises: [CancelledError, TransportError, RlpxTransportError])
+.} =
+  # https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/rlpx.md#initial-handshake
+  var
+    handshake = Handshake.init(rng[], keys, {Initiator})
+    authMsg: array[AuthMessageMaxEIP8, byte]
+
+  let
+    authMsgLen = handshake.authMessage(rng[], remotePubkey, authMsg).expect(
+        "No errors with correctly sized buffer"
+      )
+
+    writeRes = await stream.write(addr authMsg[0], authMsgLen)
+  if writeRes != authMsgLen:
+    # TOOD raising a chronos error here is a hack - rework using something else
+    raise (ref TransportIncompleteError)(msg: "Could not write RLPx handshake header")
+
+  var ackMsg = newSeqOfCap[byte](1024)
+  ackMsg.setLen(MsgLenLenEIP8)
+  await stream.readExactly(addr ackMsg[0], len(ackMsg))
+
+  let ackMsgLen = handshake.decodeAckMsgLen(ackMsg).valueOr:
+    raise
+      (ref RlpxTransportError)(msg: "Could not decode handshake ack length: " & $error)
+
+  ackMsg.setLen(ackMsgLen)
+  await stream.readExactly(addr ackMsg[MsgLenLenEIP8], ackMsgLen - MsgLenLenEIP8)
+
+  handshake.decodeAckMessage(ackMsg).isOkOr:
+    raise (ref RlpxTransportError)(msg: "Could not decode handshake ack: " & $error)
+
+  handshake.getSecrets(^authMsg, ackMsg)
+
+proc responderHandshake(
+    rng: ref HmacDrbgContext, keys: KeyPair, stream: StreamTransport
+): Future[(ConnectionSecret, PublicKey)] {.
+    async: (raises: [CancelledError, TransportError, RlpxTransportError])
+.} =
+  # https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/rlpx.md#initial-handshake
+  var
+    handshake = Handshake.init(rng[], keys, {auth.Responder})
+    authMsg = newSeqOfCap[byte](1024)
+
+  authMsg.setLen(MsgLenLenEIP8)
+  await stream.readExactly(addr authMsg[0], len(authMsg))
+
+  let authMsgLen = handshake.decodeAuthMsgLen(authMsg).valueOr:
+    raise
+      (ref RlpxTransportError)(msg: "Could not decode handshake auth length: " & $error)
+
+  authMsg.setLen(authMsgLen)
+  await stream.readExactly(addr authMsg[MsgLenLenEIP8], authMsgLen - MsgLenLenEIP8)
+
+  handshake.decodeAuthMessage(authMsg).isOkOr:
+    raise (ref RlpxTransportError)(
+      msg: "Could not decode handshake auth message: " & $error
+    )
+
+  var ackMsg: array[AckMessageMaxEIP8, byte]
+  let ackMsgLen =
+    handshake.ackMessage(rng[], ackMsg).expect("no errors with correcly sized buffer")
+
+  var res = await stream.write(addr ackMsg[0], ackMsgLen)
+  if res != ackMsgLen:
+    # TOOD raising a chronos error here is a hack - rework using something else
+    raise (ref TransportIncompleteError)(msg: "Could not write RLPx ack message")
+
+  (handshake.getSecrets(authMsg, ^ackMsg), handshake.remoteHPubkey)
+
+proc connect*(
+    _: type RlpxTransport,
+    rng: ref HmacDrbgContext,
+    keys: KeyPair,
+    address: TransportAddress,
+    remotePubkey: PublicKey,
+): Future[RlpxTransport] {.
+    async: (raises: [CancelledError, TransportError, RlpxTransportError])
+.} =
+  var stream = await connect(address)
+
+  try:
+    let secrets = await initiatorHandshake(rng, keys, stream, remotePubkey)
+    var res = RlpxTransport(stream: move(stream), pubkey: remotePubkey)
+    initSecretState(secrets, res.state)
+    res
+  finally:
+    if stream != nil:
+      stream.close()
+
+proc accept*(
+    _: type RlpxTransport,
+    rng: ref HmacDrbgContext,
+    keys: KeyPair,
+    stream: StreamTransport,
+): Future[RlpxTransport] {.
+    async: (raises: [CancelledError, TransportError, RlpxTransportError])
+.} =
+  var stream = stream
+  try:
+    let (secrets, remotePubkey) = await responderHandshake(rng, keys, stream)
+    var res = RlpxTransport(stream: move(stream), pubkey: remotePubkey)
+    initSecretState(secrets, res.state)
+    res
+  finally:
+    if stream != nil:
+      stream.close()
+
+proc recvMsg*(
+    transport: RlpxTransport
+): Future[seq[byte]] {.
+    async: (raises: [CancelledError, TransportError, RlpxTransportError])
+.} =
+  ## Read an RLPx frame from the given peer
+  var msgHeaderEnc: RlpxEncryptedHeader
+  await transport.stream.readExactly(addr msgHeaderEnc[0], msgHeaderEnc.len)
+
+  let msgHeader = decryptHeader(transport.state, msgHeaderEnc).valueOr:
+    raise (ref RlpxTransportError)(msg: "Cannot decrypt RLPx frame header")
+
+  # The header has more fields than the size, but they are unused / obsolete.
+  # Although some clients set them, we don't check this in the spirit of EIP-8
+  # https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/rlpx.md#framing
+
+  let msgSize = msgHeader.getBodySize()
+  let remainingBytes = encryptedLength(msgSize) - 32
+
+  var encryptedBytes = newSeq[byte](remainingBytes)
+  await transport.stream.readExactly(addr encryptedBytes[0], len(encryptedBytes))
+
+  let decryptedMaxLength = decryptedLength(msgSize) # Padded length
+  var msgBody = newSeq[byte](decryptedMaxLength)
+
+  if decryptBody(transport.state, encryptedBytes, msgSize, msgBody).isErr():
+    raise (ref RlpxTransportError)(msg: "Cannot decrypt message body")
+
+  reset(encryptedBytes) # Release memory (TODO: in-place decryption)
+
+  msgBody.setLen(msgSize) # Remove padding
+  msgBody
+
+proc sendMsg*(
+    transport: RlpxTransport, data: seq[byte]
+) {.async: (raises: [CancelledError, TransportError, RlpxTransportError]).} =
+  let cipherText = encryptMsg(data, transport.state)
+  var res = await transport.stream.write(cipherText)
+  if res != len(cipherText):
+    # TOOD raising a chronos error here is a hack - rework using something else
+    raise (ref TransportIncompleteError)(msg: "Could not complete writing message")
+
+proc remoteAddress*(
+    transport: RlpxTransport
+): TransportAddress {.raises: [TransportOsError].} =
+  transport.stream.remoteAddress()
+
+proc closed*(transport: RlpxTransport): bool =
+  transport.stream != nil and transport.stream.closed
+
+proc close*(transport: RlpxTransport) =
+  if transport.stream != nil:
+    transport.stream.close()
+
+proc closeWait*(
+    transport: RlpxTransport
+): Future[void] {.async: (raises: [], raw: true).} =
+  transport.stream.closeWait()
+
+when isMainModule:
+  # Simple CLI application for negotiating an RLPx connection with a peer
+
+  import stew/byteutils, std/cmdline, std/strutils, eth/rlp
+  if paramCount() < 3:
+    echo "rlpxtransport ip port pubkey"
+    quit 1
+
+  let
+    rng = newRng()
+    kp = KeyPair.random(rng[])
+
+  echo "Local key: ", toHex(kp.pubkey.toRaw())
+
+  let client = waitFor RlpxTransport.connect(
+    rng,
+    kp,
+    initTAddress(paramStr(1), parseInt(paramStr(2))),
+    PublicKey.fromHex(paramStr(3))[],
+  )
+
+  proc encodeMsg(msgId: uint64, msg: auto): seq[byte] =
+    var rlpWriter = initRlpWriter()
+    rlpWriter.append msgId
+    rlpWriter.appendRecordType(msg, typeof(msg).rlpFieldsCount > 1)
+    rlpWriter.finish
+
+  waitFor client.sendMsg(
+    encodeMsg(
+      uint64 0, (uint64 4, "nimbus", @[("eth", uint64 68)], uint64 0, kp.pubkey.toRaw())
+    )
+  )
+
+  while true:
+    echo "Reading message"
+    var data = waitFor client.recvMsg()
+    var rlp = rlpFromBytes(data)
+    let msgId = rlp.read(uint64)
+    if msgId == 0:
+      echo "Hello: ",
+        rlp.read((uint64, string, seq[(string, uint64)], uint64, seq[byte]))
+    else:
+      echo "Unknown message ", msgId, " ", toHex(data)

--- a/execution_chain/nimbus_desc.nim
+++ b/execution_chain/nimbus_desc.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -9,7 +9,7 @@
 
 import
   chronos,
-  eth/p2p,
+  ./networking/p2p,
   metrics/chronos_httpserver,
   ./rpc/rpc_server,
   ./core/chain,

--- a/execution_chain/rpc/common.nim
+++ b/execution_chain/rpc/common.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -9,7 +9,7 @@
 
 import
   stint, json_rpc/server, json_rpc/errors,
-  eth/p2p, eth/p2p/enode,
+  ../networking/[p2p, discoveryv4/enode],
   ../config,
   ../beacon/web3_eth_conv,
   web3/conversions

--- a/execution_chain/sync/beacon.nim
+++ b/execution_chain/sync/beacon.nim
@@ -11,9 +11,10 @@
 {.push raises: [].}
 
 import
-  pkg/[chronicles, chronos, eth/p2p, results],
+  pkg/[chronicles, chronos, results],
   pkg/stew/[interval_set, sorted_set],
   ../core/chain,
+  ../networking/p2p,
   ./beacon/[worker, worker_desc, worker/db],
   "."/[sync_desc, sync_sched, protocol]
 

--- a/execution_chain/sync/beacon/worker.nim
+++ b/execution_chain/sync/beacon/worker.nim
@@ -12,9 +12,10 @@
 
 import
   pkg/[chronicles, chronos],
-  pkg/eth/[common, p2p],
+  pkg/eth/common,
   pkg/stew/[interval_set, sorted_set],
   ../../common,
+  ../../networking/p2p,
   ./worker/update/[metrics, ticker],
   ./worker/[blocks_staged, headers_staged, headers_unproc, start_stop, update],
   ./worker_desc

--- a/execution_chain/sync/beacon/worker/blocks_staged/bodies.nim
+++ b/execution_chain/sync/beacon/worker/blocks_staged/bodies.nim
@@ -13,10 +13,11 @@
 import
   std/options,
   pkg/[chronicles, chronos, results],
-  pkg/eth/[common, p2p],
+  pkg/eth/common,
   pkg/stew/interval_set,
   ../../../protocol,
-  ../../worker_desc
+  ../../worker_desc,
+  ../../../../networking/p2p
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/execution_chain/sync/beacon/worker/blocks_unproc.nim
+++ b/execution_chain/sync/beacon/worker/blocks_unproc.nim
@@ -11,10 +11,11 @@
 {.push raises:[].}
 
 import
-  pkg/eth/[common, p2p],
+  pkg/eth/common,
   pkg/results,
   pkg/stew/interval_set,
-  ../worker_desc
+  ../worker_desc,
+  ../../../networking/p2p
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/execution_chain/sync/beacon/worker/headers_staged.nim
+++ b/execution_chain/sync/beacon/worker/headers_staged.nim
@@ -13,10 +13,11 @@
 import
   std/strutils,
   pkg/[chronicles, chronos],
-  pkg/eth/[common, p2p],
+  pkg/eth/common,
   pkg/stew/[interval_set, sorted_set],
   ../../../common,
   ../worker_desc,
+  ../../../networking/p2p,
   ./headers_staged/[headers, linked_hchain],
   "."/[headers_unproc, update]
 

--- a/execution_chain/sync/beacon/worker/headers_staged/headers.nim
+++ b/execution_chain/sync/beacon/worker/headers_staged/headers.nim
@@ -13,11 +13,12 @@
 import
   std/options,
   pkg/[chronicles, chronos, results],
-  pkg/eth/[common, p2p],
+  pkg/eth/common,
   pkg/stew/interval_set,
   ../../../protocol,
   ../../../protocol/eth/eth_types,
-  ../../worker_desc
+  ../../worker_desc,
+  ../../../../networking/p2p
 
 # ------------------------------------------------------------------------------
 # Private functions

--- a/execution_chain/sync/beacon/worker/headers_staged/linked_hchain.nim
+++ b/execution_chain/sync/beacon/worker/headers_staged/linked_hchain.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at
 #     https://opensource.org/licenses/MIT).
@@ -11,9 +11,10 @@
 {.push raises:[].}
 
 import
-  pkg/eth/[common, p2p, rlp],
+  pkg/eth/[common, rlp],
   ../../../../common,
-  ../../worker_desc
+  ../../worker_desc,
+  ../../../../networking/p2p
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/execution_chain/sync/beacon/worker/headers_unproc.nim
+++ b/execution_chain/sync/beacon/worker/headers_unproc.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at
 #     https://opensource.org/licenses/MIT).
@@ -11,10 +11,11 @@
 {.push raises:[].}
 
 import
-  pkg/eth/[common, p2p],
+  pkg/eth/common,
   pkg/results,
   pkg/stew/interval_set,
-  ../worker_desc
+  ../worker_desc,
+  ../../../networking/p2p
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/execution_chain/sync/beacon/worker/start_stop.nim
+++ b/execution_chain/sync/beacon/worker/start_stop.nim
@@ -11,13 +11,14 @@
 {.push raises:[].}
 
 import
-  pkg/eth/[common, p2p],
+  pkg/eth/common,
   ../../../core/chain,
+  ../../../networking/p2p,
   ../../protocol,
   ../worker_desc,
   ./blocks_staged/staged_queue,
   ./headers_staged/staged_queue,
-  "."/[blocks_unproc, db, headers_unproc, update]
+  ./[blocks_unproc, db, headers_unproc, update]
 
 # ------------------------------------------------------------------------------
 # Private functions

--- a/execution_chain/sync/beacon/worker/update/metrics.nim
+++ b/execution_chain/sync/beacon/worker/update/metrics.nim
@@ -11,7 +11,8 @@
 {.push raises:[].}
 
 import
-  pkg/[chronos, eth/p2p/peer_pool, metrics],
+  pkg/[chronos,  metrics],
+  ../../../../networking/peer_pool,
   ../../../../core/chain,
   ../../worker_desc,
   ../blocks_staged/staged_queue,

--- a/execution_chain/sync/handlers/eth.nim
+++ b/execution_chain/sync/handlers/eth.nim
@@ -14,11 +14,10 @@ import
   std/[tables, times, hashes, sets],
   chronicles, chronos,
   stew/endians2,
-  eth/p2p,
-  eth/p2p/peer_pool,
   ../protocol,
   ../protocol/eth/eth_types,
-  ../../core/[chain, tx_pool]
+  ../../core/[chain, tx_pool],
+  ../../networking/[p2p, peer_pool]
 
 logScope:
   topics = "eth-wire"

--- a/execution_chain/sync/handlers/setup.nim
+++ b/execution_chain/sync/handlers/setup.nim
@@ -11,7 +11,7 @@
 {.used, push raises: [].}
 
 import
-  eth/p2p,
+  ../../networking/p2p,
   ../../core/[chain, tx_pool],
   ../protocol,
   ./eth as handlers_eth

--- a/execution_chain/sync/peers.nim
+++ b/execution_chain/sync/peers.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -13,8 +13,7 @@ import
   std/[hashes, tables],
   chronicles,
   chronos,
-  eth/p2p,
-  eth/p2p/peer_pool,
+  ../networking/[p2p, peer_pool],
   ./protocol
 
 # Currently, this module only handles static peers

--- a/execution_chain/sync/protocol/eth/eth_types.nim
+++ b/execution_chain/sync/protocol/eth/eth_types.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -13,7 +13,8 @@
 import
   chronicles,
   results,
-  eth/[common, p2p, p2p/private/p2p_types]
+  eth/common,
+  ../../../networking/[p2p, p2p_types]
 
 logScope:
   topics = "eth-wire"

--- a/execution_chain/sync/protocol/eth68.nim
+++ b/execution_chain/sync/protocol/eth68.nim
@@ -17,10 +17,11 @@ import
   stint,
   chronicles,
   chronos,
-  eth/[common, p2p, p2p/private/p2p_types],
+  eth/common,
   stew/byteutils,
   ./trace_config,
   ./eth/eth_types,
+  ../../networking/[p2p, p2p_types],
   ../../utils/utils,
   ../../common/logging
 

--- a/execution_chain/sync/sync_desc.nim
+++ b/execution_chain/sync/sync_desc.nim
@@ -16,7 +16,7 @@
 {.push raises: [].}
 
 import
-  eth/p2p
+  ../networking/p2p
 
 type
   BuddyRunState* = enum

--- a/execution_chain/sync/sync_sched.nim
+++ b/execution_chain/sync/sync_sched.nim
@@ -86,7 +86,7 @@
 import
   std/hashes,
   chronos,
-  eth/[p2p, p2p/peer_pool],
+  ../networking/[p2p, peer_pool],
   stew/keyed_queue,
   ./sync_desc
 

--- a/hive_integration/nodocker/engine/engine_env.nim
+++ b/hive_integration/nodocker/engine/engine_env.nim
@@ -11,7 +11,7 @@
 import
   std/os,
   eth/common/keys,
-  eth/p2p as eth_p2p,
+  ../../../execution_chain/networking/p2p as eth_p2p,
   chronos,
   json_rpc/[rpcserver, rpcclient],
   results,

--- a/hive_integration/nodocker/rpc/test_env.nim
+++ b/hive_integration/nodocker/rpc/test_env.nim
@@ -9,7 +9,7 @@
 
 import
   std/[os, net],
-  eth/p2p as ethp2p,
+  ../../../execution_chain/networking/p2p as ethp2p,
   results,
   chronos, json_rpc/[rpcserver, rpcclient],
   ../../../execution_chain/sync/protocol,

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -42,7 +42,7 @@ when declared(namedBin):
     "nimbus_verified_proxy/nimbus_verified_proxy": "nimbus_verified_proxy",
   }.toTable()
 
-import std/os
+import std/[os, strutils]
 
 proc buildBinary(name: string, srcDir = "./", params = "", lang = "c") =
   if not dirExists "build":
@@ -126,3 +126,14 @@ task nimbus_verified_proxy, "Build Nimbus verified proxy":
 
 task nimbus_verified_proxy_test, "Run Nimbus verified proxy tests":
   test "nimbus_verified_proxy/tests", "test_proof_validation", "-d:chronicles_log_level=ERROR -d:nimbus_db_backend=sqlite"
+
+task build_fuzzers, "Build fuzzer test cases":
+  # This file is there to be able to quickly build the fuzzer test cases in
+  # order to avoid bit rot (e.g. for CI). Not for actual fuzzing.
+  # TODO: Building fuzzer test case one by one will make it take a bit longer,
+  # but we cannot import them in one Nim file due to the usage of
+  # `exportc: "AFLmain"` in the fuzzing test template for Windows:
+  # https://github.com/status-im/nim-testutils/blob/master/testutils/fuzzing.nim#L100
+  for file in walkDirRec("tests/networking/fuzzing/"):
+    if file.endsWith("nim"):
+      exec "nim c -c -d:release " & file

--- a/nrpc/config.nim
+++ b/nrpc/config.nim
@@ -21,9 +21,10 @@ import
     confutils/defs,
     confutils/std/net
   ],
-  eth/[common, net/nat, p2p/enode, p2p/discoveryv5/enr],
+  eth/[common, net/nat, p2p/discoveryv5/enr],
   ../execution_chain/[constants, compile_info],
   ../execution_chain/common/chain_config,
+  ../execution_chain/networking/discoveryv4/enode,
   ../execution_chain/db/opts
 
 export net, defs

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -34,8 +34,8 @@ import
     test_tracer_json,
     test_transaction_json,
     test_txpool,
-
+    test_networking,
     # These two suites are much slower than all the rest, so run them last
     test_blockchain_json,
     test_generalstate_json,
-  ]
+]

--- a/tests/networking/eth_protocol.nim
+++ b/tests/networking/eth_protocol.nim
@@ -1,0 +1,64 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  chronos,
+  eth/common,
+  ../../execution_chain/networking/p2p
+
+# for testing purpose
+# real eth protocol implementation is in nimbus-eth1 repo
+
+type
+  PeerState = ref object of RootRef
+    initialized*: bool
+
+p2pProtocol eth(version = 63,
+                peerState = PeerState,
+                useRequestIds = false):
+
+  onPeerConnected do (peer: Peer):
+    let
+      network = peer.network
+
+    discard await peer.status(63,
+                              network.networkId,
+                              0.u256,
+                              default(Hash32),
+                              default(Hash32),
+                              timeout = chronos.seconds(10))
+
+  handshake:
+    proc status(peer: Peer,
+                protocolVersion: uint,
+                networkId: NetworkId,
+                totalDifficulty: DifficultyInt,
+                bestHash: Hash32,
+                genesisHash: Hash32)
+
+  requestResponse:
+    proc getBlockHeaders(peer: Peer, request: openArray[Hash32]) {.gcsafe.} =
+      var headers: seq[Header]
+      await response.send(headers)
+
+    proc blockHeaders(p: Peer, headers: openArray[Header])
+
+  requestResponse:
+    proc getBlockBodies(peer: Peer, hashes: openArray[Hash32]) {.gcsafe.} = discard
+    proc blockBodies(peer: Peer, blocks: openArray[BlockBody])
+
+  nextID 13
+
+  requestResponse:
+    proc getNodeData(peer: Peer, hashes: openArray[Hash32]) = discard
+    proc nodeData(peer: Peer, data: openArray[seq[byte]])
+
+  requestResponse:
+    proc getReceipts(peer: Peer, hashes: openArray[Hash32]) = discard
+    proc receipts(peer: Peer, receipts: openArray[Receipt])

--- a/tests/networking/fuzzing/discoveryv4/fuzz.nim
+++ b/tests/networking/fuzzing/discoveryv4/fuzz.nim
@@ -1,0 +1,56 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  std/net,
+  testutils/fuzzing, chronicles, nimcrypto/keccak,
+  eth/[keys, rlp],
+  ../../../../execution_chain/networking/discoveryv4,
+  ../../p2p_test_helper
+
+const DefaultListeningPort = 30303
+var targetNode: DiscoveryProtocol
+
+proc packData(payload: openArray[byte], pk: PrivateKey): seq[byte] =
+  let
+    payloadSeq = @payload
+    signature = @(pk.sign(payload).toRaw())
+    msgHash = keccak256.digest(signature & payloadSeq)
+  result = @(msgHash.data) & signature & payloadSeq
+
+init:
+  # Set up a discovery node, this is the node we target when fuzzing
+  var
+    targetNodeKey = PrivateKey.fromHex("a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a617")[]
+    targetNodeAddr = localAddress(DefaultListeningPort)
+  targetNode = newDiscoveryProtocol(
+    targetNodeKey, targetNodeAddr, @[], Port(DefaultListeningPort))
+  # Create the transport as else replies on the messages send will fail.
+  targetNode.open()
+
+test:
+  var
+    msg: seq[byte]
+    address: Address
+
+  # Sending raw payload is possible but won't find us much. We need a hash and
+  # a signature, and without it there is a big chance it will always result in
+  # "Wrong msg mac from" error.
+  let nodeKey = PrivateKey.fromHex("a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a618")[]
+  msg = packData(payload, nodeKey)
+  address = localAddress(DefaultListeningPort + 1)
+
+  try:
+    targetNode.receive(address, msg)
+  # These errors are also caught in `processClient` in discovery.nim
+  # TODO: move them a layer down in discovery so we can do a cleaner test there?
+  except RlpError as e:
+    debug "Receive failed", err = e.msg
+  except DiscProtocolError as e:
+    debug "Receive failed", err = e.msg

--- a/tests/networking/fuzzing/discoveryv4/generate.nim
+++ b/tests/networking/fuzzing/discoveryv4/generate.nim
@@ -1,0 +1,81 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  std/[times, os, strformat, strutils],
+  chronos, stew/byteutils, stint, chronicles, nimcrypto,
+  eth/[keys, rlp],
+  ../../../../execution_chain/networking/discoveryv4,
+  ../../p2p_test_helper,
+  ../fuzzing_helpers
+
+template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
+const inputsDir = &"{sourceDir}{DirSep}generated-input{DirSep}"
+
+const EXPIRATION = 3600 * 24 * 365 * 10
+proc expiration(): uint32 = uint32(epochTime() + EXPIRATION)
+
+proc generate() =
+  ## Generate some valid inputs where one can start fuzzing with
+  let
+    fromAddr = localAddress(30303)
+    toAddr = localAddress(30304)
+    peerKey = PrivateKey.fromHex("a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a617")[]
+
+  # valid data for a Ping packet
+  block:
+    let payload = rlp.encode((uint64 4, fromAddr, toAddr, expiration()))
+    let encodedData = @[1.byte] & payload
+    debug "Ping", data=byteutils.toHex(encodedData)
+
+    encodedData.toFile(inputsDir & "ping")
+
+  # valid data for a Pong packet
+  block:
+    let token = keccak256.digest(@[byte 0])
+    let payload = rlp.encode((toAddr, token , expiration()))
+    let encodedData = @[2.byte] & payload
+    debug "Pong", data=byteutils.toHex(encodedData)
+
+    encodedData.toFile(inputsDir & "pong")
+
+  # valid data for a FindNode packet
+  block:
+    var data: array[64, byte]
+    data[32 .. ^1] = peerKey.toPublicKey().toNodeId().toBytesBE()
+    let payload = rlp.encode((data, expiration()))
+    let encodedData = @[3.byte] & @payload
+    debug "FindNode", data=byteutils.toHex(encodedData)
+
+    encodedData.toFile(inputsDir & "findnode")
+
+  # valid data for a Neighbours packet
+  block:
+    let
+      n1Addr = localAddress(30305)
+      n2Addr = localAddress(30306)
+      n1Key = PrivateKey.fromHex(
+        "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a618")[]
+      n2Key = PrivateKey.fromHex(
+        "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a619")[]
+
+    type Neighbour = tuple[ip: IpAddress, udpPort, tcpPort: Port, pk: PublicKey]
+    var nodes = newSeqOfCap[Neighbour](2)
+
+    nodes.add((n1Addr.ip, n1Addr.udpPort, n1Addr.tcpPort, n1Key.toPublicKey()))
+    nodes.add((n2Addr.ip, n2Addr.udpPort, n2Addr.tcpPort, n2Key.toPublicKey()))
+
+    let payload = rlp.encode((nodes, expiration()))
+    let encodedData = @[4.byte] & @payload
+    debug "Neighbours", data=byteutils.toHex(encodedData)
+
+    encodedData.toFile(inputsDir & "neighbours")
+
+discard existsOrCreateDir(inputsDir)
+generate()

--- a/tests/networking/fuzzing/fuzzing_helpers.nim
+++ b/tests/networking/fuzzing/fuzzing_helpers.nim
@@ -1,0 +1,17 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  std/streams
+
+proc toFile*(data: seq[byte], fn: string) =
+  var s = newFileStream(fn, fmWrite)
+  for x in data:
+    s.write(x)
+  s.close()

--- a/tests/networking/fuzzing/rlpx/thunk.nim
+++ b/tests/networking/fuzzing/rlpx/thunk.nim
@@ -1,0 +1,43 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  testutils/fuzzing, chronos,
+  ../../../../execution_chain/networking/[p2p, rlpx, p2p_types],
+  ../../eth_protocol,
+  ../../p2p_test_helper
+
+var
+  node1: EthereumNode
+  node2: EthereumNode
+  peer: Peer
+
+let rng = newRng()
+# This is not a good example of a fuzzing test and it would be much better
+# to mock more to get rid of anything sockets, async, etc.
+# However, it can and has provided reasonably quick results anyhow.
+init:
+  node1 = setupTestNode(rng, eth)
+  node2 = setupTestNode(rng, eth)
+
+  node2.startListening()
+  let res = waitFor node1.rlpxConnect(newNode(node2.toENode()))
+  if res.isErr():
+    quit 1
+  else:
+    peer = res.get()
+
+test:
+  aflLoop: # This appears to have unstable results with afl-clang-fast, probably
+           # because of undeterministic behaviour due to usage of network/async.
+    try:
+      var (msgId, msgData) = recvMsgMock(payload)
+      waitFor peer.invokeThunk(msgId, msgData)
+    except CatchableError as e:
+      debug "Test caused CatchableError", exception=e.name, trace=e.repr, msg=e.msg

--- a/tests/networking/p2p_test_helper.nim
+++ b/tests/networking/p2p_test_helper.nim
@@ -1,0 +1,45 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  std/strutils,
+  chronos,
+  eth/common/keys,
+  ../../execution_chain/networking/[p2p, discoveryv4]
+
+var nextPort = 30303
+
+proc localAddress*(port: int): Address =
+  let port = Port(port)
+  result = Address(udpPort: port, tcpPort: port,
+                   ip: parseIpAddress("127.0.0.1"))
+
+proc setupTestNode*(
+    rng: ref HmacDrbgContext,
+    capabilities: varargs[ProtocolInfo, `protocolInfo`]): EthereumNode {.gcsafe.} =
+  # Don't create new RNG every time in production code!
+  let keys1 = KeyPair.random(rng[])
+  var node = newEthereumNode(
+    keys1, localAddress(nextPort), NetworkId(1),
+    addAllCapabilities = false,
+    bindUdpPort = Port(nextPort), bindTcpPort = Port(nextPort),
+    rng = rng)
+  nextPort.inc
+  for capability in capabilities:
+    node.addCapability capability
+
+  node
+
+template sourceDir*: string = currentSourcePath.rsplit(DirSep, 1)[0]
+
+proc recvMsgMock*(msg: openArray[byte]): tuple[msgId: uint, msgData: Rlp] =
+  var rlp = rlpFromBytes(msg)
+
+  let msgId = rlp.read(uint32)
+  return (msgId.uint, rlp)

--- a/tests/networking/stubloglevel.nim
+++ b/tests/networking/stubloglevel.nim
@@ -1,0 +1,15 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import chronicles
+
+{.used.}
+
+when defined(chronicles_runtime_filtering):
+  setLogLevel(ERROR)

--- a/tests/networking/test_auth.nim
+++ b/tests/networking/test_auth.nim
@@ -1,0 +1,302 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.used.}
+
+import
+  unittest2,
+  nimcrypto/[utils, keccak],
+  eth/common/keys,
+  ../../execution_chain/networking/rlpx/auth
+
+# These test vectors were copied from EIP8 specification
+# https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8.md
+const eip8data = [
+  ("initiator_private_key",
+   "49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee"),
+  ("receiver_private_key",
+   "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"),
+  ("initiator_ephemeral_private_key",
+   "869d6ecf5211f1cc60418a13b9d870b22959d0c16f02bec714c960dd2298a32d"),
+  ("receiver_ephemeral_private_key",
+   "e238eb8e04fee6511ab04c6dd3c89ce097b11f25d584863ac2b6d5b35b1847e4"),
+  ("initiator_nonce",
+   "7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6"),
+  ("receiver_nonce",
+   "559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd"),
+  ("auth_ciphertext_eip8",
+   """01b304ab7578555167be8154d5cc456f567d5ba302662433674222360f08d5f15
+      34499d3678b513b0fca474f3a514b18e75683032eb63fccb16c156dc6eb2c0b15
+      93f0d84ac74f6e475f1b8d56116b849634a8c458705bf83a626ea0384d4d7341a
+      ae591fae42ce6bd5c850bfe0b999a694a49bbbaf3ef6cda61110601d3b4c02ab6
+      c30437257a6e0117792631a4b47c1d52fc0f8f89caadeb7d02770bf999cc147d2
+      df3b62e1ffb2c9d8c125a3984865356266bca11ce7d3a688663a51d82defaa8aa
+      d69da39ab6d5470e81ec5f2a7a47fb865ff7cca21516f9299a07b1bc63ba56c7a
+      1a892112841ca44b6e0034dee70c9adabc15d76a54f443593fafdc3b27af80597
+      03f88928e199cb122362a4b35f62386da7caad09c001edaeb5f8a06d2b26fb6cb
+      93c52a9fca51853b68193916982358fe1e5369e249875bb8d0d0ec36f917bc5e1
+      eafd5896d46bd61ff23f1a863a8a8dcd54c7b109b771c8e61ec9c8908c733c026
+      3440e2aa067241aaa433f0bb053c7b31a838504b148f570c0ad62837129e54767
+      8c5190341e4f1693956c3bf7678318e2d5b5340c9e488eefea198576344afbdf6
+      6db5f51204a6961a63ce072c8926c"""),
+  ("auth_ciphertext_eip8_3f",
+   """01b8044c6c312173685d1edd268aa95e1d495474c6959bcdd10067ba4c9013df9
+      e40ff45f5bfd6f72471f93a91b493f8e00abc4b80f682973de715d77ba3a005a2
+      42eb859f9a211d93a347fa64b597bf280a6b88e26299cf263b01b8dfdb7122784
+      64fd1c25840b995e84d367d743f66c0e54a586725b7bbf12acca27170ae3283c1
+      073adda4b6d79f27656993aefccf16e0d0409fe07db2dc398a1b7e8ee93bcd181
+      485fd332f381d6a050fba4c7641a5112ac1b0b61168d20f01b479e19adf7fdbfa
+      0905f63352bfc7e23cf3357657455119d879c78d3cf8c8c06375f3f7d4861aa02
+      a122467e069acaf513025ff196641f6d2810ce493f51bee9c966b15c504350535
+      0392b57645385a18c78f14669cc4d960446c17571b7c5d725021babbcd786957f
+      3d17089c084907bda22c2b2675b4378b114c601d858802a55345a15116bc61da4
+      193996187ed70d16730e9ae6b3bb8787ebcaea1871d850997ddc08b4f4ea668fb
+      f37407ac044b55be0908ecb94d4ed172ece66fd31bfdadf2b97a8bc690163ee11
+      f5b575a4b44e36e2bfb2f0fce91676fd64c7773bac6a003f481fddd0bae0a1f31
+      aa27504e2a533af4cef3b623f4791b2cca6d490"""),
+  ("authack_ciphertext_eip8",
+   """01ea0451958701280a56482929d3b0757da8f7fbe5286784beead59d95089c217
+      c9b917788989470b0e330cc6e4fb383c0340ed85fab836ec9fb8a49672712aeab
+      bdfd1e837c1ff4cace34311cd7f4de05d59279e3524ab26ef753a0095637ac88f
+      2b499b9914b5f64e143eae548a1066e14cd2f4bd7f814c4652f11b254f8a2d019
+      1e2f5546fae6055694aed14d906df79ad3b407d94692694e259191cde171ad542
+      fc588fa2b7333313d82a9f887332f1dfc36cea03f831cb9a23fea05b33deb999e
+      85489e645f6aab1872475d488d7bd6c7c120caf28dbfc5d6833888155ed69d34d
+      bdc39c1f299be1057810f34fbe754d021bfca14dc989753d61c413d261934e1a9
+      c67ee060a25eefb54e81a4d14baff922180c395d3f998d70f46f6b58306f96962
+      7ae364497e73fc27f6d17ae45a413d322cb8814276be6ddd13b885b201b943213
+      656cde498fa0e9ddc8e0b8f8a53824fbd82254f3e2c17e8eaea009c38b4aa0a3f
+      306e8797db43c25d68e86f262e564086f59a2fc60511c42abfb3057c247a8a8fe
+      4fb3ccbadde17514b7ac8000cdb6a912778426260c47f38919a91f25f4b5ffb45
+      5d6aaaf150f7e5529c100ce62d6d92826a71778d809bdf60232ae21ce8a437eca
+      8223f45ac37f6487452ce626f549b3b5fdee26afd2072e4bc75833c2464c80524
+      6155289f4"""),
+  ("authack_ciphertext_eip8_3f",
+   """01f004076e58aae772bb101ab1a8e64e01ee96e64857ce82b1113817c6cdd52c0
+      9d26f7b90981cd7ae835aeac72e1573b8a0225dd56d157a010846d888dac7464b
+      af53f2ad4e3d584531fa203658fab03a06c9fd5e35737e417bc28c1cbf5e5dfc6
+      66de7090f69c3b29754725f84f75382891c561040ea1ddc0d8f381ed1b9d0d4ad
+      2a0ec021421d847820d6fa0ba66eaf58175f1b235e851c7e2124069fbc202888d
+      db3ac4d56bcbd1b9b7eab59e78f2e2d400905050f4a92dec1c4bdf797b3fc9b2f
+      8e84a482f3d800386186712dae00d5c386ec9387a5e9c9a1aca5a573ca91082c7
+      d68421f388e79127a5177d4f8590237364fd348c9611fa39f78dcdceee3f390f0
+      7991b7b47e1daa3ebcb6ccc9607811cb17ce51f1c8c2c5098dbdd28fca547b3f5
+      8c01a424ac05f869f49c6a34672ea2cbbc558428aa1fe48bbfd61158b1b735a65
+      d99f21e70dbc020bfdface9f724a0d1fb5895db971cc81aa7608baa0920abb0a5
+      65c9c436e2fd13323428296c86385f2384e408a31e104670df0791d93e743a3a5
+      194ee6b076fb6323ca593011b7348c16cf58f66b9633906ba54a2ee803187344b
+      394f75dd2e663a57b956cb830dd7a908d4f39a2336a61ef9fda549180d4ccde21
+      514d117b6c6fd07a9102b5efe710a32af4eeacae2cb3b1dec035b9593b48b9d3c
+      a4c13d245d5f04169b0b1"""),
+  ("auth2ack2_aes_secret",
+   "80e8632c05fed6fc2a13b0f8d31a3cf645366239170ea067065aba8e28bac487"),
+  ("auth2ack2_mac_secret",
+   "2ea74ec5dae199227dff1af715362700e989d889d7a493cb0639691efb8e5f98"),
+  ("auth2ack2_ingress_message", "foo"),
+  ("auth2ack2_ingress_mac",
+   "0c7ec6340062cc46f5e9f1e3cf86f8c8c403c5a0964f5df0ebd34a75ddc86db5")
+]
+
+let rng = newRng()
+
+proc testE8Value(s: string): string =
+  for item in eip8data:
+    if item[0] == s:
+      result = item[1]
+      break
+
+suite "Ethereum P2P handshake test suite":
+  block:
+    proc newTestHandshake(flags: set[HandshakeFlag]): Handshake =
+      if Initiator in flags:
+        let pk = PrivateKey.fromHex(testE8Value("initiator_private_key"))[]
+        result = Handshake.init(rng[], pk.toKeyPair(), flags)
+
+        let esec = testE8Value("initiator_ephemeral_private_key")
+        result.ephemeral = PrivateKey.fromHex(esec)[].toKeyPair()
+        let nonce = fromHex(stripSpaces(testE8Value("initiator_nonce")))
+        result.initiatorNonce[0..^1] = nonce[0..^1]
+      elif Responder in flags:
+        let pk = PrivateKey.fromHex(testE8Value("receiver_private_key"))[]
+        result = Handshake.init(rng[], pk.toKeyPair(), flags)
+
+        let esec = testE8Value("receiver_ephemeral_private_key")
+        result.ephemeral = PrivateKey.fromHex(esec)[].toKeyPair()
+        let nonce = fromHex(stripSpaces(testE8Value("receiver_nonce")))
+        result.responderNonce[0..^1] = nonce[0..^1]
+
+    test "AUTH/ACK EIP-8 test vectors":
+      var initiator = newTestHandshake({Initiator})
+      var responder = newTestHandshake({Responder})
+      var m0 = fromHex(stripSpaces(testE8Value("auth_ciphertext_eip8")))
+      responder.decodeAuthMessage(m0).expect("decode success")
+      check:
+        responder.initiatorNonce[0..^1] == initiator.initiatorNonce[0..^1]
+      let remoteEPubkey0 = initiator.ephemeral.pubkey
+      check responder.remoteEPubkey == remoteEPubkey0
+      let remoteHPubkey0 = initiator.host.pubkey
+      check responder.remoteHPubkey == remoteHPubkey0
+      var m1 = fromHex(stripSpaces(testE8Value("authack_ciphertext_eip8")))
+      initiator.decodeAckMessage(m1).expect("decode success")
+      let remoteEPubkey1 = responder.ephemeral.pubkey
+      check:
+        initiator.remoteEPubkey == remoteEPubkey1
+        initiator.responderNonce[0..^1] == responder.responderNonce[0..^1]
+      var taes = fromHex(stripSpaces(testE8Value("auth2ack2_aes_secret")))
+      var tmac = fromHex(stripSpaces(testE8Value("auth2ack2_mac_secret")))
+
+      var csecInitiator = initiator.getSecrets(m0, m1)
+      var csecResponder = responder.getSecrets(m0, m1)
+      check:
+        csecInitiator.aesKey == csecResponder.aesKey
+        csecInitiator.macKey == csecResponder.macKey
+        taes[0..^1] == csecInitiator.aesKey[0..^1]
+        tmac[0..^1] == csecInitiator.macKey[0..^1]
+
+      var ingressMac = csecResponder.ingressMac
+      ingressMac.update(testE8Value("auth2ack2_ingress_message"))
+      check ingressMac.finish().data.toHex(true) ==
+        testE8Value("auth2ack2_ingress_mac")
+
+    test "AUTH/ACK EIP-8 with additional fields test vectors":
+      var initiator = newTestHandshake({Initiator})
+      var responder = newTestHandshake({Responder})
+      var m0 = fromHex(stripSpaces(testE8Value("auth_ciphertext_eip8_3f")))
+      responder.decodeAuthMessage(m0).expect("decode success")
+      check:
+        responder.initiatorNonce[0..^1] == initiator.initiatorNonce[0..^1]
+      let remoteEPubkey0 = initiator.ephemeral.pubkey
+      let remoteHPubkey0 = initiator.host.pubkey
+      check:
+        responder.remoteEPubkey == remoteEPubkey0
+        responder.remoteHPubkey == remoteHPubkey0
+      var m1 = fromHex(stripSpaces(testE8Value("authack_ciphertext_eip8_3f")))
+      initiator.decodeAckMessage(m1).expect("decode success")
+      let remoteEPubkey1 = responder.ephemeral.pubkey
+      check:
+        initiator.remoteEPubkey == remoteEPubkey1
+        initiator.responderNonce[0..^1] == responder.responderNonce[0..^1]
+
+    test "100 AUTH/ACK EIP-8 handshakes":
+      for i in 1..100:
+        var initiator = newTestHandshake({Initiator})
+        var responder = newTestHandshake({Responder})
+        var m0 = newSeq[byte](AuthMessageMaxEIP8)
+        let k0 = initiator.authMessage(
+          rng[], responder.host.pubkey, m0).expect("auth success")
+        m0.setLen(k0)
+        responder.decodeAuthMessage(m0).expect("decode success")
+
+        var m1 = newSeq[byte](AckMessageMaxEIP8)
+        let k1 = responder.ackMessage(rng[], m1).expect("ack success")
+        m1.setLen(k1)
+        initiator.decodeAckMessage(m1).expect("decode success")
+        var csecInitiator = initiator.getSecrets(m0, m1)
+        var csecResponder = responder.getSecrets(m0, m1)
+        check:
+          csecInitiator.aesKey == csecResponder.aesKey
+          csecInitiator.macKey == csecResponder.macKey
+
+    test "100 AUTH/ACK V4 handshakes":
+      for i in 1..100:
+        var initiator = newTestHandshake({Initiator})
+        var responder = newTestHandshake({Responder})
+        var m0 = newSeq[byte](AuthMessageMaxEIP8)
+        let k0 = initiator.authMessage(
+          rng[], responder.host.pubkey, m0).expect("auth success")
+        m0.setLen(k0)
+        responder.decodeAuthMessage(m0).expect("auth success")
+        var m1 = newSeq[byte](AckMessageMaxEIP8)
+        let k1 = responder.ackMessage(rng[], m1).expect("ack success")
+        m1.setLen(k1)
+        initiator.decodeAckMessage(m1).expect("ack success")
+
+        var csecInitiator = initiator.getSecrets(m0, m1)
+        var csecResponder = responder.getSecrets(m0, m1)
+        check:
+          csecInitiator.aesKey == csecResponder.aesKey
+          csecInitiator.macKey == csecResponder.macKey
+
+    test "Invalid AuthMessage - Minimum input size":
+      var responder = newTestHandshake({Responder})
+
+      # 1 byte short on minimum AuthMessage size
+      var m = newSeq[byte](AuthMessageEIP8Length - 1)
+
+      let res = responder.decodeAuthMessage(m)
+      check:
+        res.isErr()
+        res.error == AuthError.IncompleteError
+
+    test "Invalid AuthMessage - Minimum size prefix":
+      var responder = newTestHandshake({Responder})
+
+      # Minimum size for EIP8 AuthMessage
+      var m = newSeq[byte](AuthMessageEIP8Length)
+      # size prefix size of 281, 1 byte short
+      m[0] = 1
+      m[1] = 25
+
+      let res = responder.decodeAuthMessage(m)
+      check:
+        res.isErr()
+        res.error == AuthError.IncompleteError
+
+    test "Invalid AuthMessage - Size prefix bigger than input":
+      var responder = newTestHandshake({Responder})
+
+      # Minimum size for EIP8 AuthMessage
+      var m = newSeq[byte](AuthMessageEIP8Length)
+      # size prefix size of 283, 1 byte too many
+      m[0] = 1
+      m[1] = 27
+
+      let res = responder.decodeAuthMessage(m)
+      check:
+        res.isErr()
+        res.error == AuthError.IncompleteError
+
+    test "Invalid AckMessage - Minimum input size":
+      var initiator = newTestHandshake({Initiator,})
+
+      # 1 byte short on minimum size
+      let m = newSeq[byte](AckMessageEIP8Length - 1)
+
+      let res = initiator.decodeAckMessage(m)
+      check:
+        res.isErr()
+        res.error == AuthError.IncompleteError
+
+    test "Invalid AckMessage - Minimum size prefix":
+      var initiator = newTestHandshake({Initiator})
+
+      # Minimum size for EIP8 AckMessage
+      var m = newSeq[byte](AckMessageEIP8Length)
+      # size prefix size of 214, 1 byte short
+      m[0] = 0
+      m[1] = 214
+
+      let res = initiator.decodeAckMessage(m)
+      check:
+        res.isErr()
+        res.error == AuthError.IncompleteError
+
+    test "Invalid AckMessage - Size prefix bigger than input":
+      var initiator = newTestHandshake({Initiator})
+
+      # Minimum size for EIP8 AckMessage
+      var m = newSeq[byte](AckMessageEIP8Length)
+      # size prefix size of 216, 1 byte too many
+      m[0] = 0
+      m[1] = 216
+
+      let res = initiator.decodeAckMessage(m)
+      check:
+        res.isErr()
+        res.error == AuthError.IncompleteError

--- a/tests/networking/test_crypt.nim
+++ b/tests/networking/test_crypt.nim
@@ -1,0 +1,217 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.used.}
+
+import
+  unittest2,
+  nimcrypto/[utils, keccak, sysrand],
+  eth/common/keys,
+  ../../execution_chain/networking/rlpx/[auth, rlpxcrypt]
+
+# EIP-8 test case
+# https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8.md#rlpx-handshake
+
+const
+  staticKeyA = fromHex("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee")
+  staticKeyB = fromHex("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+  ephemeralKeyA = fromHex("869d6ecf5211f1cc60418a13b9d870b22959d0c16f02bec714c960dd2298a32d")
+  ephemeralKeyB = fromHex("e238eb8e04fee6511ab04c6dd3c89ce097b11f25d584863ac2b6d5b35b1847e4")
+  nonceA = fromHex("7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6")
+  nonceB = fromHex("559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd")
+
+  auth1 = fromHex(stripSpaces("""
+    048ca79ad18e4b0659fab4853fe5bc58eb83992980f4c9cc147d2aa31532efd29a3d3dc6a3d89eaf
+    913150cfc777ce0ce4af2758bf4810235f6e6ceccfee1acc6b22c005e9e3a49d6448610a58e98744
+    ba3ac0399e82692d67c1f58849050b3024e21a52c9d3b01d871ff5f210817912773e610443a9ef14
+    2e91cdba0bd77b5fdf0769b05671fc35f83d83e4d3b0b000c6b2a1b1bba89e0fc51bf4e460df3105
+    c444f14be226458940d6061c296350937ffd5e3acaceeaaefd3c6f74be8e23e0f45163cc7ebd7622
+    0f0128410fd05250273156d548a414444ae2f7dea4dfca2d43c057adb701a715bf59f6fb66b2d1d2
+    0f2c703f851cbf5ac47396d9ca65b6260bd141ac4d53e2de585a73d1750780db4c9ee4cd4d225173
+    a4592ee77e2bd94d0be3691f3b406f9bba9b591fc63facc016bfa8"""))
+  auth2 = fromHex(stripSpaces("""
+    01b304ab7578555167be8154d5cc456f567d5ba302662433674222360f08d5f1534499d3678b513b
+    0fca474f3a514b18e75683032eb63fccb16c156dc6eb2c0b1593f0d84ac74f6e475f1b8d56116b84
+    9634a8c458705bf83a626ea0384d4d7341aae591fae42ce6bd5c850bfe0b999a694a49bbbaf3ef6c
+    da61110601d3b4c02ab6c30437257a6e0117792631a4b47c1d52fc0f8f89caadeb7d02770bf999cc
+    147d2df3b62e1ffb2c9d8c125a3984865356266bca11ce7d3a688663a51d82defaa8aad69da39ab6
+    d5470e81ec5f2a7a47fb865ff7cca21516f9299a07b1bc63ba56c7a1a892112841ca44b6e0034dee
+    70c9adabc15d76a54f443593fafdc3b27af8059703f88928e199cb122362a4b35f62386da7caad09
+    c001edaeb5f8a06d2b26fb6cb93c52a9fca51853b68193916982358fe1e5369e249875bb8d0d0ec3
+    6f917bc5e1eafd5896d46bd61ff23f1a863a8a8dcd54c7b109b771c8e61ec9c8908c733c0263440e
+    2aa067241aaa433f0bb053c7b31a838504b148f570c0ad62837129e547678c5190341e4f1693956c
+    3bf7678318e2d5b5340c9e488eefea198576344afbdf66db5f51204a6961a63ce072c8926c"""))
+  auth3 = fromHex(stripSpaces("""
+    01b8044c6c312173685d1edd268aa95e1d495474c6959bcdd10067ba4c9013df9e40ff45f5bfd6f7
+    2471f93a91b493f8e00abc4b80f682973de715d77ba3a005a242eb859f9a211d93a347fa64b597bf
+    280a6b88e26299cf263b01b8dfdb712278464fd1c25840b995e84d367d743f66c0e54a586725b7bb
+    f12acca27170ae3283c1073adda4b6d79f27656993aefccf16e0d0409fe07db2dc398a1b7e8ee93b
+    cd181485fd332f381d6a050fba4c7641a5112ac1b0b61168d20f01b479e19adf7fdbfa0905f63352
+    bfc7e23cf3357657455119d879c78d3cf8c8c06375f3f7d4861aa02a122467e069acaf513025ff19
+    6641f6d2810ce493f51bee9c966b15c5043505350392b57645385a18c78f14669cc4d960446c1757
+    1b7c5d725021babbcd786957f3d17089c084907bda22c2b2675b4378b114c601d858802a55345a15
+    116bc61da4193996187ed70d16730e9ae6b3bb8787ebcaea1871d850997ddc08b4f4ea668fbf3740
+    7ac044b55be0908ecb94d4ed172ece66fd31bfdadf2b97a8bc690163ee11f5b575a4b44e36e2bfb2
+    f0fce91676fd64c7773bac6a003f481fddd0bae0a1f31aa27504e2a533af4cef3b623f4791b2cca6
+    d490"""))
+  ack1 = fromHex(stripSpaces("""
+    049f8abcfa9c0dc65b982e98af921bc0ba6e4243169348a236abe9df5f93aa69d99cadddaa387662
+    b0ff2c08e9006d5a11a278b1b3331e5aaabf0a32f01281b6f4ede0e09a2d5f585b26513cb794d963
+    5a57563921c04a9090b4f14ee42be1a5461049af4ea7a7f49bf4c97a352d39c8d02ee4acc416388c
+    1c66cec761d2bc1c72da6ba143477f049c9d2dde846c252c111b904f630ac98e51609b3b1f58168d
+    dca6505b7196532e5f85b259a20c45e1979491683fee108e9660edbf38f3add489ae73e3dda2c71b
+    d1497113d5c755e942d1"""))
+  ack2 = fromHex(stripSpaces("""
+    01ea0451958701280a56482929d3b0757da8f7fbe5286784beead59d95089c217c9b917788989470
+    b0e330cc6e4fb383c0340ed85fab836ec9fb8a49672712aeabbdfd1e837c1ff4cace34311cd7f4de
+    05d59279e3524ab26ef753a0095637ac88f2b499b9914b5f64e143eae548a1066e14cd2f4bd7f814
+    c4652f11b254f8a2d0191e2f5546fae6055694aed14d906df79ad3b407d94692694e259191cde171
+    ad542fc588fa2b7333313d82a9f887332f1dfc36cea03f831cb9a23fea05b33deb999e85489e645f
+    6aab1872475d488d7bd6c7c120caf28dbfc5d6833888155ed69d34dbdc39c1f299be1057810f34fb
+    e754d021bfca14dc989753d61c413d261934e1a9c67ee060a25eefb54e81a4d14baff922180c395d
+    3f998d70f46f6b58306f969627ae364497e73fc27f6d17ae45a413d322cb8814276be6ddd13b885b
+    201b943213656cde498fa0e9ddc8e0b8f8a53824fbd82254f3e2c17e8eaea009c38b4aa0a3f306e8
+    797db43c25d68e86f262e564086f59a2fc60511c42abfb3057c247a8a8fe4fb3ccbadde17514b7ac
+    8000cdb6a912778426260c47f38919a91f25f4b5ffb455d6aaaf150f7e5529c100ce62d6d92826a7
+    1778d809bdf60232ae21ce8a437eca8223f45ac37f6487452ce626f549b3b5fdee26afd2072e4bc7
+    5833c2464c805246155289f4"""))
+  ack3 = fromHex(stripSpaces("""
+    01f004076e58aae772bb101ab1a8e64e01ee96e64857ce82b1113817c6cdd52c09d26f7b90981cd7
+    ae835aeac72e1573b8a0225dd56d157a010846d888dac7464baf53f2ad4e3d584531fa203658fab0
+    3a06c9fd5e35737e417bc28c1cbf5e5dfc666de7090f69c3b29754725f84f75382891c561040ea1d
+    dc0d8f381ed1b9d0d4ad2a0ec021421d847820d6fa0ba66eaf58175f1b235e851c7e2124069fbc20
+    2888ddb3ac4d56bcbd1b9b7eab59e78f2e2d400905050f4a92dec1c4bdf797b3fc9b2f8e84a482f3
+    d800386186712dae00d5c386ec9387a5e9c9a1aca5a573ca91082c7d68421f388e79127a5177d4f8
+    590237364fd348c9611fa39f78dcdceee3f390f07991b7b47e1daa3ebcb6ccc9607811cb17ce51f1
+    c8c2c5098dbdd28fca547b3f58c01a424ac05f869f49c6a34672ea2cbbc558428aa1fe48bbfd6115
+    8b1b735a65d99f21e70dbc020bfdface9f724a0d1fb5895db971cc81aa7608baa0920abb0a565c9c
+    436e2fd13323428296c86385f2384e408a31e104670df0791d93e743a3a5194ee6b076fb6323ca59
+    3011b7348c16cf58f66b9633906ba54a2ee803187344b394f75dd2e663a57b956cb830dd7a908d4f
+    39a2336a61ef9fda549180d4ccde21514d117b6c6fd07a9102b5efe710a32af4eeacae2cb3b1dec0
+    35b9593b48b9d3ca4c13d245d5f04169b0b1"""))
+
+  aesSecret2 = fromHex("80e8632c05fed6fc2a13b0f8d31a3cf645366239170ea067065aba8e28bac487")
+  macSecret2 = fromHex("2ea74ec5dae199227dff1af715362700e989d889d7a493cb0639691efb8e5f98")
+
+let rng = newRng()
+
+suite "Ethereum RLPx encryption/decryption test suite":
+  proc newTestHandshake(flags: set[HandshakeFlag]): Handshake =
+    if Initiator in flags:
+      let pk = PrivateKey.fromRaw(staticKeyA)[]
+      result = Handshake.init(rng[], pk.toKeyPair(), flags)
+      result.ephemeral = PrivateKey.fromRaw(ephemeralKeyA)[].toKeyPair()
+      result.initiatorNonce[0..^1] = nonceA
+    elif Responder in flags:
+      let pk = PrivateKey.fromRaw(staticKeyB)[]
+      result = Handshake.init(rng[], pk.toKeyPair(), flags)
+      result.ephemeral = PrivateKey.fromRaw(ephemeralKeyB)[].toKeyPair()
+      result.responderNonce[0..^1] = nonceB
+
+  test "Fail on pre-EIP8 messages":
+    var initiator = newTestHandshake({Initiator})
+    var responder = newTestHandshake({Responder})
+    check: responder.decodeAuthMessage(auth1).isErr()
+    check: initiator.decodeAckMessage(ack1).isErr()
+
+  test "Correct shared EIP-8 secret":
+    var initiator = newTestHandshake({Initiator})
+    var responder = newTestHandshake({Responder})
+
+    check: responder.decodeAuthMessage(auth2).isOk()
+    check: initiator.decodeAckMessage(ack2).isOk()
+
+    var csecResponder = responder.getSecrets(auth2, ack2)
+
+    check:
+      csecResponder.aesKey == aesSecret2
+      csecResponder.macKey == macSecret2
+    var tmpMac = csecResponder.ingressMac
+    tmpMac.update("foo".toOpenArrayByte(0, 2))
+    check:
+      tmpMac.finish().data == fromHex("0c7ec6340062cc46f5e9f1e3cf86f8c8c403c5a0964f5df0ebd34a75ddc86db5")
+
+  test "Can parse auth/ack with extra bytes":
+    var initiator = newTestHandshake({Initiator})
+    var responder = newTestHandshake({Responder})
+    check: responder.decodeAuthMessage(auth3).isOk()
+    check: initiator.decodeAckMessage(ack3).isOk()
+
+  test "Continuous stream of different lengths (1000 times)":
+    var initiator = newTestHandshake({Initiator})
+    var responder = newTestHandshake({Responder})
+    var m0 = newSeq[byte](AuthMessageMaxEIP8)
+    let k0 = initiator.authMessage(rng[], responder.host.pubkey,
+                                m0).expect("correct buf size")
+    m0.setLen(k0)
+    check responder.decodeAuthMessage(m0).isOk
+    var m1 = newSeq[byte](AckMessageMaxEIP8)
+    let k1 = responder.ackMessage(rng[], m1).expect("correct buf size")
+    m1.setLen(k1)
+    check initiator.decodeAckMessage(m1).isOk
+
+    var csecInitiator = initiator.getSecrets(m0, m1)
+    var csecResponder = responder.getSecrets(m0, m1)
+    var stateInitiator: SecretState
+    var stateResponder: SecretState
+    var iheader: array[16, byte]
+    initSecretState(csecInitiator, stateInitiator)
+    initSecretState(csecResponder, stateResponder)
+    for i in 1..1000:
+      # initiator -> responder
+      block:
+        var ibody = newSeq[byte](i)
+        var encrypted = newSeq[byte](encryptedLength(len(ibody)))
+        iheader[0] = byte((len(ibody) shr 16) and 0xFF)
+        iheader[1] = byte((len(ibody) shr 8) and 0xFF)
+        iheader[2] = byte(len(ibody) and 0xFF)
+        check:
+          randomBytes(ibody) == len(ibody)
+          stateInitiator.encrypt(iheader, ibody,
+                                 encrypted).isOk()
+        let rheader = stateResponder.decryptHeader(
+          toOpenArray(encrypted, 0, 31)).expect("valid data")
+
+        var length = getBodySize(rheader)
+        check length == len(ibody)
+        var rbody = newSeq[byte](decryptedLength(length))
+        check:
+          stateResponder.decryptBody(
+            toOpenArray(encrypted, 32, len(encrypted) - 1),
+            length, rbody).isOk()
+        rbody.setLen(length)
+        check:
+          iheader == rheader
+          ibody == rbody
+        burnMem(iheader)
+      # responder -> initiator
+      block:
+        var ibody = newSeq[byte](i * 3)
+        var encrypted = newSeq[byte](encryptedLength(len(ibody)))
+        iheader[0] = byte((len(ibody) shr 16) and 0xFF)
+        iheader[1] = byte((len(ibody) shr 8) and 0xFF)
+        iheader[2] = byte(len(ibody) and 0xFF)
+        check:
+          randomBytes(ibody) == len(ibody)
+          stateResponder.encrypt(iheader, ibody,
+                                 encrypted).isOk()
+        let rheader = stateInitiator.decryptHeader(
+          toOpenArray(encrypted, 0, 31)).expect("valid data")
+        var length = getBodySize(rheader)
+        check length == len(ibody)
+        var rbody = newSeq[byte](decryptedLength(length))
+        check:
+          stateInitiator.decryptBody(
+            toOpenArray(encrypted, 32, len(encrypted) - 1),
+            length, rbody).isOk()
+        rbody.setLen(length)
+        check:
+          iheader == rheader
+          ibody == rbody
+        burnMem(iheader)

--- a/tests/networking/test_discoveryv4.nim
+++ b/tests/networking/test_discoveryv4.nim
@@ -1,0 +1,171 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.used.}
+
+import
+  std/sequtils,
+  chronos,
+  stew/byteutils,
+  nimcrypto/keccak,
+  testutils/unittests,
+  eth/common/keys,
+  eth/rlp,
+  ./stubloglevel,
+  ../../execution_chain/networking/discoveryv4
+
+proc localAddress(port: int): Address =
+  let port = Port(port)
+  result = Address(udpPort: port, tcpPort: port,
+                   ip: parseIpAddress("127.0.0.1"))
+
+proc initDiscoveryNode(
+    privKey: PrivateKey, address: Address,
+    bootnodes: seq[ENode]): DiscoveryProtocol =
+  let node = newDiscoveryProtocol(privKey, address, bootnodes, address.udpPort)
+  node.open()
+
+  return node
+
+proc packData(payload: openArray[byte], pk: PrivateKey): seq[byte] =
+  let
+    payloadSeq = @payload
+    signature = @(pk.sign(payload).toRaw())
+    msgHash = keccak256.digest(signature & payloadSeq)
+  result = @(msgHash.data) & signature & payloadSeq
+
+proc nodeIdInNodes(id: NodeId, nodes: openArray[Node]): bool =
+  for n in nodes:
+    if id == n.id: return true
+
+procSuite "Discovery Tests":
+  let
+    bootNodeKey = PrivateKey.fromHex(
+      "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a617")[]
+    bootNodeAddr = localAddress(20301)
+    bootENode = ENode(pubkey: bootNodeKey.toPublicKey(), address: bootNodeAddr)
+    bootNode = initDiscoveryNode(bootNodeKey, bootNodeAddr, @[])
+  waitFor bootNode.bootstrap()
+
+  asyncTest "Discover nodes":
+    let nodeKeys = [
+      PrivateKey.fromHex(
+        "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a618")[],
+      PrivateKey.fromHex(
+        "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a619")[],
+      PrivateKey.fromHex(
+        "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a620")[]
+    ]
+
+    var nodes: seq[DiscoveryProtocol]
+    for i in 0..<nodeKeys.len:
+      let node = initDiscoveryNode(nodeKeys[i], localAddress(20302 + i),
+        @[bootENode])
+      nodes.add(node)
+
+    await allFutures(nodes.mapIt(it.bootstrap()))
+    nodes.add(bootNode)
+
+    for i in nodes:
+      for j in nodes:
+        if j != i:
+          check(nodeIdInNodes(i.localNode.id, j.randomNodes(nodes.len - 1)))
+
+  test "Test Vectors":
+    # These are the test vectors from EIP-8:
+    # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8.md#rlpx-discovery-protocol
+    # However they are unpacked and the expiration is changed from 0x43b9a355
+    # to 0x6fd3aed7 so that they remain valid for a while
+    let validProtocolData = [
+      # ping packet with version 4, additional list elements
+      "01ec04cb847f000001820cfa8215a8d790000000000000000000000000000000018208ae820d05846fd3aed70102",
+      # ping packet with version 555, additional list elements and additional random data
+      "01f83e82022bd79020010db83c4d001500000000abcdef12820cfa8215a8d79020010db885a308d313198a2e037073488208ae82823a846fd3aed7c5010203040531b9019afde696e582a78fa8d95ea13ce3297d4afb8ba6433e4154caa5ac6431af1b80ba76023fa4090c408f6b4bc3701562c031041d4702971d102c9ab7fa5eed4cd6bab8f7af956f7d565ee1917084a95398b6a21eac920fe3dd1345ec0a7ef39367ee69ddf092cbfe5b93e5e568ebc491983c09c76d922dc3",
+      # pong packet with additional list elements and additional random data
+      "02f846d79020010db885a308d313198a2e037073488208ae82823aa0fbc914b16819237dcd8801d7e53f69e9719adecb3cc0e790c57e91ca4461c954846fd3aed7c6010203c2040506a0c969a58f6f9095004c0177a6b47f451530cab38966a25cca5cb58f055542124e",
+      # findnode packet with additional list elements and additional random data
+      "03f84eb840ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f846fd3aed782999983999999280dc62cc8255c73471e0a61da0c89acdc0e035e260add7fc0c04ad9ebf3919644c91cb247affc82b69bd2ca235c71eab8e49737c937a2c396",
+      # neighbours packet with additional list elements and additional random data
+      "04f9015bf90150f84d846321163782115c82115db8403155e1427f85f10a5c9a7755877748041af1bcd8d474ec065eb33df57a97babf54bfd2103575fa829115d224c523596b401065a97f74010610fce76382c0bf32f84984010203040101b840312c55512422cf9b8a4097e9a6ad79402e87a15ae909a4bfefa22398f03d20951933beea1e4dfa6f968212385e829f04c2d314fc2d4e255e0d3bc08792b069dbf8599020010db83c4d001500000000abcdef12820d05820d05b84038643200b172dcfef857492156971f0e6aa2c538d8b74010f8e140811d53b98c765dd2d96126051913f44582e8c199ad7c6d6819e9a56483f637feaac9448aacf8599020010db885a308d313198a2e037073488203e78203e8b8408dcab8618c3253b558d459da53bd8fa68935a719aff8b811197101a4b2b47dd2d47295286fc00cc081bb542d760717d1bdd6bec2c37cd72eca367d6dd3b9df73846fd3aed7010203b525a138aa34383fec3d2719a0",
+    ]
+    let
+      address = localAddress(20302)
+      nodeKey = PrivateKey.fromHex(
+        "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")[]
+
+    for data in validProtocolData:
+      # none of these may raise
+      bootNode.receive(address, packData(hexToSeqByte(data), nodeKey))
+
+  test "Invalid protocol data":
+    let invalidProtocolData = [
+      "0x00",   # invalid msg id
+      "0x01",   # empty payload
+      "0x03b8", # no list but string
+      "0x01C0", # empty list
+      # FindNode target that is 1 byte too long
+      # We currently do not raise on this, so can't really test it
+      # "0x03f847b841AA0000000000000000000000000000000000000000000000000000000000000000a99a96bd988e1839272f93257bd9dfb2e558390e1f9bff28cdc8f04c9b5d06b1846fd3aed7",
+    ]
+
+    let invalidRlpData = [
+      # valid version: "0x04f8a5f89ef84d847f000001827661827669b840ebefe173cab8832f6d6623f2a4d415959c1b80071e6af7d5986417d4bd07df19318b30d3d4fde75b025314ce22a523a714bef6c61838094e5d3640dccc6b9e34f84d847f000001827662827662b840ebefe173cab8832f6d6623f2a4d415959c1b80071e6af7d5986417d4bd07df19318b30d3d4fde75b025314ce22a523a714bef6c61838094e5d3640dccc6b9e348479e7f252",
+      # Invalid rlp item length (for the individual node list), causing a next listElem to read wrong data.
+      "0x04f8a5f89ef856847f000001827661827669b840ebefe173cab8832f6d6623f2a4d415959c1b80071e6af7d5986417d4bd07df19318b30d3d4fde75b025314ce22a523a714bef6c61838094e5d3640dccc6b9e34f84d847f000001827662827662b8403114ae2fe09b7a71d6693451c0d043df8315fb811e43c7b97ef2ff87409a2601b4425f92ffff80008417d66489cb1f8414d9dd4393ba16ebb455aa47345a222b8479e7f252",
+      # Invalid IP length in nodes
+      "0x04f8a4f89df84c837f0001827661827669b840ebefe173cab8832f6d6623f2a4d415959c1b80071e6af7d5986417d4bd07df19318b30d3d4fde75b025314ce22a523a714bef6c61838094e5d3640dccc6b9e34f84d847f000001827662827662b840ebefe173cab8832f6d6623f2a4d415959c1b80071e6af7d5986417d4bd07df19318b30d3d4fde75b025314ce22a523a714bef6c61838094e5d3640dccc6b9e348479e7f252",
+      # Invalid Public key in nodes
+      "0x04f8a5f89ef84d847f000001827661827669b840fbefe173cab8832f6d6623f2a4d415959c1b80071e6af7d5986417d4bd07df19318b30d3d4fde75b025314ce22a523a714bef6c61838094e5d3640dccc6b9e34f84d847f000001827662827662b840ebefe173cab8832f6d6623f2a4d415959c1b80071e6af7d5986417d4bd07df19318b30d3d4fde75b025314ce22a523a714bef6c61838094e5d3640dccc6b9e348479e7f252",
+      # Invalid Public key in nodes - too short
+      "0x04f8a4f89df84c847f000001827661827669b83fefe173cab8832f6d6623f2a4d415959c1b80071e6af7d5986417d4bd07df19318b30d3d4fde75b025314ce22a523a714bef6c61838094e5d3640dccc6b9e34f84d847f000001827662827662b840ebefe173cab8832f6d6623f2a4d415959c1b80071e6af7d5986417d4bd07df19318b30d3d4fde75b025314ce22a523a714bef6c61838094e5d3640dccc6b9e348479e7f252",
+      # nodes list len of 3 (removed port)
+      "0x04f8a2f89bf84a847f000001827661b840ebefe173cab8832f6d6623f2a4d415959c1b80071e6af7d5986417d4bd07df19318b30d3d4fde75b025314ce22a523a714bef6c61838094e5d3640dccc6b9e34f84d847f000001827662827662b840ebefe173cab8832f6d6623f2a4d415959c1b80071e6af7d5986417d4bd07df19318b30d3d4fde75b025314ce22a523a714bef6c61838094e5d3640dccc6b9e348479e7f252"
+    ]
+
+    let
+      address = localAddress(20302)
+      nodeKey = PrivateKey.fromHex(
+        "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a618")[]
+
+    for data in invalidProtocolData:
+      expect DiscProtocolError:
+        bootNode.receive(address, packData(hexToSeqByte(data), nodeKey))
+
+    for data in invalidRlpData:
+      expect RlpError:
+        bootNode.receive(address, packData(hexToSeqByte(data), nodeKey))
+
+    # empty msg id and payload, doesn't raise, just fails and prints wrong
+    # msg mac
+    bootNode.receive(address, packData(@[], nodeKey))
+
+  asyncTest "Two findNode calls for the same peer in rapid succession":
+    let targetKey = PrivateKey.fromHex(
+        "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a618")[]
+    let peerKey = PrivateKey.fromHex(
+        "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a619")[]
+
+    let targetNodeId = kademlia.toNodeId(targetKey.toPublicKey)
+    let peerNode = kademlia.newNode(peerKey.toPublicKey, localAddress(20302))
+    let nodesSeen = new(HashSet[Node])
+
+    # Start `findNode` but don't `await` yet, so the reply can't be processed yet.
+    let neighbours1Future = bootNode.kademlia.findNode(nodesSeen, targetNodeId, peerNode)
+
+    # This will raise an assertion error if `findNode` doesn't check for and ignore
+    # this second call to the same target and peer in rapid succession.
+    let neighbours2Future = bootNode.kademlia.findNode(nodesSeen, targetNodeId, peerNode)
+
+    # Just for completeness, verify the result is empty from the second call.
+    let neighbours2 = await neighbours2Future
+    check(neighbours2.len == 0)
+
+    # Just for completeness, wait for the first result out of order.
+    # Max delay 5 seconds.
+    discard await neighbours1Future

--- a/tests/networking/test_ecies.nim
+++ b/tests/networking/test_ecies.nim
@@ -1,0 +1,171 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.used.}
+
+import
+  unittest2,
+  nimcrypto/[utils, sha2, hmac, rijndael],
+  eth/common/keys,
+  ../../execution_chain/networking/rlpx/ecies
+
+proc compare[A, B](x: openArray[A], y: openArray[B], s: int = 0): bool =
+  result = true
+  doAssert(s >= 0)
+  var size = if s == 0: min(len(x), len(y)) else: min(s, min(len(x), len(y)))
+  for i in 0..(size - 1):
+    if x[i] != cast[A](y[i]):
+      result = false
+      break
+
+let rng = newRng()
+
+suite "ECIES test suite":
+  test "KDF test vectors":
+    # KDF test
+    # Copied from https://github.com/ethereum/pydevp2p/blob/develop/devp2p/tests/test_ecies.py#L53
+    let m0 = "961c065873443014e0371f1ed656c586c6730bf927415757f389d92acf8268df"
+    let c0 = "4050c52e6d9c08755e5a818ac66fabe478b825b1836fd5efc4d44e40d04dabcc"
+    var m = fromHex(stripSpaces(m0))
+    var c = fromHex(stripSpaces(c0))
+    var k = kdf(m)
+    check compare(k, c) == true
+
+  test "HMAC-SHA256 test vectors":
+    # HMAC-SHA256 test
+    # https://github.com/ethereum/py-evm/blob/master/tests/p2p/test_ecies.py#L64-L76
+    const keys = [
+      "07a4b6dfa06369a570f2dcba2f11a18f",
+      "af6623e52208c596e17c72cea6f1cb09"
+    ]
+    const datas = ["4dcb92ed4fc67fe86832", "3461282bcedace970df2"]
+    const expects = [
+      "c90b62b1a673b47df8e395e671a68bfa68070d6e2ef039598bb829398b89b9a9",
+      "b3ce623bce08d5793677ba9441b22bb34d3e8a7de964206d26589df3e8eb5183"
+    ]
+    for i in 0..1:
+      var k = fromHex(stripSpaces(keys[i]))
+      var m = fromHex(stripSpaces(datas[i]))
+      var digest = sha256.hmac(k, m).data
+      var expect = fromHex(stripSpaces(expects[i]))
+      check compare(digest, expect) == true
+
+  test "ECIES \"Hello World!\" encryption/decryption test":
+    # ECIES encryption
+    var m = "Hello World!"
+    var plain = cast[seq[byte]](m)
+    var encr = newSeq[byte](eciesEncryptedLength(len(m)))
+    var decr = newSeq[byte](len(m))
+    var shmac = [0x13'u8, 0x13'u8]
+    var s = PrivateKey.random(rng[])
+    var p = s.toPublicKey()
+
+    eciesEncrypt(rng[], plain, encr, p).expect("encryption should succeed")
+    eciesDecrypt(encr, decr, s).expect("decryption should succeed")
+
+    check:
+      # Without additional mac data
+      equalMem(addr m[0], addr decr[0], len(m))
+    # With additional mac data
+    eciesEncrypt(rng[], plain, encr, p, shmac).expect("encryption should succeed")
+    eciesDecrypt(encr, decr, s, shmac).expect("decryption should succeed")
+
+    check:
+      equalMem(addr m[0], addr decr[0], len(m))
+
+  test "ECIES/py-evm/cpp-ethereum test_ecies.py#L43/rlpx.cpp#L187":
+    # ECIES
+    # https://github.com/ethereum/py-evm/blob/master/tests/p2p/test_ecies.py#L43
+    # https://github.com/ethereum/cpp-ethereum/blob/develop/test/unittests/libp2p/rlpx.cpp#L187
+    const secretKeys = [
+      "c45f950382d542169ea207959ee0220ec1491755abe405cd7498d6b16adb6df8",
+      "5e173f6ac3c669587538e7727cf19b782a4f2fda07c1eaa662c593e5e85e3051"
+    ]
+    const cipherText = [
+      """04a0274c5951e32132e7f088c9bdfdc76c9d91f0dc6078e848f8e3361193dbdc
+         43b94351ea3d89e4ff33ddcefbc80070498824857f499656c4f79bbd97b6c51a
+         514251d69fd1785ef8764bd1d262a883f780964cce6a14ff206daf1206aa073a
+         2d35ce2697ebf3514225bef186631b2fd2316a4b7bcdefec8d75a1025ba2c540
+         4a34e7795e1dd4bc01c6113ece07b0df13b69d3ba654a36e35e69ff9d482d88d
+         2f0228e7d96fe11dccbb465a1831c7d4ad3a026924b182fc2bdfe016a6944312
+         021da5cc459713b13b86a686cf34d6fe6615020e4acf26bf0d5b7579ba813e77
+         23eb95b3cef9942f01a58bd61baee7c9bdd438956b426a4ffe238e61746a8c93
+         d5e10680617c82e48d706ac4953f5e1c4c4f7d013c87d34a06626f498f34576d
+         c017fdd3d581e83cfd26cf125b6d2bda1f1d56""",
+      """049934a7b2d7f9af8fd9db941d9da281ac9381b5740e1f64f7092f3588d4f87f
+         5ce55191a6653e5e80c1c5dd538169aa123e70dc6ffc5af1827e546c0e958e42
+         dad355bcc1fcb9cdf2cf47ff524d2ad98cbf275e661bf4cf00960e74b5956b79
+         9771334f426df007350b46049adb21a6e78ab1408d5e6ccde6fb5e69f0f4c92b
+         b9c725c02f99fa72b9cdc8dd53cff089e0e73317f61cc5abf6152513cb7d833f
+         09d2851603919bf0fbe44d79a09245c6e8338eb502083dc84b846f2fee1cc310
+         d2cc8b1b9334728f97220bb799376233e113"""
+    ]
+    const expectText = [
+      """884c36f7ae6b406637c1f61b2f57e1d2cab813d24c6559aaf843c3f48962f32f
+         46662c066d39669b7b2e3ba14781477417600e7728399278b1b5d801a519aa57
+         0034fdb5419558137e0d44cd13d319afe5629eeccb47fd9dfe55cc6089426e46
+         cc762dd8a0636e07a54b31169eba0c7a20a1ac1ef68596f1f283b5c676bae406
+         4abfcce24799d09f67e392632d3ffdc12e3d6430dcb0ea19c318343ffa7aae74
+         d4cd26fecb93657d1cd9e9eaf4f8be720b56dd1d39f190c4e1c6b7ec66f077bb
+         1100""",
+      """802b052f8b066640bba94a4fc39d63815c377fced6fcb84d27f791c9921ddf3e
+         9bf0108e298f490812847109cbd778fae393e80323fd643209841a3b7f110397
+         f37ec61d84cea03dcc5e8385db93248584e8af4b4d1c832d8c7453c0089687a7
+         00"""
+    ]
+    var data: array[1024, byte]
+    for i in 0..1:
+      var s = PrivateKey.fromHex(secretKeys[i])[]
+      var cipher = fromHex(stripSpaces(cipherText[i]))
+      var expect = fromHex(stripSpaces(expectText[i]))
+
+      eciesDecrypt(cipher, data, s).expect("decryption should succeed")
+
+      check:
+        compare(data, expect) == true
+
+  test "ECIES/cpp-ethereum rlpx.cpp#L432-L459":
+    # ECIES
+    # https://github.com/ethereum/cpp-ethereum/blob/develop/test/unittests/libp2p/rlpx.cpp#L432-L459
+    const secretKeys = [
+      "57baf2c62005ddec64c357d96183ebc90bf9100583280e848aa31d683cad73cb",
+      "472413e97f1fd58d84e28a559479e6b6902d2e8a0cee672ef38a3a35d263886b",
+      "472413e97f1fd58d84e28a559479e6b6902d2e8a0cee672ef38a3a35d263886b",
+      "472413e97f1fd58d84e28a559479e6b6902d2e8a0cee672ef38a3a35d263886b"
+    ]
+    const cipherData = [
+      """04ff2c874d0a47917c84eea0b2a4141ca95233720b5c70f81a8415bae1dc7b74
+         6b61df7558811c1d6054333907333ef9bb0cc2fbf8b34abb9730d14e0140f455
+         3f4b15d705120af46cf653a1dc5b95b312cf8444714f95a4f7a0425b67fc064d
+         18f4d0a528761565ca02d97faffdac23de10""",
+      """046f647e1bd8a5cd1446d31513bac233e18bdc28ec0e59d46de453137a725995
+         33f1e97c98154343420d5f16e171e5107999a7c7f1a6e26f57bcb0d2280655d0
+         8fb148d36f1d4b28642d3bb4a136f0e33e3dd2e3cffe4b45a03fb7c5b5ea5e65
+         617250fdc89e1a315563c20504b9d3a72555""",
+      """0443c24d6ccef3ad095140760bb143078b3880557a06392f17c5e368502d7953
+         2bc18903d59ced4bbe858e870610ab0d5f8b7963dd5c9c4cf81128d10efd7c7a
+         a80091563c273e996578403694673581829e25a865191bdc9954db14285b56eb
+         0043b6288172e0d003c10f42fe413222e273d1d4340c38a2d8344d7aadcbc846
+         ee""",
+      """04c4e40c86bb5324e017e598c6d48c19362ae527af8ab21b077284a4656c8735
+         e62d73fb3d740acefbec30ca4c024739a1fcdff69ecaf03301eebf156eb5f17c
+         ca6f9d7a7e214a1f3f6e34d1ee0ec00ce0ef7d2b242fbfec0f276e17941f9f1b
+         fbe26de10a15a6fac3cda039904ddd1d7e06e7b96b4878f61860e47f0b84c8ce
+         b64f6a900ff23844f4359ae49b44154980a626d3c73226c19e"""
+    ]
+    const expectData = [
+      "a", "a", "aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    ]
+    var data: array[1024, byte]
+    for i in 0..3:
+      var s = PrivateKey.fromHex(secretKeys[i])[]
+      var cipher = fromHex(stripSpaces(cipherData[i]))
+      check:
+        eciesDecrypt(cipher, data, s).isOk()
+        compare(data, expectData[i]) == true

--- a/tests/networking/test_enode.nim
+++ b/tests/networking/test_enode.nim
@@ -1,0 +1,105 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.used.}
+
+import
+  std/[net, options],
+  unittest2,
+  ../../execution_chain/networking/[discoveryv4/enode, bootnodes]
+
+suite "ENode":
+  test "Go-Ethereum tests":
+    const enodes = [
+      "http://foobar",
+      "enode://01010101@123.124.125.126:3",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@hostname:3",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:foo",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:3?discport=foo",
+      "01010101",
+      "enode://01010101",
+      "://foo",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:52150",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@[::]:52150",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@[2001:db8:3c4d:15::abcd:ef12]:52150",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:52150?discport=22334",
+    ]
+
+    const results = [
+      some IncorrectScheme,
+      some IncorrectNodeId,
+      some IncorrectIP,
+      some IncorrectPort,
+      some IncorrectDiscPort,
+      some IncorrectScheme,
+      some IncorrectNodeId,
+      some IncorrectScheme,
+      none(ENodeError),
+      none(ENodeError),
+      none(ENodeError),
+      none(ENodeError),
+    ]
+
+    for index in 0..<len(enodes):
+      let res = ENode.fromString(enodes[index])
+      check (results[index].isSome and res.error == results[index].get) or
+        res.isOk
+
+      if res.isOk:
+        check enodes[index] == $res[]
+
+  test "Custom validation tests":
+    const enodes = [
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@256.0.0.1:52150",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@1.256.0.1:52150",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@1.1.256.1:52150",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@1.1.1.256:52150",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439:@1.1.1.255:52150",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439:bar@1.1.1.255:52150",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@1.1.1.255:-1",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@1.1.1.255:65536",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@1.1.1.255:1024?discport=-1",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@1.1.1.255:1024?discport=65536",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@1.1.1.255:1024?discport=65535#bar",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@",
+      "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a43Z@1.1.1.1:25?discport=22"
+    ]
+
+    const results = [
+      some IncorrectIP,
+      some IncorrectIP,
+      some IncorrectIP,
+      some IncorrectIP,
+      none(ENodeError),
+      some IncorrectUri,
+      some IncorrectPort,
+      some IncorrectPort,
+      some IncorrectDiscPort,
+      some IncorrectDiscPort,
+      some IncorrectUri,
+      some IncorrectIP,
+      some IncorrectNodeId
+    ]
+
+    for index in 0..<len(enodes):
+      let res = ENode.fromString(enodes[index])
+
+      check (results[index].isSome and res.error == results[index].get) or
+        res.isOk
+
+  test "Bootnodes test":
+    func runBNTest(bns: openArray[string]): bool =
+      for z in bns:
+        let res = ENode.fromString(z)
+        if res.isErr: return false
+      true
+
+    check runBNTest(MainnetBootnodes)
+    check runBNTest(SepoliaBootnodes)
+    check runBNTest(HoleskyBootnodes)

--- a/tests/networking/test_protocol_handlers.nim
+++ b/tests/networking/test_protocol_handlers.nim
@@ -1,0 +1,99 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.used.}
+
+import
+  chronos, testutils/unittests,
+  ../../execution_chain/networking/p2p,
+  ./stubloglevel,
+  ./p2p_test_helper
+
+type
+  network = ref object of RootRef
+    count*: int
+
+  PeerState = ref object of RootRef
+    status*: string
+
+p2pProtocol abc(version = 1,
+                rlpxName = "abc",
+                networkState = network):
+
+  onPeerConnected do (peer: Peer):
+    peer.networkState.count += 1
+
+  onPeerDisconnected do (peer: Peer, reason: DisconnectionReason) {.gcsafe.}:
+    peer.networkState.count -= 1
+
+p2pProtocol xyz(version = 1,
+                rlpxName = "xyz",
+                networkState = network,
+                peerState = PeerState):
+
+  onPeerConnected do (peer: Peer):
+    peer.networkState.count += 1
+    peer.state.status = "connected"
+
+  onPeerDisconnected do (peer: Peer, reason: DisconnectionReason) {.gcsafe.}:
+    peer.networkState.count -= 1
+    peer.state.status = "disconnected"
+
+p2pProtocol hah(version = 1,
+                rlpxName = "hah",
+                networkState = network):
+
+  onPeerConnected do (peer: Peer):
+    if true:
+      raise newException(UselessPeerError, "Fake hah exception")
+    peer.networkState.count += 1
+
+  onPeerDisconnected do (peer: Peer, reason: DisconnectionReason) {.gcsafe.}:
+    peer.networkState.count -= 1
+
+
+suite "Testing protocol handlers":
+  asyncTest "Failing disconnection handler":
+    let rng = newRng()
+
+    var node1 = setupTestNode(rng, abc, xyz)
+    var node2 = setupTestNode(rng, abc, xyz)
+
+    node2.startListening()
+    let res = await node1.rlpxConnect(newNode(node2.toENode()))
+    check res.isOk()
+    let peer = res.get()
+    check peer.state(xyz).status == "connected"
+
+    await peer.disconnect(SubprotocolReason, true)
+    check:
+      # all disconnection handlers are called
+      node1.protocolState(abc).count == 0
+      node1.protocolState(xyz).count == 0
+      peer.state(xyz).status == "disconnected"
+
+  asyncTest "Failing connection handler":
+    let rng = newRng()
+
+    var node1 = setupTestNode(rng, hah)
+    var node2 = setupTestNode(rng, hah)
+    node2.startListening()
+    let res = await node1.rlpxConnect(newNode(node2.toENode()))
+    check:
+      res.isErr()
+      # To check if the disconnection handler did not run
+      node1.protocolState(hah).count == 0
+
+  test "Override network state":
+    let rng = newRng()
+    var node = setupTestNode(rng, hah)
+    node.addCapability(hah, network(count: 3))
+    check node.protocolState(hah).count == 3
+    node.replaceNetworkState(hah, network(count: 7))
+    check node.protocolState(hah).count == 7

--- a/tests/networking/test_rlpx_thunk.json
+++ b/tests/networking/test_rlpx_thunk.json
@@ -1,0 +1,85 @@
+{
+  "Invalid list when decoding for object": {
+    "payload": "03",
+    "error": "PeerDisconnected",
+    "description": "Object parameters are expected to be encoded in an RLP list"
+  },
+  "Message id that is not supported": {
+    "payload": "08",
+    "error": "UnsupportedMessageError",
+    "description": "This is a message id not used by devp2p or eth"
+  },
+  "Message id that is bigger than uint32": {
+    "payload": "888888888888888888",
+    "error": "UnsupportedRlpError",
+    "description": "This payload will result in too large int for a message id"
+  },
+  "Unsupported big message id": {
+    "payload": "848888888888",
+    "error": "UnsupportedMessageError",
+    "description": "This payload will result in a negative number as message id"
+  },
+  "No Hash nor Status, but empty list": {
+    "payload": "20c1c0",
+    "error": "PeerDisconnected",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "No Hash nor Status, list instead of blob": {
+    "payload": "20c2c1c0",
+    "error": "PeerDisconnected",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "No Hash nor Status, blob of 2 bytes": {
+    "payload": "20c4c3820011",
+    "error": "PeerDisconnected",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "No Hash nor Status, blob of 33 bytes": {
+    "payload": "20e3e2a100112233445566778899aabbccddeeff00112233445566778899aabbcceeddff33",
+    "error": "PeerDisconnected",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "Listing elements when no data": {
+    "payload": "01e1",
+    "error": "PeerDisconnected",
+    "description": "listElem to error on empty list"
+  },
+  "Listing elements when invalid length": {
+    "payload": "01ffdada",
+    "error": "PeerDisconnected",
+    "description": "listElem to error on invalid size encoding"
+  },
+  "Listing single element list when having more entries": {
+    "payload": "01c20420",
+    "error": "PeerDisconnected",
+    "description": "listElem to assert on not a single entry list"
+  },
+  "Listing single element list when having empty list": {
+    "payload": "01c0",
+    "error": "PeerDisconnected",
+    "description": "listElem to assert on not a single entry list"
+  },
+  "DisconnectReason: single element list with entry out off enum range": {
+    "payload": "01c111",
+    "error": "PeerDisconnected",
+    "description": "Disconnect reason code out of bounds 0..16 (got: 17)"
+  },
+  "DisconnectReason: single element out off enum range": {
+    "payload": "0111",
+    "error": "PeerDisconnected",
+    "description": "Disconnect reason code out of bounds 0..16 (got: 17)"
+  },
+  "DisconnectReason: single element list with enum hole value": {
+    "payload": "01c10C",
+    "error": "PeerDisconnected",
+    "description": "Error on Disconnect reason with enum hole value"
+  },
+  "DisconnectReason: single element with enum hole value": {
+    "payload": "010C",
+    "error": "PeerDisconnected",
+    "description": "Error on Disconnect reason with enum hole value"
+  },
+  "devp2p hello packet version 22 + additional list elements for EIP-8": {
+    "payload": "00f87137916b6e6574682f76302e39312f706c616e39cdc5836574683dc6846d6f726b1682270fb840fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877c883666f6f836261720304"
+  }
+}

--- a/tests/networking/test_rlpx_thunk.nim
+++ b/tests/networking/test_rlpx_thunk.nim
@@ -1,0 +1,68 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.used.}
+
+import
+  std/[json, os],
+  unittest2,
+  chronos, stew/byteutils,
+  ../../execution_chain/networking/p2p,
+  ./stubloglevel,
+  ./p2p_test_helper,
+  ./eth_protocol
+
+let rng = newRng()
+
+var
+  node1 = setupTestNode(rng, eth)
+  node2 = setupTestNode(rng, eth)
+
+node2.startListening()
+let res = waitFor node1.rlpxConnect(newNode(node2.toENode()))
+check res.isOk()
+
+let peer = res.get()
+
+proc testThunk(payload: openArray[byte]) =
+  var (msgId, msgData) = recvMsgMock(payload)
+  waitFor peer.invokeThunk(msgId, msgData)
+
+proc testPayloads(filename: string) =
+  let js = json.parseFile(filename)
+
+  suite extractFilename(filename):
+    for testname, testdata in js:
+      test testname:
+        let
+          payloadHex = testdata{"payload"}
+          error = testdata{"error"}
+
+        if payloadHex.isNil or payloadHex.kind != JString:
+          skip()
+          return
+
+        let payload = hexToSeqByte(payloadHex.str)
+
+        if error.isNil:
+          testThunk(payload)
+        else:
+          if error.kind != JString:
+            skip()
+            return
+
+          # TODO: can I convert the error string to an Exception type at runtime?
+          expect CatchableError:
+            try:
+              testThunk(payload)
+            except CatchableError as e:
+              check: e.name == error.str
+              raise e
+
+testPayloads(sourceDir / "test_rlpx_thunk.json")

--- a/tests/networking/test_rlpxtransport.nim
+++ b/tests/networking/test_rlpxtransport.nim
@@ -1,0 +1,69 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.used.}
+
+import
+  unittest2,
+  chronos/unittest2/asynctests,
+  eth/common/keys,
+  ../../execution_chain/networking/rlpx/rlpxtransport
+
+suite "RLPx transport":
+  setup:
+    let
+      rng = newRng()
+      keys1 = KeyPair.random(rng[])
+      keys2 = KeyPair.random(rng[])
+      server = createStreamServer(initTAddress("127.0.0.1:0"), {ReuseAddr})
+
+  teardown:
+    waitFor server.closeWait()
+
+  asyncTest "Connect/accept":
+    const msg = @[byte 0, 1, 2, 3]
+    proc serveClient(server: StreamServer) {.async.} =
+      let transp = await server.accept()
+      let a = await RlpxTransport.accept(rng, keys1, transp)
+      await a.sendMsg(msg)
+      await a.closeWait()
+
+    let serverFut = server.serveClient()
+    defer:
+      await serverFut.wait(1.seconds)
+
+    let client =
+      await RlpxTransport.connect(rng, keys2, server.localAddress(), keys1.pubkey)
+
+    defer:
+      await client.closeWait()
+    let rmsg = await client.recvMsg().wait(1.seconds)
+
+    check:
+      msg == rmsg
+
+    await serverFut
+
+  asyncTest "Detect invalid pubkey":
+    proc serveClient(server: StreamServer) {.async.} =
+      let transp = await server.accept()
+      discard await RlpxTransport.accept(rng, keys1, transp)
+      raiseAssert "should fail to accept due to pubkey error"
+
+    let serverFut = server.serveClient()
+    defer:
+      expect(RlpxTransportError):
+        await serverFut.wait(1.seconds)
+
+    let keys3 = KeyPair.random(rng[])
+
+    # accept side should close connections
+    expect(TransportError):
+      discard
+        await RlpxTransport.connect(rng, keys2, server.localAddress(), keys3.pubkey)

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -7,11 +7,12 @@
 
 import
   std/[os, macros, json, strformat, strutils, tables],
-  stew/byteutils, net, eth/[common/keys, p2p], unittest2,
+  stew/byteutils, net, eth/common/keys, unittest2,
   testutils/markdown_reports,
   ../execution_chain/[constants, config, transaction, errors],
   ../execution_chain/db/ledger,
-  ../execution_chain/common/[context, common]
+  ../execution_chain/common/[context, common],
+  ../execution_chain/networking/p2p
 
 func revTable(list: array[FkFrontier..FkLatest, string]): Table[string, EVMFork] =
   for k, v in list:

--- a/tests/test_networking.nim
+++ b/tests/test_networking.nim
@@ -1,0 +1,18 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  ./networking/test_auth,
+  ./networking/test_crypt,
+  ./networking/test_discoveryv4,
+  ./networking/test_ecies,
+  ./networking/test_enode,
+  ./networking/test_rlpx_thunk,
+  ./networking/test_rlpxtransport,
+  ./networking/test_protocol_handlers

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -12,7 +12,7 @@ import
   web3/eth_api,
   stew/byteutils,
   json_rpc/[rpcserver, rpcclient],
-  eth/[p2p, rlp, trie/hexary_proof_verification],
+  eth/[rlp, trie/hexary_proof_verification],
   eth/common/[transaction_utils, addresses],
   ../hive_integration/nodocker/engine/engine_client,
   ../execution_chain/[constants, transaction, config, version],
@@ -23,6 +23,7 @@ import
   ../execution_chain/[common, rpc],
   ../execution_chain/rpc/rpc_types,
   ../execution_chain/beacon/web3_eth_conv,
+  ../execution_chain/networking/p2p,
    ./test_helpers,
    ./macro_assembler,
    ./test_block_fixture

--- a/tests/test_tools_build.nim
+++ b/tests/test_tools_build.nim
@@ -12,8 +12,6 @@
 {.warning[UnusedImport]: off.}
 
 import
-  #./tracerTestGen,          # -- ditto
-  #./persistBlockTestGen,    # -- ditto
   ../hive_integration/nodocker/rpc/rpc_sim,
   ../hive_integration/nodocker/consensus/consensus_sim,
   ../hive_integration/nodocker/engine/engine_sim,


### PR DESCRIPTION
Except discovery-v5, nimbus EL networking code including rlpx, discovery-v4, p2p macro, and peer pool are moved to here.
This is to prepare for rate limiter in eth/68, and enabling disc-v5 in nimbus EL along with other improvements.