### PR TITLE
evm: less bounds checks in hotspot

### DIFF
--- a/execution_chain/evm/code_bytes.nim
+++ b/execution_chain/evm/code_bytes.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)

--- a/execution_chain/evm/code_bytes.nim
+++ b/execution_chain/evm/code_bytes.nim
@@ -45,15 +45,18 @@ func fromHex*(T: type CodeBytesRef, hex: string): Opt[CodeBytesRef] =
   except ValueError:
     Opt.none(CodeBytesRef)
 
-func invalidPosition(c: CodeBytesRef, pos: int): bool =
-  let (bpos, bbit) = bitpos(pos)
-  (c.invalidPositions[bpos] and bbit) > 0
-
 func bytes*(c: CodeBytesRef): lent seq[byte] =
   c[].bytes
 
 func len*(c: CodeBytesRef): int =
   len(c.bytes)
+
+# Bounds checking done manually - this is a hotspot in the EVM
+{.push checks: off.}
+
+template invalidPosition(c: CodeBytesRef, pos: int): bool =
+  let (bpos, bbit) = bitpos(pos)
+  (c.invalidPositions[bpos] and bbit) > 0
 
 func isValidOpcode*(c: CodeBytesRef, position: int): bool =
   if position >= len(c):
@@ -78,6 +81,8 @@ func isValidOpcode*(c: CodeBytesRef, position: int): bool =
     c.processed = i - 1
 
     not c.invalidPosition(position)
+
+{.pop.}
 
 func `==`*(a: CodeBytesRef, b: openArray[byte]): bool =
   a.bytes == b

--- a/execution_chain/evm/code_stream.nim
+++ b/execution_chain/evm/code_stream.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)

--- a/execution_chain/evm/code_stream.nim
+++ b/execution_chain/evm/code_stream.nim
@@ -49,12 +49,13 @@ template next*(c: var CodeStream): Op =
   # Retrieve the next opcode (or stop) - this is a hot spot in the interpreter
   # and must be kept small for performance
   let
-    # uint: range checked manually -> benefit from smaller codegen
-    pc = uint(c.pc)
+    pc = c.pc
     bytes {.cursor.} = c.code.bytes
-  if pc < uint(bytes.len):
+  if pc < bytes.len:
+    {.push checks: off.}
     let op = Op(bytes[pc])
-    c.pc = cast[int](pc + 1)
+    c.pc = pc + 1
+    {.pop.}
     op
   else:
     Op.Stop
@@ -66,13 +67,17 @@ iterator items*(c: var CodeStream): Op =
     nextOpcode = c.next()
 
 func `[]`*(c: CodeStream, offset: int): Op =
-  Op(c.code.bytes[offset])
-
-func peek*(c: var CodeStream): Op =
-  if c.pc < c.code.bytes.len:
-    Op(c.code.bytes[c.pc])
+  let bytes {.cursor.} = c.code.bytes
+  if offset >= 0 and offset < bytes.len:
+    {.push checks: off.}
+    let op = Op(bytes[offset])
+    {.pop.}
+    op
   else:
     Op.Stop
+
+func peek*(c: var CodeStream): Op =
+  c[c.pc]
 
 func updatePc*(c: var CodeStream, value: int) =
   c.pc = min(value, len(c))


### PR DESCRIPTION
`invalidPosition` is a hotspot (2% cpu when processing blocks) - this tiny fix improves the bounds checking further by extending its avoidance to the invalid position list whose length is determined by the code length and therefore safe to access in valid code positions.

Doesn't make a huge difference but it's also not nothing - might as well do it properly.