### PR TITLE
Fix FC updateHead/updateFinalized

### DIFF
--- a/execution_chain/beacon/api_handler/api_forkchoice.nim
+++ b/execution_chain/beacon/api_handler/api_forkchoice.nim
@@ -159,14 +159,13 @@ proc forkchoiceUpdated*(ben: BeaconEngineRef,
 
   # If the beacon client also advertised a finalized block, mark the local
   # chain final and completely in PoS mode.
-  let baseTxFrame = ben.chain.baseTxFrame
   let finalizedBlockHash = update.finalizedBlockHash
   if finalizedBlockHash != zeroHash32:
     if not ben.chain.equalOrAncestorOf(finalizedBlockHash, headHash):
       warn "Final block not in canonical tree",
         hash=finalizedBlockHash.short
       raise invalidForkChoiceState("finalized block not in canonical tree")
-    baseTxFrame.finalizedHeaderHash(finalizedBlockHash)
+    # similar to headHash, finalizedBlockHash is saved by FC module
 
   let safeBlockHash = update.safeBlockHash
   if safeBlockHash != zeroHash32:
@@ -174,7 +173,10 @@ proc forkchoiceUpdated*(ben: BeaconEngineRef,
       warn "Safe block not in canonical tree",
         hash=safeBlockHash.short
       raise invalidForkChoiceState("safe block not in canonical tree")
-    baseTxFrame.safeHeaderHash(safeBlockHash)
+    # Current version of FC module is not interested in safeBlockHash
+    # so we save it here
+    let txFrame = ben.chain.txFrame(safeBlockHash)
+    txFrame.safeHeaderHash(safeBlockHash)
 
   chain.forkChoice(headHash, update.finalizedBlockHash).isOkOr:
     return invalidFCU(error, chain, header)

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -213,7 +213,7 @@ proc newPayload*(ben: BeaconEngineRef,
     let blockHash = latestValidHash(txFrame, parent, ttd)
     return acceptedStatus(blockHash)
 
-  trace "Inserting block without sethead",
+  trace "Importing block without sethead",
     hash = blockHash, number = header.number
   let vres = ben.chain.importBlock(blk)
   if vres.isErr:

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -276,21 +276,6 @@ proc persistTransactions*(
       trace info, blockKey, error=($$error)
       return
 
-proc forgetHistory*(
-    db: CoreDbTxRef;
-    blockNum: BlockNumber;
-      ): bool =
-  ## Remove all data related to the block number argument `num`. This function
-  ## returns `true`, if some history was available and deleted.
-  let blockHash = db.getBlockHash(blockNum).valueOr:
-    return false
-
-  # delete blockNum->blockHash
-  discard db.del(blockNumberToHashKey(blockNum).toOpenArray)
-  # delete blockHash->header, stateRoot->blockNum
-  discard db.del(genericHashKey(blockHash).toOpenArray)
-  true
-
 proc getTransactionByIndex*(
     db: CoreDbTxRef;
     txRoot: Hash32;
@@ -476,7 +461,7 @@ proc getTransactionKey*(
         return ok(default(TransactionKey))
     return ok(rlp.decode(tx, TransactionKey))
 
-proc headerExists*(db: CoreDbTxRef; blockHash: Hash32): bool =
+proc headerExists(db: CoreDbTxRef; blockHash: Hash32): bool =
   ## Returns True if the header with the given block hash is in our DB.
   db.hasKeyRc(genericHashKey(blockHash).toOpenArray).valueOr:
     if error.error != KvtNotFound:
@@ -529,7 +514,7 @@ proc getReceipts*(
       receipts.add(r)
     return ok(receipts)
 
-proc persistScore*(
+proc persistScore(
     db: CoreDbTxRef;
     blockHash: Hash32;
     score: UInt256


### PR DESCRIPTION
A preparation for #3002

This is a piece of break up from bigger FC module fix. Easier for reviewer. Basically this is a fix based on this paragraph:

> that head update, it should not be written to the base txframe but rather to the txframe of the block being selected has head - same for finalized etc, they should always go into the same frame as the block that gets selected so that when we write the base to disk, we don't accidentally write a head hash that is not yet on disk