### PR TITLE
Extend frame shapshot to leaf caches

### DIFF
--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -73,10 +73,9 @@ type
 
     blockNumber*: Opt[uint64]              ## Block number set when checkpointing the frame
 
-    snapshot*: Table[RootedVertexID, Snapshot]
+    snapshot*: Snapshot
       ## Optional snapshot containing the cumulative changes from ancestors and
       ## the current frame
-    snapshotLevel*: Opt[int] # base level when the snapshot was taken
 
     level*: int
       ## Ancestry level of frame, increases with age but otherwise meaningless -
@@ -84,7 +83,13 @@ type
       ## -1 = stored in database, where relevant though typically should be
       ## compared with the base layer level instead.
 
-  Snapshot* = (VertexRef, HashKey, int)
+  Snapshot* = object
+    vtx*: Table[RootedVertexID, VtxSnapshot]
+    acc*: Table[Hash32, (VertexRef, int)]
+    sto*: Table[Hash32, (VertexRef, int)]
+    level*: Opt[int] # when this snapshot was taken
+
+  VtxSnapshot* = (VertexRef, HashKey, int)
     ## Unlike sTab/kMap, snapshot contains both vertex and key since at the time
     ## of writing, it's primarily used in contexts where both are present
 
@@ -212,7 +217,7 @@ iterator rstack*(tx: AristoTxRef, stopAtSnapshot = false): AristoTxRef =
   while tx != nil:
     yield tx
 
-    if stopAtSnapshot and tx.snapshotLevel.isSome():
+    if stopAtSnapshot and tx.snapshot.level.isSome():
       break
 
     tx = tx.parent

--- a/execution_chain/db/aristo/aristo_init/init_common.nim
+++ b/execution_chain/db/aristo/aristo_init/init_common.nim
@@ -83,7 +83,7 @@ proc finishSession*(hdl: TypedPutHdlRef; db: TypedBackendRef) =
 
 proc initInstance*(db: AristoDbRef): Result[void, AristoError] =
   let vTop = ?db.getTuvFn()
-  db.txRef = AristoTxRef(db: db, vTop: vTop, snapshotLevel: Opt.some(0))
+  db.txRef = AristoTxRef(db: db, vTop: vTop, snapshot: Snapshot(level: Opt.some(0)))
   db.accLeaves = LruCache[Hash32, VertexRef].init(ACC_LRU_SIZE)
   db.stoLeaves = LruCache[Hash32, VertexRef].init(ACC_LRU_SIZE)
   ok()


### PR DESCRIPTION
Leaf lookups make up the bulk of vertex loading, so might as well provide snapshot coverage for them as well as the time spent iterating over layers currently makes up 30% of all leaf lookup time.