### PR TITLE
aristo: simplify delete errors

### DIFF
--- a/execution_chain/db/aristo/aristo_delete.nim
+++ b/execution_chain/db/aristo/aristo_delete.nim
@@ -73,10 +73,8 @@ proc deleteImpl(
     nbl = br.vtx.branchStillNeeded(hike.legs[^2].nibble).valueOr:
       return err(DelBranchWithoutRefs)
 
-  # Clear all Merkle hash keys up to the root key
-  for n in 0 .. hike.legs.len - 2:
-    let wp = hike.legs[n].wp
-    db.layersResKey((hike.root, wp.vid), wp.vtx)
+  # Clear keys that include `br` - `br` itself will be replaced below
+  db.layersResKeys(hike, skip = 2)
 
   if 0 <= nbl:
     # Branch has only one entry - move that entry to where the branch was and
@@ -130,19 +128,19 @@ proc deleteAccountRecord*(
     accPath: Hash32;
       ): Result[void,AristoError] =
   ## Delete the account leaf entry addressed by the argument `path`. If this
-  ## leaf entry referres to a storage tree, this one will be deleted as well.
+  ## leaf entry references a storage tree, this one will be deleted as well.
   ##
   var accHike: Hike
   db.fetchAccountHike(accPath, accHike).isOkOr:
     if error == FetchAccInaccessible:
-      return err(DelPathNotFound)
+      return ok() # Trying to delete something that doesn't exist is ok
     return err(error)
   let
     stoID = accHike.legs[^1].wp.vtx.lData.stoID
 
   # Delete storage tree if present
   if stoID.isValid:
-    ? db.delStoTreeImpl((stoID.vid, stoID.vid), accPath)
+    ? db.delStoTreeImpl(stoID.vid, accPath)
 
   let otherLeaf = ?db.deleteImpl(accHike)
 
@@ -159,13 +157,12 @@ proc deleteStorageData*(
     db: AristoTxRef;
     accPath: Hash32;          # Implies storage data tree
     stoPath: Hash32;
-      ): Result[bool,AristoError] =
+      ): Result[void,AristoError] =
   ## For a given account argument `accPath`, this function deletes the
   ## argument `stoPath` from the associated storage tree (if any, at all.) If
   ## the if the argument `stoPath` deleted was the last one on the storage tree,
   ## account leaf referred to by `accPath` will be updated so that it will
-  ## not refer to a storage tree anymore. In the latter case only the function
-  ## will return `true`.
+  ## not refer to a storage tree anymore.
   ##
 
   let
@@ -173,12 +170,12 @@ proc deleteStorageData*(
     stoLeaf = db.cachedStoLeaf(mixPath)
 
   if stoLeaf == Opt.some(nil):
-    return err(DelPathNotFound)
+    return ok() # Trying to delete something that doesn't exist is ok
 
   var accHike: Hike
   db.fetchAccountHike(accPath, accHike).isOkOr:
     if error == FetchAccInaccessible:
-      return err(DelStoAccMissing)
+      return ok() # Trying to delete something that doesn't exist is ok
     return err(error)
 
   let
@@ -186,17 +183,17 @@ proc deleteStorageData*(
     stoID = wpAcc.vtx.lData.stoID
 
   if not stoID.isValid:
-    return err(DelStoRootMissing)
+    return ok() # Trying to delete something that doesn't exist is ok
 
   let stoNibbles = NibblesBuf.fromBytes(stoPath.data)
   var stoHike: Hike
   stoNibbles.hikeUp(stoID.vid, db, stoLeaf, stoHike).isOkOr:
     if error[1] in HikeAcceptableStopsNotFound:
-      return err(DelPathNotFound)
+      return ok()
     return err(error[1])
 
-  # Mark account path Merkle keys for update
-  db.layersResKeys accHike
+  # Mark account path Merkle keys for update, except for the vtx we update below
+  db.layersResKeys(accHike, skip = if stoHike.legs.len == 1: 1 else: 0)
 
   let otherLeaf = ?db.deleteImpl(stoHike)
   db.layersPutStoLeaf(mixPath, nil)
@@ -208,15 +205,14 @@ proc deleteStorageData*(
     db.layersPutStoLeaf(leafMixPath, otherLeaf)
 
   # If there was only one item (that got deleted), update the account as well
-  if stoHike.legs.len > 1:
-    return ok(false)
+  if stoHike.legs.len == 1:
+    # De-register the deleted storage tree from the account record
+    let leaf = wpAcc.vtx.dup           # Dup on modify
+    leaf.lData.stoID.isValid = false
+    db.layersPutAccLeaf(accPath, leaf)
+    db.layersPutVtx((accHike.root, wpAcc.vid), leaf)
 
-  # De-register the deleted storage tree from the account record
-  let leaf = wpAcc.vtx.dup           # Dup on modify
-  leaf.lData.stoID.isValid = false
-  db.layersPutAccLeaf(accPath, leaf)
-  db.layersPutVtx((accHike.root, wpAcc.vid), leaf)
-  ok(true)
+  ok()
 
 proc deleteStorageTree*(
     db: AristoTxRef;                   # Database, top layer
@@ -228,7 +224,7 @@ proc deleteStorageTree*(
   var accHike: Hike
   db.fetchAccountHike(accPath, accHike).isOkOr:
     if error == FetchAccInaccessible:
-      return err(DelStoAccMissing)
+      return ok() # Trying to delete something that doesn't exist is ok
     return err(error)
 
   let
@@ -236,12 +232,12 @@ proc deleteStorageTree*(
     stoID = wpAcc.vtx.lData.stoID
 
   if not stoID.isValid:
-    return err(DelStoRootMissing)
+    return ok() # Trying to delete something that doesn't exist is ok
 
-  # Mark account path Merkle keys for update
-  db.layersResKeys accHike
+  # Mark account path Merkle keys for update, except for the vtx we update below
+  db.layersResKeys(accHike, skip = 1)
 
-  ? db.delStoTreeImpl((stoID.vid, stoID.vid), accPath)
+  ? db.delStoTreeImpl(stoID.vid, accPath)
 
   # De-register the deleted storage tree from the accounts record
   let leaf = wpAcc.vtx.dup             # Dup on modify

--- a/execution_chain/db/aristo/aristo_delete/delete_subtree.nim
+++ b/execution_chain/db/aristo/aristo_delete/delete_subtree.nim
@@ -52,11 +52,11 @@ proc delStoTreeNow(
 
 proc delStoTreeImpl*(
     db: AristoTxRef;                   # Database, top layer
-    rvid: RootedVertexID;              # Root vertex
+    root: VertexID;                    # Root vertex
     accPath: Hash32;
       ): Result[void,AristoError] =
   ## Implementation of *delete* sub-trie.
-  db.delStoTreeNow(rvid, accPath, NibblesBuf())
+  db.delStoTreeNow((root, root), accPath, NibblesBuf())
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/db/aristo/aristo_desc/desc_error.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_error.nim
@@ -61,10 +61,7 @@ type
     DelBranchWithoutRefs
     DelDanglingStoTrie
     DelLeafExpexted
-    DelPathNotFound
     DelRootVidMissing
-    DelStoAccMissing
-    DelStoRootMissing
     DelStoRootNotAccepted
     DelVidStaleVtx
 

--- a/execution_chain/db/aristo/aristo_layers.nim
+++ b/execution_chain/db/aristo/aristo_layers.nim
@@ -125,9 +125,9 @@ func layersResKey*(db: AristoTxRef; rvid: RootedVertexID, vtx: VertexRef) =
   ## equivalent of a delete function.
   db.layersPutVtx(rvid, vtx)
 
-func layersResKeys*(db: AristoTxRef; hike: Hike) =
+func layersResKeys*(db: AristoTxRef; hike: Hike, skip: int) =
   ## Reset all cached keys along the given hike
-  for i in 1..hike.legs.len:
+  for i in (skip + 1)..hike.legs.len:
     db.layersResKey((hike.root, hike.legs[^i].wp.vid), hike.legs[^i].wp.vtx)
 
 func layersPutAccLeaf*(db: AristoTxRef; accPath: Hash32; leafVtx: VertexRef) =

--- a/execution_chain/db/aristo/aristo_merge.nim
+++ b/execution_chain/db/aristo/aristo_merge.nim
@@ -233,8 +233,8 @@ proc mergeStorageData*(
 
       return err(error)
 
-  # Mark account path Merkle keys for update
-  db.layersResKeys(accHike)
+  # Mark account path Merkle keys for update, except for the vtx we update below
+  db.layersResKeys(accHike, skip = if not stoID.isValid: 1 else: 0)
 
   # Update leaf cache both of the merged value and potentially the displaced
   # leaf resulting from splitting a leaf into a branch with two leaves

--- a/execution_chain/db/core_db/base.nim
+++ b/execution_chain/db/core_db/base.nim
@@ -242,14 +242,10 @@ proc delete*(
   ## Delete the particular account indexed by the key `accPath`. This
   ## will also destroy an associated storage area.
   ##
-  let rc = acc.aTx.deleteAccountRecord(accPath)
-  if rc.isOk:
-    ok()
-  elif rc.error == DelPathNotFound:
-    # TODO: Would it be conseqient to just return `ok()` here?
-    err(rc.error.toError("", AccNotFound))
-  else:
-    err(rc.error.toError(""))
+  acc.aTx.deleteAccountRecord(accPath).isOkOr:
+    return err(error.toError(""))
+
+  ok()
 
 proc clearStorage*(
     acc: CoreDbTxRef;
@@ -258,11 +254,10 @@ proc clearStorage*(
   ## Delete all data slots from the storage area associated with the
   ## particular account indexed by the key `accPath`.
   ##
-  let rc = acc.aTx.deleteStorageTree(accPath)
-  if rc.isOk or rc.error in {DelStoRootMissing,DelStoAccMissing}:
-    ok()
-  else:
-    err(rc.error.toError(""))
+  acc.aTx.deleteStorageTree(accPath).isOkOr:
+    return err(error.toError(""))
+
+  ok()
 
 proc merge*(
     acc: CoreDbTxRef;
@@ -338,15 +333,10 @@ proc slotDelete*(
     stoPath: Hash32;
       ):  CoreDbRc[void] =
   ## Like `delete()` but with cascaded index `(accPath,slot)`.
-  let rc = acc.aTx.deleteStorageData(accPath, stoPath)
-  if rc.isOk or rc.error == DelStoRootMissing:
-    # The second `if` clause is insane but legit: A storage column was
-    # announced for an account but no data have been added, yet.
-    ok()
-  elif rc.error == DelPathNotFound:
-    err(rc.error.toError("", StoNotFound))
-  else:
-    err(rc.error.toError(""))
+  acc.aTx.deleteStorageData(accPath, stoPath).isOkOr:
+    return err(error.toError(""))
+
+  ok()
 
 proc slotHasPath*(
     acc: CoreDbTxRef;

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -343,9 +343,7 @@ proc persistStorage(acc: AccountRef, ac: LedgerRef) =
 
     else:
       ac.txFrame.slotDelete(acc.toAccountKey, slotKey).isOkOr:
-        if error.error != StoNotFound:
-          raiseAssert info & $$error
-        discard
+        raiseAssert info & $$error
       acc.originalStorage.del(slot)
 
     if ac.storeSlotHash and not cached:


### PR DESCRIPTION
Deleting items that don't exist isn't treated as an error in the higher levels of abstraction - as a consequence, there's no need to make the lower levels more complex than they have to be either.