### PR TITLE
Fluffy: Implement debug_callByStateRoot RPC endpoint

### DIFF
--- a/fluffy/rpc/rpc_calls/rpc_debug_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_debug_calls.nim
@@ -1,5 +1,5 @@
 # fluffy
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -19,3 +19,10 @@ createRpcSigsFromNim(RpcClient):
   ): FixedBytes[32]
 
   proc debug_getCodeByStateRoot(data: Address, stateRoot: Hash32): seq[byte]
+  proc debug_getProofByStateRoot(
+    address: Address, slots: seq[UInt256], stateRoot: Hash32
+  ): ProofResponse
+
+  proc debug_callByStateRoot(
+    tx: TransactionArgs, stateRoot: Hash32, blockId: Opt[BlockIdentifier]
+  ): seq[byte]

--- a/fluffy/rpc/rpc_calls/rpc_eth_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_eth_calls.nim
@@ -47,3 +47,5 @@ createRpcSigsFromNim(RpcClient):
   proc eth_getProof(
     address: Address, slots: seq[UInt256], blockId: BlockIdentifier
   ): ProofResponse
+
+  proc eth_call(tx: TransactionArgs, blockId: BlockIdentifier): seq[byte]

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -448,17 +448,10 @@ proc installEthApiHandlers*(
       evm = asyncEvm.getOrRaise()
       header = (await hn.getVerifiedBlockHeader(quantityTag.number.uint64)).valueOr:
         raise newException(ValueError, "Unable to get block header")
+      optimisticStateFetch = optimisticStateFetch.valueOr:
+        true
 
-    let callResult = (
-      await evm.call(
-        header,
-        tx,
-        if optimisticStateFetch.isNone():
-          true
-        else:
-          optimisticStateFetch.get(),
-      )
-    ).valueOr:
+    let callResult = (await evm.call(header, tx, optimisticStateFetch)).valueOr:
       raise newException(ValueError, error)
 
     if callResult.error.len() > 0:


### PR DESCRIPTION
This endpoint can be used to test the evm call functionality without requiring the history network to be enabled. This is useful for scenarios where we don't yet have the block headers seeded into the history network or when testing locally/running a local testnet without the history network data.

