### PR TITLE
Fluffy: Only send offers to peers when content falls within radius

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -397,6 +397,13 @@ type
       name: "debug-disable-ban-nodes"
     .}: bool
 
+    radiusCacheSize* {.
+      hidden,
+      desc: "Size of the in memory radius cache.",
+      defaultValue: defaultPortalProtocolConfig.radiusCacheSize,
+      name: "debug-radius-cache-size"
+    .}: int
+
     case cmd* {.command, defaultValue: noCommand.}: PortalCmd
     of noCommand:
       discard

--- a/fluffy/eth_data/history_data_seeding.nim
+++ b/fluffy/eth_data/history_data_seeding.nim
@@ -98,7 +98,10 @@ proc historyGossipHeadersWithProof*(
 
   for (contentKey, contentValue) in f.headersWithProof(epochRecord):
     let peers = await p.neighborhoodGossip(
-      Opt.none(NodeId), ContentKeysList(@[contentKey]), @[contentValue]
+      Opt.none(NodeId),
+      ContentKeysList(@[contentKey]),
+      @[contentValue],
+      enableNodeLookup = true,
     )
     info "Gossiped block header", contentKey, peers
 
@@ -114,7 +117,10 @@ proc historyGossipBlockContent*(
 
   for (contentKey, contentValue) in f.blockContent():
     let peers = await p.neighborhoodGossip(
-      Opt.none(NodeId), ContentKeysList(@[contentKey]), @[contentValue]
+      Opt.none(NodeId),
+      ContentKeysList(@[contentKey]),
+      @[contentValue],
+      enableNodeLookup = true,
     )
     info "Gossiped block content", contentKey, peers
 

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -201,6 +201,7 @@ proc run(fluffy: Fluffy, config: PortalConf) {.raises: [CatchableError].} =
       config.radiusConfig, config.disablePoke, config.maxGossipNodes,
       config.contentCacheSize, config.disableContentCache, config.offerCacheSize,
       config.disableOfferCache, config.maxConcurrentOffers, config.disableBanNodes,
+      config.radiusCacheSize,
     )
 
     portalNodeConfig = PortalNodeConfig(

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -1710,6 +1710,7 @@ proc neighborhoodGossip*(
     srcNodeId: Opt[NodeId],
     contentKeys: ContentKeysList,
     content: seq[seq[byte]],
+    enableNodeLookup = false,
 ): Future[int] {.async: (raises: [CancelledError]).} =
   ## Run neighborhood gossip for provided content.
   ## Returns the number of peers to which content was attempted to be gossiped.
@@ -1760,7 +1761,8 @@ proc neighborhoodGossip*(
 
   var numberOfGossipedNodes = 0
 
-  if gossipNodes.len() >= p.config.maxGossipNodes: # use local nodes for gossip
+  if not enableNodeLookup or gossipNodes.len() >= p.config.maxGossipNodes:
+    # use local nodes for gossip
     portal_gossip_without_lookup.inc(labelValues = [$p.protocolId])
 
     for node in gossipNodes:
@@ -1801,8 +1803,9 @@ proc neighborhoodGossipDiscardPeers*(
     srcNodeId: Opt[NodeId],
     contentKeys: ContentKeysList,
     content: seq[seq[byte]],
+    enableNodeLookup = false,
 ): Future[void] {.async: (raises: [CancelledError]).} =
-  discard await p.neighborhoodGossip(srcNodeId, contentKeys, content)
+  discard await p.neighborhoodGossip(srcNodeId, contentKeys, content, enableNodeLookup)
 
 proc randomGossip*(
     p: PortalProtocol,

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -1714,6 +1714,12 @@ proc neighborhoodGossip*(
 ): Future[int] {.async: (raises: [CancelledError]).} =
   ## Run neighborhood gossip for provided content.
   ## Returns the number of peers to which content was attempted to be gossiped.
+  ## When enableNodeLookup is true then if the local routing table doesn't
+  ## have enough nodes with a radius in range of the content then a node lookup
+  ## is used to find nodes from the network. Note: For this part to work efficiently
+  ## the radius cache should be relatively large (ideally equal to the total number
+  ## of nodes in the network) to reduce the number of pings required to populate
+  ## the cache over time as old content is removed when the cache is full.
   if content.len() == 0:
     return 0
 

--- a/fluffy/network/wire/portal_protocol_config.nim
+++ b/fluffy/network/wire/portal_protocol_config.nim
@@ -48,6 +48,7 @@ type
     disableOfferCache*: bool
     maxConcurrentOffers*: int
     disableBanNodes*: bool
+    radiusCacheSize*: int
 
 const
   defaultRadiusConfig* = RadiusConfig(kind: Dynamic)
@@ -62,6 +63,7 @@ const
   defaultAlpha* = 3
   revalidationTimeout* = chronos.seconds(30)
   defaultDisableBanNodes* = true
+  defaultRadiusCacheSize* = 512
 
   defaultPortalProtocolConfig* = PortalProtocolConfig(
     tableIpLimits: DefaultTableIpLimits,
@@ -76,6 +78,7 @@ const
     disableOfferCache: defaultDisableOfferCache,
     maxConcurrentOffers: defaultMaxConcurrentOffers,
     disableBanNodes: defaultDisableBanNodes,
+    radiusCacheSize: defaultRadiusCacheSize,
   )
 
 proc init*(
@@ -93,6 +96,7 @@ proc init*(
     disableOfferCache: bool,
     maxConcurrentOffers: int,
     disableBanNodes: bool,
+    radiusCacheSize: int,
 ): T =
   PortalProtocolConfig(
     tableIpLimits:
@@ -108,6 +112,7 @@ proc init*(
     disableOfferCache: disableOfferCache,
     maxConcurrentOffers: maxConcurrentOffers,
     disableBanNodes: disableBanNodes,
+    radiusCacheSize: radiusCacheSize,
   )
 
 func fromLogRadius*(T: type UInt256, logRadius: uint16): T =

--- a/fluffy/rpc/rpc_portal_beacon_api.nim
+++ b/fluffy/rpc/rpc_portal_beacon_api.nim
@@ -141,7 +141,10 @@ proc installPortalBeaconApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
       # TODO: validate and store content locally
       # storedLocally = p.storeContent(keyBytes, contentId, valueBytes)
       peerCount = await p.neighborhoodGossip(
-        Opt.none(NodeId), ContentKeysList(@[keyBytes]), @[offerValueBytes]
+        Opt.none(NodeId),
+        ContentKeysList(@[keyBytes]),
+        @[offerValueBytes],
+        enableNodeLookup = true,
       )
 
     PutContentResult(storedLocally: false, peerCount: peerCount)

--- a/fluffy/rpc/rpc_portal_history_api.nim
+++ b/fluffy/rpc/rpc_portal_history_api.nim
@@ -158,7 +158,10 @@ proc installPortalHistoryApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
       # As no validation is done here, the content is not stored locally.
       # TODO: Add default on validation by optional validation parameter.
       peerCount = await p.neighborhoodGossip(
-        Opt.none(NodeId), ContentKeysList(@[keyBytes]), @[offerValueBytes]
+        Opt.none(NodeId),
+        ContentKeysList(@[keyBytes]),
+        @[offerValueBytes],
+        enableNodeLookup = true,
       )
 
     PutContentResult(storedLocally: false, peerCount: peerCount)

--- a/fluffy/rpc/rpc_portal_state_api.nim
+++ b/fluffy/rpc/rpc_portal_state_api.nim
@@ -183,7 +183,10 @@ proc installPortalStateApiHandlers*(rpcServer: RpcServer, p: PortalProtocol) =
 
       storedLocally = p.storeContent(keyBytes, contentId, valueBytes)
       peerCount = await p.neighborhoodGossip(
-        Opt.none(NodeId), ContentKeysList(@[keyBytes]), @[offerValueBytes]
+        Opt.none(NodeId),
+        ContentKeysList(@[keyBytes]),
+        @[offerValueBytes],
+        enableNodeLookup = true,
       )
 
     PutContentResult(storedLocally: storedLocally, peerCount: peerCount)


### PR DESCRIPTION
Changes in this PR:
- Improve gossip so that we only send offers that are within the peer's radius. Previously when doing a network lookup we were not checking the radius. This reduces the wasted effort/resources used on sending offers to nodes which will always decline the offer because the content is outside their radius.
- In order to check the the peer's radius, when doing a nodes lookup, we now ping each peer if we don't have their radius in the cache. This change significantly improves bridge performance (when node lookup is enabled) because we fill up the radius cache faster and overall reduce the number of node lookups required when gossiping content into the network.
- Increase the size of the radius cache. This improves the performance of `neighborhoodGossip` by caching more of the network in memory.
- Makes nodes lookup configurable in `neighborhoodGossip`. Nodes lookup is disabled by default and only enabled when called via the JSON-RPC API. This update is related to the recent spec change here: https://github.com/ethereum/portal-network-specs/pull/394. I've added this into this PR to reduce the impact of the node lookup changes on the nodes in the network as they won't be using the node lookup at all unless being called via the JSON-RPC API.