### PR TITLE
Fluffy: Rename PortalNodeState to PortalNodeStatus and other minor updates

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -344,14 +344,14 @@ when isMainModule:
         raiseAssert exc.msg # shouldn't happen
 
     notice "Shutting down after having received SIGINT"
-    node.state = PortalNodeState.Stopping
+    node.status = PortalNodeStatus.Stopping
 
   try:
     setControlCHook(controlCHandler)
   except Exception as exc: # TODO Exception
     warn "Cannot set ctrl-c handler", msg = exc.msg
 
-  while node.state == PortalNodeState.Running:
+  while node.status == PortalNodeStatus.Running:
     try:
       poll()
     except CatchableError as e:

--- a/fluffy/network/beacon/beacon_network.nim
+++ b/fluffy/network/beacon/beacon_network.nim
@@ -448,10 +448,10 @@ proc processContentLoop(n: BeaconNetwork) {.async: (raises: []).} =
 proc statusLogLoop(n: BeaconNetwork) {.async: (raises: []).} =
   try:
     while true:
+      await sleepAsync(60.seconds)
+
       info "Beacon network status",
         routingTableNodes = n.portalProtocol.routingTable.len()
-
-      await sleepAsync(60.seconds)
   except CancelledError:
     trace "statusLogLoop canceled"
 

--- a/fluffy/network/history/history_network.nim
+++ b/fluffy/network/history/history_network.nim
@@ -428,10 +428,10 @@ proc processContentLoop(n: HistoryNetwork) {.async: (raises: []).} =
 proc statusLogLoop(n: HistoryNetwork) {.async: (raises: []).} =
   try:
     while true:
+      await sleepAsync(60.seconds)
+
       info "History network status",
         routingTableNodes = n.portalProtocol.routingTable.len()
-
-      await sleepAsync(60.seconds)
   except CancelledError:
     trace "statusLogLoop canceled"
 

--- a/fluffy/network/state/state_endpoints.nim
+++ b/fluffy/network/state/state_endpoints.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/fluffy/network/state/state_endpoints.nim
+++ b/fluffy/network/state/state_endpoints.nim
@@ -161,8 +161,11 @@ proc getStorageProof(
   doAssert(nibblesIdx <= nibbles.len())
   ok((proof, nibblesIdx == nibbles.len()))
 
-proc getAccount(
-    n: StateNetwork, stateRoot: Hash32, address: Address, maybeBlockHash: Opt[Hash32]
+proc getAccount*(
+    n: StateNetwork,
+    stateRoot: Hash32,
+    address: Address,
+    maybeBlockHash = Opt.none(Hash32),
 ): Future[Opt[Account]] {.async: (raises: [CancelledError]).} =
   let (accountProof, exists) = (
     await n.getAccountProof(stateRoot, address, maybeBlockHash)

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -262,10 +262,10 @@ proc processContentLoop(n: StateNetwork) {.async: (raises: []).} =
 proc statusLogLoop(n: StateNetwork) {.async: (raises: []).} =
   try:
     while true:
+      await sleepAsync(60.seconds)
+
       info "State network status",
         routingTableNodes = n.portalProtocol.routingTable.len()
-
-      await sleepAsync(60.seconds)
   except CancelledError:
     trace "statusLogLoop canceled"
 

--- a/fluffy/portal_node.nim
+++ b/fluffy/portal_node.nim
@@ -25,7 +25,7 @@ export
   beacon_light_client, history_network, state_network, portal_protocol_config, forks
 
 type
-  PortalNodeState* = enum
+  PortalNodeStatus* = enum
     Starting
     Running
     Stopping
@@ -40,7 +40,7 @@ type
     contentRequestRetries*: int
 
   PortalNode* = ref object
-    state*: PortalNodeState
+    status*: PortalNodeStatus
     discovery: protocol.Protocol
     contentDB: ContentDB
     streamManager: StreamManager
@@ -228,7 +228,7 @@ proc start*(n: PortalNode) =
 
   n.statusLogLoop = statusLogLoop(n)
 
-  n.state = PortalNodeState.Running
+  n.status = PortalNodeStatus.Running
 
 proc stop*(n: PortalNode) {.async: (raises: []).} =
   debug "Stopping Portal node"


### PR DESCRIPTION
This PR contains a few minor updates:
- Renamed PortalNodeState to PortalNodeStatus. 'PortalNodeState' is a misleading name so picking a better one.
- Move logs on startup. Improves the readability of the logs.
- Make state network getAccount proc public. Required for some use cases such as in the PortalEvm.