### PR TITLE
Fluffy: eth_createAccessList fixes and improvements

### DIFF
--- a/fluffy/evm/async_evm.nim
+++ b/fluffy/evm/async_evm.nim
@@ -333,7 +333,8 @@ proc call*(
 
   let
     vmState = evm.setupVmState(txFrame, header)
-    callResult = ?(await evm.callFetchingState(vmState, header, tx, optimisticStateFetch))
+    callResult =
+      ?(await evm.callFetchingState(vmState, header, tx, optimisticStateFetch))
 
   if callResult.error.len() > 0:
     err("EVM execution failed: " & callResult.error)

--- a/fluffy/evm/async_evm.nim
+++ b/fluffy/evm/async_evm.nim
@@ -277,8 +277,7 @@ proc callFetchingState(
         vmState.ledger.setCode(q.address, code)
         fetchedCode.incl(q.address)
     except CatchableError as e:
-      # TODO: why do the above futures throw a CatchableError and not CancelledError?
-      raiseAssert(e.msg)
+      raise newException(CancelledError, e.msg)
 
   evmResult.toCallResult()
 
@@ -377,8 +376,6 @@ proc createAccessList*(
 
   let finalCallResult = ?evm.call(vmState, header, txWithAl)
 
-  # TODO: Do we need to use the estimate gas calculation here to get a more acturate
-  # estimation of the gas requirement?
   ok((txWithAl.accessList.get(@[]), finalCallResult.gasUsed))
 
 proc estimateGas*(

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -502,12 +502,12 @@ proc installEthApiHandlers*(
       optimisticStateFetch = optimisticStateFetch.valueOr:
         true
 
-    let (accessList, gasUsed) = (
+    let (accessList, error, gasUsed) = (
       await evm.createAccessList(header, tx, optimisticStateFetch)
     ).valueOr:
       raise newException(ValueError, error)
 
-    return AccessListResult(accessList: accessList, gasUsed: gasUsed.Quantity)
+    return AccessListResult(accessList: accessList, error: error, gasUsed: gasUsed.Quantity)
 
   rpcServer.rpc("eth_estimateGas") do(
     tx: TransactionArgs, quantityTag: RtBlockIdentifier, optimisticStateFetch: Opt[bool]

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -507,7 +507,8 @@ proc installEthApiHandlers*(
     ).valueOr:
       raise newException(ValueError, error)
 
-    return AccessListResult(accessList: accessList, error: error, gasUsed: gasUsed.Quantity)
+    return
+      AccessListResult(accessList: accessList, error: error, gasUsed: gasUsed.Quantity)
 
   rpcServer.rpc("eth_estimateGas") do(
     tx: TransactionArgs, quantityTag: RtBlockIdentifier, optimisticStateFetch: Opt[bool]

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -486,7 +486,7 @@ proc installEthApiHandlers*(
     ## quantityTag: integer block number, or the string "latest", "earliest" or "pending",
     ##   see the default block parameter.
     ## Returns: the access list object which contains the addresses and storage keys which
-    ##   are read by the transaction.
+    ##   are read and written by the transaction.
 
     if tx.to.isNone():
       raise newException(ValueError, "to address is required")

--- a/fluffy/tests/evm/test_async_evm.nim
+++ b/fluffy/tests/evm/test_async_evm.nim
@@ -186,13 +186,14 @@ suite "Async EVM":
           input: Opt.some(testCase.txArgs.input.hexToSeqByte()),
         )
 
-      let (accessList, gasUsed) = (
+      let (accessList, error, gasUsed) = (
         waitFor evm.createAccessList(header, tx, optimisticStateFetch = true)
       ).expect("success")
 
       check:
         accessList.len() == testCase.expected.accessList.len()
         gasUsed > 0
+        error.isNone()
 
       for accessPair in accessList:
         let
@@ -220,13 +221,14 @@ suite "Async EVM":
           input: Opt.some(testCase.txArgs.input.hexToSeqByte()),
         )
 
-      let (accessList, gasUsed) = (
+      let (accessList, error, gasUsed) = (
         waitFor evm.createAccessList(header, tx, optimisticStateFetch = false)
       ).expect("success")
 
       check:
         accessList.len() == testCase.expected.accessList.len()
         gasUsed > 0
+        error.isNone()
 
       for accessPair in accessList:
         let


### PR DESCRIPTION
Changes in this PR:
- Access list is still returned when the evm execution reverts.
- The evm error message is return in the AccessListResult error field.
- Access list is sorted before returning to align with Geth's implementation.