### PR TITLE
Fluffy: Make portal evm backend configurable

### DIFF
--- a/fluffy/evm/portal_evm.nim
+++ b/fluffy/evm/portal_evm.nim
@@ -106,19 +106,13 @@ proc init*(
     accProc: GetAccountProc,
     storageProc: GetStorageProc,
     codeProc: GetCodeProc,
+    networkId: NetworkId = MainNet,
 ): T =
-  let config =
-    try:
-      networkParams(MainNet).config
-    except ValueError as e:
-      raiseAssert(e.msg) # Should not fail
-    except RlpError as e:
-      raiseAssert(e.msg) # Should not fail
 
   let com = CommonRef.new(
     DefaultDbMemory.newCoreDbRef(),
     taskpool = nil,
-    config = config,
+    config = chainConfigForNetwork(networkId),
     initializeDb = false,
   )
 

--- a/fluffy/rpc/rpc_debug_api.nim
+++ b/fluffy/rpc/rpc_debug_api.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/fluffy/rpc/rpc_debug_api.nim
+++ b/fluffy/rpc/rpc_debug_api.nim
@@ -79,10 +79,10 @@ proc installDebugApiHandlers*(rpcServer: RpcServer, stateNetwork: Opt[StateNetwo
 
     let
       sn = stateNetwork.getOrRaise()
-      bytecode = (await sn.getCodeByStateRoot(stateRoot, address)).valueOr:
+      code = (await sn.getCodeByStateRoot(stateRoot, address)).valueOr:
         raise newException(ValueError, "Unable to get code")
 
-    return bytecode.asSeq()
+    return code
 
   rpcServer.rpc("debug_getProofByStateRoot") do(
     address: Address, slots: seq[UInt256], stateRoot: Hash32

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -152,7 +152,7 @@ proc installEthApiHandlers*(
             stateNetwork.get().getStorageAtByStateRoot(stateRoot, address, slotKey),
           proc(
               stateRoot: Hash32, address: Address
-          ): Future[Opt[Bytecode]] {.async: (raw: true, raises: [CancelledError]).} =
+          ): Future[Opt[seq[byte]]] {.async: (raw: true, raises: [CancelledError]).} =
             stateNetwork.get().getCodeByStateRoot(stateRoot, address),
         )
       )
@@ -396,9 +396,9 @@ proc installEthApiHandlers*(
     let
       sn = stateNetwork.getOrRaise()
       blockNumber = quantityTag.number.uint64
-      bytecode = (await sn.getCode(blockNumber, data)).valueOr:
+      code = (await sn.getCode(blockNumber, data)).valueOr:
         raise newException(ValueError, "Unable to get code")
-    return bytecode.asSeq()
+    return code
 
   rpcServer.rpc("eth_getProof") do(
     data: Address, slots: seq[UInt256], quantityTag: RtBlockIdentifier

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -128,7 +128,8 @@ template getOrRaise(stateNetwork: Opt[StateNetwork]): StateNetwork =
 
 template getOrRaise(portalEvm: Opt[PortalEvm]): PortalEvm =
   let evm = portalEvm.valueOr:
-    raise newException(ValueError, "portal evm not enabled")
+    raise
+      newException(ValueError, "portal evm requires state sub-network to be enabled")
   evm
 
 proc installEthApiHandlers*(
@@ -138,8 +139,23 @@ proc installEthApiHandlers*(
     stateNetwork: Opt[StateNetwork],
 ) =
   let portalEvm =
-    if historyNetwork.isSome() and stateNetwork.isSome():
-      Opt.some(PortalEvm.init(historyNetwork.get(), stateNetwork.get()))
+    if stateNetwork.isSome():
+      Opt.some(
+        PortalEvm.init(
+          proc(
+              stateRoot: Hash32, address: Address
+          ): Future[Opt[Account]] {.async: (raw: true, raises: [CancelledError]).} =
+            stateNetwork.get().getAccount(stateRoot, address),
+          proc(
+              stateRoot: Hash32, address: Address, slotKey: UInt256
+          ): Future[Opt[UInt256]] {.async: (raw: true, raises: [CancelledError]).} =
+            stateNetwork.get().getStorageAtByStateRoot(stateRoot, address, slotKey),
+          proc(
+              stateRoot: Hash32, address: Address
+          ): Future[Opt[Bytecode]] {.async: (raw: true, raises: [CancelledError]).} =
+            stateNetwork.get().getCodeByStateRoot(stateRoot, address),
+        )
+      )
     else:
       Opt.none(PortalEvm)
 
@@ -444,13 +460,14 @@ proc installEthApiHandlers*(
 
     let
       hn = historyNetwork.getOrRaise()
-      sn = stateNetwork.getOrRaise()
       evm = portalEvm.getOrRaise()
+      header = (await hn.getVerifiedBlockHeader(quantityTag.number.uint64)).valueOr:
+        raise newException(ValueError, "Unable to get block header")
 
     let callResult = (
       await evm.call(
+        header,
         tx,
-        quantityTag.number.uint64,
         if optimisticStateFetch.isNone():
           true
         else:

--- a/fluffy/tests/state_network_tests/test_state_endpoints_genesis.nim
+++ b/fluffy/tests/state_network_tests/test_state_endpoints_genesis.nim
@@ -157,7 +157,7 @@ suite "State Endpoints - Genesis JSON Files":
           # get code of existing account
           let codeRes = await stateNode.stateNetwork.getCode(blockNumber, address)
           check:
-            codeRes.get().asSeq() == account.code
+            codeRes.get() == account.code
 
           let storageState = storageStates.getOrDefault(address)
           for slotKey, slotValue in account.storage:
@@ -177,7 +177,7 @@ suite "State Endpoints - Genesis JSON Files":
             slotRes1 =
               await stateNode.stateNetwork.getStorageAt(blockNumber, address, 1.u256)
           check:
-            codeRes.get().asSeq().len() == 0
+            codeRes.get().len() == 0
             slotRes0.get() == 0.u256
             slotRes1.get() == 0.u256
 
@@ -197,7 +197,7 @@ suite "State Endpoints - Genesis JSON Files":
         check:
           balanceRes.get() == 0.u256
           nonceRes.get() == 0.uint64
-          codeRes.get().asSeq().len() == 0
+          codeRes.get().len() == 0
           slotRes.get() == 0.u256
 
     await stateNode.stop()

--- a/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
+++ b/fluffy/tests/state_network_tests/test_state_endpoints_vectors.nim
@@ -273,7 +273,7 @@ procSuite "State Endpoints":
           addresses.Address.fromHex("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
         badAddress =
           addresses.Address.fromHex("0xbadaaa39b223fe8d0a0e5c4f27ead9083c756cc2")
-        expectedCode = contentValue.code
+        expectedCode = contentValue.code.asSeq()
 
         codeRes = await stateNode2.stateNetwork.getCode(contentValue.blockHash, address)
         badCodeRes =


### PR DESCRIPTION
Changes in this PR:
- Portal evm no longer depends on history network or state network.
- The functions used to fetch state are now configurable (getAccountProc, getStorageProc, getCodeProc). 
- The block header is now passed in as a parameter to the call function.

This allows the portal async evm to be re-used in the Nimbus Verified Proxy and also makes unit testing easier because the state and header data can be fetched from another location other than portal.