### PR TITLE
Add architecture documentation to the Fluffy guide website

### DIFF
--- a/.github/workflows/fluffy_docs.yml
+++ b/.github/workflows/fluffy_docs.yml
@@ -32,7 +32,7 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocs-mermaid2-plugin
       - name: Run mkdocs github deploy
         working-directory: ./fluffy/docs/the_fluffy_book/
         run: |

--- a/fluffy/docs/the_fluffy_book/docs/adding-documentation.md
+++ b/fluffy/docs/the_fluffy_book/docs/adding-documentation.md
@@ -9,7 +9,7 @@ All the documentation related files can be found under the `./fluffy/docs/the_fl
 ## How to test and add documentation changes
 
 - Install `mkdocs`
-- Install Material for MkDocs by running `pip install mkdocs-material`.
+- Install Material for MkDocs by running `pip install mkdocs-material mkdocs-mermaid2-plugin`.
 - Make your changes to the documentation
 - Run `mkdocs serve` from the `./fluffy/docs/the_fluffy_book` directory and test your changes. Alter as required.
 - Push your changes to a PR on nimbus-eth1

--- a/fluffy/docs/the_fluffy_book/docs/adding-documentation.md
+++ b/fluffy/docs/the_fluffy_book/docs/adding-documentation.md
@@ -1,4 +1,4 @@
-# Adding Documentation
+# Adding documentation
 
 The documentation visible on [https://fluffy.guide](https://fluffy.guide) is generated with [mkdocs](https://www.mkdocs.org/getting-started/).
 

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -52,7 +52,7 @@ have separate instances per subnetwork.
 The `Discv5Protocol` type implements the Discv5 protocol which is used as a transport to send messages between
 Portal nodes. Each Portal subnetwork (such as the `BeaconNetwork`, `HistoryNetwork` and `StateNetwork`) holds an instance of
 `PortalProtocol` which implements the Portal Wire protocol and an instance of `ContentQueue` which receives Portal
-content from the `PortalStream` type when the node receives content from peers. When a content transfer is
+content from the `PortalStream` when the node receives content from peers. When a content transfer is
 initiated which is bigger than the max Discv5 message size, then the `PortalStream` transfers the content using
 the `UtpDiscv5Protocol` type which implements uTP on top of Discv5.
 

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -1,110 +1,41 @@
 # Fluffy Architecture
 
-The following diagram outlines the Fluffy high-level architecture.
+This diagram outlines the Fluffy high-level architecture. The arrows indicate a dependancy relationship between each component. 
 
-```mermaid
-graph LR
-    portal_bridge --> nimbus_execution_client
-    portal_bridge --> fluffy
-```
-
-## Fluffy Components
 
 ```mermaid
 
 graph TD;
-    Fluffy --> id2(PortalNode) & id3(RpcHttpServer) & id4(RpcWebSocketServer) & id5(MetricsHttpServer)
-    id3(RpcHttpServer) & id4(RpcWebSocketServer) & id2(PortalNode) --> id7(BeaconNetwork)
-    id3(RpcHttpServer) & id4(RpcWebSocketServer) & id2(PortalNode) ---> id8(HistoryNetwork)
-    id3(RpcHttpServer) & id4(RpcWebSocketServer) & id2(PortalNode) ----> id9(StateNetwork)
-    id3(RpcHttpServer) & id4(RpcWebSocketServer) ----> id6(AsyncEvm)
+    Fluffy ---> id2(PortalNode) & id5(MetricsHttpServer)
+    Fluffy ---> id3(RpcHttpServer) & id4(RpcWebSocketServer)
+    id3(RpcHttpServer) & id4(RpcWebSocketServer) & id2(PortalNode) ---> id7(BeaconNetwork)
+    id3(RpcHttpServer) & id4(RpcWebSocketServer) & id2(PortalNode) ----> id8(HistoryNetwork)
+    id3(RpcHttpServer) & id4(RpcWebSocketServer) & id2(PortalNode) -----> id9(StateNetwork)
+    id3(RpcHttpServer) & id4(RpcWebSocketServer) -----> id6(AsyncEvm)
+    id2(PortalNode) --> id10(Discv5_Protocol)
 ```
 
-## Portal Node Components
+## Portal Subnetworks
 
 ```mermaid
 
-graph LR
-    PortalNode --> Discv5_Protocol
-    PortalNode --> ContentDB
-    PortalNode --> StreamManager
-    ContentDB --> sqlite
-    PortalNode --> BeaconNetwork
-    PortalNode --> HistoryNetwork
-    PortalNode --> StateNetwork
-    PortalNode --> LightClient
-
+graph TD;
+    PortalSubnetwork --> id1(PortalProtocol)
+    PortalSubnetwork --> id2(ContentQueue)
+    id1(PortalProtocol) --> id3(Discv5Protocol)
+    id1(PortalProtocol) --> id4(RoutingTable)
+    id1(PortalProtocol) ---> id5(RadiusCache)
+    id1(PortalProtocol) --> id6(OfferCache)
+    id1(PortalProtocol) ---> id7(ContentCache)
+    id1(PortalProtocol) --> id8(ContentDb)
+    id1(PortalProtocol) ---> id9(OfferQueue)
+    id1(PortalProtocol) --> id10(PortalStream)
+    id10(PortalStream) --> id11(UtpDiscv5Protocol)
+    id10(PortalStream) --> id2(ContentQueue)
+    id11(UtpDiscv5Protocol) --> id3(Discv5Protocol)
 ```
 
-## State Network Components
-
-```mermaid
-
-graph LR
-    StateNetwork --> State_ContentQueue
-    StateNetwork --> State_PortalProtocol
-    StateNetwork --> HistoryNetwork
-    State_PortalProtocol --> State_PortalStream
-    State_PortalStream --> State_ContentQueue
-    State_PortalProtocol --> ContentDB
-
-```
-
-## History Network Components
-
-```mermaid
-
-graph LR
-    HistoryNetwork --> History_ContentQueue
-    HistoryNetwork --> History_PortalProtocol
-    History_PortalProtocol --> History_PortalStream
-    History_PortalStream --> History_ContentQueue
-    History_PortalProtocol --> ContentDB
-
-```
-
-## Beacon Network Components
-
-```mermaid
-
-graph LR
-    LightClient --> BeaconNetwork
-    LightClient --> ForkedLightClientStore
-    LightClient --> LightClientProcessor
-    LightClient --> LightClientManager
-    LightClientManager --> BeaconNetwork
-    BeaconNetwork --> Beacon_ContentQueue
-    BeaconNetwork --> Beacon_PortalProtocol
-    Beacon_PortalProtocol --> Beacon_PortalStream
-    BeaconNetwork --> BeaconDb
-    BeaconNetwork --> LightClientProcessor
-
-```
-
-## Portal Protocol Components
-
-```mermaid
-
-graph LR
-    PortalProtocol --> Discv5_Protocol & RoutingTable & ContentCache & OfferCache & ContentDb & PortalStream & RadiusCache & OfferQueue
-
-```
-
-## Stream Manager Components
-
-```mermaid
-
-graph LR
-    PortalStream --> UtpDiscv5Protocol
-    PortalStream --> ContentQueue
-    StreamManager --> UtpDiscv5Protocol
-    StreamManager --> PortalStream
-    UtpDiscv5Protocol --> Discv5_Protocol
-
-```
-
-
-## Async Evm Components
+## Async Evm
 
 ```mermaid
 

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -20,7 +20,7 @@ graph TD;
 
 When Fluffy starts it runs an instance of `PortalNode` which manages the `Discv5Protocol`, `BeaconNetwork`, `HistoryNetwork` and `StateNetwork` instances. There is a single instance of each of these components and each of the subnetwork instances can be enabled/disabled depending on the startup configuration selected. The `PortalNode` instance includes everything needed to participate in the Portal network to enable storage of offered content and serving content requests from other Portal nodes. It may become part of a library in the future which would allow other projects to easily embed an instance of Fluffy in their codebase.
 
-The `RpcHttpServer` and `RpcWebSocketServer` enable serving JSON-RPC requests from portal network over HTTP and WebSocket respectively. These RPC servers depend on the Fluffy EVM (`AsyncEvm`) in order to implement the various endpoints which require asyncronous transaction execution while fetching state from the portal network.
+The `RpcHttpServer` and `RpcWebSocketServer` enable serving JSON-RPC requests from Portal network over HTTP and WebSocket respectively. These RPC servers depend on the Fluffy EVM (`AsyncEvm`) in order to implement the various endpoints which require asyncronous transaction execution while fetching state from the Portal network.
 
 
 ## Portal subnetworks

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -25,7 +25,7 @@ The `RpcHttpServer` and `RpcWebSocketServer` enable serving JSON-RPC requests fr
 
 ## Portal subnetworks
 
-This diagram outlines the generic architecture of each portal subnetwork.
+This diagram outlines the generic architecture of each Portal subnetwork.
 
 ```mermaid
 

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -4,7 +4,113 @@ The following diagram outlines the Fluffy high-level architecture.
 
 ```mermaid
 graph LR
-    hello --> world
-    world --> again
-    again --> hello
+    portal_bridge --> nimbus_execution_client
+    portal_bridge --> fluffy
+```
+
+## Fluffy Components
+
+```mermaid
+
+graph TD;
+    Fluffy --> id2(PortalNode) & id3(RpcHttpServer) & id4(RpcWebSocketServer) & id5(MetricsHttpServer)
+    id3(RpcHttpServer) & id4(RpcWebSocketServer) & id2(PortalNode) --> id7(BeaconNetwork)
+    id3(RpcHttpServer) & id4(RpcWebSocketServer) & id2(PortalNode) ---> id8(HistoryNetwork)
+    id3(RpcHttpServer) & id4(RpcWebSocketServer) & id2(PortalNode) ----> id9(StateNetwork)
+    id3(RpcHttpServer) & id4(RpcWebSocketServer) ----> id6(AsyncEvm)
+```
+
+## Portal Node Components
+
+```mermaid
+
+graph LR
+    PortalNode --> Discv5_Protocol
+    PortalNode --> ContentDB
+    PortalNode --> StreamManager
+    ContentDB --> sqlite
+    PortalNode --> BeaconNetwork
+    PortalNode --> HistoryNetwork
+    PortalNode --> StateNetwork
+    PortalNode --> LightClient
+
+```
+
+## State Network Components
+
+```mermaid
+
+graph LR
+    StateNetwork --> State_ContentQueue
+    StateNetwork --> State_PortalProtocol
+    StateNetwork --> HistoryNetwork
+    State_PortalProtocol --> State_PortalStream
+    State_PortalStream --> State_ContentQueue
+    State_PortalProtocol --> ContentDB
+
+```
+
+## History Network Components
+
+```mermaid
+
+graph LR
+    HistoryNetwork --> History_ContentQueue
+    HistoryNetwork --> History_PortalProtocol
+    History_PortalProtocol --> History_PortalStream
+    History_PortalStream --> History_ContentQueue
+    History_PortalProtocol --> ContentDB
+
+```
+
+## Beacon Network Components
+
+```mermaid
+
+graph LR
+    LightClient --> BeaconNetwork
+    LightClient --> ForkedLightClientStore
+    LightClient --> LightClientProcessor
+    LightClient --> LightClientManager
+    LightClientManager --> BeaconNetwork
+    BeaconNetwork --> Beacon_ContentQueue
+    BeaconNetwork --> Beacon_PortalProtocol
+    Beacon_PortalProtocol --> Beacon_PortalStream
+    BeaconNetwork --> BeaconDb
+    BeaconNetwork --> LightClientProcessor
+
+```
+
+## Portal Protocol Components
+
+```mermaid
+
+graph LR
+    PortalProtocol --> Discv5_Protocol & RoutingTable & ContentCache & OfferCache & ContentDb & PortalStream & RadiusCache & OfferQueue
+
+```
+
+## Stream Manager Components
+
+```mermaid
+
+graph LR
+    PortalStream --> UtpDiscv5Protocol
+    PortalStream --> ContentQueue
+    StreamManager --> UtpDiscv5Protocol
+    StreamManager --> PortalStream
+    UtpDiscv5Protocol --> Discv5_Protocol
+
+```
+
+
+## Async Evm Components
+
+```mermaid
+
+graph LR
+  AsyncEvm --> NimbusEvm
+  AsyncEvm --> AsyncEvmPortalBackend
+  AsyncEvmPortalBackend --> StateNetwork
+
 ```

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -59,7 +59,7 @@ the `UtpDiscv5Protocol` type which implements uTP on top of Discv5.
 The `RoutingTable` implements a Kademlia based DHT which holds the peer ENRs which Fluffy discovers while participating
 in each of the Portal Wire subprotocols. The `RadiusCache` holds the last known radius for each peer which is collected
 when pinging each node in the routing table periodically. The `OfferCache` caches the content ids of the most recent content successfully offered and stored so that Fluffy can reject content that it already has without doing a database lookup. The `ContentCache` improves the performance of content lookups (used by the JSON-RPC API's) by caching the most recently fetched
-content in a LRUCache.
+content in a LRU cache.
 
 The `ContentDb` is the main database in Fluffy which internally uses sqlite to store the content data on disk. The `PortalProtocol`
 uses the `OfferQueue` to hold pending offer requests which are passed to the `PortalStream` by the concurrent offer workers

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -1,3 +1,10 @@
 # Fluffy Architecture
 
 The following diagram outlines the Fluffy high-level architecture.
+
+```mermaid
+graph LR
+    hello --> world
+    world --> again
+    again --> hello
+```

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -46,7 +46,7 @@ graph TD;
 ```
 
 There are some differences between each of the subnetworks but the components used in each are mostly the same.
-Only the `Discv5Protocol` and `ContentDb` instances are shared between the portal subnetworks while the other components
+Only the `Discv5Protocol` and `ContentDb` instances are shared between the Portal subnetworks while the other components
 have separate instances per subnetwork.
 
 The `Discv5Protocol` type implements the Discv5 protocol which is used as a transport to send messages between

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -51,7 +51,7 @@ have separate instances per subnetwork.
 
 The `Discv5Protocol` type implements the Discv5 protocol which is used as a transport to send messages between
 Portal nodes. Each Portal subnetwork (such as the `BeaconNetwork`, `HistoryNetwork` and `StateNetwork`) holds an instance of
-`PortalProtocol` which implements the Portal Wire protocol and an instance of `ContentQueue` which receives portal
+`PortalProtocol` which implements the Portal Wire protocol and an instance of `ContentQueue` which receives Portal
 content from the `PortalStream` type when the node receives content from peers. When a content transfer is
 initiated which is bigger than the max Discv5 message size, then the `PortalStream` transfers the content using
 the `UtpDiscv5Protocol` type which implements uTP on top of Discv5.

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -50,7 +50,7 @@ Only the `Discv5Protocol` and `ContentDb` instances are shared between the Porta
 have separate instances per subnetwork.
 
 The `Discv5Protocol` type implements the Discv5 protocol which is used as a transport to send messages between
-portal nodes. Each portal subnetwork (such as the `BeaconNetwork`, `HistoryNetwork` and `StateNetwork`) holds an instance of
+Portal nodes. Each Portal subnetwork (such as the `BeaconNetwork`, `HistoryNetwork` and `StateNetwork`) holds an instance of
 `PortalProtocol` which implements the Portal Wire protocol and an instance of `ContentQueue` which receives portal
 content from the `PortalStream` type when the node receives content from peers. When a content transfer is
 initiated which is bigger than the max Discv5 message size, then the `PortalStream` transfers the content using

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -1,0 +1,3 @@
+# Fluffy Architecture
+
+The following diagram outlines the Fluffy high-level architecture.

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -18,7 +18,7 @@ graph TD;
     id2(PortalNode) --> id10(Discv5Protocol)
 ```
 
-When Fluffy starts it runs an instance of `PortalNode` which manages the `Discv5Protocol`, `BeaconNetwork`, `HistoryNetwork` and `StateNetwork` instances. There is a single instance of each of these components and each of the subnetwork instances can be enabled/disabled depending on the startup configuration selected. The `PortalNode` instance includes everything needed to participant in the portal network to enable storage of offered content and serving content requests from other portal nodes. It may become part of a library in the future which would allow other projects to easily embed an instance of Fluffy in their codebase.
+When Fluffy starts it runs an instance of `PortalNode` which manages the `Discv5Protocol`, `BeaconNetwork`, `HistoryNetwork` and `StateNetwork` instances. There is a single instance of each of these components and each of the subnetwork instances can be enabled/disabled depending on the startup configuration selected. The `PortalNode` instance includes everything needed to participate in the Portal network to enable storage of offered content and serving content requests from other Portal nodes. It may become part of a library in the future which would allow other projects to easily embed an instance of Fluffy in their codebase.
 
 The `RpcHttpServer` and `RpcWebSocketServer` enable serving JSON-RPC requests from portal network over HTTP and WebSocket respectively. These RPC servers depend on the Fluffy EVM (`AsyncEvm`) in order to implement the various endpoints which require asyncronous transaction execution while fetching state from the portal network.
 

--- a/fluffy/docs/the_fluffy_book/docs/architecture.md
+++ b/fluffy/docs/the_fluffy_book/docs/architecture.md
@@ -1,8 +1,11 @@
 # Fluffy Architecture
 
-This diagram outlines the Fluffy high-level architecture. The arrows indicate a dependancy relationship between each component. 
+This section outlines Fluffy's architecture and shows the main components in the codebase. The arrows indicate a dependancy relationship between each component.
 
 
+## Fluffy high level architecture
+
+This diagram outlines the Fluffy high-level architecture.
 ```mermaid
 
 graph TD;
@@ -12,10 +15,17 @@ graph TD;
     id3(RpcHttpServer) & id4(RpcWebSocketServer) & id2(PortalNode) ----> id8(HistoryNetwork)
     id3(RpcHttpServer) & id4(RpcWebSocketServer) & id2(PortalNode) -----> id9(StateNetwork)
     id3(RpcHttpServer) & id4(RpcWebSocketServer) -----> id6(AsyncEvm)
-    id2(PortalNode) --> id10(Discv5_Protocol)
+    id2(PortalNode) --> id10(Discv5Protocol)
 ```
 
-## Portal Subnetworks
+When Fluffy starts it runs an instance of `PortalNode` which manages the `Discv5Protocol`, `BeaconNetwork`, `HistoryNetwork` and `StateNetwork` instances. There is a single instance of each of these components and each of the subnetwork instances can be enabled/disabled depending on the startup configuration selected. The `PortalNode` instance includes everything needed to participant in the portal network to enable storage of offered content and serving content requests from other portal nodes. It may become part of a library in the future which would allow other projects to easily embed an instance of Fluffy in their codebase.
+
+The `RpcHttpServer` and `RpcWebSocketServer` enable serving JSON-RPC requests from portal network over HTTP and WebSocket respectively. These RPC servers depend on the Fluffy EVM (`AsyncEvm`) in order to implement the various endpoints which require asyncronous transaction execution while fetching state from the portal network.
+
+
+## Portal subnetworks
+
+This diagram outlines the generic architecture of each portal subnetwork.
 
 ```mermaid
 
@@ -23,25 +33,52 @@ graph TD;
     PortalSubnetwork --> id1(PortalProtocol)
     PortalSubnetwork --> id2(ContentQueue)
     id1(PortalProtocol) --> id3(Discv5Protocol)
-    id1(PortalProtocol) --> id4(RoutingTable)
-    id1(PortalProtocol) ---> id5(RadiusCache)
-    id1(PortalProtocol) --> id6(OfferCache)
-    id1(PortalProtocol) ---> id7(ContentCache)
-    id1(PortalProtocol) --> id8(ContentDb)
-    id1(PortalProtocol) ---> id9(OfferQueue)
+    id1(PortalProtocol) ---> id4(RoutingTable)
+    id1(PortalProtocol) --> id5(RadiusCache)
+    id1(PortalProtocol) ---> id6(OfferCache)
+    id1(PortalProtocol) --> id7(ContentCache)
+    id1(PortalProtocol) ---> id8(ContentDb)
+    id1(PortalProtocol) --> id9(OfferQueue)
     id1(PortalProtocol) --> id10(PortalStream)
     id10(PortalStream) --> id11(UtpDiscv5Protocol)
     id10(PortalStream) --> id2(ContentQueue)
     id11(UtpDiscv5Protocol) --> id3(Discv5Protocol)
 ```
 
-## Async Evm
+There are some differences between each of the subnetworks but the components used in each are mostly the same.
+Only the `Discv5Protocol` and `ContentDb` instances are shared between the portal subnetworks while the other components
+have separate instances per subnetwork.
+
+The `Discv5Protocol` type implements the Discv5 protocol which is used as a transport to send messages between
+portal nodes. Each portal subnetwork (such as the `BeaconNetwork`, `HistoryNetwork` and `StateNetwork`) holds an instance of
+`PortalProtocol` which implements the Portal Wire protocol and an instance of `ContentQueue` which receives portal
+content from the `PortalStream` type when the node receives content from peers. When a content transfer is
+initiated which is bigger than the max Discv5 message size, then the `PortalStream` transfers the content using
+the `UtpDiscv5Protocol` type which implements uTP on top of Discv5.
+
+The `RoutingTable` implements a Kademlia based DHT which holds the peer ENRs which Fluffy discovers while participating
+in each of the Portal Wire subprotocols. The `RadiusCache` holds the last known radius for each peer which is collected
+when pinging each node in the routing table periodically. The `OfferCache` caches the content ids of the most recent content successfully offered and stored so that Fluffy can reject content that it already has without doing a database lookup. The `ContentCache` improves the performance of content lookups (used by the JSON-RPC API's) by caching the most recently fetched
+content in a LRUCache.
+
+The `ContentDb` is the main database in Fluffy which internally uses sqlite to store the content data on disk. The `PortalProtocol`
+uses the `OfferQueue` to hold pending offer requests which are passed to the `PortalStream` by the concurrent offer workers
+which run as a part of `PortalProtocol`.
+
+
+## Fluffy EVM
+
+This diagram outlines the architecture of the Fluffy EVM.
 
 ```mermaid
 
-graph LR
-  AsyncEvm --> NimbusEvm
-  AsyncEvm --> AsyncEvmPortalBackend
-  AsyncEvmPortalBackend --> StateNetwork
+graph TD;
+  AsyncEvm --> id1(NimbusEvm)
+  AsyncEvm --> id2(AsyncEvmPortalBackend)
+  id2(AsyncEvmPortalBackend) --> id3(StateNetwork)
 
 ```
+
+The Fluffy EVM is used by the `eth_call` and `eth_estimateGas` RPC endpoints which both need to execute bytecode in the EVM.
+It uses an instance of the `AsyncEvm` which is built on top of the Nimbus EVM in order to provide asyncronous transaction execution that can fetch state concurrently from a configured backend. In this case we use the `AsyncEvmPortalBackend` which wires in the `StateNetwork` which provides the account, storage and bytecode state on demand from the portal state network when executing
+a transaction.

--- a/fluffy/docs/the_fluffy_book/docs/basics-for-developers.md
+++ b/fluffy/docs/the_fluffy_book/docs/basics-for-developers.md
@@ -22,11 +22,11 @@ The code follows the
 
 ## Nim code formatting
 
-The fluffy codebase is formatted with [nph](https://github.com/arnetheduck/nph).
+The Fluffy codebase is formatted with [nph](https://github.com/arnetheduck/nph).
 Check out the [this page](https://arnetheduck.github.io/nph/installation.html)
 on how to install nph.
 
-The fluffy CI tests check the code formatting according to the style rules of nph.
+The Fluffy CI tests check the code formatting according to the style rules of nph.
 Developers will need to make sure the code changes in PRs are formatted as such.
 
 !!! note

--- a/fluffy/docs/the_fluffy_book/docs/index.md
+++ b/fluffy/docs/the_fluffy_book/docs/index.md
@@ -27,7 +27,7 @@ The Portal history, beacon and state sub-networks are already operational on the
 
 Fluffy is default ran on the [Portal mainnet](https://github.com/ethereum/portal-network-specs/blob/master/bootnodes.md#bootnodes-mainnet) but can also be run on a (local) testnet.
 
-### Supported sub-networks and content:
+### Supported sub-networks and content
 
 - [History network](https://github.com/ethereum/portal-network-specs/blob/e8e428c55f34893becfe936fe323608e9937956e/history/history-network.md): headers, blocks, and receipts.
     - Note: Canonical verification is currently only enabled for pre-merge blocks.
@@ -35,22 +35,26 @@ Fluffy is default ran on the [Portal mainnet](https://github.com/ethereum/portal
     - Note: The Portal mainnet does not yet hold all states, nor the recent state.
 - [Beacon network](https://github.com/ethereum/portal-network-specs/blob/e8e428c55f34893becfe936fe323608e9937956e/beacon-chain/beacon-network.md): consensus light client data and historical summaries.
 
-### Supported functionality:
+### Supported functionality
 
 - [Portal JSON-RPC API](https://github.com/ethereum/portal-network-specs/tree/e8e428c55f34893becfe936fe323608e9937956e/jsonrpc)
 - [Consensus light client sync](https://github.com/ethereum/consensus-specs/blob/a09d0c321550c5411557674a981e2b444a1178c0/specs/altair/light-client/light-client.md) through content available on the Portal beacon network.
 - Partial support of [Execution JSON-RPC API](https://github.com/ethereum/execution-apis):
     - web3_clientVersion
     - eth_chainId
-    - eth_getBalance
+    - eth_blockNumber
     - eth_getBlockByHash
     - eth_getBlockByNumber
     - eth_getBlockTransactionCountByHash
-    - eth_getCode
     - eth_getLogs (partial support: queries by blockhash)
-    - eth_getProof
-    - eth_getStorageAt
+    - eth_getBalance
     - eth_getTransactionCount
+    - eth_getStorageAt
+    - eth_getCode
+    - eth_getProof
+    - eth_call
+    - eth_createAccessList
+    - eth_estimateGas
 
 ## Get in touch
 

--- a/fluffy/docs/the_fluffy_book/docs/protocol-interop-testing.md
+++ b/fluffy/docs/the_fluffy_book/docs/protocol-interop-testing.md
@@ -1,4 +1,4 @@
-# Protocol Interoperability Testing
+# Protocol interoperability testing
 This document shows a set of commands that can be used to test the individual
 protocol messages per network (Discovery v5 and Portal networks), e.g. to test
 client protocol interoperability.
@@ -19,7 +19,7 @@ Next run it with the JSON-RPC server enabled:
 ./build/fluffy --rpc --rpc-api:portal,discovery --bootstrap-node:enr:<base64 encoding of ENR>
 ```
 
-### Testing Discovery v5 Layer
+### Testing Discovery v5 layer
 Testing the Discovery v5 protocol messages:
 
 ```bash
@@ -38,7 +38,7 @@ curl -s -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":"1
 curl -s -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":"1","method":"discv5_routingTableInfo","params":[]}' http://localhost:8545 | jq
 ```
 
-### Testing Portal Networks Layer
+### Testing Portal Networks layer
 Testing the Portal wire protocol messages:
 
 ```bash
@@ -62,7 +62,7 @@ curl -s -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":"1
 
 ## Test Discovery and Portal Wire protocol messages with cli tools
 
-### Testing Discovery v5 Layer: dcli
+### Testing Discovery v5 layer: dcli
 
 ```bash
 # Build dcli from nim-eth vendor module
@@ -87,7 +87,7 @@ e.g.:
 > Each `dcli` run will default generate a new network key and thus a new node id
 and ENR.
 
-### Testing Portal Networks Layer: portalcli
+### Testing Portal Networks layer: portalcli
 
 ```bash
 # Build portalcli

--- a/fluffy/docs/the_fluffy_book/mkdocs.yml
+++ b/fluffy/docs/the_fluffy_book/mkdocs.yml
@@ -77,6 +77,9 @@ nav:
       - 'state-content-bridging.md'
     - 'db_pruning.md'
 
+  - Concepts:
+    - 'architecture.md'
+    
   - Developers:
     - 'basics-for-developers.md'
     - 'test-suite.md'

--- a/fluffy/docs/the_fluffy_book/mkdocs.yml
+++ b/fluffy/docs/the_fluffy_book/mkdocs.yml
@@ -37,6 +37,10 @@ repo_url: https://github.com/status-im/nimbus-eth1
 edit_uri: edit/master/fluffy/docs/the_fluffy_book/docs
 docs_dir: docs
 
+plugins:
+  - search
+  - mermaid2
+
 markdown_extensions:
   - admonition
   - pymdownx.details
@@ -51,6 +55,12 @@ markdown_extensions:
   - toc:
       toc_depth: 3
       permalink: "#"
+  - pymdownx.superfences:
+        # make exceptions to highlighting of code:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:mermaid2.fence_mermaid_custom
 
 nav:
   - Home:
@@ -79,7 +89,7 @@ nav:
 
   - Concepts:
     - 'architecture.md'
-    
+
   - Developers:
     - 'basics-for-developers.md'
     - 'test-suite.md'


### PR DESCRIPTION
Changes in this PR:
- Added a new 'Concepts' section to the fluffy.guide website
- Added Mermaid diagramming tool to the website configuration.
- Added diagrams and some comments explaining the components in Fluffy.
- Updated the section listing the supported JSON-RPCs endpoints.
- Some minor updates to capitalization in text and titles to make things more consistent.
