### PR TITLE
Adjust tests for supporting SSZ vector Capella and Deneb HWP

### DIFF
--- a/fluffy/eth_data/yaml_eth_types.nim
+++ b/fluffy/eth_data/yaml_eth_types.nim
@@ -17,9 +17,16 @@ type
     beacon_block_proof*: array[14, string]
     slot*: uint64
 
-  YamlTestProof* = object
+  YamlTestProofCapella* = object
     execution_block_header*: string # Not part of the actual proof
     execution_block_proof*: array[11, string]
+    beacon_block_root*: string
+    beacon_block_proof*: array[13, string]
+    slot*: uint64
+
+  YamlTestProofDeneb* = object
+    execution_block_header*: string # Not part of the actual proof
+    execution_block_proof*: array[12, string]
     beacon_block_root*: string
     beacon_block_proof*: array[13, string]
     slot*: uint64

--- a/fluffy/network/history/history_validation.nim
+++ b/fluffy/network/history/history_validation.nim
@@ -66,31 +66,28 @@ func verifyBlockHeaderProof*(
 ): Result[void, string] =
   let timestamp = Moment.init(header.timestamp.int64, Second)
 
-  # Note: Capella onwards currently disabled
-  # - No effective means to get historical summaries yet over the network
-  # - Proof is currently not as per spec, as we prefer to use SSZ Vectors
+  # Note: As long as no up to date historical_summaries list is provided Capella
+  # and onwards will always fail verification.
   if isCancun(chainConfig, timestamp):
-    # let proof = decodeSsz(proof.asSeq(), BlockProofHistoricalSummariesDeneb).valueOr:
-    #   return err("Failed decoding historical_summaries based block proof: " & error)
+    let proof = decodeSsz(proof.asSeq(), BlockProofHistoricalSummariesDeneb).valueOr:
+      return err("Failed decoding historical_summaries based block proof: " & error)
 
-    # if a.historicalSummaries.verifyProof(
-    #   proof, Digest(data: header.computeRlpHash().data), cfg
-    # ):
-    #   ok()
-    # else:
-    #   err("Block proof verification failed (historical_summaries)")
-    err("Cancun block proof verification not yet activated")
+    if a.historicalSummaries.verifyProof(
+      proof, Digest(data: header.computeRlpHash().data), cfg
+    ):
+      ok()
+    else:
+      err("Block proof verification failed (historical_summaries)")
   elif isShanghai(chainConfig, timestamp):
-    # let proof = decodeSsz(proof.asSeq(), BlockProofHistoricalSummaries).valueOr:
-    #   return err("Failed decoding historical_summaries based block proof: " & error)
+    let proof = decodeSsz(proof.asSeq(), BlockProofHistoricalSummaries).valueOr:
+      return err("Failed decoding historical_summaries based block proof: " & error)
 
-    # if a.historicalSummaries.verifyProof(
-    #   proof, Digest(data: header.computeRlpHash().data), cfg
-    # ):
-    #   ok()
-    # else:
-    #   err("Block proof verification failed (historical_summaries)")
-    err("Shanghai block proof verification not yet activated")
+    if a.historicalSummaries.verifyProof(
+      proof, Digest(data: header.computeRlpHash().data), cfg
+    ):
+      ok()
+    else:
+      err("Block proof verification failed (historical_summaries)")
   elif isPoSBlock(chainConfig, header.number):
     let proof = decodeSsz(proof.asSeq(), BlockProofHistoricalRoots).valueOr:
       return err("Failed decoding historical_roots based block proof: " & error)

--- a/fluffy/network/history/validation/block_proof_historical_summaries.nim
+++ b/fluffy/network/history/validation/block_proof_historical_summaries.nim
@@ -163,6 +163,9 @@ func verifyProof*(
     historicalRootsIndex = getHistoricalSummariesIndex(proof.slot, cfg)
     blockRootIndex = getBlockRootsIndex(proof.slot)
 
+  if historical_summaries.len().uint64 <= historicalRootsIndex:
+    return false
+
   blockHash.verifyProof(proof.executionBlockProof, proof.beaconBlockRoot) and
     proof.beaconBlockRoot.verifyProof(
       proof.beaconBlockProof,

--- a/fluffy/tests/history_network_tests/test_block_proof_historical_summaries_vectors.nim
+++ b/fluffy/tests/history_network_tests/test_block_proof_historical_summaries_vectors.nim
@@ -27,7 +27,7 @@ suite "History Block Proofs - Historical Summaries - Test Vectors":
       testsPath =
         "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/block_proofs_capella/"
       historicalSummaries_path =
-        "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/block_proofs_capella/historical_summaries_at_slot_8953856.ssz"
+        "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/beacon_data/historical_summaries_at_slot_11476992.ssz"
       networkData = loadNetworkData("mainnet")
       historicalSummaries = readHistoricalSummaries(historicalSummaries_path).valueOr:
         raiseAssert "Cannot read historical summaries: " & error
@@ -35,7 +35,7 @@ suite "History Block Proofs - Historical Summaries - Test Vectors":
     for kind, path in walkDir(testsPath):
       if kind == pcFile and path.splitFile.ext == ".yaml":
         let
-          testProof = YamlTestProof.loadFromYaml(path).valueOr:
+          testProof = YamlTestProofCapella.loadFromYaml(path).valueOr:
             raiseAssert "Cannot read test vector: " & error
 
           blockHash = Digest.fromHex(testProof.execution_block_header)
@@ -44,6 +44,36 @@ suite "History Block Proofs - Historical Summaries - Test Vectors":
             beaconBlockRoot: Digest.fromHex(testProof.beacon_block_root),
             executionBlockProof: ExecutionBlockProof(
               array[11, Digest].fromHex(testProof.execution_block_proof)
+            ),
+            slot: Slot(testProof.slot),
+          )
+
+        check verifyProof(
+          historicalSummaries, blockProof, blockHash, networkData.metadata.cfg
+        )
+
+  test "BlockProofHistoricalSummariesDeneb for Execution BlockHeader":
+    let
+      testsPath =
+        "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/block_proofs_deneb/"
+      historicalSummaries_path =
+        "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/beacon_data/historical_summaries_at_slot_11476992.ssz"
+      networkData = loadNetworkData("mainnet")
+      historicalSummaries = readHistoricalSummaries(historicalSummaries_path).valueOr:
+        raiseAssert "Cannot read historical summaries: " & error
+
+    for kind, path in walkDir(testsPath):
+      if kind == pcFile and path.splitFile.ext == ".yaml":
+        let
+          testProof = YamlTestProofDeneb.loadFromYaml(path).valueOr:
+            raiseAssert "Cannot read test vector: " & error
+
+          blockHash = Digest.fromHex(testProof.execution_block_header)
+          blockProof = BlockProofHistoricalSummariesDeneb(
+            beaconBlockProof: array[13, Digest].fromHex(testProof.beacon_block_proof),
+            beaconBlockRoot: Digest.fromHex(testProof.beacon_block_root),
+            executionBlockProof: ExecutionBlockProofDeneb(
+              array[12, Digest].fromHex(testProof.execution_block_proof)
             ),
             slot: Slot(testProof.slot),
           )

--- a/fluffy/tests/history_network_tests/test_history_content.nim
+++ b/fluffy/tests/history_network_tests/test_history_content.nim
@@ -88,7 +88,7 @@ suite "History Content Values":
     const
       testsPath = "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/"
       historicalSummaries_path =
-        "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/block_proofs_capella/historical_summaries_at_slot_8953856.ssz"
+        "./vendor/portal-spec-tests/tests/mainnet/history/headers_with_proof/beacon_data/historical_summaries_at_slot_11476992.ssz"
 
     let historicalSummaries = readHistoricalSummaries(historicalSummaries_path).valueOr:
       raiseAssert "Cannot read historical summaries: " & error
@@ -112,31 +112,22 @@ suite "History Content Values":
         check contentKeyRes.isOk()
         let contentKey = contentKeyRes.get()
 
-        # Note: This part is only needed to avoid testing the block headers with
-        # proof post shanghai/capella fork as these are currently disabled.
-        # TODO: Remove after bellatrix and later forks are enabled for headers.
-
         # Decode content value
         let contentValueRes = decodeSsz(contentValueEncoded, BlockHeaderWithProof)
         check contentValueRes.isOk()
         let blockHeaderWithProof = contentValueRes.get()
-        # Decode header
-        let res = decodeRlp(blockHeaderWithProof.header.asSeq(), Header)
-        check res.isOk()
-        let header = res.get()
-        let timestamp = Moment.init(header.timestamp.int64, Second)
-        if not isShanghai(chainConfig, timestamp):
-          # Verifies if block header is canonical and if it matches the hash
-          # of provided content key.
-          check validateCanonicalHeaderBytes(
-            contentValueEncoded, contentKey.blockHeaderKey.blockHash, accumulators, cfg
-          )
-          .isOk()
 
-          # Encode content key and content value
-          check:
-            SSZ.encode(blockHeaderWithProof) == contentValueEncoded
-            encode(contentKey).asSeq() == contentKeyEncoded
+        # Verifies if block header is canonical and if it matches the hash
+        # of provided content key.
+        check validateCanonicalHeaderBytes(
+          contentValueEncoded, contentKey.blockHeaderKey.blockHash, accumulators, cfg
+        )
+        .isOk()
+
+        # Re-encode content key and content value
+        check:
+          SSZ.encode(blockHeaderWithProof) == contentValueEncoded
+          encode(contentKey).asSeq() == contentKeyEncoded
 
   test "PortalBlockBody (Legacy) Encoding/Decoding and Verification":
     const

--- a/fluffy/tools/eth_data_exporter/downloader.nim
+++ b/fluffy/tools/eth_data_exporter/downloader.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Copyright (c) 2020-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -77,3 +77,18 @@ proc requestBlock*(blockNumber: BlockNumber, client: RpcClient): Block =
   result.header = parseBlockHeader(header)
   result.body = requestBlockBody(header, blockNumber, client)
   result.receipts = requestReceipts(header, client)
+
+proc downloadHeader*(client: RpcClient, i: uint64): headers.Header =
+  try:
+    let jsonHeader = requestHeader(i, client)
+    parseBlockHeader(jsonHeader)
+  except CatchableError as e:
+    fatal "Error while requesting BlockHeader", error = e.msg, number = i
+    quit 1
+
+proc downloadBlock*(i: uint64, client: RpcClient): Block =
+  try:
+    return requestBlock(i, client)
+  except CatchableError as e:
+    fatal "Error while requesting Block", error = e.msg, number = i
+    quit 1

--- a/fluffy/tools/eth_data_exporter/exporter_common.nim
+++ b/fluffy/tools/eth_data_exporter/exporter_common.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -29,16 +29,18 @@ proc writePortalContentToJson*(
     fatal "Error occured while writing to file", error = e.msg
     quit 1
 
-proc writePortalContentToYaml*(file: string, contentKey: string, contentValue: string) =
-  let
-    yamlPortalContent =
-      YamlPortalContent(content_key: contentKey, content_value: contentValue)
-    res = yamlPortalContent.dumpToYaml(file)
+proc writeDataToYaml*[T](data: T, file: string) =
+  let res = data.dumpToYaml(file)
   if res.isErr():
     error "Failed writing content to file", file, error = res.error
-    quit 1
+    quit QuitFailure
   else:
     notice "Successfully wrote content to file", file
+
+proc writePortalContentToYaml*(file: string, contentKey: string, contentValue: string) =
+  let yamlPortalContent =
+    YamlPortalContent(content_key: contentKey, content_value: contentValue)
+  yamlPortalContent.writeDataToYaml(file)
 
 proc createAndOpenFile*(dataDir: string, fileName: string): OutputStreamHandle =
   # Creates directory and file, if file already exists

--- a/fluffy/tools/eth_data_exporter/exporter_conf.nim
+++ b/fluffy/tools/eth_data_exporter/exporter_conf.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -66,8 +66,9 @@ type
     exportLCFinalityUpdate = "Export Light Client Finality Update"
     exportLCOptimisticUpdate = "Export Light Client Optimistic Update"
     exportHistoricalRoots = "Export historical roots from the beacon state (SSZ format)"
-    exportBeaconBlockProof =
-      "Export EL beacon block proof from era files (Bellatrix and later)"
+    exportBlockProof = "Export EL block proof from era files (Bellatrix and later)"
+    exportHeaderWithProof =
+      "Export EL block header with proof from era files + web3 provider (Bellatrix and later)"
 
   ExporterConf* = object
     logLevel* {.
@@ -203,11 +204,21 @@ type
         discard
       of exportHistoricalRoots:
         discard
-      of exportBeaconBlockProof:
+      of exportBlockProof:
         slotNumber* {.
           desc: "The slot for which to export the beacon block proof", name: "slot"
         .}: uint64
         eraDir* {.desc: "Directory containing era files", name: "era-dir".}: InputDir
+      of exportHeaderWithProof:
+        slotNumber1* {.
+          desc: "The slot for which to export the beacon block proof", name: "slot"
+        .}: uint64
+        eraDir1* {.desc: "Directory containing era files", name: "era-dir".}: InputDir
+        web3Url1* {.
+          desc: "Execution layer JSON-RPC API URL",
+          defaultValue: defaultWeb3Url,
+          name: "web3-url"
+        .}: Web3Url
 
 proc parseCmdArg*(T: type Web3Url, p: string): T {.raises: [ValueError].} =
   let


### PR DESCRIPTION
- Adjust tests for supporting HeaderWithProof updated version with SSZ vector instead of list
- Add & adjust generation of test vectors for this
- Enable validation of this for Capella & Deneb onwards, however it will still fail due to no recent historical_summaries download
- Update portal-spec-tests test vectors