### PR TITLE
Rename rlpHash/blockHash to computeRlpHash/computeBlockHash

### DIFF
--- a/execution_chain/beacon/api_handler/api_utils.nim
+++ b/execution_chain/beacon/api_handler/api_utils.nim
@@ -51,7 +51,7 @@ proc validateBlockHash*(header: common.Header,
                         wantHash: common.Hash32,
                         version: Version): Result[void, PayloadStatusV1]
                           {.gcsafe, raises: [ValueError].} =
-  let gotHash = header.blockHash
+  let gotHash = header.computeBlockHash
   if wantHash != gotHash:
     let status = if version == Version.V1:
                    PayloadExecutionStatus.invalid_block_hash
@@ -180,7 +180,7 @@ proc latestValidHash*(txFrame: CoreDbTxRef,
   # TODO shouldn't this be in forkedchainref?
   let ptd = txFrame.getScore(parent.parentHash).valueOr(0.u256)
   if ptd >= ttd:
-    parent.blockHash
+    parent.computeBlockHash
   else:
     # If the most recent valid ancestor is a PoW block,
     # latestValidHash MUST be set to ZERO

--- a/execution_chain/beacon/payload_conv.nim
+++ b/execution_chain/beacon/payload_conv.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -58,7 +58,7 @@ func executionPayload*(blk: Block): ExecutionPayload =
     timestamp    : w3Qty blk.header.timestamp,
     extraData    : w3ExtraData blk.header.extraData,
     baseFeePerGas: blk.header.baseFeePerGas.get(0.u256),
-    blockHash    : blk.header.rlpHash,
+    blockHash    : blk.header.computeRlpHash,
     transactions : w3Txs blk.txs,
     withdrawals  : w3Withdrawals blk.withdrawals,
     blobGasUsed  : w3Qty blk.header.blobGasUsed,
@@ -79,7 +79,7 @@ func executionPayloadV1V2*(blk: Block): ExecutionPayloadV1OrV2 =
     timestamp    : w3Qty blk.header.timestamp,
     extraData    : w3ExtraData blk.header.extraData,
     baseFeePerGas: blk.header.baseFeePerGas.get(0.u256),
-    blockHash    : blk.header.rlpHash,
+    blockHash    : blk.header.computeRlpHash,
     transactions : w3Txs blk.txs,
     withdrawals  : w3Withdrawals blk.withdrawals,
   )

--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -91,7 +91,7 @@ type
 # ------------------------------------------------------------------------------
 
 func setForkId(com: CommonRef, genesis: Header) =
-  com.genesisHash = genesis.blockHash
+  com.genesisHash = genesis.computeBlockHash
   let genesisCRC = crc32(0, com.genesisHash.data)
   com.forkIdCalculator = initForkIdCalculator(
     com.forkTransitionTable,
@@ -111,7 +111,7 @@ proc initializeDb(com: CommonRef) =
     txFrame.hasKeyRc(key).expect "valid bool"
   if canonicalHeadHashKey().toOpenArray notin txFrame:
     info "Writing genesis to DB",
-      blockHash = com.genesisHeader.rlpHash,
+      blockHash = com.genesisHeader.computeBlockHash,
       stateRoot = com.genesisHeader.stateRoot,
       difficulty = com.genesisHeader.difficulty,
       gasLimit = com.genesisHeader.gasLimit,
@@ -145,9 +145,9 @@ proc initializeDb(com: CommonRef) =
       quit 1
 
   info "Database initialized",
-    base = (base.blockHash, base.number),
-    finalized = (finalized.blockHash, finalized.number),
-    head = (head.blockHash, head.number)
+    base = (base.computeBlockHash, base.number),
+    finalized = (finalized.computeBlockHash, finalized.number),
+    head = (head.computeBlockHash, head.number)
 
 proc init(com         : CommonRef,
           db          : CoreDbRef,

--- a/execution_chain/core/chain/forked_chain/chain_header_cache.nim
+++ b/execution_chain/core/chain/forked_chain/chain_header_cache.nim
@@ -287,7 +287,7 @@ proc fcUpdateFromCL(fc: ForkedCacheRef; h: Header; f: Hash32) =
         mode:     notified,
         ante:     h,
         head:     h,
-        headHash: h.blockHash(),
+        headHash: h.computeBlockHash(),
         finHash:  f)
 
       # Inform client app about that a new session is available.
@@ -323,7 +323,7 @@ proc accept*(fc: ForkedCacheRef; fin: Header): bool =
      fc.baseNum < fin.number and
      fin.number <= fc.session.head.number:
 
-    let finHash = fin.blockHash()
+    let finHash = fin.computeBlockHash()
     if fc.session.finHash != finHash:
       return false
 
@@ -494,7 +494,7 @@ proc fcHeaderPut*(
         return ok()
 
       # Check parent link
-      let hash = hdr.blockHash
+      let hash = hdr.computeBlockHash
       if vetted[^1].parent != hash:
         # There is no need to clean up as nothing was store on the DB
         return err("Parent hash mismatch for rev[" & $n & "].number=" &

--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -155,7 +155,7 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
   )
 
   if NoPersistHeader notin p.flags:
-    let blockHash = header.blockHash()
+    let blockHash = header.computeBlockHash()
     ?txFrame.persistHeaderAndSetHead(blockHash, header, com.startOfHistory)
 
   if NoPersistTransactions notin p.flags:

--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -174,7 +174,7 @@ proc procBlkPreamble(
       let h = vmState.ledger.txFrame.persistUncles(blk.uncles)
       if h != header.ommersHash:
         return err("ommersHash mismatch")
-    elif not skipValidation and rlpHash(blk.uncles) != header.ommersHash:
+    elif not skipValidation and computeRlpHash(blk.uncles) != header.ommersHash:
       return err("ommersHash mismatch")
   elif blk.uncles.len > 0:
     return err("Uncles in block with empty uncle hash")

--- a/execution_chain/core/tx_pool.nim
+++ b/execution_chain/core/tx_pool.nim
@@ -106,7 +106,7 @@ export
 
 proc removeNewBlockTxs*(xp: TxPoolRef, blk: Block, optHash = Opt.none(Hash32)) =
   let fromHash = if optHash.isSome: optHash.get
-                 else: blk.header.blockHash
+                 else: blk.header.computeBlockHash
 
   # Up to date, no need for further actions
   if fromHash == xp.rmHash:
@@ -115,7 +115,7 @@ proc removeNewBlockTxs*(xp: TxPoolRef, blk: Block, optHash = Opt.none(Hash32)) =
   # Remove only the latest block transactions
   if blk.header.parentHash == xp.rmHash:
     for tx in blk.transactions:
-      let txHash = rlpHash(tx)
+      let txHash = computeRlpHash(tx)
       xp.removeTx(txHash)
 
     xp.rmHash = fromHash

--- a/execution_chain/core/validate.nim
+++ b/execution_chain/core/validate.nim
@@ -119,7 +119,7 @@ proc validateUncles(com: CommonRef; header: Header; txFrame: CoreDbTxRef,
   # Check for duplicates
   var uncleSet = HashSet[Hash32]()
   for uncle in uncles:
-    let uncleHash = uncle.blockHash
+    let uncleHash = uncle.computeBlockHash
     if uncleHash in uncleSet:
       return err("Block contains duplicate uncles")
     else:
@@ -128,10 +128,10 @@ proc validateUncles(com: CommonRef; header: Header; txFrame: CoreDbTxRef,
   let
     recentAncestorHashes = ?txFrame.getAncestorsHashes(MAX_UNCLE_DEPTH + 1, header)
     recentUncleHashes = ?txFrame.getUncleHashes(recentAncestorHashes)
-    blockHash = header.blockHash
+    blockHash = header.computeBlockHash
 
   for uncle in uncles:
-    let uncleHash = uncle.blockHash
+    let uncleHash = uncle.computeBlockHash
 
     if uncleHash == blockHash:
       return err("Uncle has same hash as block")

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -240,7 +240,7 @@ proc getAncestorsHashes*(
     res = newSeq[Hash32](ancestorCount)
   while ancestorCount > 0:
     h = ?db.getBlockHeader(h.parentHash)
-    res[ancestorCount - 1] = h.rlpHash
+    res[ancestorCount - 1] = h.computeRlpHash
     dec ancestorCount
   ok(res)
 
@@ -417,7 +417,7 @@ proc getEthBlock*(
       ): Result[EthBlock, string] =
   var
     header = ?db.getBlockHeader(blockNumber)
-    headerHash = header.blockHash
+    headerHash = header.computeBlockHash
     blockBody = ?db.getBlockBody(headerHash)
   ok(EthBlock.init(move(header), move(blockBody)))
 
@@ -429,7 +429,7 @@ proc getUncleHashes*(
   var res: seq[Hash32]
   for blockHash in blockHashes:
     let body = ?db.getBlockBody(blockHash)
-    res &= body.uncles.mapIt(it.rlpHash)
+    res &= body.uncles.mapIt(it.computeRlpHash)
   ok(res)
 
 proc getUncleHashes*(
@@ -446,7 +446,7 @@ proc getUncleHashes*(
         if error.error != KvtNotFound:
           warn "getUncleHashes()", ommersHash=header.ommersHash, error=($$error)
         return ok(default(seq[Hash32]))
-    return ok(rlp.decode(encodedUncles, seq[Header]).mapIt(it.rlpHash))
+    return ok(rlp.decode(encodedUncles, seq[Header]).mapIt(it.computeRlpHash))
 
 proc getTransactionKey*(
     db: CoreDbTxRef;
@@ -589,7 +589,7 @@ proc persistHeaderAndSetHead*(
     startOfHistory = GENESIS_PARENT_HASH;
       ): Result[void, string] =
   let
-    blockHash = header.blockHash
+    blockHash = header.computeBlockHash
   db.persistHeaderAndSetHead(blockHash, header, startOfHistory)
 
 proc persistUncles*(db: CoreDbTxRef, uncles: openArray[Header]): Hash32 =

--- a/execution_chain/evm/computation.nim
+++ b/execution_chain/evm/computation.nim
@@ -190,7 +190,7 @@ proc writeContract*(c: Computation) =
   template withExtra(tracer: untyped, args: varargs[untyped]) =
     tracer args, newContract=($c.msg.contractAddress),
       blockNumber=c.vmState.blockNumber,
-      parentHash=($c.vmState.parent.blockHash)
+      parentHash=($c.vmState.parent.computeBlockHash)
 
   # In each check below, they are guarded by `len > 0`.  This includes writing
   # out the code, because the account already has zero-length code to handle

--- a/execution_chain/rpc/filters.nim
+++ b/execution_chain/rpc/filters.nim
@@ -76,7 +76,7 @@ proc deriveLogs*(
   if txHashes.isSome:
     doAssert(txHashes.get.len == len(transactions))
 
-  let blkHash = header.blockHash
+  let blkHash = header.computeBlockHash
   var resLogs: seq[FilterLog] = @[]
   var logIndex = 0'u64
 
@@ -84,11 +84,11 @@ proc deriveLogs*(
     let logs = receipt.logs.filterIt(it.match(filterOptions.address, filterOptions.topics))
     if logs.len > 0:
       # TODO avoid recomputing entirely - we should have this cached somewhere
-      let txHash = 
+      let txHash =
         if txHashes.isSome:
-            txHashes.get[i] # cached txHashes 
+            txHashes.get[i] # cached txHashes
         else:
-          transactions[i].rlpHash
+          transactions[i].computeRlpHash
 
       for log in logs:
         let filterLog = FilterLog(

--- a/execution_chain/sync/beacon/worker/blocks_staged.nim
+++ b/execution_chain/sync/beacon/worker/blocks_staged.nim
@@ -88,7 +88,7 @@ proc fetchAndCheck(
     ctx.poolMode = true
     return false
   request.blockHashes[ivReq.len - 1] =
-    blk.blocks[offset + ivReq.len - 1].header.blockHash
+    blk.blocks[offset + ivReq.len - 1].header.computeBlockHash
 
   # Fetch bodies
   let bodies = block:

--- a/execution_chain/sync/beacon/worker/headers_staged/staged_collect.nim
+++ b/execution_chain/sync/beacon/worker/headers_staged/staged_collect.nim
@@ -206,7 +206,7 @@ proc collectAndStageOnMemQueue*(
         break fetchHeadersBody           # error => exit block
 
       # Check/update hashes
-      let hash0 = rev[0].blockHash
+      let hash0 = rev[0].computeBlockHash
       if lhc.revHdrs.len == 0:
         lhc.hash = hash0
       else:

--- a/execution_chain/sync/wire_protocol/handler.nim
+++ b/execution_chain/sync/wire_protocol/handler.nim
@@ -54,7 +54,7 @@ proc getStatus*(ctx: EthWireRef): EthState =
   EthState(
     totalDifficulty: txFrame.headTotalDifficulty,
     genesisHash: com.genesisHash,
-    bestBlockHash: bestBlock.blockHash,
+    bestBlockHash: bestBlock.computeBlockHash,
     forkId: ChainForkId(
       forkHash: forkId.crc.toBytesBE,
       forkNext: forkId.nextFork

--- a/execution_chain/utils/debug.nim
+++ b/execution_chain/utils/debug.nim
@@ -58,7 +58,7 @@ proc debug*(h: Header): string =
     result.add "beaconRoot     : " & $h.parentBeaconBlockRoot.get() & "\n"
   if h.requestsHash.isSome:
     result.add "requestsHash   : " & $h.requestsHash.get() & "\n"
-  result.add "blockHash      : " & $blockHash(h) & "\n"
+  result.add "blockHash      : " & $computeBlockHash(h) & "\n"
 
 proc dumpAccounts*(vmState: BaseVMState): JsonNode =
   %dumpAccounts(vmState.ledger)
@@ -84,7 +84,7 @@ proc debugAccounts*(vmState: BaseVMState): string =
 
 proc debug*(vms: BaseVMState): string =
   result.add "proofOfStake     : " & $vms.proofOfStake()      & "\n"
-  result.add "parent           : " & $vms.parent.blockHash    & "\n"
+  result.add "parent           : " & $vms.parent.computeBlockHash    & "\n"
   result.add "timestamp        : " & $vms.blockCtx.timestamp  & "\n"
   result.add "gasLimit         : " & $vms.blockCtx.gasLimit   & "\n"
   result.add "baseFeePerGas    : " & $vms.blockCtx.baseFeePerGas & "\n"

--- a/fluffy/eth_data/era1.nim
+++ b/fluffy/eth_data/era1.nim
@@ -19,7 +19,7 @@ import
   ncli/e2store,
   ../network/history/validation/historical_hashes_accumulator
 
-from eth/common/eth_types_rlp import rlpHash
+from eth/common/eth_types_rlp import computeRlpHash
 from nimcrypto/hash import fromHex
 from ../../execution_chain/utils/utils import calcTxRoot, calcReceiptsRoot
 
@@ -462,7 +462,7 @@ proc buildAccumulator*(f: Era1File): Result[EpochRecordCached, string] =
     let totalDifficulty = ?f.getTotalDifficulty(blockNumber)
 
     headerRecords.add(
-      HeaderRecord(blockHash: header.rlpHash(), totalDifficulty: totalDifficulty)
+      HeaderRecord(blockHash: header.computeRlpHash(), totalDifficulty: totalDifficulty)
     )
 
   ok(EpochRecordCached.init(headerRecords))
@@ -478,7 +478,7 @@ proc verify*(f: Era1File): Result[Digest, string] =
     ?f.getBlockTuple(blockNumber, blockTuple)
     let
       txRoot = calcTxRoot(blockTuple.body.transactions)
-      ommershHash = rlpHash(blockTuple.body.uncles)
+      ommershHash = computeRlpHash(blockTuple.body.uncles)
 
     if blockTuple.header.txRoot != txRoot:
       return err("Invalid transactions root")
@@ -491,7 +491,7 @@ proc verify*(f: Era1File): Result[Digest, string] =
 
     headerRecords.add(
       HeaderRecord(
-        blockHash: blockTuple.header.rlpHash(), totalDifficulty: blockTuple.td
+        blockHash: blockTuple.header.computeRlpHash(), totalDifficulty: blockTuple.td
       )
     )
 

--- a/fluffy/network/history/validation/historical_hashes_accumulator.nim
+++ b/fluffy/network/history/validation/historical_hashes_accumulator.nim
@@ -104,7 +104,7 @@ func updateAccumulator*(a: var HistoricalHashesAccumulator, header: Header) =
     a.currentEpoch = EpochRecord.init(@[])
 
   let headerRecord = HeaderRecord(
-    blockHash: header.rlpHash(),
+    blockHash: header.computeRlpHash(),
     totalDifficulty: lastTotalDifficulty + header.difficulty,
   )
 

--- a/hive_integration/nodocker/engine/cancun/helpers.nim
+++ b/hive_integration/nodocker/engine/cancun/helpers.nim
@@ -62,12 +62,12 @@ func getMinExcessBlobsForBlobGasPrice*(data_gas_price: uint64): uint64 =
   return getMinExcessBlobGasForBlobGasPrice(data_gas_price) div GAS_PER_BLOB.uint64
 
 proc addBlobTransaction*(pool: TestBlobTxPool, tx: PooledTransaction) =
-  let txHash = rlpHash(tx)
+  let txHash = computeRlpHash(tx)
   pool.transactions[txHash] = tx
 
 # Test two different transactions with the same blob, and check the blob bundle.
 proc verifyTransactionFromNode*(client: RpcClient, tx: Transaction): Result[void, string] =
-  let txHash = tx.rlpHash
+  let txHash = tx.computeRlpHash
   let res = client.txByHash(txHash)
   if res.isErr:
     return err(res.error)
@@ -160,7 +160,7 @@ proc getBlobDataInPayload*(pool: TestBlobTxPool, payload: ExecutionPayload): Res
     if txData.txType != TxEip4844:
       continue
 
-    let txHash = rlpHash(txData)
+    let txHash = computeRlpHash(txData)
 
     # Find the transaction in the current pool of known transactions
     if not pool.transactions.hasKey(txHash):

--- a/hive_integration/nodocker/engine/cancun/step_newpayloads.nim
+++ b/hive_integration/nodocker/engine/cancun/step_newpayloads.nim
@@ -103,7 +103,7 @@ proc verifyPayload(step: NewPayloads,
       totalBlobCount += blobCount
 
       # Retrieve receipt from client
-      let r = client.txReceipt(tx.rlpHash)
+      let r = client.txReceipt(tx.computeRlpHash)
       let expectedBlobGasUsed = blobCount.uint64 * GAS_PER_BLOB
 
       r.expectBlobGasUsed(expectedBlobGasUsed)

--- a/hive_integration/nodocker/engine/cancun/step_sendblobtx.nim
+++ b/hive_integration/nodocker/engine/cancun/step_sendblobtx.nim
@@ -85,7 +85,7 @@ method execute*(step: SendBlobTransactions, ctx: CancunTestContext): bool =
         error "verify tx from node", msg=r.error
         return false
 
-    let txHash = rlpHash(blobTx)
+    let txHash = computeRlpHash(blobTx)
     ctx.txPool.addBlobTransaction(blobTx)
     ctx.txPool.hashesByIndex[ctx.txPool.currentTxIndex] = txHash
     ctx.txPool.currentTxIndex += 1

--- a/hive_integration/nodocker/engine/clmock.nim
+++ b/hive_integration/nodocker/engine/clmock.nim
@@ -156,7 +156,7 @@ proc waitForTTD*(cl: CLMocker): Future[bool] {.async.} =
   cl.headerHistory[header.number] = header
   cl.ttdReached = true
 
-  let headerHash = cl.latestHeader.blockHash
+  let headerHash = cl.latestHeader.computeBlockHash
   if cl.slotsToSafe == 0:
     cl.latestForkchoice.safeBlockHash = headerHash
 
@@ -257,8 +257,8 @@ proc pickNextPayloadProducer(cl: CLMocker): bool =
       return false
 
     let latestHeader = res.get
-    let lastBlockHash = latestHeader.blockHash
-    if cl.latestHeader.blockHash != lastBlockHash or
+    let lastBlockHash = latestHeader.computeBlockHash
+    if cl.latestHeader.computeBlockHash != lastBlockHash or
        cl.latestHeadNumber != latestHeader.number:
       # Selected client latest block hash does not match canonical chain, try again
       cl.nextBlockProducer = nil
@@ -346,7 +346,7 @@ proc getNextPayload(cl: CLMocker): bool =
   let parentBeaconBlockRoot = cl.latestPayloadAttributes.parentBeaconBlockRoot
   let requestsHash = calcRequestsHash(x.executionRequests)
   let header = blockHeader(cl.latestPayloadBuilt, parentBeaconBlockRoot, requestsHash)
-  let blockHash = header.blockHash
+  let blockHash = header.computeBlockHash
   if blockHash != cl.latestPayloadBuilt.blockHash:
     error "CLMocker: getNextPayload blockHash mismatch",
       expected=cl.latestPayloadBuilt.blockHash,
@@ -371,7 +371,7 @@ proc getNextPayload(cl: CLMocker): bool =
       get=cl.latestPayloadAttributes.prevRandao
     return false
 
-  if cl.latestPayloadBuilt.parentHash != cl.latestHeader.blockHash:
+  if cl.latestPayloadBuilt.parentHash != cl.latestHeader.computeBlockHash:
     error "CLMocker: Incorrect ParentHash on payload built",
       expect=cl.latestPayloadBuilt.parentHash,
       get=cl.latestHeader.blockHash
@@ -617,7 +617,7 @@ proc produceSingleBlock*(cl: CLMocker, cb: BlockProcessCallbacks): bool {.gcsafe
     return false
 
   let newHeader = res.get
-  let newHash = newHeader.blockHash
+  let newHash = newHeader.computeBlockHash
   if newHash != cl.latestPayloadBuilt.blockHash:
     error "CLMocker: None of the clients accepted the newly constructed payload",
       hash=newHash.toHex
@@ -656,7 +656,7 @@ proc produceSingleBlock*(cl: CLMocker, cb: BlockProcessCallbacks): bool {.gcsafe
   cl.headerHistory[cl.latestHeadNumber] = cl.latestHeader
 
   echo "CLMocker: New block produced: number=", newHeader.number,
-    " hash=", newHeader.blockHash
+    " hash=", newHeader.computeBlockHash
 
   return true
 

--- a/hive_integration/nodocker/engine/engine/bad_hash.nim
+++ b/hive_integration/nodocker/engine/engine/bad_hash.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -85,7 +85,7 @@ method execute(cs: BadHashOnNewPayload, env: TestEnv): bool =
         # We need to send an fcU to put the client in syncing state.
         let
           randomHeadBlock = Hash32.randomBytes()
-          latestHash = env.clMock.latestHeader.blockHash
+          latestHash = env.clMock.latestHeader.computeBlockHash
           fcU = ForkchoiceStateV1(
             headblockHash:      randomHeadBlock,
             safeblockHash:      latestHash,

--- a/hive_integration/nodocker/engine/engine/invalid_ancestor.nim
+++ b/hive_integration/nodocker/engine/engine/invalid_ancestor.nim
@@ -337,7 +337,7 @@ method execute(cs: InvalidMissingAncestorReOrgSyncTest, env: TestEnv): bool =
         fatal "TEST ISSUE - Secondary Node unable to reatrieve latest header: ", msg=res.error
 
       let head = res.get()
-      testCond head.blockHash == shadow.payloads[shadow.n-1].blockHash:
+      testCond head.computeBlockHash == shadow.payloads[shadow.n-1].blockHash:
         fatal "TEST ISSUE - Secondary Node has invalid blockHash",
           got=head.blockHash.short,
           want=shadow.payloads[shadow.n-1].blockHash.short,

--- a/hive_integration/nodocker/engine/engine/invalid_payload.nim
+++ b/hive_integration/nodocker/engine/engine/invalid_payload.nim
@@ -438,7 +438,7 @@ method execute(cs: InvalidTxChainIDTest, env: TestEnv): bool =
   testCond pbRes
 
   # Verify that the latest payload built does NOT contain the invalid chain Tx
-  let txHash = shadow.invalidTx.rlpHash
+  let txHash = shadow.invalidTx.computeRlpHash
   if txInPayload(env.clMock.latestPayloadBuilt, txHash):
     fatal "Invalid chain ID tx was included in payload"
     return false

--- a/hive_integration/nodocker/engine/engine/payload_execution.nim
+++ b/hive_integration/nodocker/engine/engine/payload_execution.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -412,7 +412,7 @@ method execute(cs: NewPayloadWithMissingFcUTest, env: TestEnv): bool =
 
   # Get last genesis block hash
   let res = env.engine.client.latestHeader()
-  let genesisHash = res.get.blockHash
+  let genesisHash = res.get.computeBlockHash
 
   # Produce blocks on the main client, these payloads will be replayed on the secondary client.
   let pbRes = env.clMock.produceBlocks(5, BlockProcessCallbacks(

--- a/hive_integration/nodocker/engine/engine/reorg.nim
+++ b/hive_integration/nodocker/engine/engine/reorg.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -137,7 +137,7 @@ proc txHash(shadow: ShadowTx): Hash32 =
   if shadow.tx.isNone:
     error "SHADOW TX IS NONE"
     return
-  shadow.tx.get.rlpHash
+  shadow.tx.get.computeRlpHash
 
 # Test transaction status after a forkchoiceUpdated re-orgs to an alternative hash where a transaction is not present
 method execute(cs: TransactionReOrgTest, env: TestEnv): bool =
@@ -254,7 +254,7 @@ method execute(cs: TransactionReOrgTest, env: TestEnv): bool =
             g.expectNoError()
 
             let payload = g.get.executionPayload
-            testCond txInPayload(payload, shadow.nextTx.rlpHash):
+            testCond txInPayload(payload, shadow.nextTx.computeRlpHash):
               fatal "Payload built does not contain the transaction"
 
             # Send the new payload and forkchoiceUpdated to it

--- a/hive_integration/nodocker/engine/engine/rpc.nim
+++ b/hive_integration/nodocker/engine/engine/rpc.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -64,7 +64,7 @@ method execute(cs: BlockStatus, env: TestEnv): bool =
       )
 
       let tx = env.makeNextTx(tc)
-      shadow.txHash = tx.rlpHash
+      shadow.txHash = tx.computeRlpHash
       let ok = env.sendTx(tx)
       testCond ok:
         fatal "Error trying to send transaction"

--- a/hive_integration/nodocker/engine/engine/suggested_fee_recipient.nim
+++ b/hive_integration/nodocker/engine/engine/suggested_fee_recipient.nim
@@ -74,7 +74,7 @@ method execute(cs: SuggestedFeeRecipientTest, env: TestEnv): bool =
   for tx in blockIncluded.transactions:
     let effGasTip = tx.effectiveGasTip(blockIncluded.header.baseFeePerGas)
 
-    let r = env.engine.client.txReceipt(tx.rlpHash)
+    let r = env.engine.client.txReceipt(tx.computeRlpHash)
     testCond r.isOk:
       fatal "unable to obtain receipt", msg=r.error
 

--- a/hive_integration/nodocker/engine/engine_client.nim
+++ b/hive_integration/nodocker/engine/engine_client.nim
@@ -471,7 +471,7 @@ proc sendTransaction*(
   wrapTry:
     let encodedTx = rlp.encode(tx)
     let res = waitFor client.eth_sendRawTransaction(encodedTx)
-    let txHash = rlpHash(tx)
+    let txHash = computeRlpHash(tx)
     let getHash = res
     if txHash != getHash:
       return err("sendTransaction: tx hash mismatch")
@@ -570,7 +570,7 @@ proc debugPrevRandaoTransaction*(
     tx: PooledTransaction,
     expectedPrevRandao: Bytes32): Result[void, string] =
   wrapTry:
-    let hash = tx.rlpHash
+    let hash = tx.computeRlpHash
     # we only interested in stack, disable all other elems
     let opts = TraceOpts(
       disableStorage: true,

--- a/hive_integration/nodocker/engine/helper.nim
+++ b/hive_integration/nodocker/engine/helper.nim
@@ -19,7 +19,7 @@ import
 proc txInPayload*(payload: ExecutionPayload, txHash: Hash32): bool =
   for txBytes in payload.transactions:
     let currTx = rlp.decode(seq[byte](txBytes), Transaction)
-    if rlpHash(currTx) == txHash:
+    if computeRlpHash(currTx) == txHash:
       return true
 
 proc checkPrevRandaoValue*(client: RpcClient, expectedPrevRandao: Bytes32, blockNumber: uint64): bool =

--- a/hive_integration/nodocker/engine/types.nim
+++ b/hive_integration/nodocker/engine/types.nim
@@ -244,8 +244,8 @@ template expectHash*(res: untyped, hash: Hash32) =
   testCond res.isOk:
     error "Unexpected expectHash Error", msg=res.error
   let s = res.get()
-  testCond s.blockHash == hash:
-    error "Unexpected expectHash", expect=hash.short, get=s.blockHash.short
+  testCond s.computeBlockHash == hash:
+    error "Unexpected expectHash", expect=hash.short, get=s.computeBlockHash.short
 
 template expectStorageEqual*(res: untyped, expectedValue: FixedBytes[32]) =
   testCond res.isOk:

--- a/hive_integration/nodocker/engine/withdrawals/wd_base_spec.nim
+++ b/hive_integration/nodocker/engine/withdrawals/wd_base_spec.nim
@@ -246,7 +246,7 @@ proc execute*(ws: WDBaseSpec, env: TestEnv): bool =
         # withdrawals before Shanghai
         var r = env.client.forkchoiceUpdatedV2(
           ForkchoiceStateV1(
-            headBlockHash: env.clMock.latestHeader.blockHash,
+            headBlockHash: env.clMock.latestHeader.computeBlockHash,
           ),
           Opt.some(PayloadAttributes(
             timestamp:             w3Qty(env.clMock.latestHeader.timestamp, ws.getBlockTimeIncrements()),
@@ -262,7 +262,7 @@ proc execute*(ws: WDBaseSpec, env: TestEnv): bool =
         # (clMock uses V1 by default)
         r = env.client.forkchoiceUpdatedV2(
           ForkchoiceStateV1(
-            headBlockHash: env.clMock.latestHeader.blockHash,
+            headBlockHash: env.clMock.latestHeader.computeBlockHash,
           ),
           Opt.some(PayloadAttributes(
             timestamp:             w3Qty(env.clMock.latestHeader.timestamp, ws.getBlockTimeIncrements()),
@@ -334,7 +334,7 @@ proc execute*(ws: WDBaseSpec, env: TestEnv): bool =
         # Shanghai
         let r = env.client.forkchoiceUpdatedV2(
           ForkchoiceStateV1(
-            headBlockHash: env.clMock.latestHeader.blockHash,
+            headBlockHash: env.clMock.latestHeader.computeBlockHash,
           ),
           Opt.some(PayloadAttributes(
             timestamp:             w3Qty(env.clMock.latestHeader.timestamp, ws.getBlockTimeIncrements()),

--- a/hive_integration/nodocker/engine/withdrawals/wd_block_value_spec.nim
+++ b/hive_integration/nodocker/engine/withdrawals/wd_block_value_spec.nim
@@ -35,7 +35,7 @@ proc execute*(ws: BlockValueSpec, env: TestEnv): bool =
     error "No transactions included in latest block"
 
   for tx in blk.txs:
-    let txHash = rlpHash(tx)
+    let txHash = computeRlpHash(tx)
     let r = env.client.txReceipt(txHash)
     r.expectNoError()
 

--- a/hive_integration/nodocker/engine/withdrawals/wd_max_init_code_spec.nim
+++ b/hive_integration/nodocker/engine/withdrawals/wd_max_init_code_spec.nim
@@ -87,7 +87,7 @@ proc execute*(ws: MaxInitcodeSizeSpec, env: TestEnv): bool =
     testCond not env.sendTx(tx):
       error "Client accepted tx exceeding the MAX_INITCODE_SIZE"
 
-    let res = env.client.txByHash(rlpHash(tx))
+    let res = env.client.txByHash(computeRlpHash(tx))
     testCond res.isErr:
       error "Invalid tx was not unknown to the client"
 

--- a/hive_integration/nodocker/engine/withdrawals/wd_reorg_spec.nim
+++ b/hive_integration/nodocker/engine/withdrawals/wd_reorg_spec.nim
@@ -295,7 +295,7 @@ proc execute*(ws: ReorgSpec, env: TestEnv): bool =
       let b = env.client.latestHeader()
       testCond b.isOk
       let header = b.get
-      if header.blockHash == sideHash:
+      if header.computeBlockHash == sideHash:
         # sync successful
         break
 

--- a/hive_integration/nodocker/pyspec/test_env.nim
+++ b/hive_integration/nodocker/pyspec/test_env.nim
@@ -44,7 +44,7 @@ proc initializeDb(memDB: CoreDbRef, node: JsonNode): Hash32 =
   ledger.persist()
   doAssert ledger.getStateRoot == genesisHeader.stateRoot
 
-  genesisHeader.blockHash
+  genesisHeader.computeBlockHash
 
 proc setupELClient*(conf: ChainConfig, taskPool: Taskpool, node: JsonNode): TestEnv =
   let

--- a/hive_integration/nodocker/rpc/rpc_tests.nim
+++ b/hive_integration/nodocker/rpc/rpc_tests.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -85,7 +85,7 @@ proc balanceAndNonceAtTest(t: TestEnv): Future[TestStatus] {.async.} =
   let tx = vault.signTx(sourceAddr, sourceNonce, targetAddr, amount, gasLimit, gasPrice)
   inc sourceNonce
 
-  let txHash = rlpHash(tx)
+  let txHash = computeRlpHash(tx)
   echo "BalanceAt: send $1 wei from 0x$2 to 0x$3 in 0x$4" % [
     $tx.tx.value, sourceAddr.toHex, targetAddr.toHex, txHash.data.toHex]
 

--- a/hive_integration/nodocker/rpc/vault.nim
+++ b/hive_integration/nodocker/rpc/vault.nim
@@ -147,5 +147,5 @@ proc createAccount*(v: Vault, amount: UInt256): Future[Address] {.async.} =
     let period = chronos.seconds(1)
     await sleepAsync(period)
 
-  let txHash = tx.rlpHash().data.toHex
+  let txHash = tx.computeRlpHash().data.toHex
   raise newException(ValueError, "could not fund account $2 in transaction $2" % [address.toHex, txHash])

--- a/nrpc/nrpc.nim
+++ b/nrpc/nrpc.nim
@@ -324,7 +324,7 @@ proc syncToEngineApi(conf: NRpcConf) {.async.} =
           (finalizedBlck, _) = client.getELBlockFromBeaconChain(
             BlockIdent.init(BlockIdentType.Finalized), clConfig
           )
-          finalizedHash = finalizedBlck.header.blockHash.asEth2Digest
+          finalizedHash = finalizedBlck.header.computeBlockHash.asEth2Digest
 
     # Update the current block number from EL rest api
     # Shows that the fcu call has succeeded
@@ -358,7 +358,7 @@ proc syncToEngineApi(conf: NRpcConf) {.async.} =
         (finalizedBlck, _) = client.getELBlockFromBeaconChain(
           BlockIdent.init(BlockIdentType.Finalized), clConfig
         )
-        finalizedHash = finalizedBlck.header.blockHash.asEth2Digest
+        finalizedHash = finalizedBlck.header.computeBlockHash.asEth2Digest
         sendFCU(headClBlck)
       else:
         error "Failed to get CL head"

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -268,7 +268,7 @@ proc initVMEnv*(network: string): BaseVMState =
       nil, conf,
       conf.chainId.NetworkId)
     parent = Header(stateRoot: EMPTY_ROOT_HASH)
-    parentHash = rlpHash(parent)
+    parentHash = computeRlpHash(parent)
     header = Header(
       number: 1'u64,
       stateRoot: EMPTY_ROOT_HASH,

--- a/tests/replay/pp.nim
+++ b/tests/replay/pp.nim
@@ -50,7 +50,7 @@ func pp*(a: NetworkPayload): string =
 
 func pp*(h: Header; sep = " "): string =
   "" &
-    &"hash={h.blockHash.pp}{sep}" &
+    &"hash={h.computeBlockHash.pp}{sep}" &
     &"blockNumber={h.number}{sep}" &
     &"parentHash={h.parentHash.pp}{sep}" &
     &"coinbase={h.coinbase.pp}{sep}" &

--- a/tests/replay/undump_blocks_gz.nim
+++ b/tests/replay/undump_blocks_gz.nim
@@ -48,7 +48,7 @@ proc dumpBlocksBeginNl*(db: CoreDbTxRef;
   if headers[0].number == 1'u64:
     let
       h0 = db.getBlockHeader(0'u64).expect("header exists")
-      b0 = db.getBlockBody(h0.blockHash).expect("block body exists")
+      b0 = db.getBlockBody(h0.computeBlockHash).expect("block body exists")
     result = "" &
       dumpBlocksBegin(@[h0]) & "\n" &
       dumpBlocksListNl(h0,b0) &

--- a/tests/test_aristo/test_compute.nim
+++ b/tests/test_aristo/test_compute.nim
@@ -12,7 +12,6 @@
 
 import
   std/[algorithm, sets],
-  stew/byteutils,
   unittest2,
   ../../execution_chain/db/aristo/[
     aristo_check,
@@ -23,9 +22,6 @@ import
     aristo_init/memory_only,
     aristo_tx_frame,
   ]
-
-func x(s: string): seq[byte] =
-  s.hexToSeqByte
 
 let samples = [
   # Somew on-the-fly provided stuff

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -78,7 +78,7 @@ proc executeCase(node: JsonNode): bool =
     return false
 
   var c = ForkedChainRef.init(com, persistBatchSize = 0)
-  if c.latestHash != env.genesisHeader.blockHash:
+  if c.latestHash != env.genesisHeader.computeBlockHash:
     debugEcho "Genesis block hash in database is different with expected genesis block hash"
     return false
 
@@ -86,7 +86,7 @@ proc executeCase(node: JsonNode): bool =
   for blk in env.blocks:
     let res = c.importBlock(blk.blk)
     if res.isOk:
-      if env.lastBlockHash == blk.blk.header.blockHash:
+      if env.lastBlockHash == blk.blk.header.computeBlockHash:
         lastStateRoot = blk.blk.header.stateRoot
       if blk.badBlock:
         debugEcho "A bug? bad block imported"

--- a/tests/test_engine_api.nim
+++ b/tests/test_engine_api.nim
@@ -123,7 +123,7 @@ proc runBasicCycleTest(env: TestEnv): Result[void, string] =
     client = env.client
     header = ? client.latestHeader()
     update = ForkchoiceStateV1(
-      headBlockHash: header.blockHash
+      headBlockHash: header.computeBlockHash
     )
     time = getTime().toUnix
     attr = PayloadAttributes(
@@ -151,7 +151,7 @@ proc runNewPayloadV4Test(env: TestEnv): Result[void, string] =
     client = env.client
     header = ? client.latestHeader()
     update = ForkchoiceStateV1(
-      headBlockHash: header.blockHash
+      headBlockHash: header.computeBlockHash
     )
     time = getTime().toUnix
     attr = PayloadAttributes(

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -80,7 +80,7 @@ proc makeBlk(txFrame: CoreDbTxRef, number: BlockNumber, parentBlk: Block): Block
 
   let header = Header(
     number     : number,
-    parentHash : parent.blockHash,
+    parentHash : parent.computeBlockHash,
     difficulty : 0.u256,
     timestamp  : parent.timestamp + 1,
     gasLimit   : parent.gasLimit,
@@ -119,7 +119,7 @@ template checkHeadHash(chain: ForkedChainRef, hashParam: Hash32) =
   check txFrame.getCanonicalHead().isOk
 
 func blockHash(x: Block): Hash32 =
-  x.header.blockHash
+  x.header.computeBlockHash
 
 proc wdWritten(c: ForkedChainRef, blk: Block): int =
   if blk.header.withdrawalsRoot.isSome:
@@ -168,7 +168,7 @@ proc forkedChainMain*() =
     var env = setupEnv()
     let
       cc = env.newCom
-      genesisHash = cc.genesisHeader.blockHash
+      genesisHash = cc.genesisHeader.computeBlockHash
       genesis = Block.init(cc.genesisHeader, BlockBody())
       baseTxFrame = cc.db.baseTxFrame()
     let
@@ -495,16 +495,16 @@ proc forkedChainMain*() =
       # cursor
       check chain.headerByNumber(8).isErr
       check chain.headerByNumber(7).expect("OK").number == 7
-      check chain.headerByNumber(7).expect("OK").blockHash == blk7.blockHash
+      check chain.headerByNumber(7).expect("OK").computeBlockHash == blk7.blockHash
       # from db
       check chain.headerByNumber(3).expect("OK").number == 3
-      check chain.headerByNumber(3).expect("OK").blockHash == blk3.blockHash
+      check chain.headerByNumber(3).expect("OK").computeBlockHash == blk3.blockHash
       # base
       check chain.headerByNumber(4).expect("OK").number == 4
-      check chain.headerByNumber(4).expect("OK").blockHash == blk4.blockHash
+      check chain.headerByNumber(4).expect("OK").computeBlockHash == blk4.blockHash
       # from cache
       check chain.headerByNumber(5).expect("OK").number == 5
-      check chain.headerByNumber(5).expect("OK").blockHash == blk5.blockHash
+      check chain.headerByNumber(5).expect("OK").computeBlockHash == blk5.blockHash
       check chain.validate info & " (9)"
     test "3 branches, alternating imports":
       const info = "3 branches, alternating imports"

--- a/tests/test_forkid.nim
+++ b/tests/test_forkid.nim
@@ -123,7 +123,7 @@ template runGenesisTimeIdTests() =
   let
     time       = 1690475657'u64
     genesis    = common.Header(timestamp: time.EthTime)
-    genesisCRC = crc32(0, genesis.blockHash.data)
+    genesisCRC = crc32(0, genesis.computeBlockHash.data)
     cases = [
       # Shanghai active before genesis, skip
       (c: config(time-1, time+1), want: (crc: genesisCRC, next: time + 1)),

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -115,7 +115,7 @@ proc testFixtureIndexes(ctx: var TestCtx, testStatusIMPL: var TestStatus) =
   block post:
     let obtainedHash = vmState.readOnlyLedger.getStateRoot()
     check obtainedHash == ctx.expectedHash
-    let actualLogsHash = rlpHash(callResult.logEntries)
+    let actualLogsHash = computeRlpHash(callResult.logEntries)
     check(ctx.expectedLogs == actualLogsHash)
     if ctx.debugMode:
       let success = ctx.expectedLogs == actualLogsHash and obtainedHash == ctx.expectedHash

--- a/tests/test_genesis.nim
+++ b/tests/test_genesis.nim
@@ -42,20 +42,20 @@ proc genesisTest() =
   suite "Genesis":
     test "Correct mainnet hash":
       let b = makeGenesis(MainNet)
-      check(b.blockHash == hash32"D4E56740F876AEF8C010B86A40D5F56745A118D0906A34E69AEC8C0DB1CB8FA3")
+      check(b.computeBlockHash == hash32"D4E56740F876AEF8C010B86A40D5F56745A118D0906A34E69AEC8C0DB1CB8FA3")
 
     test "Correct sepolia hash":
       let b = makeGenesis(SepoliaNet)
-      check b.blockHash == hash32"25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9"
+      check b.computeBlockHash == hash32"25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9"
 
     test "Correct holesky hash":
       let b = makeGenesis(HoleskyNet)
-      check b.blockHash == hash32"b5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4"
+      check b.computeBlockHash == hash32"b5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4"
       check b.stateRoot == hash32"69D8C9D72F6FA4AD42D4702B433707212F90DB395EB54DC20BC85DE253788783"
 
     test "Correct hoodi hash":
       let b = makeGenesis(HoodiNet)
-      check b.blockHash == hash32"bbe312868b376a3001692a646dd2d7d1e4406380dfd86b98aa8a34d1557c971b"
+      check b.computeBlockHash == hash32"bbe312868b376a3001692a646dd2d7d1e4406380dfd86b98aa8a34d1557c971b"
       check b.stateRoot == hash32"da87d7f5f91c51508791bbcbd4aa5baf04917830b86985eeb9ad3d5bfb657576"
 
 proc customGenesisTest() =
@@ -76,7 +76,7 @@ proc customGenesisTest() =
       let stateRoot = hash32"3b84f313bfd49c03cc94729ade2e0de220688f813c0c895a99bd46ecc9f45e1e"
       let genesisHash = hash32"a28d8d73e087a01d09d8cb806f60863652f30b6b6dfa4e0157501ff07d422399"
       check com.genesisHeader.stateRoot == stateRoot
-      check com.genesisHeader.blockHash == genesisHash
+      check com.genesisHeader.computeBlockHash == genesisHash
       check com.proofOfStake(com.genesisHeader, com.db.baseTxFrame()) == false
 
     test "Devnet5.json (aka Kiln in all but chainId and TTD)":
@@ -86,7 +86,7 @@ proc customGenesisTest() =
       let stateRoot = hash32"52e628c7f35996ba5a0402d02b34535993c89ff7fc4c430b2763ada8554bee62"
       let genesisHash = hash32"51c7fe41be669f69c45c33a56982cbde405313342d9e2b00d7c91a7b284dd4f8"
       check com.genesisHeader.stateRoot == stateRoot
-      check com.genesisHeader.blockHash == genesisHash
+      check com.genesisHeader.computeBlockHash == genesisHash
       check com.proofOfStake(com.genesisHeader, com.db.baseTxFrame()) == false
 
     test "Mainnet shadow fork 1":
@@ -97,7 +97,7 @@ proc customGenesisTest() =
       let genesisHash = hash32"d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
       let ttd = "46_089_003_871_917_200_000_000".parse(UInt256)
       check com.genesisHeader.stateRoot == stateRoot
-      check com.genesisHeader.blockHash == genesisHash
+      check com.genesisHeader.computeBlockHash == genesisHash
       check com.ttd.get == ttd
       check com.proofOfStake(com.genesisHeader, com.db.baseTxFrame()) == false
 
@@ -110,7 +110,7 @@ proc customGenesisTest() =
       let genesisHash = hash32"d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
       let ttd = "46_089_003_871_917_200_000_000".parse(UInt256)
       check com.genesisHeader.stateRoot == stateRoot
-      check com.genesisHeader.blockHash == genesisHash
+      check com.genesisHeader.computeBlockHash == genesisHash
       check com.ttd.get == ttd
       check com.proofOfStake(com.genesisHeader, com.db.baseTxFrame()) == false
       check cg.config.mergeNetsplitBlock.isSome
@@ -123,7 +123,7 @@ proc customGenesisTest() =
       let stateRoot = hash32"69D8C9D72F6FA4AD42D4702B433707212F90DB395EB54DC20BC85DE253788783"
       let genesisHash = hash32"b5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4"
       check com.genesisHeader.stateRoot == stateRoot
-      check com.genesisHeader.blockHash == genesisHash
+      check com.genesisHeader.computeBlockHash == genesisHash
       check com.chainId == 17000.u256
 
     test "Geth Holesky":
@@ -134,7 +134,7 @@ proc customGenesisTest() =
       let stateRoot = hash32"69D8C9D72F6FA4AD42D4702B433707212F90DB395EB54DC20BC85DE253788783"
       let genesisHash = hash32"b5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4"
       check com.genesisHeader.stateRoot == stateRoot
-      check com.genesisHeader.blockHash == genesisHash
+      check com.genesisHeader.computeBlockHash == genesisHash
       check com.chainId == 17000.u256
 
     test "Prague genesis":

--- a/tests/test_getproof_json.nim
+++ b/tests/test_getproof_json.nim
@@ -26,7 +26,7 @@ template toHash32(hash: untyped): Hash32 =
 
 proc verifyAccountProof(trustedStateRoot: Hash32, res: ProofResponse): MptProofVerificationResult =
   let
-    key = computeRlpHash(res.address).data
+    key = keccak256(res.address.data)
     value = rlp.encode(Account(
         nonce: res.nonce.uint64,
         balance: res.balance,
@@ -36,18 +36,18 @@ proc verifyAccountProof(trustedStateRoot: Hash32, res: ProofResponse): MptProofV
   verifyMptProof(
     seq[seq[byte]](res.accountProof),
     trustedStateRoot,
-    key,
+    key.data,
     value)
 
 proc verifySlotProof(trustedStorageRoot: Hash32, slot: StorageProof): MptProofVerificationResult =
   let
-    key = computeRlpHash(toBytesBE(slot.key)).data
+    key = keccak256(toBytesBE(slot.key))
     value = rlp.encode(slot.value)
 
   verifyMptProof(
     seq[seq[byte]](slot.proof),
     trustedStorageRoot,
-    key,
+    key.data,
     value)
 
 proc getGenesisAlloc(filePath: string): GenesisAlloc =

--- a/tests/test_getproof_json.nim
+++ b/tests/test_getproof_json.nim
@@ -26,7 +26,7 @@ template toHash32(hash: untyped): Hash32 =
 
 proc verifyAccountProof(trustedStateRoot: Hash32, res: ProofResponse): MptProofVerificationResult =
   let
-    key = keccakHash(res.address).data
+    key = computeRlpHash(res.address).data
     value = rlp.encode(Account(
         nonce: res.nonce.uint64,
         balance: res.balance,
@@ -41,7 +41,7 @@ proc verifyAccountProof(trustedStateRoot: Hash32, res: ProofResponse): MptProofV
 
 proc verifySlotProof(trustedStorageRoot: Hash32, slot: StorageProof): MptProofVerificationResult =
   let
-    key = keccakHash(toBytesBE(slot.key)).data
+    key = computeRlpHash(toBytesBE(slot.key)).data
     value = rlp.encode(slot.value)
 
   verifyMptProof(

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -97,8 +97,8 @@ proc verifySlotProof(trustedStorageRoot: Hash32, slot: StorageProof): MptProofVe
 proc persistFixtureBlock(chainDB: CoreDbTxRef) =
   let header = getBlockHeader4514995()
   # Manually inserting header to avoid any parent checks
-  discard chainDB.put(genericHashKey(header.blockHash).toOpenArray, rlp.encode(header))
-  chainDB.addBlockNumberToHashLookup(header.number, header.blockHash)
+  discard chainDB.put(genericHashKey(header.computeBlockHash).toOpenArray, rlp.encode(header))
+  chainDB.addBlockNumberToHashLookup(header.number, header.computeBlockHash)
   chainDB.persistTransactions(header.number, header.txRoot, getBlockBody4514995().transactions)
   chainDB.persistReceipts(header.receiptsRoot, getReceipts4514995())
 
@@ -256,8 +256,8 @@ proc generateBlock(env: var TestEnv) =
 
   txFrame.persistFixtureBlock()
 
-  env.txHash = tx1.rlpHash
-  env.blockHash = blk.header.blockHash
+  env.txHash = tx1.computeRlpHash
+  env.blockHash = blk.header.computeBlockHash
 
 createRpcSigsFromNim(RpcClient):
   proc web3_clientVersion(): string
@@ -518,7 +518,7 @@ proc rpcMain*() =
 
     test "eth_getLogs by blockhash, no filters":
       let testHeader = getBlockHeader4514995()
-      let testHash = testHeader.blockHash
+      let testHash = testHeader.computeBlockHash
       let filterOptions = FilterOptions(
         blockHash: Opt.some(testHash),
         topics: @[]
@@ -538,7 +538,7 @@ proc rpcMain*() =
 
     test "eth_getLogs by blockhash, filter logs at specific positions":
       let testHeader = getBlockHeader4514995()
-      let testHash = testHeader.blockHash
+      let testHash = testHeader.computeBlockHash
 
       let topic = bytes32"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
       let topic1 = bytes32"0x000000000000000000000000fdc183d01a793613736cd40a5a578f49add1772b"
@@ -560,7 +560,7 @@ proc rpcMain*() =
 
     test "eth_getLogs by blockhash, filter logs at specific postions with or options":
       let testHeader = getBlockHeader4514995()
-      let testHash = testHeader.blockHash
+      let testHash = testHeader.computeBlockHash
 
       let topic = bytes32"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
       let topic1 = bytes32"0xa64da754fccf55aa65a1f0128a648633fade3884b236e879ee9f64c78df5d5d7"

--- a/tests/test_transaction_json.nim
+++ b/tests/test_transaction_json.nim
@@ -33,7 +33,7 @@ proc transactionJsonMain*() =
 transactionJsonMain()
 
 proc txHash(tx: Transaction): string =
-  rlpHash(tx).toHex()
+  computeRlpHash(tx).toHex()
 
 proc testTxByFork(tx: Transaction, forkData: JsonNode, forkName: string, testStatusIMPL: var TestStatus) =
   let

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -186,7 +186,6 @@ proc txPoolMain*() =
       xp = env.xp
       mx = env.sender
       chain = env.chain
-      com = env.com
 
     xp.prevRandao = prevRandao
     xp.feeRecipient = feeRecipient
@@ -556,11 +555,11 @@ proc txPoolMain*() =
       check env.chain.forkChoice(latestHash, latestHash).isOk
 
       let hs = [
-        rlpHash(tx1),
-        rlpHash(tx2),
-        rlpHash(tx3),
-        rlpHash(tx4),
-        rlpHash(tx5),
+        computeRlpHash(tx1),
+        computeRlpHash(tx2),
+        computeRlpHash(tx3),
+        computeRlpHash(tx4),
+        computeRlpHash(tx5),
       ]
 
       let res = chain.blockByNumber(chain.latestHeader.number - 1)
@@ -713,7 +712,7 @@ proc txPoolMain*() =
 
       xp.checkAddTx(tx1bad, txErrorOversized)
       xp.checkAddTx(tx2bad, txErrorOversized)
-      xp.checkAddTx(tx2bad, txErrorOversized)
+      xp.checkAddTx(tx3bad, txErrorOversized)
 
       # exceeds max init code size
       xp.checkAddTx(tx4init, txErrorBasicValidation)

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -75,7 +75,7 @@ proc verifyResult(ctx: var StateContext,
       [($obtainedHash).toLowerAscii, $ctx.expectedHash]
     return
 
-  let actualLogsHash = rlpHash(callResult.logEntries)
+  let actualLogsHash = computeRlpHash(callResult.logEntries)
   if actualLogsHash != ctx.expectedLogs:
     ctx.error = "post state log hash mismatch: got $1, want $2" %
       [($actualLogsHash).toLowerAscii, $ctx.expectedLogs]

--- a/tools/t8n/helpers.nim
+++ b/tools/t8n/helpers.nim
@@ -258,6 +258,10 @@ proc parseTxJson(txo: TxObject, chainId: ChainId): Result[Transaction, string] =
     required(maxFeePerGas)
     optional(accessList)
     required(authorizationList)
+  of TxEip7873:
+    required(chainId)
+    optional(accessList)
+    required(initCodes)
 
   # Ignore chainId if txType == TxLegacy
   if tx.txType > TxLegacy and tx.chainId != chainId:

--- a/tools/t8n/t8n_debug.nim
+++ b/tools/t8n/t8n_debug.nim
@@ -154,13 +154,13 @@ func toInput(prevAlloc: JsonString,
 func collectHashes(genesis: Block, blocks: openArray[Block]): BCTHashes =
   result.hashes.add BCTHash(
     number: w3Qty(genesis.header.number),
-    hash: rlpHash(genesis.header),
+    hash: computeRlpHash(genesis.header),
   )
 
   for blk in blocks:
     result.hashes.add BCTHash(
       number: w3Qty(blk.header.number),
-      hash: rlpHash(blk.header),
+      hash: computeRlpHash(blk.header),
     )
 
 func eth(n: int): UInt256 {.compileTime.} =

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -133,7 +133,7 @@ proc toTxReceipt(rec: Receipt,
     cumulativeGasUsed: rec.cumulativeGasUsed,
     logsBloom: rec.logsBloom,
     logs: rec.logs,
-    transactionHash: rlpHash(tx),
+    transactionHash: computeRlpHash(tx),
     contractAddress: contractAddress,
     gasUsed: gasUsed,
     blockHash: default(Hash32),
@@ -144,7 +144,7 @@ proc calcLogsHash(receipts: openArray[Receipt]): Hash32 =
   var logs: seq[Log]
   for rec in receipts:
     logs.add rec.logs
-  rlpHash(logs)
+  computeRlpHash(logs)
 
 proc defaultTraceStreamFilename(conf: T8NConf,
                                 txIndex: int,
@@ -268,7 +268,7 @@ proc exec(ctx: TransContext,
 
     var closeStream = true
     if conf.traceEnabled.isSome:
-      closeStream = setupTrace(conf, txIndex, rlpHash(tx), vmState)
+      closeStream = setupTrace(conf, txIndex, computeRlpHash(tx), vmState)
 
     let rc = vmState.processTransaction(tx, sender, header)
 

--- a/tools/t8n/types.nim
+++ b/tools/t8n/types.nim
@@ -74,6 +74,7 @@ type
     maxFeePerBlobGas*    : Opt[UInt256]
     blobVersionedHashes* : Opt[seq[Hash32]]
     authorizationList*   : Opt[seq[Authorization]]
+    initCodes* : Opt[seq[seq[byte]]]
 
   TxList* = seq[Result[Transaction, string]]
 


### PR DESCRIPTION
There are still some false deprecation warning with Nim 2.0.14
The bug is fixed in Nim 2.2.x but not backported to Nim 2.0.x

fix #3168