### PR TITLE
Fix FC inconsistent hashToBlock vs number of blocks in branches

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -477,7 +477,8 @@ proc updateBase(c: ForkedChainRef, newBase: BlockPos) =
   # Older branches will gone
   branch = branch.parent
   while not branch.isNil:
-    disposeBlocks(number, branch)
+    var delNumber = branch.headNumber    
+    disposeBlocks(delNumber, branch)
 
     for i, brc in c.branches:
       if brc == branch:

--- a/tests/test_forked_chain/chain_debug.nim
+++ b/tests/test_forked_chain/chain_debug.nim
@@ -101,8 +101,11 @@ func validate*(c: ForkedChainRef): Result[void,string] =
     if chain[0] != c.baseHash:
       return err("unbased chain: " & chain.cnStr(c))
 
+  var numBlocksInBranches = 0
   # Cursor heads must refer to items of `c.blocks[]`
   for brc in c.branches:
+    numBlocksInBranches += brc.len
+
     for bd in brc.blocks:
       if not c.hashToBlock.hasKey(bd.hash):
         return err("stray block: " & pp(bd))
@@ -114,6 +117,10 @@ func validate*(c: ForkedChainRef): Result[void,string] =
     if not parent.isNil:
       if brc.tailNumber < parent.tailNumber:
         return err("branch junction too small: " & $brc.tailNumber)
+
+  if numBlocksInBranches != c.hashToBlock.len:
+    return err("inconsistent number of blocks in branches: " & $numBlocksInBranches &
+      " vs number of block hashes " & $c.hashToBlock.len)
 
   ok()
 


### PR DESCRIPTION
Because of this bug, hashToBlock still contains refs to deleted branches. Possible outcome are:
- OOM because those hashes never deleted.
- Worst case is crash if the caller try to access deleted blocks.

Condition to trigger this bug:
- Branches with junction older than base

This PR fix the problem. Tests are fixed, two of the test cases contains condition to reproduce this bug. 
No new test cases added.