### PR TITLE
Fluffy: Remove -j${ncpu} when running fluffy-test

### DIFF
--- a/.github/workflows/fluffy.yml
+++ b/.github/workflows/fluffy.yml
@@ -277,7 +277,7 @@ jobs:
           rm -rf nimcache
           mingw32-make ${DEFAULT_MAKE_FLAGS} fluffy-tools
           rm -rf nimcache
-          mingw32-make ${DEFAULT_MAKE_FLAGS} fluffy-test
+          mingw32-make fluffy-test
           rm -rf nimcache
 
       - name: Run fluffy tests (Linux)
@@ -292,7 +292,7 @@ jobs:
           build/fluffy --help
           env CC=gcc make ${DEFAULT_MAKE_FLAGS} fluffy-tools
           # CC is needed to select correct compiler 32/64 bit
-          env CC=gcc CXX=g++ make ${DEFAULT_MAKE_FLAGS} fluffy-test
+          env CC=gcc CXX=g++ make fluffy-test
 
       - name: Run fluffy tests (Macos)
         if: runner.os == 'Macos'
@@ -302,7 +302,7 @@ jobs:
           build/fluffy --help
           make ${DEFAULT_MAKE_FLAGS} fluffy-tools
           # "-static" option will not work for osx unless static system libraries are provided
-          make ${DEFAULT_MAKE_FLAGS} fluffy-test
+          make fluffy-test
 
       - name: Run fluffy testnet
         run: |


### PR DESCRIPTION
When I run the tests locally I sometimes get test failures when setting the `-j${ncpu}` parameter to a value greater than 1. This is because we have two separate test binaries that get triggered under `fluffy-test` and some of the tests use the same port across the binaries. 

Debugging failed tests will also be easier if the tests are run sequentially so that the logs are less confusing. 