### PR TITLE
fix: handle garbage txs inside payload

### DIFF
--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -120,8 +120,7 @@ proc newPayload*(ben: BeaconEngineRef,
   trace "Engine API request received",
     meth = "newPayload",
     number = payload.blockNumber,
-    hash = payload.blockHash,
-    payload = payload
+    hash = payload.blockHash
 
   if apiVersion >= Version.V3:
     if beaconRoot.isNone:
@@ -147,7 +146,13 @@ proc newPayload*(ben: BeaconEngineRef,
 
   let
     requestsHash = calcRequestsHash(executionRequests)
-    blk = ethBlock(payload, beaconRoot, requestsHash)
+    blk = 
+      try:
+        ethBlock(payload, beaconRoot, requestsHash)
+      except RlpError as e:
+        warn "Failed to decode payload",
+          error = e.msg
+        return invalidStatus(payload.blockHash, "Failed to decode payload")
 
   template header: Header = blk.header
 

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -120,7 +120,8 @@ proc newPayload*(ben: BeaconEngineRef,
   trace "Engine API request received",
     meth = "newPayload",
     number = payload.blockNumber,
-    hash = payload.blockHash
+    hash = payload.blockHash,
+    payload = payload
 
   if apiVersion >= Version.V3:
     if beaconRoot.isNone:


### PR DESCRIPTION
Issue found using hive, reported by EF testing team
```bash
DBG 2025-04-10 21:29:24.340+00:00 Error occurred within RPC                  methodName=engine_newPayloadV3 err="Unsigned integer expected, but the source RLP is a list"
```
Returning `engineApiServerError`
```bash
The above exception was the direct cause of the following exception:
src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py:93: in test_blockchain_via_engine
    raise Exception(f"unexpected error: {e.code} - {e.message}") from e
E   Exception: unexpected error: -32000 - `engine_newPayloadV3` raised an exception
# Captured Output from Test Setup
```

This is due to garbage txs inside payload. Which can happen due to some reason, but according to spec we must return `INVALID`