### PR TITLE
switch from deprecated newSeqUninitialized to newSeqUninit

### DIFF
--- a/fluffy/database/content_db_custom_sql_functions.nim
+++ b/fluffy/database/content_db_custom_sql_functions.nim
@@ -13,7 +13,7 @@ func xorDistance(a: openArray[byte], b: openArray[byte]): seq[byte] =
   doAssert(a.len == b.len)
 
   let length = a.len
-  var distance: seq[byte] = newSeqUninitialized[byte](length)
+  var distance: seq[byte] = newSeqUninit[byte](length)
   for i in 0 ..< length:
     distance[i] = a[i] xor b[i]
 

--- a/fluffy/database/content_db_custom_sql_functions.nim
+++ b/fluffy/database/content_db_custom_sql_functions.nim
@@ -1,5 +1,5 @@
 # Fluffy
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/fluffy/eth_data/era1.nim
+++ b/fluffy/eth_data/era1.nim
@@ -125,7 +125,7 @@ proc readBlockIndex*(f: IoHandle): Result[BlockIndex, string] =
   if blockNumber > int32.high().uint64:
     return err("fishy block number")
 
-  var offsets = newSeqUninitialized[int64](count)
+  var offsets = newSeqUninit[int64](count)
   for i in 0 ..< count:
     let
       offset = uint64.fromBytesLE(buf.toOpenArray(pos, pos + 7))


### PR DESCRIPTION
[newSeqUninitialized](https://nim-lang.org/docs/system.html#newSeqUninitialized%2CNatural) states:
>  **Deprecated**: Use [`newSeqUninit`](https://nim-lang.org/docs/system.html#newSeqUninit%2CNatural) instead,