### PR TITLE
Remove persistent backend import which was causing rocksdb to be imported when using the in memory db

### DIFF
--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -15,7 +15,7 @@ import
   chronicles,
   eth/common/[accounts_rlp, base_rlp, hashes_rlp],
   results,
-  "."/[aristo_desc, aristo_get, aristo_tx_frame, aristo_walk/persistent],
+  "."/[aristo_desc, aristo_get, aristo_tx_frame],
   ./aristo_desc/desc_backend
 
 type WriteBatch = tuple[writer: PutHdlRef, count: int, depth: int, prefix: uint64]


### PR DESCRIPTION
When using `DefaultDbMemory.newCoreDbRef()` we shouldn't need to import rocksdb because we are only using the in memory database. This fixes the issue so that the persistent backend is no longer imported when we only use the in memory db.

