### PR TITLE
Clear some obsolete or wrong asserts

### DIFF
--- a/execution_chain/sync/beacon/worker/blocks_staged.nim
+++ b/execution_chain/sync/beacon/worker/blocks_staged.nim
@@ -363,7 +363,6 @@ proc blocksStagedImport*(
           finHash = if nBn < ctx.layout.final: nthHash
                     else: ctx.layout.finalHash
 
-        doAssert nBn == ctx.chain.latestNumber()
         ctx.pool.chain.forkChoice(nthHash, finHash).isOkOr:
           ctx.poolMode = true
           warn info & ": fork choice error (reorg triggered)", n, iv,

--- a/execution_chain/sync/beacon/worker/headers_staged.nim
+++ b/execution_chain/sync/beacon/worker/headers_staged.nim
@@ -116,9 +116,6 @@ proc headersStagedCollect*(
 
     # End block: `fetchHeadersBody`
 
-  # The cache `antecedent` must match variable `D` (aka dangling)
-  doAssert ctx.hdrCache.fcHeaderAntecedent().number <= ctx.layout.dangling
-
   let nHeaders = nDeterministic + nOpportunistic.uint64
   if nHeaders == 0:
     return false
@@ -148,8 +145,6 @@ proc headersStagedProcess*(buddy: BeaconBuddyRef; info: static[string]) =
     # Fetch list with largest block numbers
     let qItem = ctx.hdr.staged.le(high BlockNumber).valueOr:
       break # all done
-
-    doAssert qItem.key == qItem.data.revHdrs[0].number
 
     let
       minNum = qItem.data.revHdrs[^1].number


### PR DESCRIPTION
why
  It is wrong to depend on a particular state of other modules (e.g.
  `FC` module) unless they are fully controlled by this one.