### PR TITLE
Beacon sync handle widely varying block sizes

### DIFF
--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -339,13 +339,13 @@ type
       desc: "Number of worker threads (\"0\" = use as many threads as there are CPU cores available)"
       name: "num-threads" .}: int
 
-    beaconSyncScrumFile* {.
+    beaconSyncTargetFile* {.
       hidden
       desc: "Load a file containg an rlp-encoded object \"(Header,Hash32)\" " &
             "to be used " &
-            "as the first scrum target before any other request from the CL " &
-            " is accepted"
-      name: "debug-beacon-sync-scrum-file" .}: Option[InputFile]
+            "as the first target before any other request from the CL " &
+            "is accepted"
+      name: "debug-beacon-sync-target-file" .}: Option[InputFile]
 
     beaconSyncBlocksQueueHwm* {.
       hidden

--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -349,7 +349,7 @@ type
 
     beaconSyncBlocksQueueHwm* {.
       hidden
-      desc: "Limit number of blocks on staging queue for beacon sync"
+      desc: "Limit memory size of the staged block queue for beacon sync"
       defaultValue: 0
       name: "debug-beacon-sync-blocks-queue-hwm" .}: int
 

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -110,8 +110,8 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf,
     nimbus.ethNode, nimbus.fc, conf.maxPeers, conf.beaconSyncBlocksQueueHwm)
 
   # Optional for pre-setting the sync target (i.e. debugging)
-  if conf.beaconSyncScrumFile.isSome():
-    nimbus.beaconSyncRef.scrumInit conf.beaconSyncScrumFile.unsafeGet.string
+  if conf.beaconSyncTargetFile.isSome():
+    nimbus.beaconSyncRef.targetInit conf.beaconSyncTargetFile.unsafeGet.string
 
   # Connect directly to the static nodes
   let staticPeers = conf.getStaticPeers()

--- a/execution_chain/sync/beacon.nim
+++ b/execution_chain/sync/beacon.nim
@@ -70,9 +70,9 @@ proc init*(
   desc.ctx.pool.chain = chain
   desc
 
-proc scrumInit*(desc: BeaconSyncRef; rlpFile: string) =
+proc targetInit*(desc: BeaconSyncRef; rlpFile: string) =
   ## Set up inital sprint (intended for debugging)
-  desc.ctx.initalScrumFromFile(rlpFile, "scrumInit").isOkOr:
+  desc.ctx.initalTargetFromFile(rlpFile, "targetInit").isOkOr:
     raiseAssert error
 
 proc start*(desc: BeaconSyncRef): bool =

--- a/execution_chain/sync/beacon.nim
+++ b/execution_chain/sync/beacon.nim
@@ -66,7 +66,7 @@ proc init*(
       ): T =
   var desc = T()
   desc.initSync(ethNode, maxPeers)
-  desc.ctx.pool.blkStagedHwm = blockQueueHwm
+  desc.ctx.pool.blkStagedWeightHwm = blockQueueHwm
   desc.ctx.pool.chain = chain
   desc
 

--- a/execution_chain/sync/beacon/worker.nim
+++ b/execution_chain/sync/beacon/worker.nim
@@ -86,24 +86,25 @@ proc start*(buddy: BeaconBuddyRef; info: static[string]): bool =
     if not ctx.hibernate: debug info & ": failed", peer
     return false
 
-  if not ctx.hibernate: debug info & ": new peer", peer
+  if not ctx.hibernate: debug info & ": new peer",
+    peer, nSyncPeers=buddy.ctx.pool.nBuddies
   true
 
 proc stop*(buddy: BeaconBuddyRef; info: static[string]) =
   ## Clean up this peer
   if not buddy.ctx.hibernate: debug info & ": release peer", peer=buddy.peer,
-    ctrl=buddy.ctrl.state, nLaps=buddy.only.nMultiLoop,
-    lastIdleGap=buddy.only.multiRunIdle.toStr
+    ctrl=buddy.ctrl.state, nSyncPeers=buddy.ctx.pool.nBuddies,
+    nLaps=buddy.only.nMultiLoop, lastIdleGap=buddy.only.multiRunIdle.toStr
   buddy.stopBuddy()
 
 # --------------------
 
-proc initalScrumFromFile*(
+proc initalTargetFromFile*(
     ctx: BeaconCtxRef;
     file: string;
     info: static[string];
       ): Result[void,string] =
-  ## Set up inital sprint from argument file (itended for debugging)
+  ## Set up inital target from argument file (itended for debugging)
   var
     mesg: SyncClMesg
   try:

--- a/execution_chain/sync/beacon/worker/blocks_staged.nim
+++ b/execution_chain/sync/beacon/worker/blocks_staged.nim
@@ -321,8 +321,10 @@ proc blocksStagedCollect*(
   if not haveError:
     buddy.only.nBdyProcErrors = 0
 
-  info "Downloaded blocks", iv=blk.blocks.bnStr,
-    nBlocks=blk.blocks.len, nStaged=ctx.blk.staged.len,
+  info "Downloaded blocks", peer, iv=blk.blocks.bnStr, nBlocks=blk.blocks.len,
+    nStaged=ctx.blk.staged.len.uint.toSI,
+    estimStagedSize=ctx.blk.weight.uint.toSI,
+    stagedSizeHwm=ctx.pool.blkStagedWeightHwm.uint.toSI,
     nSyncPeers=ctx.pool.nBuddies
 
   return true

--- a/execution_chain/sync/beacon/worker/blocks_staged/staged_queue.nim
+++ b/execution_chain/sync/beacon/worker/blocks_staged/staged_queue.nim
@@ -27,13 +27,16 @@ func blocksStagedQueueLen*(ctx: BeaconCtxRef): int =
 
 func blocksStagedQueueIsEmpty*(ctx: BeaconCtxRef): bool =
   ## `true` iff no data are on the queue.
-  ctx.blk.staged.len == 0
+  if ctx.blk.staged.len == 0:
+    doAssert ctx.blk.weight == 0
+    return true
 
 # ----------------
 
 func blocksStagedQueueClear*(ctx: BeaconCtxRef) =
   ## Clear queue
-  ctx.blk.staged.clear
+  ctx.blk.staged.clear()
+  ctx.blk.weight = 0
 
 func blocksStagedQueueInit*(ctx: BeaconCtxRef) =
   ## Constructor

--- a/execution_chain/sync/beacon/worker/helpers.nim
+++ b/execution_chain/sync/beacon/worker/helpers.nim
@@ -16,10 +16,11 @@ import
   pkg/chronos,
   pkg/eth/common,
   pkg/stew/interval_set,
+  ../../../utils/prettify,
   ../../../utils/utils
 
 export
-  short
+  prettify, short
 
 func bnStr*(w: BlockNumber): string =
   "#" & $w

--- a/execution_chain/sync/beacon/worker/start_stop.nim
+++ b/execution_chain/sync/beacon/worker/start_stop.nim
@@ -81,11 +81,11 @@ proc setupDatabase*(ctx: BeaconCtxRef; info: static[string]) =
   # objects.
   let hwm = if blocksStagedLwm <= ctx.pool.blkStagedHwm: ctx.pool.blkStagedHwm
             else: blocksStagedHwmDefault
-  ctx.pool.blkStagedLenHwm = (hwm + nFetchBodiesBatch - 1) div nFetchBodiesBatch
+  ctx.pool.blkStagedWeightHwm = hwm * (fetchBodiesReqMinAvgBodySize + 1024)
 
   # Set blocks batch import queue size
   if ctx.pool.blkStagedHwm != 0:
-    debug info & ": import block lists queue", limit=ctx.pool.blkStagedLenHwm
+    debug info & ": import block lists queue", limit=ctx.pool.blkStagedWeightHwm
   ctx.pool.blkStagedHwm = hwm
 
 

--- a/execution_chain/sync/beacon/worker/start_stop.nim
+++ b/execution_chain/sync/beacon/worker/start_stop.nim
@@ -75,18 +75,9 @@ proc setupDatabase*(ctx: BeaconCtxRef; info: static[string]) =
   # into `ForkedChainRef` (i.e. `ctx.pool.chain`.)
   ctx.pool.hdrCache = ForkedCacheRef.init(ctx.pool.chain)
 
-  # Take it easy and assume that queue records contain full block list (which
-  # is mostly the case anyway.) So the the staging queue is limited by the
-  # number of sub-list records rather than the number of accumulated block
-  # objects.
-  let hwm = if blocksStagedLwm <= ctx.pool.blkStagedHwm: ctx.pool.blkStagedHwm
-            else: blocksStagedHwmDefault
-  ctx.pool.blkStagedWeightHwm = hwm * (fetchBodiesReqMinAvgBodySize + 1024)
-
-  # Set blocks batch import queue size
-  if ctx.pool.blkStagedHwm != 0:
-    debug info & ": import block lists queue", limit=ctx.pool.blkStagedWeightHwm
-  ctx.pool.blkStagedHwm = hwm
+  # Initialise block queue size limit
+  if ctx.pool.blkStagedWeightHwm < blocksStagedWeightLwm:
+    ctx.pool.blkStagedWeightHwm = blocksStagedWeightHwmDefault
 
 
 proc setupServices*(ctx: BeaconCtxRef; info: static[string]) =

--- a/execution_chain/sync/beacon/worker/update/ticker.nim
+++ b/execution_chain/sync/beacon/worker/update/ticker.nim
@@ -21,7 +21,6 @@ when enableTicker:
     pkg/[stint, stew/interval_set],
     ../headers_staged/staged_queue,
     ../blocks_staged/staged_queue,
-    ../../../../utils/prettify,
     ../helpers,
     ../[blocks_unproc, headers_unproc]
 

--- a/execution_chain/sync/beacon/worker_config.nim
+++ b/execution_chain/sync/beacon/worker_config.nim
@@ -111,7 +111,7 @@ const
     ## Similar to `nFetchHeadersRequest`
 
   fetchBodiesReqErrThresholdZombie* = chronos.seconds(4)
-  fetchBodiesReqErrThresholdCount* = 2
+  fetchBodiesReqErrThresholdCount* = 3
     ## Similar to `fetchHeadersReqThreshold*`
 
   fetchBodiesProcessErrThresholdCount* = 2
@@ -119,6 +119,11 @@ const
 
   fetchBodiesReqMinResponsePC* = 10
     ## Similar to `fetchHeadersReqMinResponsePC`
+
+  fetchBodiesReqMinAvgBodySize* = 90 * 1024
+    ## Calculatory body size to figure out the minimum expected response size
+    ## when applying `fetchBodiesReqMinResponsePC`. On `mainnet`, an average
+    ## body size of 90KiB/block is typical at block height ~#22m.
 
   nFetchBodiesBatch* = 3 * nFetchBodiesRequest
     ## Similar to `nFetchHeadersBatch`

--- a/execution_chain/sync/beacon/worker_config.nim
+++ b/execution_chain/sync/beacon/worker_config.nim
@@ -138,7 +138,9 @@ const
     ##
     ## If the staged block queue exceeds this many number of block objects for
     ## import, no further block objets are added (but the current sub-list is
-    ## completed.)
+    ## completed.) This again is used relative to the average block size. So
+    ## the data size to work with assuming data blocks `(i.e. header+body)`
+    ## is `blocksStagedHwmDefault * (fetchBodiesReqMinAvgBodySize+1024)`.
 
   blocksStagedLwm* = nFetchBodiesBatch
     ## Minimal accepted initialisation value for `blocksStagedHwm`. The latter

--- a/execution_chain/sync/beacon/worker_config.nim
+++ b/execution_chain/sync/beacon/worker_config.nim
@@ -126,10 +126,12 @@ const
     ## body size of 90KiB/block is typical at block height ~#22m.
 
   nFetchBodiesBatch* = 3 * nFetchBodiesRequest
-    ## Similar to `nFetchHeadersBatch`
+    ## Similar to `nFetchHeadersBatch`, this limits the record size of the
+    ## the blocks queue.
     ##
-    ## With an average less than 90KiB/block (on `mainnet` at block ~#22m),
-    ## one arrives at a total of at most 35MiB per block batch.
+    ## Similar to the minimum expected response size, the block count argument
+    ## is translated into the calculatory data size of a block (i.e.
+    ## header+body), `nFetchBodiesBatch * (fetchBodiesReqMinAvgBodySize+1024)`.
 
   blocksStagedHwmDefault* = 8 * nFetchBodiesBatch
     ## This is an initialiser value for `blocksStagedHwm`.

--- a/execution_chain/sync/beacon/worker_config.nim
+++ b/execution_chain/sync/beacon/worker_config.nim
@@ -133,20 +133,23 @@ const
     ## is translated into the calculatory data size of a block (i.e.
     ## header+body), `nFetchBodiesBatch * (fetchBodiesReqMinAvgBodySize+1024)`.
 
-  blocksStagedHwmDefault* = 8 * nFetchBodiesBatch
-    ## This is an initialiser value for `blocksStagedHwm`.
+  blocksStagedWeightHwmDefault* =
+      8 * nFetchBodiesBatch * fetchBodiesReqMinAvgBodySize
+    ## This is an initialiser value for `blocksStagedWeightHwm`.
     ##
-    ## If the staged block queue exceeds this many number of block objects for
-    ## import, no further block objets are added (but the current sub-list is
-    ## completed.) This again is used relative to the average block size. So
-    ## the data size to work with assuming data blocks `(i.e. header+body)`
-    ## is `blocksStagedHwmDefault * (fetchBodiesReqMinAvgBodySize+1024)`.
+    ## If the accumulated size of staged block queue exceeds this data size,
+    ## no further block objects are added.
+    ##
+    ## The calculation of block sizes uses rlp based estimates. So it is
+    ## called weight rather than size (where the latter suggest somewhat more
+    ## accurateness.)
 
-  blocksStagedLwm* = nFetchBodiesBatch
-    ## Minimal accepted initialisation value for `blocksStagedHwm`. The latter
-    ## will be initalised with `blocksStagedHwmDefault` if smaller than the LWM.
+  blocksStagedWeightLwm* = nFetchBodiesBatch * fetchBodiesReqMinAvgBodySize
+    ## Minimal accepted initialisation value for `blocksStagedWeihgtHwm`. The
+    ## latter will be initalised with `blocksStagedHwmDefault` if smaller than
+    ## the LWM.
 
-  finaliserChainLengthMax* = 32 # -- to be obsoleted soon
+  finaliserChainLengthMax* = 32
     ## When importing with `importBlock()`, finalise after at most this many
     ## invocations of `importBlock()`.
 
@@ -162,7 +165,7 @@ static:
 
   doAssert 0 < nFetchBodiesRequest
   doAssert nFetchBodiesRequest <= nFetchBodiesBatch
-  doAssert 0 < blocksStagedLwm
-  doAssert blocksStagedLwm <= blocksStagedHwmDefault
+  doAssert 0 < blocksStagedWeightLwm
+  doAssert blocksStagedWeightLwm <= blocksStagedWeightHwmDefault
 
 # End

--- a/execution_chain/sync/beacon/worker_desc.nim
+++ b/execution_chain/sync/beacon/worker_desc.nim
@@ -115,6 +115,7 @@ type
     unprocessed*: BnRangeSet         ## Blocks download requested
     borrowed*: BnRangeSet            ## Fetched/locked fetched ranges
     staged*: StagedBlocksQueue       ## Blocks ready for import
+    weight*: int                     ## Accumulated `staged` weights
 
   # -------------------
 
@@ -144,7 +145,7 @@ type
     # Blocks import/execution settings
     blkImportOk*: bool               ## Don't fetch data while block importing
     blkStagedHwm*: int               ## Set a `staged` queue limit
-    blkStagedLenHwm*: int            ## Figured out as # staged records
+    blkStagedWeightHwm*: int         ## Translated to the data size
 
     # Info, debugging, and error handling stuff
     nReorg*: int                     ## Number of reorg invocations (info only)

--- a/execution_chain/sync/beacon/worker_desc.nim
+++ b/execution_chain/sync/beacon/worker_desc.nim
@@ -49,6 +49,7 @@ type
   BlocksForImport* = object
     ## Block request item sorted by least block number (i.e. from `blocks[0]`.)
     blocks*: seq[EthBlock]           ## List of blocks for import
+    weight*: int                     ## Calculatory size of this record
 
   # -------------------
 

--- a/execution_chain/sync/beacon/worker_desc.nim
+++ b/execution_chain/sync/beacon/worker_desc.nim
@@ -144,8 +144,7 @@ type
 
     # Blocks import/execution settings
     blkImportOk*: bool               ## Don't fetch data while block importing
-    blkStagedHwm*: int               ## Set a `staged` queue limit
-    blkStagedWeightHwm*: int         ## Translated to the data size
+    blkStagedWeightHwm*: int         ## Block queue size threshold
 
     # Info, debugging, and error handling stuff
     nReorg*: int                     ## Number of reorg invocations (info only)


### PR DESCRIPTION
Needed to run on panda/devnet-6