### PR TITLE
Refactor wire protocol(eth68): separate request methods and response handlers

### DIFF
--- a/execution_chain/common/logging.nim
+++ b/execution_chain/common/logging.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.used.}
+
 import
   std/[typetraits, net],
   json_serialization,

--- a/execution_chain/core/chain/forked_chain/chain_header_cache.nim
+++ b/execution_chain/core/chain/forked_chain/chain_header_cache.nim
@@ -143,10 +143,6 @@ proc putState(db: CoreDbTxRef; state: FcHdrState) =
   db.put(LhcStateKey.toOpenArray, encodePayload(state)).isOkOr:
     raiseAssert RaisePfx & "put(state) failed: " & $$error
 
-proc delState(db: CoreDbTxRef) =
-  discard db.del(LhcStateKey.toOpenArray)
-
-
 proc putHeader(db: CoreDbTxRef; bn: BlockNumber; data: seq[byte]) =
   ## Store rlp encoded header
   db.put(beaconHeaderKey(bn).toOpenArray, data).isOkOr:

--- a/execution_chain/networking/p2p.nim
+++ b/execution_chain/networking/p2p.nim
@@ -13,6 +13,7 @@ import
   std/[tables, algorithm, random, typetraits, strutils, net],
   chronos, chronos/timer, chronicles,
   eth/common/keys,
+  results,
   ./[discoveryv4, peer_pool, rlpx, p2p_types]
 
 export
@@ -213,7 +214,7 @@ proc randomPeerWith*(node: EthereumNode, Protocol: type): Peer =
   if candidates.len > 0:
     return candidates.rand()
 
-proc getPeer*(node: EthereumNode, peerId: NodeId, Protocol: type): Option[Peer] =
+proc getPeer*(node: EthereumNode, peerId: NodeId, Protocol: type): Opt[Peer] =
   for peer in node.peers(Protocol):
     if peer.remote.id == peerId:
       return some(peer)

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -11,7 +11,7 @@ import
   ../execution_chain/compile_info
 
 import
-  std/[os, osproc, strutils, net],
+  std/[os, osproc, strutils, net, options],
   chronicles,
   eth/net/nat,
   metrics,

--- a/execution_chain/sync/beacon/worker/headers_staged/headers.nim
+++ b/execution_chain/sync/beacon/worker/headers_staged/headers.nim
@@ -11,7 +11,6 @@
 {.push raises:[].}
 
 import
-  std/options,
   pkg/[chronicles, chronos, results],
   pkg/eth/common,
   pkg/stew/interval_set,
@@ -50,7 +49,7 @@ proc headersFetchReversed*(
     peer = buddy.peer
     req = block:
       if topHash != emptyRoot:
-        EthBlocksRequest(
+        BlockHeadersRequest(
           maxResults: ivReq.len.uint,
           skip:       0,
           reverse:    true,
@@ -58,7 +57,7 @@ proc headersFetchReversed*(
             isHash:   true,
             hash:     topHash))
       else:
-        EthBlocksRequest(
+        BlockHeadersRequest(
           maxResults: ivReq.len.uint,
           skip:       0,
           reverse:    true,
@@ -71,7 +70,7 @@ proc headersFetchReversed*(
     nReq=req.maxResults, hash=topHash.toStr, hdrErrors=buddy.hdrErrors
 
   # Fetch headers from peer
-  var resp: Option[blockHeadersObj]
+  var resp: Opt[BlockHeadersPacket]
   try:
     # There is no obvious way to set an individual timeout for this call. The
     # eth/xx driver sets a global response timeout to `10s`. By how it is

--- a/execution_chain/sync/beacon/worker/headers_staged/staged_collect.nim
+++ b/execution_chain/sync/beacon/worker/headers_staged/staged_collect.nim
@@ -180,10 +180,6 @@ proc collectAndStageOnMemQueue*(
         # Request interval
         ivReq = BnRange.new(ivReqMin, ivTop)
 
-        # Current length of the headers queue. This is used to calculate the
-        # response length from the network.
-        nLhcHeaders = lhc.revHdrs.len
-
         # Fetch headers for this range of block numbers
         rev = (await buddy.fetchRev(ivReq, parent, info)).valueOr:
           break fetchHeadersBody         # error => exit block

--- a/execution_chain/sync/wire_protocol.nim
+++ b/execution_chain/sync/wire_protocol.nim
@@ -8,12 +8,14 @@
 # those terms.
 
 import
-  ./wire_protocol/implementation,
+  ./wire_protocol/requester,
+  ./wire_protocol/responder,
   ./wire_protocol/types,
   ./wire_protocol/setup
 
 export
-  implementation,
+  requester,
+  responder,
   types,
   setup
 

--- a/execution_chain/sync/wire_protocol/implementation.nim
+++ b/execution_chain/sync/wire_protocol/implementation.nim
@@ -170,7 +170,7 @@ p2pProtocol eth68(version = protocolVersion,
 
   requestResponse:
     # User message 0x03: GetBlockHeaders.
-    proc getBlockHeaders(peer: Peer, request: EthBlocksRequest) =
+    proc getBlockHeaders(peer: Peer, request: BlockHeadersRequest) =
       when trEthTracePacketsOk:
         trace trEthRecvReceived & "GetBlockHeaders (0x03)", peer,
           count=request.maxResults

--- a/execution_chain/sync/wire_protocol/requester.nim
+++ b/execution_chain/sync/wire_protocol/requester.nim
@@ -1,0 +1,152 @@
+# nimbus-execution-client
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  chronos,
+  eth/common,
+  ./types,
+  ../../networking/rlpx,
+  ../../networking/p2p_types
+
+export
+  common,
+  chronos,
+  types,
+  rlpx,
+  p2p_types
+
+const
+  protocolVersion* = 68
+
+defineProtocol(PROTO = eth68,
+               version = protocolVersion,
+               rlpxName = "eth",
+               peerState = EthPeerState,
+               networkState = EthWireRef)
+
+type
+  StatusPacket* = object
+    ethVersion*: uint64
+    networkId*: NetworkId
+    totalDifficulty*: DifficultyInt
+    bestHash*: Hash32
+    genesisHash*: Hash32
+    forkId*: ChainForkId
+
+  BlockHeadersPacket* = object
+    headers*: seq[Header]
+
+  BlockBodiesPacket* = object
+    bodies*: seq[BlockBody]
+
+  PooledTransactionsPacket* = object
+    transactions*: seq[PooledTransaction]
+
+  ReceiptsPacket* = object
+    receipts*: seq[seq[Receipt]]
+
+  NewBlockHashesPacket* = object
+    hashes*: seq[NewBlockHashesAnnounce]
+
+  NewBlockPacket* = object
+    blk*: EthBlock
+    totalDifficulty*: DifficultyInt
+
+  TransactionsPacket* = object
+    transactions*: seq[Transaction]
+
+  NewPooledTransactionHashesPacket* = object
+    txTypes*: seq[byte]
+    txSizes*: seq[uint64]
+    txHashes*: seq[Hash32]
+
+const
+  StatusMsg*                     =  0'u64
+  NewBlockHashesMsg*             =  1'u64
+  TransactionMsg*                =  2'u64
+  GetBlockHeadersMsg*            =  3'u64
+  BlockHeadersMsg*               =  4'u64
+  GetBlockBodiesMsg*             =  5'u64
+  BlockBodiesMsg*                =  6'u64
+  NewBlockMsg*                   =  7'u64
+  NewPooledTransactionHashesMsg* =  8'u64
+  GetPooledTransactionsMsg*      =  9'u64
+  PooledTransactionsMsg*         = 10'u64
+  GetReceiptsMsg*                = 15'u64
+  ReceiptsMsg*                   = 16'u64
+
+proc status*(peer: Peer; packet: StatusPacket;
+             timeout: Duration = milliseconds(10000'i64)):
+              Future[StatusPacket] {.async: (raises: [CancelledError, EthP2PError], raw: true).} =
+  let
+    sendingFut = eth68.rlpxSendMessage(peer, StatusMsg,
+                    packet.ethVersion,
+                    packet.networkId,
+                    packet.totalDifficulty,
+                    packet.bestHash,
+                    packet.genesisHash,
+                    packet.forkId)
+
+    responseFut = eth68.nextMsg(peer, StatusPacket, StatusMsg)
+  handshakeImpl[StatusPacket](peer, sendingFut, responseFut, timeout)
+
+proc transactions*(peer: Peer; transactions: openArray[Transaction]): Future[
+    void] {.async: (raises: [CancelledError, EthP2PError], raw: true).} =
+  eth68.rlpxSendMessage(peer, TransactionMsg, transactions)
+
+proc getBlockHeaders*(peer: Peer; request: BlockHeadersRequest;
+                      timeout: Duration = milliseconds(10000'i64)): Future[
+    Opt[BlockHeadersPacket]] {.async: (raises: [CancelledError, EthP2PError],
+                                       raw: true).} =
+  eth68.rlpxSendRequest(peer, GetBlockHeadersMsg, request)
+
+proc blockHeaders*(responder: Responder;
+                   headers: openArray[Header]): Future[void] {.
+    async: (raises: [CancelledError, EthP2PError], raw: true).} =
+  eth68.rlpxSendMessage(responder, BlockHeadersMsg, headers)
+
+proc getBlockBodies*(peer: Peer; packet: BlockBodiesRequest;
+                     timeout: Duration = milliseconds(10000'i64)): Future[
+    Opt[BlockBodiesPacket]] {.async: (raises: [CancelledError, EthP2PError],
+                                      raw: true).} =
+  eth68.rlpxSendRequest(peer, GetBlockBodiesMsg, packet.blockHashes)
+
+proc blockBodies*(responder: Responder;
+                  bodies: openArray[BlockBody]): Future[void] {.
+    async: (raises: [CancelledError, EthP2PError], raw: true).} =
+  eth68.rlpxSendMessage(responder, BlockBodiesMsg, bodies)
+
+proc newPooledTransactionHashes*(peer: Peer; txTypes: seq[byte];
+                                 txSizes: openArray[uint64];
+                                 txHashes: openArray[Hash32]): Future[void] {.
+    async: (raises: [CancelledError, EthP2PError], raw: true).} =
+  eth68.rlpxSendMessage(peer, NewPooledTransactionHashesMsg,
+    txTypes, txSizes, txHashes)
+
+proc getPooledTransactions*(peer: Peer; packet: PooledTransactionsRequest;
+                            timeout: Duration = milliseconds(10000'i64)): Future[
+    Opt[PooledTransactionsPacket]] {.async: (
+    raises: [CancelledError, EthP2PError], raw: true).} =
+  eth68.rlpxSendRequest(peer, GetPooledTransactionsMsg, packet.txHashes)
+
+proc pooledTransactions*(responder: Responder;
+                         transactions: openArray[PooledTransaction]): Future[
+    void] {.async: (raises: [CancelledError, EthP2PError], raw: true).} =
+  eth68.rlpxSendMessage(responder, PooledTransactionsMsg, transactions)
+
+proc getReceipts*(peer: Peer; packet: ReceiptsRequest;
+                  timeout: Duration = milliseconds(10000'i64)): Future[
+    Opt[ReceiptsPacket]] {.async: (raises: [CancelledError, EthP2PError],
+                                   raw: true).} =
+  eth68.rlpxSendRequest(peer, GetReceiptsMsg, packet.blockHashes)
+
+proc receipts*(responder: Responder;
+               receipts: openArray[seq[Receipt]]): Future[void] {.
+    async: (raises: [CancelledError, EthP2PError], raw: true).} =
+  eth68.rlpxSendMessage(responder, ReceiptsMsg, receipts)

--- a/execution_chain/sync/wire_protocol/responder.nim
+++ b/execution_chain/sync/wire_protocol/responder.nim
@@ -1,0 +1,338 @@
+# nimbus-execution-client
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  stint,
+  chronicles,
+  stew/byteutils,
+  ./handler,
+  ./requester,
+  ./trace_config,  
+  ../../utils/utils,
+  ../../common/logging,
+  ../../networking/p2p_protocol_dsl,
+  ../../networking/p2p_types
+
+export
+  requester
+
+logScope:
+  topics = "eth68"
+
+const
+  prettyEthProtoName* = "[eth/" & $protocolVersion & "]"
+
+  # Pickeled tracer texts
+  trEthRecvReceived* =
+    "<< " & prettyEthProtoName & " Received "
+  trEthRecvReceivedBlockHeaders* =
+    trEthRecvReceived & "BlockHeaders (0x04)"
+  trEthRecvReceivedBlockBodies* =
+    trEthRecvReceived & "BlockBodies (0x06)"
+
+  trEthRecvProtocolViolation* =
+    "<< " & prettyEthProtoName & " Protocol violation, "
+  trEthRecvError* =
+    "<< " & prettyEthProtoName & " Error "
+  trEthRecvTimeoutWaiting* =
+    "<< " & prettyEthProtoName & " Timeout waiting "
+  trEthRecvDiscarding* =
+    "<< " & prettyEthProtoName & " Discarding "
+
+  trEthSendSending* =
+    ">> " & prettyEthProtoName & " Sending "
+  trEthSendSendingGetBlockHeaders* =
+    trEthSendSending & "GetBlockHeaders (0x03)"
+  trEthSendSendingGetBlockBodies* =
+    trEthSendSending & "GetBlockBodies (0x05)"
+
+  trEthSendReplying* =
+    ">> " & prettyEthProtoName & " Replying "
+
+  trEthSendDelaying* =
+    ">> " & prettyEthProtoName & " Delaying "
+
+  trEthRecvNewBlock* =
+    "<< " & prettyEthProtoName & " Received NewBlock"
+  trEthRecvNewBlockHashes* =
+    "<< " & prettyEthProtoName & " Received NewBlockHashes"
+  trEthSendNewBlock* =
+    ">> " & prettyEthProtoName & " Sending NewBlock"
+  trEthSendNewBlockHashes* =
+    ">> " & prettyEthProtoName & " Sending NewBlockHashes"
+
+proc statusUserHandler(peer: Peer; packet: StatusPacket) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  trace trEthRecvReceived & "Status (0x00)", peer,
+    networkId = packet.networkId,
+    totalDifficulty = packet.totalDifficulty,
+    bestHash = packet.bestHash.short,
+    genesisHash = packet.genesisHash.short,
+    forkHash = packet.forkId.forkHash.toHex,
+    forkNext = packet.forkId.forkNext
+
+proc statusThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithPacketHandler(StatusPacket, peer, data,
+                               [ethVersion, networkId,
+                                totalDifficulty, bestHash,
+                                genesisHash, forkId]):
+    await statusUserHandler(peer, packet)
+
+
+proc newBlockHashesUserHandler(peer: Peer; packet: NewBlockHashesPacket) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  when trEthTraceGossipOk:
+    trace trEthRecvReceived & "NewBlockHashes (0x01)", peer, hashes = packet.hashes.len
+  raise newException(EthP2PError, "block broadcasts disallowed")
+
+proc newBlockHashesThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithPacketHandler(NewBlockHashesPacket, peer, data, [hashes]):
+    await newBlockHashesUserHandler(peer, packet)
+
+
+proc transactionsUserHandler(peer: Peer; packet: TransactionsPacket) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  when trEthTraceGossipOk:
+    trace trEthRecvReceived & "Transactions (0x02)", peer,
+          transactions = packet.transactions.len
+  let ctx = peer.networkState(eth68)
+  ctx.handleAnnouncedTxs(packet)
+
+proc transactionsThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithPacketHandler(TransactionsPacket, peer, data, [transactions]):
+    await transactionsUserHandler(peer, packet)
+
+
+proc getBlockHeadersUserHandler(response: Responder;
+                                request: BlockHeadersRequest) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+
+  let peer = response.peer
+  when trEthTracePacketsOk:
+    trace trEthRecvReceived & "GetBlockHeaders (0x03)", peer,
+          count = request.maxResults
+  let ctx = peer.networkState(eth68)
+  let headers = ctx.getBlockHeaders(request)
+  if headers.len > 0:
+    trace trEthSendReplying & "with BlockHeaders (0x04)", peer,
+          sent = headers.len, requested = request.maxResults
+  else:
+    trace trEthSendReplying & "EMPTY BlockHeaders (0x04)", peer, sent = 0,
+          requested = request.maxResults
+  await response.blockHeaders(headers)
+
+proc getBlockHeadersThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithPacketResponder(BlockHeadersRequest, peer, data):
+    await getBlockHeadersUserHandler(response, packet)
+
+
+proc blockHeadersThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithFutureHandler(BlockHeadersPacket,
+    BlockHeadersMsg, peer, data, [headers])
+
+
+proc blockBodiesThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithFutureHandler(BlockBodiesPacket,
+    BlockBodiesMsg, peer, data, [bodies])
+
+
+proc getBlockBodiesUserHandler(response: Responder; hashes: seq[Hash32]) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+
+  let peer = response.peer
+  trace trEthRecvReceived & "GetBlockBodies (0x05)", peer, hashes = hashes.len
+  let ctx = peer.networkState(eth68)
+  let bodies = ctx.getBlockBodies(hashes)
+  if bodies.len > 0:
+    trace trEthSendReplying & "with BlockBodies (0x06)", peer,
+          sent = bodies.len, requested = hashes.len
+  else:
+    trace trEthSendReplying & "EMPTY BlockBodies (0x06)", peer, sent = 0,
+          requested = hashes.len
+  await response.blockBodies(bodies)
+
+proc getBlockBodiesThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithPacketResponder(seq[Hash32], peer, data):
+    await getBlockBodiesUserHandler(response, packet)
+
+
+proc newBlockUserHandler(peer: Peer; packet: NewBlockPacket) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  when trEthTraceGossipOk:
+    trace trEthRecvReceived & "NewBlock (0x07)", peer, packet.totalDifficulty,
+          blockNumber = packet.blk.header.number,
+          blockDifficulty = packet.blk.header.difficulty
+  raise newException(EthP2PError, "block broadcasts disallowed")
+
+proc newBlockThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithPacketHandler(NewBlockPacket, peer, data, [blk, totalDifficulty]):
+    await newBlockUserHandler(peer, packet)
+
+
+proc newPooledTransactionHashesUserHandler(peer: Peer; packet: NewPooledTransactionHashesPacket) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+
+  when trEthTraceGossipOk:
+    trace trEthRecvReceived & "NewPooledTransactionHashes (0x08)", peer,
+          txTypes = packet.txTypes.toHex, txSizes = packet.txSizes.toStr,
+          hashes = packet.txHashes.len
+
+proc newPooledTransactionHashesThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithPacketHandler(NewPooledTransactionHashesPacket,
+                              peer, data, [txTypes, txSizes, txHashes]):
+    await newPooledTransactionHashesUserHandler(peer, packet)
+
+
+proc getPooledTransactionsUserHandler(response: Responder;
+                                      txHashes: seq[Hash32]) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+
+  let peer = response.peer
+  trace trEthRecvReceived & "GetPooledTransactions (0x09)", peer,
+        hashes = txHashes.len
+  let ctx = peer.networkState(eth68)
+  let txs = ctx.getPooledTransactions(txHashes)
+  if txs.len > 0:
+    trace trEthSendReplying & "with PooledTransactions (0x0a)", peer,
+          sent = txs.len, requested = txHashes.len
+  else:
+    trace trEthSendReplying & "EMPTY PooledTransactions (0x0a)", peer, sent = 0,
+          requested = txHashes.len
+  await response.pooledTransactions(txs)
+
+proc getPooledTransactionsThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithPacketResponder(seq[Hash32], peer, data):
+    await getPooledTransactionsUserHandler(response, packet)
+
+
+proc pooledTransactionsThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithFutureHandler(PooledTransactionsPacket,
+    PooledTransactionsMsg, peer, data, [transactions])
+
+
+proc getReceiptsUserHandler(response: Responder; hashes: seq[Hash32]) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  let peer = response.peer
+  trace trEthRecvReceived & "GetReceipts (0x0f)", peer, hashes = hashes.len
+  let ctx = peer.networkState(eth68)
+  let rec = ctx.getReceipts(hashes)
+  if rec.len > 0:
+    trace trEthSendReplying & "with Receipts (0x10)", peer, sent = rec.len,
+          requested = hashes.len
+  else:
+    trace trEthSendReplying & "EMPTY Receipts (0x10)", peer, sent = 0,
+          requested = hashes.len
+  await response.receipts(rec)
+
+proc getReceiptsThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithPacketResponder(seq[Hash32], peer, data):
+    await getReceiptsUserHandler(response, packet)
+
+
+proc receiptsThunk(peer: Peer; data: Rlp) {.
+    async: (raises: [CancelledError, EthP2PError]).} =
+  eth68.rlpxWithFutureHandler(ReceiptsPacket,
+    ReceiptsMsg, peer, data, [receipts])
+
+
+proc eth68PeerConnected(peer: Peer) {.async: (
+    raises: [CancelledError, EthP2PError]).} =
+  let
+    network = peer.network
+    ctx = peer.networkState(eth68)
+    status = ctx.getStatus()
+    packet = StatusPacket(
+      ethVersion: protocolVersion,
+      networkId : network.networkId,
+      totalDifficulty: status.totalDifficulty,
+      bestHash: status.bestBlockHash,
+      genesisHash: status.genesisHash,
+      forkId: status.forkId,
+    )
+
+  trace trEthSendSending & "Status (0x00)", peer,
+     td = status.totalDifficulty,
+     bestHash = short(status.bestBlockHash),
+     networkId = network.networkId,
+     genesis = short(status.genesisHash),
+     forkHash = status.forkId.forkHash.toHex,
+     forkNext = status.forkId.forkNext
+
+  let m = await peer.status(packet, timeout = chronos.seconds(10))
+  when trEthTraceHandshakesOk:
+    trace "Handshake: Local and remote networkId", local = network.networkId,
+          remote = m.networkId
+    trace "Handshake: Local and remote genesisHash",
+          local = short(status.genesisHash), remote = short(m.genesisHash)
+    trace "Handshake: Local and remote forkId", local = (
+        status.forkId.forkHash.toHex & "/" & $status.forkId.forkNext),
+          remote = (m.forkId.forkHash.toHex & "/" & $m.forkId.forkNext)
+  if m.networkId != network.networkId:
+    trace "Peer for a different network (networkId)", peer,
+          expectNetworkId = network.networkId, gotNetworkId = m.networkId
+    raise newException(UselessPeerError, "Eth handshake for different network")
+  if m.genesisHash != status.genesisHash:
+    trace "Peer for a different network (genesisHash)", peer,
+          expectGenesis = short(status.genesisHash),
+          gotGenesis = short(m.genesisHash)
+    raise newException(UselessPeerError, "Eth handshake for different network")
+  trace "Peer matches our network", peer
+
+  peer.state(eth68).initialized = true
+  peer.state(eth68).bestDifficulty = m.totalDifficulty
+  peer.state(eth68).bestBlockHash = m.bestHash
+
+
+proc eth68Registration() =
+  let
+    protocol = eth68.initProtocol()
+
+  setEventHandlers(protocol, eth68PeerConnected, nil)
+  registerMsg(protocol, StatusMsg, "status",
+              statusThunk, StatusPacket)
+  registerMsg(protocol, NewBlockHashesMsg, "newBlockHashes",
+              newBlockHashesThunk, NewBlockHashesPacket)
+  registerMsg(protocol, TransactionMsg, "transactions",
+              transactionsThunk, TransactionsPacket)
+  registerMsg(protocol, BlockHeadersMsg, "blockHeaders",
+              blockHeadersThunk, BlockHeadersPacket)
+  registerMsg(protocol, GetBlockHeadersMsg, "getBlockHeaders",
+              getBlockHeadersThunk, BlockHeadersRequest)
+  registerMsg(protocol, BlockBodiesMsg, "blockBodies",
+              blockBodiesThunk, BlockBodiesPacket)
+  registerMsg(protocol, GetBlockBodiesMsg, "getBlockBodies",
+              getBlockBodiesThunk, BlockBodiesRequest)
+  registerMsg(protocol, NewBlockMsg, "newBlock",
+              newBlockThunk, NewBlockPacket)
+  registerMsg(protocol, NewPooledTransactionHashesMsg, "newPooledTransactionHashes",
+              newPooledTransactionHashesThunk, NewPooledTransactionHashesPacket)
+  registerMsg(protocol, PooledTransactionsMsg, "pooledTransactions",
+              pooledTransactionsThunk, PooledTransactionsPacket)
+  registerMsg(protocol, GetPooledTransactionsMsg, "getPooledTransactions",
+              getPooledTransactionsThunk, PooledTransactionsRequest)
+  registerMsg(protocol, ReceiptsMsg, "receipts",
+              receiptsThunk, ReceiptsPacket)
+  registerMsg(protocol, GetReceiptsMsg, "getReceipts",
+              getReceiptsThunk, ReceiptsRequest)
+
+  registerProtocol(protocol)
+
+eth68Registration()

--- a/execution_chain/sync/wire_protocol/setup.nim
+++ b/execution_chain/sync/wire_protocol/setup.nim
@@ -13,7 +13,7 @@
 import
   ../../networking/p2p,
   ../../core/tx_pool,
-  ./implementation,
+  ./requester,
   ./handler
 
 # ------------------------------------------------------------------------------
@@ -25,7 +25,7 @@ proc addEthHandlerCapability*(
       ) =
   ## Install `eth` handlers.
   node.addCapability(
-    implementation.eth68,
+    requester.eth68,
     EthWireRef.new(txPool))
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/sync/wire_protocol/types.nim
+++ b/execution_chain/sync/wire_protocol/types.nim
@@ -11,8 +11,9 @@
 {.push raises: [].}
 
 import
-  eth/common
-
+  eth/common,
+  ../../core/[chain, tx_pool]
+  
 type
   NewBlockHashesAnnounce* = object
     hash*: Hash32
@@ -33,7 +34,21 @@ type
     bestBlockHash*: Hash32
     bestDifficulty*: DifficultyInt
 
-  EthBlocksRequest* = object
+  BlockHeadersRequest* = object
     startBlock*: BlockHashOrNumber
     maxResults*, skip*: uint
     reverse*: bool
+
+  BlockBodiesRequest* =object
+    blockHashes*: seq[Hash32]
+
+  PooledTransactionsRequest* =object
+    txHashes*: seq[Hash32]
+
+  ReceiptsRequest* =object
+    blockHashes*: seq[Hash32]
+
+  EthWireRef* = ref object of RootRef
+    chain* : ForkedChainRef
+    txPool*: TxPoolRef
+    

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -9,7 +9,7 @@
 {.push raises: [].}
 
 import
-  eth/common/eth_types, stint, stew/ptrops,
+  eth/common/eth_types, stint,
   chronos,
   results,
   ../evm/[types, state],

--- a/hive_integration/nodocker/engine/cancun/step_devp2p_pooledtx.nim
+++ b/hive_integration/nodocker/engine/cancun/step_devp2p_pooledtx.nim
@@ -90,8 +90,10 @@ method execute*(step: DevP2PRequestPooledTransactionHash, ctx: CancunTestContext
         return false
 
   # Send the request for the pooled transactions
-  let peer = sec.peer
-  let res = waitFor peer.getPooledTransactions(txHashes)
+  let 
+    peer = sec.peer
+    request = PooledTransactionsRequest(txHashes: txHashes)
+    res = waitFor peer.getPooledTransactions(request)
   if res.isNone:
     error "getPooledTransactions returns none"
     return false

--- a/tests/networking/fuzzing/discoveryv4/fuzz.nim
+++ b/tests/networking/fuzzing/discoveryv4/fuzz.nim
@@ -10,7 +10,7 @@
 import
   std/net,
   testutils/fuzzing, chronicles, nimcrypto/keccak,
-  eth/[keys, rlp],
+  eth/[common/keys, rlp],
   ../../../../execution_chain/networking/discoveryv4,
   ../../p2p_test_helper
 

--- a/tests/networking/fuzzing/discoveryv4/generate.nim
+++ b/tests/networking/fuzzing/discoveryv4/generate.nim
@@ -10,7 +10,7 @@
 import
   std/[times, os, strformat, strutils],
   chronos, stew/byteutils, stint, chronicles, nimcrypto,
-  eth/[keys, rlp],
+  eth/[common/keys, rlp],
   ../../../../execution_chain/networking/discoveryv4,
   ../../p2p_test_helper,
   ../fuzzing_helpers


### PR DESCRIPTION
Separation of request methods and response handlers into their own module will help us avoid cyclic import or employ convoluted abstractions for user handler.

So the dependency graph can be arranged like:
  response_handlers -> user_handlers -> request_methods

Now the p2pProtocol macro is not used for eth68 anymore, only for devP2P. Next PR may reintroduce a simpler but more versatile macro, if needed. Or we can use a more sophisticated template, or both.

With this refactoring, implementation of transactions broadcast, including blob transactions, will be much easier.

This PR also introduce some modifications to reduce copies when the packet received, intended to be rebroadcasted again. This optimization cannot be achieved if most of the code hide behind macros. Or the macros become too complex.
Future PR could address the simplification of of writing both request methods and response handlers. 
