### PR TITLE
fix: spec deviation in `newPayloadV4`

### DIFF
--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -87,7 +87,7 @@ template validatePayload(apiVersion, payloadVersion, payload) =
       raise invalidParams("newPayload" & $apiVersion &
         "excessBlobGas is expected from execution payload")
 
-# https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#engine_newpayloadv4
+# https://github.com/ethereum/execution-apis/blob/40088597b8b4f48c45184da002e27ffc3c37641f/src/engine/prague.md#request
 template validateExecutionRequest(requests: openArray[seq[byte]], apiVersion: Version) =
   var previousRequestType = -1
   for request in requests:

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -120,8 +120,7 @@ proc newPayload*(ben: BeaconEngineRef,
   trace "Engine API request received",
     meth = "newPayload",
     number = payload.blockNumber,
-    hash = payload.blockHash,
-    payload = payload
+    hash = payload.blockHash
 
   if apiVersion >= Version.V3:
     if beaconRoot.isNone:
@@ -147,7 +146,13 @@ proc newPayload*(ben: BeaconEngineRef,
 
   let
     requestsHash = calcRequestsHash(executionRequests)
-    blk = ethBlock(payload, beaconRoot, requestsHash)
+    blk = 
+      try:
+        ethBlock(payload, beaconRoot, requestsHash)
+      except RlpError as e:
+        warn "Failed to decode payload",
+          error = e.msg
+        return invalidStatus(payload.blockHash, "Failed to decode payload")
 
   template header: Header = blk.header
 

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -120,7 +120,8 @@ proc newPayload*(ben: BeaconEngineRef,
   trace "Engine API request received",
     meth = "newPayload",
     number = payload.blockNumber,
-    hash = payload.blockHash
+    hash = payload.blockHash,
+    payload = payload
 
   if apiVersion >= Version.V3:
     if beaconRoot.isNone:

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -87,28 +87,30 @@ template validatePayload(apiVersion, payloadVersion, payload) =
       raise invalidParams("newPayload" & $apiVersion &
         "excessBlobGas is expected from execution payload")
 
-func validateExecutionRequest(requests: openArray[seq[byte]]): Result[void, string] {.raises:[].} =
+template validateExecutionRequest(requests: openArray[seq[byte]], apiVersion: Version) =
   var previousRequestType = -1
   for request in requests:
     if request.len == 0:
-      return err("Execution request data must not be empty")
+      raise invalidParams("newPayload" & $apiVersion &
+        ": " & "Execution request data must not be empty")
 
     let requestType = request[0]
     if requestType.int <= previousRequestType:
-      return err("Execution requests are not in strictly ascending order")
+      raise invalidParams("newPayload" & $apiVersion &
+        ": " & "Execution requests are not in strictly ascending order")
 
     if request.len == 1:
-      return err("Empty data for request type " & $requestType)
+      raise invalidParams("newPayload" & $apiVersion &
+        ": " & "Empty data for request type " & $requestType)
 
     if requestType notin [
        DEPOSIT_REQUEST_TYPE,
        WITHDRAWAL_REQUEST_TYPE,
        CONSOLIDATION_REQUEST_TYPE]:
-      return err("Invalid execution request type: " & $requestType)
+      return invalidStatus(payload.blockHash, "Invalid execution request type" & $requestType)
 
     previousRequestType = requestType.int
 
-  ok()
 
 proc newPayload*(ben: BeaconEngineRef,
                  apiVersion: Version,
@@ -131,9 +133,7 @@ proc newPayload*(ben: BeaconEngineRef,
       raise invalidParams("newPayload" & $apiVersion &
         ": executionRequests is expected from execution payload")
 
-    validateExecutionRequest(executionRequests.get).isOkOr:
-      raise invalidParams("newPayload" & $apiVersion &
-        ": " & error)
+    validateExecutionRequest(executionRequests.get, apiVersion)
 
   let
     com = ben.com

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -87,6 +87,7 @@ template validatePayload(apiVersion, payloadVersion, payload) =
       raise invalidParams("newPayload" & $apiVersion &
         "excessBlobGas is expected from execution payload")
 
+# https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#engine_newpayloadv4
 template validateExecutionRequest(requests: openArray[seq[byte]], apiVersion: Version) =
   var previousRequestType = -1
   for request in requests:

--- a/tests/test_engine_api.nim
+++ b/tests/test_engine_api.nim
@@ -285,7 +285,7 @@ proc newPayloadV4InvalidRequestType(env: TestEnv): Result[void, string] =
     return err("res should success")
 
   if res.get.status != PayloadExecutionStatus.invalid:
-    return err("res.status should equals to PayloadExecutionStatus.invalid")
+    return err("res.status should be equal to PayloadExecutionStatus.invalid")
 
   ok()
 

--- a/tests/test_engine_api.nim
+++ b/tests/test_engine_api.nim
@@ -244,7 +244,6 @@ proc newPayloadV4InvalidRequests(env: TestEnv): Result[void, string] =
     paramsFiles = [
       "tests/engine_api/newPayloadV4_invalid_requests.json",
       "tests/engine_api/newPayloadV4_empty_requests_data.json",
-      "tests/engine_api/newPayloadV4_invalid_requests_type.json",
       "tests/engine_api/newPayloadV4_invalid_requests_order.json",
     ]
 
@@ -266,6 +265,27 @@ proc newPayloadV4InvalidRequests(env: TestEnv): Result[void, string] =
 
     if "request" notin res.error:
       return err("expect \"request\" in error message: " & res.error)
+
+  ok()
+
+proc newPayloadV4InvalidRequestType(env: TestEnv): Result[void, string] =
+  const
+    paramsFile = "tests/engine_api/newPayloadV4_invalid_requests_type.json"
+
+  let
+    client = env.client
+    params = JrpcConv.loadFile(paramsFile, NewPayloadV4Params)
+    res = client.newPayloadV4(
+      params.payload,
+      params.expectedBlobVersionedHashes,
+      params.parentBeaconBlockRoot,
+      params.executionRequests)
+
+  if res.isErr:
+    return err("res should success")
+
+  if res.get.status != PayloadExecutionStatus.invalid:
+    return err("res.status should equals to PayloadExecutionStatus.invalid")
 
   ok()
 
@@ -295,6 +315,11 @@ const testList = [
     name: "newPayloadV4 invalid execution requests",
     fork: Prague,
     testProc: newPayloadV4InvalidRequests
+  ),
+  TestSpec(
+    name: "newPayloadV4 invalid execution request type",
+    fork: Prague,
+    testProc: newPayloadV4InvalidRequestType
   ),
   ]
 


### PR DESCRIPTION
Found using hive, reported by EF testing team 

> executionRequests: Array of DATA - List of execution layer triggered requests. Each list element is a requests byte array as defined by [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685). The first byte of each element is the request_type and the remaining bytes are the request_data. Elements of the list MUST be ordered by request_type in ascending order. Elements with empty request_data MUST be excluded from the list. If any element is out of order, has a length of 1-byte or shorter, or more than one element has the same type byte, client software MUST return -32602: Invalid params error.

Ref -> https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#request

This infers to if execution request type is invalid in length then we issue a invalid params error, other than that we must return INVALID as payloadStatus

