### PR TITLE
Fluffy: Implement AsyncEvm estimateGas and eth_estimateGas RPC endpoint

### DIFF
--- a/fluffy/rpc/rpc_calls/rpc_eth_calls.nim
+++ b/fluffy/rpc/rpc_calls/rpc_eth_calls.nim
@@ -52,3 +52,5 @@ createRpcSigsFromNim(RpcClient):
   proc eth_createAccessList(
     tx: TransactionArgs, blockId: BlockIdentifier
   ): AccessListResult
+
+  proc eth_estimateGas(tx: TransactionArgs, blockId: BlockIdentifier): Quantity

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -544,7 +544,7 @@ proc installEthApiHandlers*(
       optimisticStateFetch = optimisticStateFetch.valueOr:
         true
 
-    # let gasUsed = (await evm.estimateGas(header, tx, optimisticStateFetch)).valueOr:
-    #   raise newException(ValueError, error)
+    let gasEstimate = (await evm.estimateGas(header, tx, optimisticStateFetch)).valueOr:
+      raise newException(ValueError, error)
 
-    # return gasUsed.Quantity
+    return gasEstimate.Quantity

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -508,3 +508,43 @@ proc installEthApiHandlers*(
       raise newException(ValueError, error)
 
     return AccessListResult(accessList: accessList, gasUsed: gasUsed.Quantity)
+
+  rpcServer.rpc("eth_estimateGas") do(
+    tx: TransactionArgs, quantityTag: RtBlockIdentifier, optimisticStateFetch: Opt[bool]
+  ) -> Quantity:
+    ## Generates and returns an estimate of how much gas is necessary to allow the
+    ## transaction to complete. The transaction will not be added to the blockchain.
+    ## Note that the estimate may be significantly more than the amount of gas actually
+    ## used by the transaction, for a variety of reasons including EVM mechanics and
+    ## node performance.
+    ##
+    ## tx: the transaction call object which contains
+    ##   from: (optional) The address the transaction is sent from.
+    ##   to: The address the transaction is directed to.
+    ##   gas: (optional) Integer of the gas provided for the transaction execution.
+    ##     eth_call consumes zero gas, but this parameter may be needed by some executions.
+    ##   gasPrice: (optional) Integer of the gasPrice used for each paid gas.
+    ##   value: (optional) Integer of the value sent with this transaction.
+    ##   input: (optional) Hash of the method signature and encoded parameters.
+    ## quantityTag: integer block number, or the string "latest", "earliest" or "pending",
+    ##   see the default block parameter.
+    ## Returns: the amount of gas used.
+
+    if tx.to.isNone():
+      raise newException(ValueError, "to address is required")
+
+    if quantityTag.kind == bidAlias:
+      raise newException(ValueError, "tag not yet implemented")
+
+    let
+      hn = historyNetwork.getOrRaise()
+      evm = asyncEvm.getOrRaise()
+      header = (await hn.getVerifiedBlockHeader(quantityTag.number.uint64)).valueOr:
+        raise newException(ValueError, "Unable to get block header")
+      optimisticStateFetch = optimisticStateFetch.valueOr:
+        true
+
+    # let gasUsed = (await evm.estimateGas(header, tx, optimisticStateFetch)).valueOr:
+    #   raise newException(ValueError, error)
+
+    # return gasUsed.Quantity

--- a/fluffy/tests/evm/test_async_evm.nim
+++ b/fluffy/tests/evm/test_async_evm.nim
@@ -62,7 +62,7 @@ procSuite "Async EVM":
     address = "0x6e38a457c722c6011b2dfa06d49240e797844d66".address()
     testState = setupTestEvmState(address)
     evm = AsyncEvm.init(testState.toAsyncEvmStateBackend())
-    header = Header(number: 999962.uint64)
+    header = Header(number: 999962.uint64, gasLimit: 50_000_000.GasInt)
     callData = "0xa888c2cd0000000000000000000000000000000000000000000000000000000000000007".hexToSeqByte()
     tx = TransactionArgs(to: Opt.some(address), input: Opt.some(callData))
 
@@ -167,3 +167,15 @@ procSuite "Async EVM":
           "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e579"
         )
       )
+
+  asyncTest "Estimate Gas - optimistic state fetch enabled":
+    let gasEstimate = (await evm.estimateGas(header, tx, optimisticStateFetch = true)).expect(
+      "successful call"
+    )
+    check gasEstimate == 22497.GasInt
+
+  asyncTest "Estimate Gas - optimistic state fetch disabled":
+    let gasEstimate = (await evm.estimateGas(header, tx, optimisticStateFetch = false)).expect(
+      "successful call"
+    )
+    check gasEstimate == 22497.GasInt


### PR DESCRIPTION
Changes in this PR:
- `AsyncEvm` cleanup and refactor.
- `estimateGas` function added to `AsyncEvm` so that it can be reused by the Nimbus Verified Proxy and also tested in isolation.
- Implemented `eth_estimateGas` RPC endpoint.
- Tests for `AsyncEvm` `estimateGas`.