### PR TITLE
fluffy: add Portal wire accept codes

### DIFF
--- a/fluffy/network/wire/messages.nim
+++ b/fluffy/network/wire/messages.nim
@@ -27,7 +27,7 @@ const
 
 type
   ContentKeysList* = List[ContentKeyByteList, contentKeysLimit]
-  ContentKeysBitList* = BitList[contentKeysLimit]
+  ContentKeysAcceptList* = ByteList[contentKeysLimit]
 
   MessageKind* = enum
     ping = 0x00
@@ -80,7 +80,7 @@ type
 
   AcceptMessage* = object
     connectionId*: Bytes2
-    contentKeys*: ContentKeysBitList
+    contentKeys*: ContentKeysAcceptList
 
   Message* = object
     case kind*: MessageKind

--- a/fluffy/tests/wire_protocol_tests/test_portal_wire_encoding.nim
+++ b/fluffy/tests/wire_protocol_tests/test_portal_wire_encoding.nim
@@ -246,14 +246,13 @@ suite "Portal Wire Protocol Message Encodings":
       message.offer.contentKeys == contentKeys
 
   test "Accept Response":
-    var contentKeys = ContentKeysBitList.init(8)
-    contentKeys.setBit(0)
     let
+      contentKeys = ContentKeysAcceptList.init(@[byte 0, 1, 2, 3, 4, 5, 1, 1])
       connectionId = Bytes2([byte 0x01, 0x02])
       a = AcceptMessage(connectionId: connectionId, contentKeys: contentKeys)
 
     let encoded = encodeMessage(a)
-    check encoded.toHex == "070102060000000101"
+    check encoded.toHex == "070102060000000001020304050101"
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()


### PR DESCRIPTION
Add accept/decline codes for offer's accept response: https://github.com/ethereum/portal-network-specs/pull/370

Put in draft as this needs to become selective by version