### PR TITLE
Adjust and activate post-merge pre-capella proofs for block headers

### DIFF
--- a/fluffy/eth_data/yaml_eth_types.nim
+++ b/fluffy/eth_data/yaml_eth_types.nim
@@ -1,5 +1,5 @@
 # fluffy
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -12,16 +12,16 @@ import ssz_serialization/types, stew/byteutils
 type
   YamlTestProofBellatrix* = object
     execution_block_header*: string # Not part of the actual proof
-    beacon_block_proof*: array[11, string]
+    execution_block_proof*: array[11, string]
     beacon_block_root*: string
-    historical_roots_proof*: array[14, string]
+    beacon_block_proof*: array[14, string]
     slot*: uint64
 
   YamlTestProof* = object
     execution_block_header*: string # Not part of the actual proof
-    beacon_block_proof*: array[11, string]
+    execution_block_proof*: array[11, string]
     beacon_block_root*: string
-    historical_summaries_proof*: array[13, string]
+    beacon_block_proof*: array[13, string]
     slot*: uint64
 
 proc fromHex*[n](T: type array[n, Digest], a: array[n, string]): T =

--- a/fluffy/network/history/content/content_values.nim
+++ b/fluffy/network/history/content/content_values.nim
@@ -30,8 +30,6 @@ const
 
 type
   ## BlockHeader types
-  HistoricalHashesAccumulatorProof* = array[15, Digest]
-
   BlockHeaderWithProof* = object
     header*: ByteList[MAX_HEADER_LENGTH] # RLP data
     proof*: ByteList[MAX_HEADER_PROOF_LENGTH]

--- a/fluffy/network/history/history_validation.nim
+++ b/fluffy/network/history/history_validation.nim
@@ -10,13 +10,22 @@
 import
   chronos/timer,
   eth/trie/ordered_trie,
+  beacon_chain/spec/presets,
   ../../network_metadata,
   ./history_type_conversions,
-  ./validation/historical_hashes_accumulator
+  ./validation/[
+    historical_hashes_accumulator, block_proof_historical_roots,
+    block_proof_historical_summaries,
+  ]
 
 from eth/common/eth_types_rlp import rlpHash
 
 export historical_hashes_accumulator
+
+type HistoryAccumulators* = object
+  historicalHashes*: FinishedHistoricalHashesAccumulator
+  historicalRoots*: HistoricalRoots
+  historicalSummaries*: HistoricalSummaries
 
 func validateHeader(header: Header, blockHash: Hash32): Result[void, string] =
   if not (header.rlpHash() == blockHash):
@@ -50,32 +59,57 @@ func validateHeaderBytes*(
   ok(header)
 
 func verifyBlockHeaderProof*(
-    a: FinishedHistoricalHashesAccumulator,
+    a: HistoryAccumulators,
     header: Header,
     proof: ByteList[MAX_HEADER_PROOF_LENGTH],
+    cfg: RuntimeConfig,
 ): Result[void, string] =
   let timestamp = Moment.init(header.timestamp.int64, Second)
 
   if isShanghai(chainConfig, timestamp):
-    # TODO: Add verification post merge based on historical_summaries
-    err("Shanghai block verification not implemented")
+    # Note: currently disabled
+    # - No effective means to get historical summaries yet over the network
+    # - Proof is currently not as per spec, as we prefer to use SSZ Vectors
+
+    # let proof = decodeSsz(proof.asSeq(), BlockProofHistoricalSummaries).valueOr:
+    #   return err("Failed decoding historical_summaries based block proof: " & error)
+
+    # if a.historicalSummaries.verifyProof(
+    #   proof, Digest(data: header.rlpHash().data), cfg
+    # ):
+    #   ok()
+    # else:
+    #   err("Block proof verification failed (historical_summaries)")
+    err("Shanghai block proof verification not yet activated")
   elif isPoSBlock(chainConfig, header.number):
-    # TODO: Add verification post merge based on historical_roots
-    err("PoS block verification not implemented")
+    let proof = decodeSsz(proof.asSeq(), BlockProofHistoricalRoots).valueOr:
+      return err("Failed decoding historical_roots based block proof: " & error)
+
+    if a.historicalRoots.verifyProof(proof, Digest(data: header.rlpHash().data)):
+      ok()
+    else:
+      err("Block proof verification failed (historical roots)")
   else:
     let accumulatorProof = decodeSsz(proof.asSeq(), HistoricalHashesAccumulatorProof).valueOr:
-      return err("Failed decoding accumulator proof: " & error)
+      return
+        err("Failed decoding historical hashes accumulator based block proof: " & error)
 
-    a.verifyAccumulatorProof(header, accumulatorProof)
+    if a.historicalHashes.verifyProof(header, accumulatorProof):
+      ok()
+    else:
+      err("Block proof verification failed (historical hashes accumulator)")
 
 func validateCanonicalHeaderBytes*(
-    bytes: openArray[byte], id: uint64 | Hash32, a: FinishedHistoricalHashesAccumulator
+    bytes: openArray[byte],
+    id: uint64 | Hash32,
+    accumulators: HistoryAccumulators,
+    cfg: RuntimeConfig,
 ): Result[Header, string] =
   let headerWithProof = decodeSsz(bytes, BlockHeaderWithProof).valueOr:
     return err("Failed decoding header with proof: " & error)
   let header = ?validateHeaderBytes(headerWithProof.header.asSeq(), id)
 
-  ?a.verifyBlockHeaderProof(header, headerWithProof.proof)
+  ?accumulators.verifyBlockHeaderProof(header, headerWithProof.proof, cfg)
 
   ok(header)
 

--- a/fluffy/network/history/validation/block_proof_historical_roots.nim
+++ b/fluffy/network/history/validation/block_proof_historical_roots.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -78,10 +78,12 @@ import
   ssz_serialization,
   ssz_serialization/[proofs, merkleization],
   beacon_chain/spec/eth2_ssz_serialization,
+  beacon_chain/spec/ssz_codec,
   beacon_chain/spec/datatypes/bellatrix,
+  beacon_chain/spec/forks,
   ./block_proof_common
 
-export block_proof_common
+export block_proof_common, ssz_codec
 
 type
   BeaconBlockProofHistoricalRoots* = array[14, Digest]
@@ -92,6 +94,8 @@ type
     beaconBlockRoot*: Digest
     executionBlockProof*: ExecutionBlockProof
     slot*: Slot
+
+  HistoricalRoots* = HashList[Digest, Limit HISTORICAL_ROOTS_LIMIT]
 
 func getHistoricalRootsIndex*(slot: Slot): uint64 =
   slot div SLOTS_PER_HISTORICAL_ROOT
@@ -149,7 +153,7 @@ func verifyProof*(
   verify_merkle_multiproof(@[blockHeaderRoot], proof, @[gIndex], historicalRoot)
 
 func verifyProof*(
-    historical_roots: HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT],
+    historical_roots: HistoricalRoots,
     proof: BlockProofHistoricalRoots,
     blockHash: Digest,
 ): bool =

--- a/fluffy/network/history/validation/block_proof_historical_summaries.nim
+++ b/fluffy/network/history/validation/block_proof_historical_summaries.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -28,11 +28,12 @@ import
   ssz_serialization,
   ssz_serialization/[proofs, merkleization],
   beacon_chain/spec/eth2_ssz_serialization,
-  beacon_chain/spec/presets,
+  beacon_chain/spec/ssz_codec,
   beacon_chain/spec/datatypes/capella,
+  beacon_chain/spec/forks,
   ./block_proof_common
 
-export block_proof_common
+export block_proof_common, ssz_codec
 
 type
   BeaconBlockProofHistoricalRoots* = array[13, Digest]
@@ -43,6 +44,8 @@ type
     beaconBlockRoot*: Digest
     executionBlockProof*: ExecutionBlockProof
     slot*: Slot
+
+  HistoricalSummaries* = HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT]
 
 template `[]`(x: openArray[Eth2Digest], chunk: Limit): Eth2Digest =
   # Nim 2.0 requires arrays to be indexed by the same type they're declared with.
@@ -104,7 +107,7 @@ func verifyProof*(
   verify_merkle_multiproof(@[blockHeaderRoot], proof, @[gIndex], historicalRoot)
 
 func verifyProof*(
-    historical_summaries: HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT],
+    historical_summaries: HistoricalSummaries,
     proof: BlockProofHistoricalSummaries,
     blockHash: Digest,
     cfg: RuntimeConfig,

--- a/fluffy/portal_node.nim
+++ b/fluffy/portal_node.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -137,6 +137,7 @@ proc new*(
             discovery,
             contentDB,
             streamManager,
+            networkData.metadata.cfg,
             accumulator,
             bootstrapRecords = bootstrapRecords,
             portalConfig = config.portalConfig,

--- a/fluffy/tests/history_network_tests/test_block_proof_historical_roots_vectors.nim
+++ b/fluffy/tests/history_network_tests/test_block_proof_historical_roots_vectors.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -33,10 +33,10 @@ suite "History Block Proofs - Historical Roots - Test Vectors":
 
           blockHash = Digest.fromHex(testProof.execution_block_header)
           blockProof = BlockProofHistoricalRoots(
-            beaconBlockProof:
-              array[14, Digest].fromHex(testProof.historical_roots_proof),
+            beaconBlockProof: array[14, Digest].fromHex(testProof.beacon_block_proof),
             beaconBlockRoot: Digest.fromHex(testProof.beacon_block_root),
-            executionBlockProof: array[11, Digest].fromHex(testProof.beacon_block_proof),
+            executionBlockProof:
+              array[11, Digest].fromHex(testProof.execution_block_proof),
             slot: Slot(testProof.slot),
           )
 

--- a/fluffy/tests/history_network_tests/test_block_proof_historical_summaries.nim
+++ b/fluffy/tests/history_network_tests/test_block_proof_historical_summaries.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -112,7 +112,7 @@ suite "History Block Proofs - Historical Summaries":
     for i in blocksToTest:
       let beaconBlock = blocks[i].message
 
-      let res = buildProof(beaconBlock)
+      let res = block_proof_historical_summaries.buildProof(beaconBlock)
       check res.isOk()
       let proof = res.get()
 

--- a/fluffy/tests/history_network_tests/test_block_proof_historical_summaries_vectors.nim
+++ b/fluffy/tests/history_network_tests/test_block_proof_historical_summaries_vectors.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -18,30 +18,8 @@ import
   beacon_chain/spec/datatypes/capella,
   ../../network/history/validation/block_proof_historical_summaries,
   ../../network/beacon/beacon_init_loader,
-  ../../eth_data/[yaml_utils, yaml_eth_types]
-
-proc toString(v: IoErrorCode): string =
-  try:
-    ioErrorMsg(v)
-  except Exception as e:
-    raiseAssert e.msg
-
-# Testing only proc as in the real network the historical_summaries are
-# retrieved from the network.
-proc readHistoricalSummaries(
-    file: string
-): Result[HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT], string] =
-  let encodedHistoricalSummaries = ?readAllFile(file).mapErr(toString)
-
-  try:
-    ok(
-      SSZ.decode(
-        encodedHistoricalSummaries,
-        HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT],
-      )
-    )
-  except SerializationError as err:
-    err("Failed decoding historical_summaries: " & err.msg)
+  ../../eth_data/[yaml_utils, yaml_eth_types],
+  ./test_history_util
 
 suite "History Block Proofs - Historical Summaries - Test Vectors":
   test "BlockProofHistoricalSummaries for Execution BlockHeader":
@@ -62,10 +40,11 @@ suite "History Block Proofs - Historical Summaries - Test Vectors":
 
           blockHash = Digest.fromHex(testProof.execution_block_header)
           blockProof = BlockProofHistoricalSummaries(
-            beaconBlockProof:
-              array[13, Digest].fromHex(testProof.historical_summaries_proof),
+            beaconBlockProof: array[13, Digest].fromHex(testProof.beacon_block_proof),
             beaconBlockRoot: Digest.fromHex(testProof.beacon_block_root),
-            executionBlockProof: array[11, Digest].fromHex(testProof.beacon_block_proof),
+            executionBlockProof: ExecutionBlockProof(
+              array[11, Digest].fromHex(testProof.execution_block_proof)
+            ),
             slot: Slot(testProof.slot),
           )
 

--- a/fluffy/tests/history_network_tests/test_historical_hashes_accumulator.nim
+++ b/fluffy/tests/history_network_tests/test_historical_hashes_accumulator.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -53,13 +53,13 @@ suite "Historical Hashes Accumulator":
         let proof = buildProof(header, epochRecords)
         check:
           proof.isOk()
-          verifyAccumulatorProof(accumulator, header, proof.get()).isOk()
+          verifyProof(accumulator, header, proof.get())
 
     block: # Test invalid headers
       # Post merge block number must fail (> than latest header in accumulator)
       var proof: HistoricalHashesAccumulatorProof
       let header = Header(number: mergeBlockNumber)
-      check verifyAccumulatorProof(accumulator, header, proof).isErr()
+      check verifyProof(accumulator, header, proof) == false
 
       # Test altered block headers by altering the difficulty
       for i in headersToTest:
@@ -69,13 +69,13 @@ suite "Historical Hashes Accumulator":
         # Alter the block header so the proof no longer matches
         let header = Header(number: i.uint64, difficulty: 2.stuint(256))
 
-        check verifyAccumulatorProof(accumulator, header, proof.get()).isErr()
+        check verifyProof(accumulator, header, proof.get()) == false
 
     block: # Test invalid proofs
       var proof: HistoricalHashesAccumulatorProof
 
       for i in headersToTest:
-        check verifyAccumulatorProof(accumulator, headers[i], proof).isErr()
+        check verifyProof(accumulator, headers[i], proof) == false
 
   test "Historical Hashes Accumulator - Not Finished":
     # Less headers than needed to finish the accumulator

--- a/fluffy/tests/history_network_tests/test_history_content.nim
+++ b/fluffy/tests/history_network_tests/test_history_content.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -14,6 +14,7 @@ import
   stew/byteutils,
   eth/common/headers_rlp,
   ../../network_metadata,
+  ../../network/beacon/beacon_init_loader,
   ../../eth_data/[history_data_json_store, history_data_ssz_e2s],
   ../../network/history/[history_content, history_type_conversions, history_validation],
   ../../eth_data/yaml_utils,
@@ -38,7 +39,9 @@ suite "History Content Values":
         raiseAssert "Invalid epoch accumulator file: " & accumulatorFile
       blockHeadersWithProof = buildHeadersWithProof(blockHeaders, epochRecord).valueOr:
         raiseAssert "Could not build headers with proof"
-      accumulator = loadAccumulator()
+      accumulators = HistoryAccumulators(historicalHashes: loadAccumulator())
+      networkData = loadNetworkData("mainnet")
+      cfg = networkData.metadata.cfg
 
     let res = readJsonType(headersWithProofFile, JsonPortalContentTable)
     check res.isOk()
@@ -72,7 +75,9 @@ suite "History Content Values":
       check res.isOk()
       let header = res.get()
 
-      check accumulator.verifyBlockHeaderProof(header, blockHeaderWithProof.proof).isOk()
+      check accumulators
+      .verifyBlockHeaderProof(header, blockHeaderWithProof.proof, cfg)
+      .isOk()
 
       # Encode content
       check:
@@ -80,41 +85,58 @@ suite "History Content Values":
         encode(contentKey.get()).asSeq() == contentKeyEncoded
 
   test "HeaderWithProof Encoding/Decoding and Verification":
-    const testsPath =
-      "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/"
+    const
+      testsPath = "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/"
+      historicalSummaries_path =
+        "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/block_proofs_capella/historical_summaries_at_slot_8953856.ssz"
+
+    let historicalSummaries = readHistoricalSummaries(historicalSummaries_path).valueOr:
+      raiseAssert "Cannot read historical summaries: " & error
+    let cfg = loadNetworkData("mainnet").metadata.cfg
 
     for kind, path in walkDir(testsPath):
       if kind == pcFile and path.splitFile.ext == ".yaml":
         let
           content = YamlPortalContent.loadFromYaml(path).valueOr:
             raiseAssert "Invalid data file: " & error
-          accumulator = loadAccumulator()
+          accumulators = HistoryAccumulators(
+            historicalHashes: loadAccumulator(),
+            historicalRoots: loadHistoricalRoots(),
+            historicalSummaries: historicalSummaries,
+          )
           contentKeyEncoded = content.content_key.hexToSeqByte()
           contentValueEncoded = content.content_value.hexToSeqByte()
 
-        # Decode content
-        let
-          contentKey = decodeSsz(contentKeyEncoded, ContentKey)
-          contentValue = decodeSsz(contentValueEncoded, BlockHeaderWithProof)
+        # Decode content key
+        let contentKeyRes = decodeSsz(contentKeyEncoded, ContentKey)
+        check contentKeyRes.isOk()
+        let contentKey = contentKeyRes.get()
 
-        check:
-          contentKey.isOk()
-          contentValue.isOk()
+        # Note: This part is only needed to avoid testing the block headers with
+        # proof post shanghai/capella fork as these are currently disabled.
+        # TODO: Remove after bellatrix and later forks are enabled for headers.
 
-        let blockHeaderWithProof = contentValue.get()
-
+        # Decode content value
+        let contentValueRes = decodeSsz(contentValueEncoded, BlockHeaderWithProof)
+        check contentValueRes.isOk()
+        let blockHeaderWithProof = contentValueRes.get()
+        # Decode header
         let res = decodeRlp(blockHeaderWithProof.header.asSeq(), Header)
         check res.isOk()
         let header = res.get()
+        let timestamp = Moment.init(header.timestamp.int64, Second)
+        if not isShanghai(chainConfig, timestamp):
+          # Verifies if block header is canonical and if it matches the hash
+          # of provided content key.
+          check validateCanonicalHeaderBytes(
+            contentValueEncoded, contentKey.blockHeaderKey.blockHash, accumulators, cfg
+          )
+          .isOk()
 
-        check accumulator
-        .verifyBlockHeaderProof(header, blockHeaderWithProof.proof)
-        .isOk()
-
-        # Encode content
-        check:
-          SSZ.encode(blockHeaderWithProof) == contentValueEncoded
-          encode(contentKey.get()).asSeq() == contentKeyEncoded
+          # Encode content key and content value
+          check:
+            SSZ.encode(blockHeaderWithProof) == contentValueEncoded
+            encode(contentKey).asSeq() == contentKeyEncoded
 
   test "PortalBlockBody (Legacy) Encoding/Decoding and Verification":
     const

--- a/fluffy/tests/history_network_tests/test_history_network.nim
+++ b/fluffy/tests/history_network_tests/test_history_network.nim
@@ -15,6 +15,7 @@ import
   ../../network/history/
     [history_network, history_content, validation/historical_hashes_accumulator],
   ../../database/content_db,
+  ../../network/beacon/beacon_init_loader,
   ../test_helpers,
   ./test_history_util
 
@@ -35,8 +36,10 @@ proc newHistoryNode(
       "", uint32.high, RadiusConfig(kind: Dynamic), node.localNode.id, inMemory = true
     )
     streamManager = StreamManager.new(node)
+    networkData = loadNetworkData("mainnet")
+    cfg = networkData.metadata.cfg
     historyNetwork =
-      HistoryNetwork.new(PortalNetwork.none, node, db, streamManager, accumulator)
+      HistoryNetwork.new(PortalNetwork.none, node, db, streamManager, cfg, accumulator)
 
   return HistoryNode(discoveryProtocol: node, historyNetwork: historyNetwork)
 
@@ -72,7 +75,7 @@ proc createEmptyHeaders(fromNum: int, toNum: int): seq[Header] =
   var headers: seq[Header]
   for i in fromNum .. toNum:
     var bh = Header()
-    bh.number = BlockNumber(i)
+    bh.number = i.uint64
     bh.difficulty = u256(i)
     # empty so that we won't care about creating fake block bodies
     bh.ommersHash = EMPTY_UNCLE_HASH

--- a/fluffy/tests/history_network_tests/test_history_util.nim
+++ b/fluffy/tests/history_network_tests/test_history_util.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,8 +9,10 @@
 
 import
   results,
+  stew/io2,
   eth/common/headers,
-  ../../network/history/[history_content, validation/historical_hashes_accumulator]
+  ../../network/history/[history_content, validation/historical_hashes_accumulator],
+  ../../network/history/validation/block_proof_historical_summaries
 
 from eth/common/eth_types_rlp import rlpHash
 
@@ -94,3 +96,19 @@ func buildHeadersWithProof*(
     headersWithProof.add(?buildHeaderWithProof(header, epochRecords))
 
   ok(headersWithProof)
+
+proc toString(v: IoErrorCode): string =
+  try:
+    ioErrorMsg(v)
+  except Exception as e:
+    raiseAssert e.msg
+
+# Testing only proc as in the real network the historical_summaries are
+# retrieved from the network.
+proc readHistoricalSummaries*(file: string): Result[HistoricalSummaries, string] =
+  let encodedHistoricalSummaries = ?readAllFile(file).mapErr(toString)
+
+  try:
+    ok(SSZ.decode(encodedHistoricalSummaries, HistoricalSummaries))
+  except SerializationError as err:
+    err("Failed decoding historical_summaries: " & err.msg)

--- a/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
+++ b/fluffy/tests/rpc_tests/test_portal_rpc_client.nim
@@ -38,7 +38,12 @@ proc newHistoryNode(rng: ref HmacDrbgContext, port: int): HistoryNode =
     )
     streamManager = StreamManager.new(node)
     historyNetwork = HistoryNetwork.new(
-      PortalNetwork.none, node, db, streamManager, FinishedHistoricalHashesAccumulator()
+      PortalNetwork.none,
+      node,
+      db,
+      streamManager,
+      RuntimeConfig(),
+      FinishedHistoricalHashesAccumulator(),
     )
 
   return HistoryNode(discoveryProtocol: node, historyNetwork: historyNetwork)

--- a/fluffy/tests/state_network_tests/state_test_helpers.nim
+++ b/fluffy/tests/state_network_tests/state_test_helpers.nim
@@ -121,7 +121,12 @@ proc newStateNode*(
     )
     sm = StreamManager.new(node)
     hn = HistoryNetwork.new(
-      PortalNetwork.none, node, db, sm, FinishedHistoricalHashesAccumulator()
+      PortalNetwork.none,
+      node,
+      db,
+      sm,
+      RuntimeConfig(),
+      FinishedHistoricalHashesAccumulator(),
     )
     sn =
       StateNetwork.new(PortalNetwork.none, node, db, sm, historyNetwork = Opt.some(hn))

--- a/fluffy/tools/eth_data_exporter/cl_data_exporter.nim
+++ b/fluffy/tools/eth_data_exporter/cl_data_exporter.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -287,16 +287,16 @@ proc exportBeaconBlockProofBellatrix(
       error "Failed to load Bellatrix block", slot
       quit QuitFailure
 
-    blockProof = buildProof(batch, beaconBlock.message).valueOr:
+    blockProof = block_proof_historical_roots.buildProof(batch, beaconBlock.message).valueOr:
       error "Failed to build proof for Bellatrix block", slot, error
       quit QuitFailure
 
   let yamlTestProof = YamlTestProofBellatrix(
     execution_block_header:
       beaconBlock.message.body.execution_payload.block_hash.data.to0xHex(),
-    beacon_block_proof: blockProof.executionBlockProof.toHex(array[11, string]),
+    execution_block_proof: blockProof.executionBlockProof.toHex(array[11, string]),
     beacon_block_root: blockProof.beaconBlockRoot.data.to0xHex(),
-    historical_roots_proof: blockProof.beaconBlockProof.toHex(array[14, string]),
+    beacon_block_proof: blockProof.beaconBlockProof.toHex(array[14, string]),
     slot: blockProof.slot.uint64,
   )
 
@@ -413,9 +413,9 @@ proc exportBeaconBlockProofCapella(
   let yamlTestProof = YamlTestProof(
     execution_block_header:
       beaconBlock.message.body.execution_payload.block_hash.data.to0xHex(),
-    beacon_block_proof: blockProof.executionBlockProof.toHex(array[11, string]),
+    execution_block_proof: blockProof.executionBlockProof.toHex(array[11, string]),
     beacon_block_root: blockProof.beaconBlockRoot.data.to0xHex(),
-    historical_summaries_proof: blockProof.beaconBlockProof.toHex(array[13, string]),
+    beacon_block_proof: blockProof.beaconBlockProof.toHex(array[13, string]),
     slot: blockProof.slot.uint64,
   )
 


### PR DESCRIPTION
Only activated post-merge proofs pre capella/shanghai.