### PR TITLE
Fix bad merge of `seq[byte]` resulting in `gasUsed mismatch` during s…

### DIFF
--- a/execution_chain/db/aristo/aristo_layers.nim
+++ b/execution_chain/db/aristo/aristo_layers.nim
@@ -52,7 +52,6 @@ func layersGetKey*(db: AristoTxRef; rvid: RootedVertexID): Opt[(HashKey, int)] =
     if rvid in w.sTab:
       return Opt.some((VOID_HASH_KEY, w.level))
 
-
   Opt.none((HashKey, int))
 
 func layersGetKeyOrVoid*(db: AristoTxRef; rvid: RootedVertexID): HashKey =
@@ -168,6 +167,9 @@ proc copyFrom*(snapshot: var Snapshot, tx: AristoTxRef) =
     snapshot.acc[k] = (v, tx.level)
   for k, v in tx.stoLeaves:
     snapshot.sto[k] = (v, tx.level)
+
+proc mergeAndDiscard*(trg, src: var HashKey) =
+  trg = src
 
 proc mergeAndReset*(trg, src: AristoTxRef) =
   ## Merges the argument `src` into the argument `trg` and clears `src`.

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -426,6 +426,13 @@ proc rollback*(ac: LedgerRef, sp: LedgerSpRef) =
   when debugLedgerRef:
     inspectSavePoint("rollback", ac.savePoint)
 
+proc mergeAndReset(tgt, src: var seq[Log]) =
+  if tgt.len == 0:
+    tgt = move(src)
+  else:
+    tgt.add src
+    src.reset
+
 proc commit*(ac: LedgerRef, sp: LedgerSpRef) =
   # Transactions should be handled in a strictly nested fashion.
   # Any child transaction must be committed or rolled-back before

--- a/execution_chain/db/transient_storage.nim
+++ b/execution_chain/db/transient_storage.nim
@@ -25,7 +25,10 @@ type
 # Private helpers
 #######################################################################
 
-proc mergeAndReset*(a, b: StorageTable) =
+proc mergeAndDiscard*(trg, src: var UInt256) =
+  trg = src # no need to reset, the entire source map gets cleared
+
+proc mergeAndDiscard*(a, b: StorageTable) =
   a.map.mergeAndReset(b.map)
 
 #######################################################################

--- a/scripts/make_states.sh
+++ b/scripts/make_states.sh
@@ -34,7 +34,7 @@ do
     --era1-dir:"${ERA_DIR}" \
     --era-dir:"${ERA1_DIR}" \
     --debug-csv-stats:"${STATS_DIR}/stats-${DATE}-${REV}.csv" \
-    --max-blocks:1000000 "$@"
+    --max-blocks:${MAX_BLOCKS:-1000000} "$@"
   cp -ar "${DATA_DIR}" "${DATA_DIR}-$(printf "%04d" $counter)"
   counter=$((counter+1))
 done

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -21,6 +21,7 @@ import
     test_genesis,
     test_getproof_json,
     test_jwt_auth,
+    test_kvt,
     test_ledger,
     test_multi_keys,
     test_op_arith,

--- a/tests/test_kvt.nim
+++ b/tests/test_kvt.nim
@@ -1,0 +1,51 @@
+# Nimbus
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+{.used.}
+
+import
+  unittest2,
+  stew/endians2,
+  results,
+  eth/common/hashes,
+  ../execution_chain/db/kvt, ../execution_chain/db/kvt/[kvt_tx_frame, kvt_utils]
+
+suite "Kvt TxFrame":
+  setup:
+    let db = KvtDbRef.init()
+
+  test "Frames should independently keep data":
+    let
+      tx0 = db.txFrameBegin(db.baseTxFrame())
+      tx1 = db.txFrameBegin(tx0)
+      tx2 = db.txFrameBegin(tx1)
+      tx2b = db.txFrameBegin(tx1)
+      tx2c = db.txFrameBegin(tx1)
+
+    check:
+      tx0.put([byte 0, 1, 2], [byte 0, 1, 2]).isOk()
+      tx1.put([byte 0, 1, 2], [byte 0, 1, 3]).isOk()
+
+    check:
+      tx0.get([byte 0, 1, 2]).expect("entry") == @[byte 0, 1, 2]
+      tx1.get([byte 0, 1, 2]).expect("entry") == @[byte 0, 1, 3]
+
+    let batch = db.putBegFn().expect("working batch")
+    db.persist(batch, tx1)
+    check:
+      db.putEndFn(batch).isOk()
+
+    db.finish()
+
+    block:
+      # using the same backend but new txRef and cache
+      let tx = db.baseTxFrame()
+      check:
+        tx.get([byte 0, 1, 2]).expect("entry") == @[byte 0, 1, 3]


### PR DESCRIPTION
…yncing

This PR fixes an annoying and spurious issue that would occur when merging seq[byte]-based kvt entries - EVM `code` in particular - when syncing due to the accidental use of a "merge" function that joins the two seqs instead of overwriting them.

Under the condition that the same code gets updated in _separate_ blocks but within a single database checkpoint (such as happens when syncing and updating base every 32 blocks), this would lead to an invalid code snippet being written to the database. When the entry expired for the code cache and got loaded again, it would lead to a `gasUsed mismatch` in some random block down the line that was unlucky enough to load the bad code from the database.