### PR TITLE
Fluffy: Implement AsyncEvm createAccessList and eth_createAccessList RPC endpoint

### DIFF
--- a/fluffy/rpc/rpc_calls/rpc_eth_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_eth_calls.nim
@@ -49,3 +49,6 @@ createRpcSigsFromNim(RpcClient):
   ): ProofResponse
 
   proc eth_call(tx: TransactionArgs, blockId: BlockIdentifier): seq[byte]
+  proc eth_createAccessList(
+    tx: TransactionArgs, blockId: BlockIdentifier
+  ): AccessListResult

--- a/fluffy/rpc/rpc_debug_api.nim
+++ b/fluffy/rpc/rpc_debug_api.nim
@@ -174,7 +174,4 @@ proc installDebugApiHandlers*(rpcServer: RpcServer, stateNetwork: Opt[StateNetwo
     let callResult = (await evm.call(header, tx, optimisticStateFetch)).valueOr:
       raise newException(ValueError, error)
 
-    if callResult.error.len() > 0:
-      raise newException(ValueError, callResult.error)
-
     callResult.output

--- a/fluffy/tests/evm/test_async_evm.nim
+++ b/fluffy/tests/evm/test_async_evm.nim
@@ -66,16 +66,104 @@ procSuite "Async EVM":
     callData = "0xa888c2cd0000000000000000000000000000000000000000000000000000000000000007".hexToSeqByte()
     tx = TransactionArgs(to: Opt.some(address), input: Opt.some(callData))
 
-  asyncTest "Test basic call - optimistic state fetch enabled":
+  asyncTest "Basic call - optimistic state fetch enabled":
     let callResult = (await evm.call(header, tx, optimisticStateFetch = true)).expect(
       "successful call"
     )
     check callResult.output ==
       "0x000000000000000000000000fb7bc66a002762e28545ea0a7fc970d381863c420000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000c5df000000000000000000000000000000000000000000000000000000000000002d536174697366792056616c756573207468726f75676820467269656e647368697020616e6420506f6e6965732100000000000000000000000000000000000000".hexToSeqByte()
 
-  asyncTest "Test basic call - optimistic state fetch disabled":
+  asyncTest "Basic call - optimistic state fetch disabled":
     let callResult = (await evm.call(header, tx, optimisticStateFetch = false)).expect(
       "successful call"
     )
     check callResult.output ==
       "0x000000000000000000000000fb7bc66a002762e28545ea0a7fc970d381863c420000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000c5df000000000000000000000000000000000000000000000000000000000000002d536174697366792056616c756573207468726f75676820467269656e647368697020616e6420506f6e6965732100000000000000000000000000000000000000".hexToSeqByte()
+
+  asyncTest "Create access list - optimistic state fetch enabled":
+    let (accessList, gasUsed) = (
+      await evm.createAccessList(header, tx, optimisticStateFetch = true)
+    ).expect("successful call")
+
+    check:
+      accessList.len() == 1
+      gasUsed > 0
+      accessList[0].address == address
+
+    let storageKeys = accessList[0].storageKeys
+    check:
+      storageKeys.len() == 6
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x80f0598597d7a1012e2e0a89cab2b766e02a3a5e30768662751fe258f5389667"
+        )
+      )
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x80f0598597d7a1012e2e0a89cab2b766e02a3a5e30768662751fe258f5389668"
+        )
+      )
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x0000000000000000000000000000000000000000000000000000000000000000"
+        )
+      )
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e578"
+        )
+      )
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e57a"
+        )
+      )
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e579"
+        )
+      )
+
+  asyncTest "Create access list - optimistic state fetch disabled":
+    let (accessList, gasUsed) = (
+      await evm.createAccessList(header, tx, optimisticStateFetch = false)
+    ).expect("successful call")
+
+    check:
+      accessList.len() == 1
+      gasUsed > 0
+      accessList[0].address == address
+
+    let storageKeys = accessList[0].storageKeys
+    check:
+      storageKeys.len() == 6
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x80f0598597d7a1012e2e0a89cab2b766e02a3a5e30768662751fe258f5389667"
+        )
+      )
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x80f0598597d7a1012e2e0a89cab2b766e02a3a5e30768662751fe258f5389668"
+        )
+      )
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x0000000000000000000000000000000000000000000000000000000000000000"
+        )
+      )
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e578"
+        )
+      )
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e57a"
+        )
+      )
+      storageKeys.contains(
+        Bytes32.fromHex(
+          "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e579"
+        )
+      )


### PR DESCRIPTION
Changes in this PR:
- `createAccessList` function added to `AsyncEvm` so that it can be reused by the Nimbus Verified Proxy and also tested in isolation.
- Implemented `eth_createAccessList` RPC endpoint.
- Tests for `AsyncEvm` `createAccessList`.