### PR TITLE
Clean `lastSnapshots` when finalizing

### DIFF
--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -161,7 +161,7 @@ proc newPayload*(ben: BeaconEngineRef,
 
   # If we already have the block locally, ignore the entire execution and just
   # return a fake success.
-  if ben.chain.haveBlockLocally(blockHash):
+  if ben.chain.haveBlockAndState(blockHash):
     warn "Ignoring already known beacon payload",
       number = header.number, hash = blockHash.short
     return validStatus(blockHash)

--- a/execution_chain/core/chain/forked_chain/chain_desc.nim
+++ b/execution_chain/core/chain/forked_chain/chain_desc.nim
@@ -34,7 +34,8 @@ type
     extraValidation*: bool
     baseDistance*: uint64
 
-    lastSnapshots*: Deque[CoreDbTxRef]
+    lastSnapshots*: array[10, CoreDbTxRef]
+    lastSnapshotPos*: int
 # ----------------
 
 func txRecords*(c: ForkedChainRef): var Table[Hash32, (Hash32, uint64)] =


### PR DESCRIPTION
When cleaning snapshots, it may happen that frames have already been written (via base updates) leading to a crash when trying to clean up their snapshot - `deques` doesn't readily support removing items in the middle so use a circular buffer instead.

Also fixes an issue where a partial database write may lead to a "future" block header turning up in the database - when this happens, we don't have an in-memory state that can be advanced and the next block will fail to apply. Most likely, this happens because of how the syncer shortcuts txframe updates when writing headers, which in and of itself is a problem that needs a proper solution - in the meantime however, checking that the state exists allows recovering from such an inconsistent database.