### PR TITLE
docs: update broken link

### DIFF
--- a/fluffy/network/wire/README.md
+++ b/fluffy/network/wire/README.md
@@ -1,7 +1,7 @@
 # Portal Network Wire Protocol
 ## Introduction
 The `fluffy/network/wire` directory holds a Nim implementation of the
-[Portal Network Wire Protocol](https://github.com/ethereum/portal-network-specs/blob/master/state-network.md#wire-protocol).
+[Portal Network Wire Protocol](https://github.com/ethereum/portal-network-specs/blob/master/state/state-network.md#wire-protocol).
 
 The wire protocol builds on top of the Node Discovery v5.1 protocol its
 `talkreq` and `talkresp` messages.


### PR DESCRIPTION
Hi! I fixed a broken link in the `fluffy/network/wire/README.md` file. The link to the `Portal Network Wire Protocol` documentation was outdated and pointed to an incorrect path.