### PR TITLE
remove redundant mapIt(it); make nodesToConnect an iterator

### DIFF
--- a/execution_chain/db/aristo/aristo_init/memory_db.nim
+++ b/execution_chain/db/aristo/aristo_init/memory_db.nim
@@ -59,15 +59,15 @@ when extraTraceMessages:
 # Private helpers
 # ------------------------------------------------------------------------------
 
-proc newSession(db: MemBackendRef): MemPutHdlRef =
+func newSession(db: MemBackendRef): MemPutHdlRef =
   new result
   result.TypedPutHdlRef.beginSession db
 
-proc getSession(hdl: PutHdlRef; db: MemBackendRef): MemPutHdlRef =
+func getSession(hdl: PutHdlRef; db: MemBackendRef): MemPutHdlRef =
   hdl.TypedPutHdlRef.verifySession db
   hdl.MemPutHdlRef
 
-proc endSession(hdl: PutHdlRef; db: MemBackendRef): MemPutHdlRef =
+func endSession(hdl: PutHdlRef; db: MemBackendRef): MemPutHdlRef =
   hdl.TypedPutHdlRef.finishSession db
   hdl.MemPutHdlRef
 
@@ -75,7 +75,7 @@ proc endSession(hdl: PutHdlRef; db: MemBackendRef): MemPutHdlRef =
 # Private functions: interface
 # ------------------------------------------------------------------------------
 
-proc getVtxFn(db: MemBackendRef): GetVtxFn =
+func getVtxFn(db: MemBackendRef): GetVtxFn =
   result =
     proc(rvid: RootedVertexID, flags: set[GetVtxFlag]): Result[VertexRef,AristoError] =
       # Fetch serialised data record
@@ -88,7 +88,7 @@ proc getVtxFn(db: MemBackendRef): GetVtxFn =
         return rc
       err(GetVtxNotFound)
 
-proc getKeyFn(db: MemBackendRef): GetKeyFn =
+func getKeyFn(db: MemBackendRef): GetKeyFn =
   result =
     proc(rvid: RootedVertexID, flags: set[GetVtxFlag]): Result[(HashKey, VertexRef),AristoError] =
       let data = db.sTab.getOrDefault(rvid, EmptyBlob)
@@ -100,25 +100,25 @@ proc getKeyFn(db: MemBackendRef): GetKeyFn =
         return ok((key, nil))
       err(GetKeyNotFound)
 
-proc getTuvFn(db: MemBackendRef): GetTuvFn =
+func getTuvFn(db: MemBackendRef): GetTuvFn =
   result =
     proc(): Result[VertexID,AristoError]=
       db.tUvi or ok(VertexID(0))
 
-proc getLstFn(db: MemBackendRef): GetLstFn =
+func getLstFn(db: MemBackendRef): GetLstFn =
   result =
     proc(): Result[SavedState,AristoError]=
       db.lSst or err(GetLstNotFound)
 
 # -------------
 
-proc putBegFn(db: MemBackendRef): PutBegFn =
+func putBegFn(db: MemBackendRef): PutBegFn =
   result =
     proc(): Result[PutHdlRef,AristoError] =
       ok db.newSession()
 
 
-proc putVtxFn(db: MemBackendRef): PutVtxFn =
+func putVtxFn(db: MemBackendRef): PutVtxFn =
   result =
     proc(hdl: PutHdlRef; rvid: RootedVertexID; vtx: VertexRef, key: HashKey) =
       let hdl = hdl.getSession db
@@ -128,21 +128,21 @@ proc putVtxFn(db: MemBackendRef): PutVtxFn =
         else:
           hdl.sTab[rvid] = EmptyBlob
 
-proc putTuvFn(db: MemBackendRef): PutTuvFn =
+func putTuvFn(db: MemBackendRef): PutTuvFn =
   result =
     proc(hdl: PutHdlRef; vs: VertexID)  =
       let hdl = hdl.getSession db
       if hdl.error.isNil:
         hdl.tUvi = Opt.some(vs)
 
-proc putLstFn(db: MemBackendRef): PutLstFn =
+func putLstFn(db: MemBackendRef): PutLstFn =
   result =
     proc(hdl: PutHdlRef; lst: SavedState) =
       let hdl = hdl.getSession db
       if hdl.error.isNil:
         hdl.lSst = Opt.some(lst)
 
-proc putEndFn(db: MemBackendRef): PutEndFn =
+func putEndFn(db: MemBackendRef): PutEndFn =
   result =
     proc(hdl: PutHdlRef): Result[void,AristoError] =
       let hdl = hdl.endSession db
@@ -174,7 +174,7 @@ proc putEndFn(db: MemBackendRef): PutEndFn =
 
 # -------------
 
-proc closeFn(db: MemBackendRef): CloseFn =
+func closeFn(db: MemBackendRef): CloseFn =
   result =
     proc(ignore: bool) =
       discard
@@ -183,7 +183,7 @@ proc closeFn(db: MemBackendRef): CloseFn =
 # Public functions
 # ------------------------------------------------------------------------------
 
-proc memoryBackend*(): AristoDbRef =
+func memoryBackend*(): AristoDbRef =
   let 
     be = MemBackendRef(beKind: BackendMemory)
     db = AristoDbRef()
@@ -211,7 +211,7 @@ iterator walkVtx*(
     kinds = {Branch, ExtBranch, AccLeaf, StoLeaf};
       ): tuple[rvid: RootedVertexID, vtx: VertexRef] =
   ##  Iteration over the vertex sub-table.
-  for n,rvid in be.sTab.keys.toSeq.mapIt(it).sorted:
+  for n,rvid in be.sTab.keys.toSeq.sorted:
     let data = be.sTab.getOrDefault(rvid, EmptyBlob)
     if 0 < data.len:
       let rc = data.deblobify VertexRef
@@ -226,7 +226,7 @@ iterator walkKey*(
     be: MemBackendRef;
       ): tuple[rvid: RootedVertexID, key: HashKey] =
   ## Iteration over the Markle hash sub-table.
-  for n,rvid in be.sTab.keys.toSeq.mapIt(it).sorted:
+  for n,rvid in be.sTab.keys.toSeq.sorted:
     let data = be.sTab.getOrDefault(rvid, EmptyBlob)
     if 0 < data.len:
       let rc = data.deblobify HashKey

--- a/hive_integration/nodocker/engine/cancun/step_newpayloads.nim
+++ b/hive_integration/nodocker/engine/cancun/step_newpayloads.nim
@@ -296,7 +296,7 @@ method execute*(step: NewPayloads, ctx: CancunTestContext): bool =
       onNewPayloadBroadcast: proc(): bool =
         if step.newPayloadCustomizer != nil:
           step.newPayloadCustomizer.setEngineAPIVersionResolver(env.engine.com)
-          # Send a test NewPayload directive with either a modified payload or modifed versioned hashes
+          # Send a test NewPayload directive with either a modified payload or modified versioned hashes
           var
             payload        = env.clMock.latestExecutableData
             expectedError  = step.newPayloadCustomizer.getExpectedError()

--- a/hive_integration/nodocker/engine/engine/payload_attributes.nim
+++ b/hive_integration/nodocker/engine/engine/payload_attributes.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -65,7 +65,7 @@ method execute(cs: InvalidPayloadAttributesTest, env: TestEnv): bool =
       # 4) Start payload build process and respond with VALID
       let timeVer = env.clMock.latestPayloadBuilt.timestamp
       if cs.syncing:
-        # If we are SYNCING, the outcome should be SYNCING regardless of the validity of the payload atttributes
+        # If we are SYNCING, the outcome should be SYNCING regardless of the validity of the payload attributes
         let r = env.engine.forkchoiceUpdated(timeVer, fcu, attr)
         r.expectPayloadStatus(PayloadExecutionStatus.syncing)
         r.expectPayloadID(Opt.none(Bytes8))


### PR DESCRIPTION
The other parts are mostly opportunistic.

Also, that `node notin p.discovery.bootstrapNodes` either in the previous or PR code is technically O(n), but typically the bootstrap node count is (a) known and (b) not very large, so it's likely not worth using other approaches for, but it won't scale.