### PR TITLE
Fluffy: Create a top level wrapper type to hold all running services

### DIFF
--- a/fluffy/portal_node.nim
+++ b/fluffy/portal_node.nim
@@ -25,11 +25,6 @@ export
   beacon_light_client, history_network, state_network, portal_protocol_config, forks
 
 type
-  PortalNodeStatus* = enum
-    Starting
-    Running
-    Stopping
-
   PortalNodeConfig* = object
     accumulatorFile*: Opt[string]
     disableStateRootValidation*: bool
@@ -40,7 +35,6 @@ type
     contentRequestRetries*: int
 
   PortalNode* = ref object
-    status*: PortalNodeStatus
     discovery: protocol.Protocol
     contentDB: ContentDB
     streamManager: StreamManager
@@ -227,8 +221,6 @@ proc start*(n: PortalNode) =
     n.beaconLightClient.value.start()
 
   n.statusLogLoop = statusLogLoop(n)
-
-  n.status = PortalNodeStatus.Running
 
 proc stop*(n: PortalNode) {.async: (raises: []).} =
   debug "Stopping Portal node"


### PR DESCRIPTION
This is a minor refactor to improve the structure of some of the code related to startup and shutdown. 

Changes in this PR::
- Removed the status field from PortalNode.
- Created a new wrapper type to hold all the running services.
- Added the status field to the new wrapper type.
- Implement shutdown function.