### PR TITLE
Add Portal protocol versioning

### DIFF
--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -31,6 +31,7 @@ import
     rpc_portal_nimbus_beacon_api, rpc_portal_debug_history_api,
   ],
   ./database/content_db,
+  ./network/wire/portal_protocol_version,
   ./portal_node,
   ./version,
   ./logging
@@ -153,7 +154,8 @@ proc run(fluffy: Fluffy, config: PortalConf) {.raises: [CatchableError].} =
       # Note: The addition of default clientInfo to the ENR is a temporary
       # measure to easily identify & debug the clients used in the testnet.
       # Might make this into a, default off, cli option.
-      localEnrFields = {"c": enrClientInfoShort},
+      localEnrFields =
+        {"c": enrClientInfoShort, portalVersionKey: SSZ.encode(localSupportedVersions)},
       bootstrapRecords = bootstrapRecords,
       previousRecord = previousEnr,
       bindIp = bindIp,

--- a/fluffy/network/wire/portal_protocol_version.nim
+++ b/fluffy/network/wire/portal_protocol_version.nim
@@ -1,0 +1,48 @@
+# Nimbus
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import
+  std/sequtils,
+  ssz_serialization,
+  eth/p2p/discoveryv5/[enr, node],
+  ../../common/common_types
+
+export ssz_serialization
+
+type PortalVersionValue* = List[uint8, 8]
+
+const
+  portalVersionKey* = "pv"
+  localSupportedVersions* = PortalVersionValue(@[0'u8, 1'u8])
+
+func getPortalVersions(record: Record): Result[PortalVersionValue, string] =
+  let valueBytes = record.get(portalVersionKey, seq[byte]).valueOr:
+    return ok(PortalVersionValue(@[0'u8]))
+
+  decodeSsz(valueBytes, PortalVersionValue)
+
+func highestCommonPortalVersion(
+    versions: PortalVersionValue, supportedVersions: PortalVersionValue
+): Result[uint8, string] =
+  let commonVersions = versions.filterIt(supportedVersions.contains(it))
+  if commonVersions.len == 0:
+    return err("No common protocol versions found")
+
+  ok(max(commonVersions))
+
+func highestCommonPortalVersion*(
+    record: Record, supportedVersions: PortalVersionValue
+): Result[uint8, string] =
+  let versions = ?record.getPortalVersions()
+  versions.highestCommonPortalVersion(supportedVersions)
+
+func highestCommonPortalVersion*(
+    node: Node, supportedVersions: PortalVersionValue
+): Result[uint8, string] =
+  node.record.highestCommonPortalVersion(supportedVersions)

--- a/fluffy/rpc/rpc_portal_common_api.nim
+++ b/fluffy/rpc/rpc_portal_common_api.nim
@@ -36,10 +36,11 @@ proc installPortalCommonApiHandlers*(
 
   rpcServer.rpc("portal_" & networkStr & "AddEnr") do(enr: Record) -> bool:
     let node = Node.fromRecord(enr)
-    let addResult = p.addNode(node)
-    if addResult == Added:
+    if p.addNode(node) == Added:
       p.routingTable.setJustSeen(node)
-    return addResult == Added
+      true
+    else:
+      false
 
   rpcServer.rpc("portal_" & networkStr & "AddEnrs") do(enrs: seq[Record]) -> bool:
     # Note: unspecified RPC, but useful for our local testnet test

--- a/fluffy/tests/wire_protocol_tests/all_wire_protocol_tests.nim
+++ b/fluffy/tests/wire_protocol_tests/all_wire_protocol_tests.nim
@@ -10,4 +10,5 @@
 import
   ./test_portal_wire_encoding,
   ./test_portal_wire_protocol,
+  ./test_portal_wire_version,
   ./test_ping_extensions_encoding

--- a/fluffy/tests/wire_protocol_tests/test_portal_wire_encoding.nim
+++ b/fluffy/tests/wire_protocol_tests/test_portal_wire_encoding.nim
@@ -246,14 +246,13 @@ suite "Portal Wire Protocol Message Encodings":
       message.offer.contentKeys == contentKeys
 
   test "Accept Response":
-    var contentKeys = ContentKeysBitList.init(8)
-    contentKeys.setBit(0)
     let
+      contentKeys = ContentKeysAcceptList.init(@[byte 0, 1, 2, 3, 4, 5, 1, 1])
       connectionId = Bytes2([byte 0x01, 0x02])
       a = AcceptMessage(connectionId: connectionId, contentKeys: contentKeys)
 
     let encoded = encodeMessage(a)
-    check encoded.toHex == "070102060000000101"
+    check encoded.toHex == "070102060000000001020304050101"
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()

--- a/fluffy/tests/wire_protocol_tests/test_portal_wire_version.nim
+++ b/fluffy/tests/wire_protocol_tests/test_portal_wire_version.nim
@@ -1,0 +1,89 @@
+# Nimbus
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  std/net,
+  unittest2,
+  eth/p2p/discoveryv5/enr,
+  eth/common/keys,
+  ../../network/wire/portal_protocol_version
+
+suite "Portal Wire Protocol Version":
+  setup:
+    let
+      pk = PrivateKey
+        .fromHex("5d2908f3f09ea1ff2e327c3f623159639b00af406e9009de5fd4b910fc34049d")
+        .expect("valid private key")
+      ip = Opt.none(IpAddress)
+      port = Opt.none(Port)
+
+  test "ENR with no Portal version field":
+    let
+      localSupportedVersions = PortalVersionValue(@[0'u8, 1'u8])
+      enr = Record.init(1, pk, ip, port, port, []).expect("Valid ENR init")
+
+    let version = enr.highestCommonPortalVersion(localSupportedVersions)
+    check:
+      version.isOk()
+      version.get() == 0'u8
+
+  test "ENR with empty Portal version list":
+    let
+      localSupportedVersions = PortalVersionValue(@[0'u8, 1'u8])
+      portalVersions = PortalVersionValue(@[])
+      customEnrFields = [toFieldPair(portalVersionKey, SSZ.encode(portalVersions))]
+      enr = Record.init(1, pk, ip, port, port, customEnrFields).expect("Valid ENR init")
+
+    let version = enr.highestCommonPortalVersion(localSupportedVersions)
+    check version.isErr()
+
+  test "ENR with unsupported Portal versions":
+    let
+      localSupportedVersions = PortalVersionValue(@[0'u8, 1'u8])
+      portalVersions = PortalVersionValue(@[255'u8, 100'u8, 2'u8])
+      customEnrFields = [toFieldPair(portalVersionKey, SSZ.encode(portalVersions))]
+      enr = Record.init(1, pk, ip, port, port, customEnrFields).expect("Valid ENR init")
+
+    let version = enr.highestCommonPortalVersion(localSupportedVersions)
+    check version.isErr()
+
+  test "ENR with supported Portal version":
+    let
+      localSupportedVersions = PortalVersionValue(@[0'u8, 1'u8])
+      portalVersions = PortalVersionValue(@[3'u8, 2'u8, 1'u8])
+      customEnrFields = [toFieldPair(portalVersionKey, SSZ.encode(portalVersions))]
+      enr = Record.init(1, pk, ip, port, port, customEnrFields).expect("Valid ENR init")
+
+    let version = enr.highestCommonPortalVersion(localSupportedVersions)
+    check:
+      version.isOk()
+      version.get() == 1'u8
+
+  test "ENR with multiple supported Portal versions":
+    let
+      localSupportedVersions = PortalVersionValue(@[0'u8, 1'u8, 2'u8])
+      portalVersions = PortalVersionValue(@[0'u8, 2'u8, 2'u8, 3'u8])
+      customEnrFields = [toFieldPair(portalVersionKey, SSZ.encode(portalVersions))]
+      enr = Record.init(1, pk, ip, port, port, customEnrFields).expect("Valid ENR init")
+
+    let version = enr.highestCommonPortalVersion(localSupportedVersions)
+    check:
+      version.isOk()
+      version.get() == 2'u8
+
+  test "ENR with too many Portal versions":
+    let
+      localSupportedVersions = PortalVersionValue(@[0'u8, 1'u8, 2'u8])
+      portalVersions =
+        PortalVersionValue(@[0'u8, 1'u8, 2'u8, 3'u8, 4'u8, 5'u8, 6'u8, 7'u8, 8'u8])
+      customEnrFields = [toFieldPair(portalVersionKey, SSZ.encode(portalVersions))]
+      enr = Record.init(1, pk, ip, port, port, customEnrFields).expect("Valid ENR init")
+
+    let version = enr.highestCommonPortalVersion(localSupportedVersions)
+    check version.isErr()


### PR DESCRIPTION
Incomplete as it is currently not possible to always retrieve the ENR from a peer from which the node gets an incoming request. 

The best solution that I see for this right now is to add ENRs to the discv5 SessionCache and thus make this retrievable for each node that has an ongoing session.

edit: currently fully implemented with v1 functionality enabled also, relies on https://github.com/status-im/nim-eth/pull/790