### PR TITLE
Switch VertexRef to inheritance

### DIFF
--- a/execution_chain/db/aristo/aristo_check/check_top.nim
+++ b/execution_chain/db/aristo/aristo_check/check_top.nim
@@ -87,9 +87,8 @@ proc checkTopCommon*(
       if topVid < rvid.vid:
         topVid = rvid.vid
       case vtx.vType:
-      of Leaf:
-        if vtx.lData.pType == AccountData:
-          let stoID = vtx.lData.stoID
+      of AccLeaf:
+          let stoID = AccLeafRef(vtx).stoID
           if stoID.isValid:
             let stoVid = stoID.vid
             if stoVid in stoRoots:
@@ -97,7 +96,8 @@ proc checkTopCommon*(
             if vTop < stoVid:
               return err((stoVid,CheckAnyVidDeadStorageRoot))
             stoRoots.incl stoVid
-      of Branch:
+      of StoLeaf: discard
+      of Branches:
         block check42Links:
           var seen = false
           for _, _ in vtx.pairs():

--- a/execution_chain/db/aristo/aristo_delete.nim
+++ b/execution_chain/db/aristo/aristo_delete.nim
@@ -25,7 +25,7 @@ import
 # Private heplers
 # ------------------------------------------------------------------------------
 
-proc branchStillNeeded(vtx: VertexRef, removed: int8): Result[int8,void] =
+proc branchStillNeeded(vtx: BranchRef, removed: int8): Result[int8,void] =
   ## Returns the nibble if there is only one reference left.
   var nibble = -1'i8
   for n in 0'i8 .. 15'i8:
@@ -48,13 +48,13 @@ proc branchStillNeeded(vtx: VertexRef, removed: int8): Result[int8,void] =
 proc deleteImpl(
     db: AristoTxRef;                   # Database, top layer
     hike: Hike;                        # Fully expanded path
-      ): Result[VertexRef,AristoError] =
+      ): Result[LeafRef, AristoError] =
   ## Removes the last node in the hike and returns the updated leaf in case
   ## a branch collapsed
 
   # Remove leaf entry
   let lf = hike.legs[^1].wp
-  if lf.vtx.vType != Leaf:
+  if lf.vtx.vType notin Leaves:
     return err(DelLeafExpexted)
 
   db.layersResVtx((hike.root, lf.vid))
@@ -64,13 +64,14 @@ proc deleteImpl(
     # leaves to update
     return ok(nil)
 
-  if hike.legs[^2].wp.vtx.vType != Branch:
+  if hike.legs[^2].wp.vtx.vType notin Branches:
     return err(DelBranchExpexted)
 
   # Get current `Branch` vertex `br`
   let
     br = hike.legs[^2].wp
-    nbl = br.vtx.branchStillNeeded(hike.legs[^2].nibble).valueOr:
+    brVtx = BranchRef(br.vtx)
+    nbl = brVtx.branchStillNeeded(hike.legs[^2].nibble).valueOr:
       return err(DelBranchWithoutRefs)
 
   # Clear keys that include `br` - `br` itself will be replaced below
@@ -82,38 +83,43 @@ proc deleteImpl(
 
     # Get child vertex (there must be one after a `Branch` node)
     let
-      vid = br.vtx.bVid(uint8 nbl)
+      vid = brVtx.bVid(uint8 nbl)
       nxt = db.getVtx (hike.root, vid)
     if not nxt.isValid:
       return err(DelVidStaleVtx)
 
     db.layersResVtx((hike.root, vid))
-
-    let vtx =
-      case nxt.vType
-      of Leaf:
-        VertexRef(
-          vType: Leaf,
-          pfx:  br.vtx.pfx & NibblesBuf.nibble(nbl.byte) & nxt.pfx,
-          lData: nxt.lData)
-
-      of Branch:
-        VertexRef(
-          vType: Branch,
-          pfx:  br.vtx.pfx & NibblesBuf.nibble(nbl.byte) & nxt.pfx,
-          startVid: nxt.startVid,
-          used: nxt.used)
+    let
+      pfx =
+        if brVtx.vType == Branch:
+          NibblesBuf.nibble(nbl.byte)
+        else:
+          ExtBranchRef(brVtx).pfx & NibblesBuf.nibble(nbl.byte)
+      vtx =
+        case nxt.vType
+        of AccLeaf:
+          let nxt = AccLeafRef(nxt)
+          AccLeafRef.init(pfx & nxt.pfx, nxt.account, nxt.stoID)
+        of StoLeaf:
+          let nxt = StoLeafRef(nxt)
+          StoLeafRef.init(pfx & nxt.pfx, nxt.stoData)
+        of Branch:
+          let nxt = BranchRef(nxt)
+          ExtBranchRef.init(pfx, nxt.startVid, nxt.used)
+        of ExtBranch:
+          let nxt = ExtBranchRef(nxt)
+          ExtBranchRef.init(pfx & nxt.pfx, nxt.startVid, nxt.used)
 
     # Put the new vertex at the id of the obsolete branch
     db.layersPutVtx((hike.root, br.vid), vtx)
 
-    if vtx.vType == Leaf:
-      ok(vtx)
+    if vtx.vType in Leaves:
+      ok(LeafRef(vtx))
     else:
       ok(nil)
   else:
     # Clear the removed leaf from the branch (that still contains other children)
-    let brDup = br.vtx.dup
+    let brDup = brVtx.dup
     discard brDup.setUsed(uint8 hike.legs[^2].nibble, false)
     db.layersPutVtx((hike.root, br.vid), brDup)
 
@@ -135,12 +141,11 @@ proc deleteAccountRecord*(
     if error == FetchAccInaccessible:
       return ok() # Trying to delete something that doesn't exist is ok
     return err(error)
-  let
-    stoID = accHike.legs[^1].wp.vtx.lData.stoID
+  let stoID = AccLeafRef(accHike.legs[^1].wp.vtx).stoID
 
   # Delete storage tree if present
   if stoID.isValid:
-    ? db.delStoTreeImpl(stoID.vid, accPath)
+    ?db.delStoTreeImpl(stoID.vid, accPath)
 
   let otherLeaf = ?db.deleteImpl(accHike)
 
@@ -149,7 +154,8 @@ proc deleteAccountRecord*(
   if otherLeaf.isValid:
     db.layersPutAccLeaf(
       Hash32(getBytes(NibblesBuf.fromBytes(accPath.data).replaceSuffix(otherLeaf.pfx))),
-      otherLeaf)
+      AccLeafRef(otherLeaf),
+    )
 
   ok()
 
@@ -180,7 +186,7 @@ proc deleteStorageData*(
 
   let
     wpAcc = accHike.legs[^1].wp
-    stoID = wpAcc.vtx.lData.stoID
+    stoID = AccLeafRef(wpAcc.vtx).stoID
 
   if not stoID.isValid:
     return ok() # Trying to delete something that doesn't exist is ok
@@ -199,16 +205,15 @@ proc deleteStorageData*(
   db.layersPutStoLeaf(mixPath, nil)
 
   if otherLeaf.isValid:
-    let leafMixPath = mixUp(
-      accPath,
-      Hash32(getBytes(stoNibbles.replaceSuffix(otherLeaf.pfx))))
-    db.layersPutStoLeaf(leafMixPath, otherLeaf)
+    let leafMixPath =
+      mixUp(accPath, Hash32(getBytes(stoNibbles.replaceSuffix(otherLeaf.pfx))))
+    db.layersPutStoLeaf(leafMixPath, StoLeafRef(otherLeaf))
 
   # If there was only one item (that got deleted), update the account as well
   if stoHike.legs.len == 1:
     # De-register the deleted storage tree from the account record
-    let leaf = wpAcc.vtx.dup           # Dup on modify
-    leaf.lData.stoID.isValid = false
+    let leaf = AccLeafRef(wpAcc.vtx).dup # Dup on modify
+    leaf.stoID.isValid = false
     db.layersPutAccLeaf(accPath, leaf)
     db.layersPutVtx((accHike.root, wpAcc.vid), leaf)
 
@@ -229,7 +234,8 @@ proc deleteStorageTree*(
 
   let
     wpAcc = accHike.legs[^1].wp
-    stoID = wpAcc.vtx.lData.stoID
+    accVtx = AccLeafRef(wpAcc.vtx)
+    stoID = accVtx.stoID
 
   if not stoID.isValid:
     return ok() # Trying to delete something that doesn't exist is ok
@@ -237,11 +243,11 @@ proc deleteStorageTree*(
   # Mark account path Merkle keys for update, except for the vtx we update below
   db.layersResKeys(accHike, skip = 1)
 
-  ? db.delStoTreeImpl(stoID.vid, accPath)
+  ?db.delStoTreeImpl(stoID.vid, accPath)
 
   # De-register the deleted storage tree from the accounts record
-  let leaf = wpAcc.vtx.dup             # Dup on modify
-  leaf.lData.stoID.isValid = false
+  let leaf = accVtx.dup # Dup on modify
+  leaf.stoID.isValid = false
   db.layersPutAccLeaf(accPath, leaf)
   db.layersPutVtx((accHike.root, wpAcc.vid), leaf)
   ok()

--- a/execution_chain/db/aristo/aristo_delete/delete_subtree.nim
+++ b/execution_chain/db/aristo/aristo_delete/delete_subtree.nim
@@ -33,15 +33,21 @@ proc delStoTreeNow(
 
   case vtx.vType
   of Branch:
+    let vtx = BranchRef(vtx)
     for n, subvid in vtx.pairs():
-      ? db.delStoTreeNow(
-        (rvid.root, subvid), accPath,
-        stoPath & vtx.pfx & NibblesBuf.nibble(n))
-
-  of Leaf:
+      ?db.delStoTreeNow((rvid.root, subvid), accPath, stoPath & NibblesBuf.nibble(n))
+  of ExtBranch:
+    let vtx = ExtBranchRef(vtx)
+    for n, subvid in vtx.pairs():
+      ?db.delStoTreeNow(
+        (rvid.root, subvid), accPath, stoPath & vtx.pfx & NibblesBuf.nibble(n)
+      )
+  of StoLeaf:
+    let vtx = StoLeafRef(vtx)
     let stoPath = Hash32((stoPath & vtx.pfx).getBytes())
     db.layersPutStoLeaf(mixUp(accPath, stoPath), nil)
-
+  of AccLeaf:
+    raiseAssert "Removing storage leaves only!"
   db.layersResVtx(rvid)
 
   ok()

--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -68,8 +68,8 @@ type
     kMap*: Table[RootedVertexID,HashKey]   ## Merkle hash key mapping
     vTop*: VertexID                        ## Last used vertex ID
 
-    accLeaves*: Table[Hash32, VertexRef]   ## Account path -> VertexRef
-    stoLeaves*: Table[Hash32, VertexRef]   ## Storage path -> VertexRef
+    accLeaves*: Table[Hash32, AccLeafRef]  ## Account path -> VertexRef
+    stoLeaves*: Table[Hash32, StoLeafRef]  ## Storage path -> VertexRef
 
     blockNumber*: Opt[uint64]              ## Block number set when checkpointing the frame
 
@@ -85,8 +85,8 @@ type
 
   Snapshot* = object
     vtx*: Table[RootedVertexID, VtxSnapshot]
-    acc*: Table[Hash32, (VertexRef, int)]
-    sto*: Table[Hash32, (VertexRef, int)]
+    acc*: Table[Hash32, (AccLeafRef, int)]
+    sto*: Table[Hash32, (StoLeafRef, int)]
     level*: Opt[int] # when this snapshot was taken
 
   VtxSnapshot* = (VertexRef, HashKey, int)
@@ -110,7 +110,7 @@ type
 
     txRef*: AristoTxRef              ## Bottom-most in-memory frame
 
-    accLeaves*: LruCache[Hash32, VertexRef]
+    accLeaves*: LruCache[Hash32, AccLeafRef]
       ## Account path to payload cache - accounts are frequently accessed by
       ## account path when contracts interact with them - this cache ensures
       ## that we don't have to re-traverse the storage trie for every such
@@ -118,7 +118,7 @@ type
       ## TODO a better solution would probably be to cache this in a type
       ## exposed to the high-level API
 
-    stoLeaves*: LruCache[Hash32, VertexRef]
+    stoLeaves*: LruCache[Hash32, StoLeafRef]
       ## Mixed account/storage path to payload cache - same as above but caches
       ## the full lookup of storage slots
 
@@ -172,13 +172,13 @@ func getOrVoid*[W](tab: Table[W,HashSet[RootedVertexID]]; w: W): HashSet[RootedV
 # --------
 
 func isValid*(vtx: VertexRef): bool =
-  vtx != VertexRef(nil)
+  not isNil(vtx)
 
 func isValid*(nd: NodeRef): bool =
-  nd != NodeRef(nil)
+  not isNil(nd)
 
 func isValid*(tx: AristoTxRef): bool =
-  tx != AristoTxRef(nil)
+  not isNil(tx)
 
 func isValid*(root: Hash32): bool =
   root != emptyRoot

--- a/execution_chain/db/aristo/aristo_init/init_common.nim
+++ b/execution_chain/db/aristo/aristo_init/init_common.nim
@@ -84,8 +84,8 @@ proc finishSession*(hdl: TypedPutHdlRef; db: TypedBackendRef) =
 proc initInstance*(db: AristoDbRef): Result[void, AristoError] =
   let vTop = ?db.getTuvFn()
   db.txRef = AristoTxRef(db: db, vTop: vTop, snapshot: Snapshot(level: Opt.some(0)))
-  db.accLeaves = LruCache[Hash32, VertexRef].init(ACC_LRU_SIZE)
-  db.stoLeaves = LruCache[Hash32, VertexRef].init(ACC_LRU_SIZE)
+  db.accLeaves = LruCache[Hash32, AccLeafRef].init(ACC_LRU_SIZE)
+  db.stoLeaves = LruCache[Hash32, StoLeafRef].init(ACC_LRU_SIZE)
   ok()
 
 proc finish*(db: AristoDbRef; eradicate = false) =

--- a/execution_chain/db/aristo/aristo_init/memory_db.nim
+++ b/execution_chain/db/aristo/aristo_init/memory_db.nim
@@ -208,7 +208,7 @@ proc memoryBackend*(): AristoDbRef =
 
 iterator walkVtx*(
     be: MemBackendRef;
-    kinds = {Branch, Leaf};
+    kinds = {Branch, ExtBranch, AccLeaf, StoLeaf};
       ): tuple[rvid: RootedVertexID, vtx: VertexRef] =
   ##  Iteration over the vertex sub-table.
   for n,rvid in be.sTab.keys.toSeq.mapIt(it).sorted:

--- a/execution_chain/db/aristo/aristo_init/rocks_db.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db.nim
@@ -245,7 +245,7 @@ proc rocksDbBackend*(
 
 iterator walkVtx*(
     be: RdbBackendRef;
-    kinds = {Branch, Leaf};
+    kinds = {Branch, ExtBranch, AccLeaf, StoLeaf};
       ): tuple[evid: RootedVertexID, vtx: VertexRef] =
   ## Variant of `walk()` iteration over the vertex sub-table.
   for (rvid, vtx) in be.rdb.walkVtx(kinds):

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_get.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_get.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_get.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_get.nim
@@ -162,8 +162,9 @@ proc getKey*(
       (GetVtxFlag.PeekCache notin flags or rdb.rdKeyLru.len < rdb.rdKeyLru.capacity):
     rdb.rdKeyLru.put(rvid.vid, res.value())
 
-  if vtx.isOk() and
-      (GetVtxFlag.PeekCache notin flags or rdb.rdVtxLru.len < rdb.rdVtxLru.capacity):
+  if vtx.isOk() and rdb.rdVtxLru.len < rdb.rdVtxLru.capacity:
+    # Don't invalidate vertex cache entries because of key reads - the latter
+    # follow a different access pattern!
     rdb.rdVtxLru.put(rvid.vid, vtx.value())
 
   ok (res.valueOr(VOID_HASH_KEY), vtx.valueOr(nil))

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_init.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_init.nim
@@ -91,7 +91,7 @@ proc init*(rdb: var RdbInst, opts: DbOptions, baseDb: RocksDbInstanceRef) =
     opts.rdbKeyCacheSize div (sizeof(VertexID) + sizeof(HashKey) + lruOverhead)
   rdb.rdVtxSize =
     opts.rdbVtxCacheSize div
-    (sizeof(VertexID) + sizeof(default(VertexRef)[]) + lruOverhead)
+    (sizeof(VertexID) + sizeof(default(StoLeafRef)[]) + lruOverhead)
 
   rdb.rdBranchSize =
     opts.rdbBranchCacheSize div (sizeof(typeof(rdb.rdBranchLru).V) + lruOverhead)

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_put.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_put.nim
@@ -91,7 +91,8 @@ proc putVtx*(
     # likely to evict more useful items (when putting many items, we might even
     # evict those that were just added)
 
-    if vtx.vType == Branch and vtx.pfx.len == 0:
+    if vtx.vType == Branch:
+      let vtx = BranchRef(vtx)
       rdb.rdVtxLru.del(rvid.vid)
       if rdb.rdBranchLru.len < rdb.rdBranchLru.capacity:
         rdb.rdBranchLru.put(rvid.vid, (vtx.startVid, vtx.used))

--- a/execution_chain/db/aristo/aristo_layers.nim
+++ b/execution_chain/db/aristo/aristo_layers.nim
@@ -58,7 +58,7 @@ func layersGetKeyOrVoid*(db: AristoTxRef; rvid: RootedVertexID): HashKey =
   ## Simplified version of `layersGetKey()`
   (db.layersGetKey(rvid).valueOr (VOID_HASH_KEY, 0))[0]
 
-func layersGetAccLeaf*(db: AristoTxRef; accPath: Hash32): Opt[VertexRef] =
+func layersGetAccLeaf*(db: AristoTxRef; accPath: Hash32): Opt[AccLeafRef] =
   for w in db.rstack(stopAtSnapshot = true):
     if w.snapshot.level.isSome():
       w.snapshot.acc.withValue(accPath, item):
@@ -68,9 +68,9 @@ func layersGetAccLeaf*(db: AristoTxRef; accPath: Hash32): Opt[VertexRef] =
     w.accLeaves.withValue(accPath, item):
       return Opt.some(item[])
 
-  Opt.none(VertexRef)
+  Opt.none(AccLeafRef)
 
-func layersGetStoLeaf*(db: AristoTxRef; mixPath: Hash32): Opt[VertexRef] =
+func layersGetStoLeaf*(db: AristoTxRef; mixPath: Hash32): Opt[StoLeafRef] =
   for w in db.rstack(stopAtSnapshot = true):
     if w.snapshot.level.isSome():
       w.snapshot.sto.withValue(mixPath, item):
@@ -80,7 +80,7 @@ func layersGetStoLeaf*(db: AristoTxRef; mixPath: Hash32): Opt[VertexRef] =
     w.stoLeaves.withValue(mixPath, item):
       return Opt.some(item[])
 
-  Opt.none(VertexRef)
+  Opt.none(StoLeafRef)
 
 # ------------------------------------------------------------------------------
 # Public functions: setter variants
@@ -129,13 +129,13 @@ func layersResKeys*(db: AristoTxRef; hike: Hike, skip: int) =
   for i in (skip + 1)..hike.legs.len:
     db.layersResKey((hike.root, hike.legs[^i].wp.vid), hike.legs[^i].wp.vtx)
 
-func layersPutAccLeaf*(db: AristoTxRef; accPath: Hash32; leafVtx: VertexRef) =
+func layersPutAccLeaf*(db: AristoTxRef; accPath: Hash32; leafVtx: AccLeafRef) =
   db.accLeaves[accPath] = leafVtx
 
   if db.snapshot.level.isSome():
     db.snapshot.acc[accPath] = (leafVtx, db.level)
 
-func layersPutStoLeaf*(db: AristoTxRef; mixPath: Hash32; leafVtx: VertexRef) =
+func layersPutStoLeaf*(db: AristoTxRef; mixPath: Hash32; leafVtx: StoLeafRef) =
   db.stoLeaves[mixPath] = leafVtx
 
   if db.snapshot.level.isSome():

--- a/execution_chain/db/aristo/aristo_nearby.nim
+++ b/execution_chain/db/aristo/aristo_nearby.nim
@@ -49,9 +49,10 @@ iterator rightPairs*(
         var x = hike.legs[^1]
 
         case x.wp.vtx.vType
-        of Branch:
-          for i in uint8(x.nibble + 1)..<16u8:
-            let b = x.wp.vtx.bVid(i)
+        of Branches:
+          let vtx = BranchRef(x.wp.vtx)
+          for i in uint8(x.nibble + 1) ..< 16u8:
+            let b = vtx.bVid(i)
             if b.isValid():
               hike.legs[^1].nibble = int8(i)
 
@@ -59,8 +60,9 @@ iterator rightPairs*(
               break nextLeg
 
           hike.legs.setLen(hike.legs.len - 1)
-        of Leaf:
-          yield (Hash32(hike.to(NibblesBuf).getBytes()), hike.legs[^1].wp.vtx)
+        of Leaves:
+          let vtx = LeafRef(hike.legs[^1].wp.vtx)
+          yield (Hash32(hike.to(NibblesBuf).getBytes()), vtx)
           hike.legs.setLen(hike.legs.len - 1)
 
 iterator rightPairsStorage*(
@@ -73,7 +75,7 @@ iterator rightPairsStorage*(
       break body
     if stoID.isValid:
       for (path, vtx) in db.rightPairs(stoID):
-        yield (path, vtx.lData.stoData)
+        yield (path, StoLeafRef(vtx).stoData)
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/db/aristo/aristo_proof.nim
+++ b/execution_chain/db/aristo/aristo_proof.nim
@@ -50,13 +50,14 @@ proc chainRlpNodes(
 
   # Follow up child node
   case vtx.vType:
-  of Leaf:
+  of Leaves:
     if path != vtx.pfx:
       err(PartChnLeafPathMismatch)
     else:
       ok()
 
-  of Branch:
+  of Branches:
+    let vtx = BranchRef(vtx)
     let nChewOff = sharedPrefixLen(vtx.pfx, path)
     if nChewOff != vtx.pfx.len:
       err(PartChnExtPfxMismatch)

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -65,11 +65,11 @@ proc buildSnapshot(txFrame: AristoTxRef, minLevel: int) =
           max(1024, max(frame.sTab.len, frame.snapshot.vtx.len))
         )
 
-        txFrame.snapshot.acc = initTable[Hash32, (VertexRef, int)](
+        txFrame.snapshot.acc = initTable[Hash32, (AccLeafRef, int)](
           max(1024, max(frame.accLeaves.len, frame.snapshot.acc.len))
         )
 
-        txFrame.snapshot.sto = initTable[Hash32, (VertexRef, int)](
+        txFrame.snapshot.sto = initTable[Hash32, (StoLeafRef, int)](
           max(1024, max(frame.stoLeaves.len, frame.snapshot.sto.len))
         )
 

--- a/execution_chain/db/aristo/aristo_walk/memory_only.nim
+++ b/execution_chain/db/aristo/aristo_walk/memory_only.nim
@@ -29,7 +29,7 @@ export
 iterator walkVtxBe*[T: MemBackendRef](
    _: type T;
    db: AristoDbRef;
-   kinds = {Branch, Leaf};
+   kinds = {Branch, ExtBranch, AccLeaf, StoLeaf};
      ): tuple[rvid: RootedVertexID, vtx: VertexRef] =
   ## Iterate over filtered memory backend or backend-less vertices. This
   ## function depends on the particular backend type name which must match

--- a/execution_chain/db/aristo/aristo_walk/persistent.nim
+++ b/execution_chain/db/aristo/aristo_walk/persistent.nim
@@ -34,7 +34,7 @@ export
 iterator walkVtxBe*[T: RdbBackendRef](
    _: type T;
    db: AristoDbRef;
-   kinds = {Branch, Leaf};
+   kinds = {Branch, ExtBranch, AccLeaf, StoLeaf};
      ): tuple[rvid: RootedVertexID, vtx: VertexRef] =
   ## Iterate over RocksDB backend vertices. This function depends on
   ## the particular backend type name which must match the backend descriptor.

--- a/execution_chain/db/opts.nim
+++ b/execution_chain/db/opts.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/execution_chain/db/opts.nim
+++ b/execution_chain/db/opts.nim
@@ -22,11 +22,11 @@ const
     ## The row cache is disabled by default as the rdb lru caches do a better
     ## job at a similar abstraction level - ie they work at the same granularity
     ## as the rocksdb row cache but with less overhead
-  defaultBlockCacheSize* = 1024 * 1024 * 1024 * 5 div 2
+  defaultBlockCacheSize* = 1024 * 1024 * 1024 * 2
     ## The block cache is used to cache indicies, ribbon filters and
     ## decompressed data, roughly in that priority order. At the time of writing
     ## we have about 2 giga-entries in the MPT - with the ribbon filter
-    ## using about 8 bits per entry we need 2gb of space just for the filters.
+    ## using about 8 bits per entry we need ~2gb of space just for the filters.
     ##
     ## When the filters don't fit in memory, random access patterns such as
     ## MPT root computations suffer because of filter evictions and subsequent
@@ -35,7 +35,7 @@ const
     ## A bit of space on top of the filter is left for data block caching
   defaultRdbVtxCacheSize* = 512 * 1024 * 1024
     ## Cache of branches and leaves in the state MPTs (world and account)
-  defaultRdbKeyCacheSize* = 256 * 1024 * 1024
+  defaultRdbKeyCacheSize* = 1280 * 1024 * 1024
     ## Hashes of the above
   defaultRdbBranchCacheSize* = 1024 * 1024 * 1024
     ## Cache of branches and leaves in the state MPTs (world and account)

--- a/tests/test_aristo/test_blobify.nim
+++ b/tests/test_aristo/test_blobify.nim
@@ -15,22 +15,21 @@ import unittest2, std/sequtils, ../../execution_chain/db/aristo/aristo_blobify
 suite "Aristo blobify":
   test "VertexRef roundtrip":
     let
-      leafAccount = VertexRef(
-        vType: Leaf,
+      leafAccount = AccLeafRef(
+        vType: AccLeaf,
         pfx: NibblesBuf.nibble(1),
-        lData: LeafPayload(
-          pType: AccountData, account: AristoAccount(nonce: 100, balance: 123.u256)
-        ),
+        account: AristoAccount(nonce: 100, balance: 123.u256),
+        stoID: (isValid: true, vid: VertexID(5))
       )
-      leafStoData = VertexRef(
-        vType: Leaf,
+      leafStoData = StoLeafRef(
+        vType: StoLeaf,
         pfx: NibblesBuf.nibble(3),
-        lData: LeafPayload(pType: StoData, stoData: 42.u256),
+        stoData: 42.u256,
       )
-      branch = VertexRef(vType: Branch, startVid: VertexID(0x334452), used: 0x43'u16)
+      branch = BranchRef(vType: Branch, startVid: VertexID(0x334452), used: 0x43'u16)
 
-      extension = VertexRef(
-        vType: Branch,
+      extension = ExtBranchRef(
+        vType: ExtBranch,
         pfx: NibblesBuf.nibble(2),
         startVid: VertexID(0x55),
         used: 0x12'u16,
@@ -46,3 +45,8 @@ suite "Aristo blobify":
 
       deblobify(blobify(branch, key), HashKey)[] == key
       deblobify(blobify(extension, key), HashKey)[] == key
+
+      deblobifyType(blobify(leafAccount, key), VertexRef)[] == AccLeaf
+      deblobifyType(blobify(leafStoData, key), VertexRef)[] == StoLeaf
+      deblobifyType(blobify(branch, key), VertexRef)[] == Branch
+      deblobifyType(blobify(extension, key), VertexRef)[] == ExtBranch


### PR DESCRIPTION
The current VertexRef is a composition of two case object types - this layout is inefficient in that each VertexRef instance takes up as much memory as its largest member. Adding to the insult are the two case fields which each take up space.

Here, we use inhertance instead to create optimally sized verticies for each node kind - in particular, the Brach kind kan drop the prefix and reduce its memory usage to a fraction of what it was using before.

The memory savings are instead invested in a larger key cache - when processing blocks for live syncing, key lookups are the source of a significant majority (95%) of database reads - when importing, the key cache is simply allotted to verticies instead.