### PR TITLE
Improve collection of witness keys in ledger

### DIFF
--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -191,8 +191,6 @@ proc procBlkEpilogue(
 
   # Reward beneficiary
   vmState.mutateLedger:
-    if vmState.collectWitnessData:
-      db.collectWitnessData()
 
     # Clearing the account cache here helps manage its size when replaying
     # large ranges of blocks, implicitly limiting its size using the gas limit

--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -120,9 +120,6 @@ proc processTransactionImpl(
     else:
       err(txRes.error)
 
-  if vmState.collectWitnessData:
-    vmState.ledger.collectWitnessData()
-
   vmState.ledger.persist(clearEmptyAccount = fork >= FkSpurious)
 
   res

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -148,7 +148,7 @@ when debugLedgerRef:
 template logTxt(info: static[string]): static[string] =
   "LedgerRef " & info
 
-template toAccountKey*(acc: AccountRef): Hash32 =
+template toAccountKey(acc: AccountRef): Hash32 =
   acc.accPath
 
 template toAccountKey*(eAddr: Address): Hash32 =

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -94,7 +94,7 @@ type
       ## write amplification that ensues
 
     when statelessEnabled:
-      witnessKeys: OrderedTableRef[(Address, Hash32), WitnessKey]
+      witnessKeys: OrderedTable[(Address, Hash32), WitnessKey]
         ## Used to collect the keys of all read accounts, code and storage slots.
         ## Maps a tuple of address and hash of the key (address or slot) to the
         ## witness key which can be either a storage key or an account key
@@ -386,7 +386,7 @@ proc init*(x: typedesc[LedgerRef], db: CoreDbTxRef, storeSlotHash: bool): Ledger
   discard result.beginSavepoint
 
   when statelessEnabled:
-    result.witnessKeys = newOrderedTable[(Address, Hash32), WitnessKey]()
+    result.witnessKeys = initOrderedTable[(Address, Hash32), WitnessKey]()
 
 proc init*(x: typedesc[LedgerRef], db: CoreDbTxRef): LedgerRef =
   init(x, db, false)
@@ -920,7 +920,7 @@ proc getStorageProof*(ac: LedgerRef, address: Address, slots: openArray[UInt256]
   storageProof
 
 when statelessEnabled:
-  func getWitnessKeys*(ac: LedgerRef): OrderedTableRef[(Address, Hash32), WitnessKey] =
+  func getWitnessKeys*(ac: LedgerRef): OrderedTable[(Address, Hash32), WitnessKey] =
     ac.witnessKeys
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/evm/state.nim
+++ b/execution_chain/evm/state.nim
@@ -237,13 +237,6 @@ proc `status=`*(vmState: BaseVMState, status: bool) =
  if status: vmState.flags.incl ExecutionOK
  else: vmState.flags.excl ExecutionOK
 
-proc collectWitnessData*(vmState: BaseVMState): bool =
-  CollectWitnessData in vmState.flags
-
-proc `collectWitnessData=`*(vmState: BaseVMState, status: bool) =
-  if status: vmState.flags.incl CollectWitnessData
-  else: vmState.flags.excl CollectWitnessData
-
 func tracingEnabled*(vmState: BaseVMState): bool =
   vmState.tracer.isNil.not
 

--- a/execution_chain/evm/types.nim
+++ b/execution_chain/evm/types.nim
@@ -21,7 +21,6 @@ export stack, memory
 type
   VMFlag* = enum
     ExecutionOK
-    CollectWitnessData
 
   BlockContext* = object
     timestamp*        : EthTime

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -724,7 +724,7 @@ proc runLedgerBasicOperationsTests() =
 
         let
           witnessKeys = ac.getWitnessKeys()
-          keyData = witnessKeys.getOrDefault((addr1, addr1.toAccountKey.data))
+          keyData = witnessKeys.getOrDefault((addr1, addr1.toAccountKey))
         check:
           witnessKeys.len() == 1
           keyData.address == addr1
@@ -739,7 +739,7 @@ proc runLedgerBasicOperationsTests() =
 
         let
           witnessKeys = ac.getWitnessKeys()
-          keyData = witnessKeys.getOrDefault((addr1, addr1.toAccountKey.data))
+          keyData = witnessKeys.getOrDefault((addr1, addr1.toAccountKey))
         check:
           witnessKeys.len() == 1
           keyData.address == addr1
@@ -755,10 +755,10 @@ proc runLedgerBasicOperationsTests() =
 
         let
           witnessKeys = ac.getWitnessKeys()
-          keyData = witnessKeys.getOrDefault((addr1, slot1.toSlotKey.data))
+          keyData = witnessKeys.getOrDefault((addr1, slot1.toSlotKey))
         check:
           witnessKeys.len() == 2
-          keyData.storageSlot == slot1.toBytesBE()
+          keyData.storageSlot == slot1
 
       test "Witness keys - Get account, code and storage":
         var
@@ -780,7 +780,7 @@ proc runLedgerBasicOperationsTests() =
         let witnessKeys = ac.getWitnessKeys()
         check witnessKeys.len() == 5
 
-        var keysList = newSeq[(Address, KeyData)]()
+        var keysList = newSeq[(Address, WitnessKey)]()
         for k, v in witnessKeys:
           let (adr, _) = k
           keysList.add((adr, v))
@@ -795,10 +795,10 @@ proc runLedgerBasicOperationsTests() =
           keysList[1][1].codeTouched == true
 
           keysList[2][0] == addr2
-          keysList[2][1].storageSlot == slot1.toBytesBE()
+          keysList[2][1].storageSlot == slot1
 
           keysList[3][0] == addr1
-          keysList[3][1].storageSlot == slot1.toBytesBE()
+          keysList[3][1].storageSlot == slot1
 
           keysList[4][0] == addr3
           keysList[4][1].address == addr3

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -715,6 +715,7 @@ proc runLedgerBasicOperationsTests() =
       check 3.u256 in vals
 
     when defined(stateless):
+    
       test "Witness keys - Get account":
         var
           ac = LedgerRef.init(memDB.baseTxFrame())
@@ -752,6 +753,21 @@ proc runLedgerBasicOperationsTests() =
           slot1 = 1.u256
 
         discard ac.getStorage(addr1, slot1)
+
+        let
+          witnessKeys = ac.getWitnessKeys()
+          keyData = witnessKeys.getOrDefault((addr1, slot1.toSlotKey))
+        check:
+          witnessKeys.len() == 2
+          keyData.storageSlot == slot1
+
+      test "Witness keys - Set storage":
+        var
+          ac = LedgerRef.init(memDB.baseTxFrame())
+          addr1 = initAddr(1)
+          slot1 = 1.u256
+
+        ac.setStorage(addr1, slot1, slot1)
 
         let
           witnessKeys = ac.getWitnessKeys()

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -25,6 +25,7 @@ import
 
 import results
 
+
 const
   genesisFile = "tests/customgenesis/cancun123.json"
   hexPrivKey  = "af1a9be9f1a54421cac82943820a0fe0f601bb5f4f6d0bccc81c613f0ce6ae22"
@@ -713,45 +714,98 @@ proc runLedgerBasicOperationsTests() =
       check 2.u256 in vals
       check 3.u256 in vals
 
-    # TODO: Update these tests
-    # test "Test MultiKeys - Set storage":
-    #   var
-    #     ac = LedgerRef.init(memDB.baseTxFrame())
-    #     addr1 = initAddr(1)
+    when defined(stateless):
+      test "Witness keys - Get account":
+        var
+          ac = LedgerRef.init(memDB.baseTxFrame())
+          addr1 = initAddr(1)
 
-    #   ac.setStorage(addr1, 1.u256, 1.u256) # Non-zero value
-    #   ac.setStorage(addr1, 2.u256, 0.u256) # Zero value
+        discard ac.getAccount(addr1)
 
-    #   ac.collectWitnessData()
-    #   let multikeys = ac.makeMultiKeys().keys
+        let
+          witnessKeys = ac.getWitnessKeys()
+          keyData = witnessKeys.getOrDefault((addr1, addr1.toAccountKey.data))
+        check:
+          witnessKeys.len() == 1
+          keyData.address == addr1
+          keyData.codeTouched == false
 
-    #   check:
-    #     multikeys.len() == 1
-    #     multikeys[0].storageMode == false
-    #     multikeys[0].address == addr1
-    #     multikeys[0].storageKeys.keys.len() == 2
-    #     multikeys[0].storageKeys.keys[0].storageSlot == 2.u256.toBytesBE()
-    #     multikeys[0].storageKeys.keys[1].storageSlot == 1.u256.toBytesBE()
+      test "Witness keys - Get code":
+        var
+          ac = LedgerRef.init(memDB.baseTxFrame())
+          addr1 = initAddr(1)
 
-    # test "Test MultiKeys - Get storage":
-    #   var
-    #     ac = LedgerRef.init(memDB.baseTxFrame())
-    #     addr1 = initAddr(1)
+        discard ac.getCode(addr1)
 
-    #   ac.setStorage(addr1, 3.u256, 1.u256)
-    #   discard ac.getStorage(addr1, 3.u256) # Returns non-zero value
-    #   discard ac.getStorage(addr1, 4.u256) # Returns default zero value
+        let
+          witnessKeys = ac.getWitnessKeys()
+          keyData = witnessKeys.getOrDefault((addr1, addr1.toAccountKey.data))
+        check:
+          witnessKeys.len() == 1
+          keyData.address == addr1
+          keyData.codeTouched == true
 
-    #   ac.collectWitnessData()
-    #   let multikeys = ac.makeMultiKeys().keys
+      test "Witness keys - Get storage":
+        var
+          ac = LedgerRef.init(memDB.baseTxFrame())
+          addr1 = initAddr(1)
+          slot1 = 1.u256
 
-    #   check:
-    #     multikeys.len() == 1
-    #     multikeys[0].storageMode == false
-    #     multikeys[0].address == addr1
-    #     multikeys[0].storageKeys.keys.len() == 2
-    #     multikeys[0].storageKeys.keys[0].storageSlot == 4.u256.toBytesBE()
-    #     multikeys[0].storageKeys.keys[1].storageSlot == 3.u256.toBytesBE()
+        discard ac.getStorage(addr1, slot1)
+
+        let
+          witnessKeys = ac.getWitnessKeys()
+          keyData = witnessKeys.getOrDefault((addr1, slot1.toSlotKey.data))
+        check:
+          witnessKeys.len() == 2
+          keyData.storageSlot == slot1.toBytesBE()
+
+      test "Witness keys - Get account, code and storage":
+        var
+          ac = LedgerRef.init(memDB.baseTxFrame())
+          addr1 = initAddr(1)
+          addr2 = initAddr(2)
+          addr3 = initAddr(3)
+          slot1 = 1.u256
+
+
+        discard ac.getAccount(addr1)
+        discard ac.getCode(addr2)
+        discard ac.getCode(addr1)
+        discard ac.getStorage(addr2, slot1)
+        discard ac.getStorage(addr1, slot1)
+        discard ac.getStorage(addr2, slot1)
+        discard ac.getAccount(addr3)
+
+        let witnessKeys = ac.getWitnessKeys()
+        check witnessKeys.len() == 5
+
+        var keysList = newSeq[(Address, KeyData)]()
+        for k, v in witnessKeys:
+          let (adr, _) = k
+          keysList.add((adr, v))
+
+        check:
+          keysList[0][0] == addr1
+          keysList[0][1].address == addr1
+          keysList[0][1].codeTouched == true
+
+          keysList[1][0] == addr2
+          keysList[1][1].address == addr2
+          keysList[1][1].codeTouched == true
+
+          keysList[2][0] == addr2
+          keysList[2][1].storageSlot == slot1.toBytesBE()
+
+          keysList[3][0] == addr1
+          keysList[3][1].storageSlot == slot1.toBytesBE()
+
+          keysList[4][0] == addr3
+          keysList[4][1].address == addr3
+          keysList[4][1].codeTouched == false
+
+
+
 
 # ------------------------------------------------------------------------------
 # Main function(s)

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -713,44 +713,45 @@ proc runLedgerBasicOperationsTests() =
       check 2.u256 in vals
       check 3.u256 in vals
 
-    test "Test MultiKeys - Set storage":
-      var
-        ac = LedgerRef.init(memDB.baseTxFrame())
-        addr1 = initAddr(1)
+    # TODO: Update these tests
+    # test "Test MultiKeys - Set storage":
+    #   var
+    #     ac = LedgerRef.init(memDB.baseTxFrame())
+    #     addr1 = initAddr(1)
 
-      ac.setStorage(addr1, 1.u256, 1.u256) # Non-zero value
-      ac.setStorage(addr1, 2.u256, 0.u256) # Zero value
+    #   ac.setStorage(addr1, 1.u256, 1.u256) # Non-zero value
+    #   ac.setStorage(addr1, 2.u256, 0.u256) # Zero value
 
-      ac.collectWitnessData()
-      let multikeys = ac.makeMultiKeys().keys
+    #   ac.collectWitnessData()
+    #   let multikeys = ac.makeMultiKeys().keys
 
-      check:
-        multikeys.len() == 1
-        multikeys[0].storageMode == false
-        multikeys[0].address == addr1
-        multikeys[0].storageKeys.keys.len() == 2
-        multikeys[0].storageKeys.keys[0].storageSlot == 2.u256.toBytesBE()
-        multikeys[0].storageKeys.keys[1].storageSlot == 1.u256.toBytesBE()
+    #   check:
+    #     multikeys.len() == 1
+    #     multikeys[0].storageMode == false
+    #     multikeys[0].address == addr1
+    #     multikeys[0].storageKeys.keys.len() == 2
+    #     multikeys[0].storageKeys.keys[0].storageSlot == 2.u256.toBytesBE()
+    #     multikeys[0].storageKeys.keys[1].storageSlot == 1.u256.toBytesBE()
 
-    test "Test MultiKeys - Get storage":
-      var
-        ac = LedgerRef.init(memDB.baseTxFrame())
-        addr1 = initAddr(1)
+    # test "Test MultiKeys - Get storage":
+    #   var
+    #     ac = LedgerRef.init(memDB.baseTxFrame())
+    #     addr1 = initAddr(1)
 
-      ac.setStorage(addr1, 3.u256, 1.u256)
-      discard ac.getStorage(addr1, 3.u256) # Returns non-zero value
-      discard ac.getStorage(addr1, 4.u256) # Returns default zero value
+    #   ac.setStorage(addr1, 3.u256, 1.u256)
+    #   discard ac.getStorage(addr1, 3.u256) # Returns non-zero value
+    #   discard ac.getStorage(addr1, 4.u256) # Returns default zero value
 
-      ac.collectWitnessData()
-      let multikeys = ac.makeMultiKeys().keys
+    #   ac.collectWitnessData()
+    #   let multikeys = ac.makeMultiKeys().keys
 
-      check:
-        multikeys.len() == 1
-        multikeys[0].storageMode == false
-        multikeys[0].address == addr1
-        multikeys[0].storageKeys.keys.len() == 2
-        multikeys[0].storageKeys.keys[0].storageSlot == 4.u256.toBytesBE()
-        multikeys[0].storageKeys.keys[1].storageSlot == 3.u256.toBytesBE()
+    #   check:
+    #     multikeys.len() == 1
+    #     multikeys[0].storageMode == false
+    #     multikeys[0].address == addr1
+    #     multikeys[0].storageKeys.keys.len() == 2
+    #     multikeys[0].storageKeys.keys[0].storageSlot == 4.u256.toBytesBE()
+    #     multikeys[0].storageKeys.keys[1].storageSlot == 3.u256.toBytesBE()
 
 # ------------------------------------------------------------------------------
 # Main function(s)


### PR DESCRIPTION
Changes in this PR:
- Remove existing unused witness keys implementation
- Improve the witness keys implementation by:
  - Using a compile time flag to improve performance when the feature is disabled
  - Using an ordered table to store the keys so we can know the absolute order of state accesses. Duplicates are not added and so the first access for a particular key is what defines it's place in the list.
  - Fixes an existing issue with the previous implementation where touched code of recursive contract calls was not being returned

These changes are needed for the Fluffy async evm implementation in the short term and may also be useful when implementing a stateless Nimbus EL in the future.