### PR TITLE
Nimbus EVM: Fix gas calculation when setting up message for call

### DIFF
--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -142,7 +142,7 @@ proc setupHost(call: CallParams, keepStack: bool): TransactionHost =
                          CallKind.Call,
       # flags: {},
       # depth: 0,
-      gas:             call.gasLimit - intrinsicGas,
+      gas:             if call.gasLimit < intrinsicGas: 0.GasInt else: call.gasLimit - intrinsicGas,
       contractAddress: call.to,
       codeAddress:     call.to,
       sender:          call.sender,


### PR DESCRIPTION
I discovered that the intrinsicGas deduction was not correctly being applied when running my implementation of eth_call and it turned out that in that scenario I had set a very low gas limit which was less than the intrinsicGas but the message.gas field is an unsigned integer so in this case the value underflows to a very large number. 

I also found that in the evm call tests we use `testCallEvm` which sets up the call parameters using callParamsForTest which disables the intrinsicGas setting it to zero so this scenario isn't triggered.

