### PR TITLE
Add transaction size limit to txpool

### DIFF
--- a/execution_chain/core/tx_pool/tx_item.nim
+++ b/execution_chain/core/tx_pool/tx_item.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/execution_chain/core/tx_pool/tx_item.nim
+++ b/execution_chain/core/tx_pool/tx_item.nim
@@ -37,6 +37,7 @@ type
     txErrorSenderMaxTxs
     txErrorTxInvalid
     txErrorChainIdMismatch
+    txErrorOversized
 
   TxItemRef* = ref object
     ptx   : PooledTransaction  ## Transaction data


### PR DESCRIPTION
Discovered during testing with hive devp2p/eth wire protocol simulator.