### PR TITLE
Implement rlpx peer connections limit

### DIFF
--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -296,8 +296,13 @@ type
       defaultValueDesc: "default to --tcp-port"
       name: "udp-port" }: Port
 
+    minPeers* {.
+      desc: "Minimum number of peers to keep connected with"
+      defaultValue: 10
+      name: "min-peers" }: int
+
     maxPeers* {.
-      desc: "Maximum number of peers to connect to"
+      desc: "Maximum number of peer connections"
       defaultValue: 25
       name: "max-peers" }: int
 
@@ -832,6 +837,11 @@ proc makeConfig*(cmdLine = commandLineParams()): NimbusConf
     if result.udpPort == Port(0):
       # if udpPort not set in cli, then
       result.udpPort = result.tcpPort
+
+  if not (0 <= result.minPeers and result.minPeers <= result.maxPeers):
+    fatal "Invalid min/max peers options", `min-peers`=result.minPeers,
+      `max-peers`=result.maxPeers
+    quit QuitFailure
 
   # see issue #1346
   if result.keyStore.string == defaultKeystoreDir() and

--- a/execution_chain/networking/p2p_types.nim
+++ b/execution_chain/networking/p2p_types.nim
@@ -39,6 +39,7 @@ type
     protocolStates*: seq[RootRef]
     discovery*: DiscoveryProtocol
     rng*: ref HmacDrbgContext
+    maxPeers*: int # limit on accepting incoming connection requests
 
   Peer* = ref object
     remote*: Node

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -96,7 +96,9 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf,
 
   nimbus.ethNode = newEthereumNode(
     keypair, address, conf.networkId, conf.agentString,
-    addAllCapabilities = false, minPeers = conf.maxPeers,
+    addAllCapabilities = false,
+    minPeers = conf.minPeers,
+    maxPeers = conf.maxPeers,
     bootstrapNodes = bootstrapNodes,
     bindUdpPort = conf.udpPort, bindTcpPort = conf.tcpPort,
     bindIp = conf.listenAddress,


### PR DESCRIPTION
why
  The number of incoming connections were not restricted in the `p2p`
  handler. Even worse, there was a nimbus option `--max-peers` which
  was used to set up the minimum(sic) number of peers to keep
  connected with.

  Now, the re-organised nimbus options mean:
  * `--min-peers` -- minimum number of connections to hold
  * `--max-peers` -- maximum number of all peer connections

caveat
  While the p2p module now rejects new incoming connections when
  the limit is reached it does allow more connection list entries
  for outgoing connection when explicitly using the `connectToNode()`
  function (as in `rpc/common.nim`, `sync/peers.nim` and probably
  others.) In practice, this lead to at most one more connections on
  the list.