### PR TITLE
Relieve synchronizer and header cache form calling FC.forkChoice

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -116,7 +116,7 @@ proc validateBlock(c: ForkedChainRef,
     return ok()
 
   if blkHash == c.pendingFCU:
-    # Resolve the number into latestFinalizedBlockNumber
+    # Resolve the hash into latestFinalizedBlockNumber
     c.latestFinalizedBlockNumber = blk.header.number
 
   let
@@ -263,7 +263,7 @@ func calculateNewBase(
 
   # If there is a new base, make sure it moves
   # with large enough step to accomodate for bulk
-  # state root verification.
+  # state root verification/bulk persist.
   let distance = target - c.baseBranch.tailNumber
   if distance < c.persistBatchSize:
     # If the step is not large enough, do nothing.
@@ -546,7 +546,7 @@ proc importBlock*(c: ForkedChainRef, blk: Block): Result[void, string] =
 
     ?c.validateBlock(bd[], blk)
   do:
-    # If it's parent is an invalid block
+    # If its parent is an invalid block
     # there is no hope the descendant is valid
     debug "Parent block not found",
       blockHash = header.blockHash.short,

--- a/execution_chain/core/chain/forked_chain/chain_branch.nim
+++ b/execution_chain/core/chain/forked_chain/chain_branch.nim
@@ -62,6 +62,12 @@ func lastBlockPos*(brc: BranchRef): BlockPos =
     index : brc.len - 1,
   )
 
+func firstBlockPos*(brc: BranchRef): BlockPos =
+  BlockPos(
+    branch: brc,
+    index : 0,
+  )
+
 func `==`*(a, b: BranchRef): bool =
   a.headHash == b.headHash
 

--- a/execution_chain/core/chain/forked_chain/chain_desc.nim
+++ b/execution_chain/core/chain/forked_chain/chain_desc.nim
@@ -43,7 +43,7 @@ type
       # When our latest imported block is far away from
       # latestFinalizedBlockNumber, we can move the base
       # forward when importing block
-    baseAutoForwardDistance*: uint64
+    persistBatchSize*: uint64
       # When in auto base forward mode, this is the minimum distance
       # to move the base
 
@@ -58,5 +58,5 @@ func notifyBlockHashAndNumber*(c: ForkedChainRef,
                                blockNumber: uint64) =
   if blockHash == c.pendingFCU:
     c.latestFinalizedBlockNumber = blockNumber
-    
+
 # End

--- a/execution_chain/core/chain/forked_chain/chain_desc.nim
+++ b/execution_chain/core/chain/forked_chain/chain_desc.nim
@@ -36,8 +36,16 @@ type
     lastSnapshots*: array[10, CoreDbTxRef]
     lastSnapshotPos*: int
 
-    hdrChainFinHeader*: Header # finalised block header from the `CL` (if any)
-    hdrChainFinHash*: Hash32   # block hash of `hdrChainFinHeader`
+    pendingFCU*  : Hash32
+      # When we know finalizedHash from CL but has yet to resolve
+      # the hash into a latestFinalizedBlockNumber
+    latestFinalizedBlockNumber*: uint64
+      # When our latest imported block is far away from
+      # latestFinalizedBlockNumber, we can move the base
+      # forward when importing block
+    baseAutoForwardDistance*: uint64
+      # When in auto base forward mode, this is the minimum distance
+      # to move the base
 
 # ----------------
 
@@ -45,4 +53,10 @@ func txRecords*(c: ForkedChainRef): var Table[Hash32, (Hash32, uint64)] =
   ## Avoid clash with `forked_chain.txRecords()`
   c.txRecords
 
+func notifyBlockHashAndNumber*(c: ForkedChainRef,
+                               blockHash: Hash32,
+                               blockNumber: uint64) =
+  if blockHash == c.pendingFCU:
+    c.latestFinalizedBlockNumber = blockNumber
+    
 # End

--- a/execution_chain/core/chain/forked_chain/chain_desc.nim
+++ b/execution_chain/core/chain/forked_chain/chain_desc.nim
@@ -22,30 +22,46 @@ type
   ForkedChainRef* = ref object
     com*: CommonRef
     hashToBlock* : Table[Hash32, BlockPos]
+      # A map of block hash to a block position in a branch.
+
     branches*    : seq[BranchRef]
     baseBranch*  : BranchRef
+      # A branch contain the base block
+
     activeBranch*: BranchRef
+      # Every time a new block added to a branch,
+      # that branch automatically become the active branch.
 
     txRecords    : Table[Hash32, (Hash32, uint64)]
+      # A map of transsaction hashes to block hash and block number.
+
     baseTxFrame* : CoreDbTxRef
       # Frame that skips all in-memory state that ForkedChain holds - used to
       # lookup items straight from the database
 
     baseDistance*: uint64
+      # Minimum number of blocks and its state stored in memory.
+      # User can query for block state while it is still in memory.
+      # Any state older than base block are purged.
 
     lastSnapshots*: array[10, CoreDbTxRef]
     lastSnapshotPos*: int
+      # The snapshot contains the cumulative changes of all ancestors and
+      # txFrame allowing the lookup recursion to stop whenever it is encountered.
 
     pendingFCU*  : Hash32
       # When we know finalizedHash from CL but has yet to resolve
       # the hash into a latestFinalizedBlockNumber
+
     latestFinalizedBlockNumber*: uint64
       # When our latest imported block is far away from
       # latestFinalizedBlockNumber, we can move the base
       # forward when importing block
+
     persistBatchSize*: uint64
-      # When in auto base forward mode, this is the minimum distance
-      # to move the base
+      # When move forward, this is the minimum distance
+      # to move the base. And the bulk writing can works
+      # efficiently.
 
 # ----------------
 
@@ -56,6 +72,8 @@ func txRecords*(c: ForkedChainRef): var Table[Hash32, (Hash32, uint64)] =
 func notifyBlockHashAndNumber*(c: ForkedChainRef,
                                blockHash: Hash32,
                                blockNumber: uint64) =
+  ## Syncer will tell FC a block have been downloaded,
+  ## please check if it's useful for you.
   if blockHash == c.pendingFCU:
     c.latestFinalizedBlockNumber = blockNumber
 

--- a/execution_chain/sync/beacon/worker/headers_staged/staged_collect.nim
+++ b/execution_chain/sync/beacon/worker/headers_staged/staged_collect.nim
@@ -169,7 +169,6 @@ proc collectAndStageOnMemQueue*(
   ## The function returns the largest block number not fetched/stored.
   ##
   let
-    ctx = buddy.ctx
     peer = buddy.peer
   var
     ivTop = iv.maxPt                     # top end of the current range to fetch

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -77,7 +77,7 @@ proc executeCase(node: JsonNode): bool =
     debugEcho "Failed to put genesis header into database: ", error
     return false
 
-  var c = ForkedChainRef.init(com)
+  var c = ForkedChainRef.init(com, persistBatchSize = 0)
   if c.latestHash != env.genesisHeader.blockHash:
     debugEcho "Genesis block hash in database is different with expected genesis block hash"
     return false


### PR DESCRIPTION
based on #3002 description

Only fix problems in FC module. Looks like any reference to finalized hash in syncer also need to be removed in future PR.

fix #3002