### PR TITLE
Fluffy: Only create a single instance of AsyncEvm and reenable tests

### DIFF
--- a/fluffy/rpc/rpc_debug_api.nim
+++ b/fluffy/rpc/rpc_debug_api.nim
@@ -12,7 +12,7 @@ import
   chronicles,
   web3/[eth_api_types, conversions],
   ../network/state/state_endpoints,
-  ../evm/[async_evm, async_evm_portal_backend]
+  ../evm/async_evm
 
 template getOrRaise(stateNetwork: Opt[StateNetwork]): StateNetwork =
   let sn = stateNetwork.valueOr:
@@ -25,13 +25,9 @@ template getOrRaise(asyncEvm: Opt[AsyncEvm]): AsyncEvm =
       newException(ValueError, "portal evm requires state sub-network to be enabled")
   evm
 
-proc installDebugApiHandlers*(rpcServer: RpcServer, stateNetwork: Opt[StateNetwork]) =
-  let asyncEvm =
-    if stateNetwork.isSome():
-      Opt.some(AsyncEvm.init(stateNetwork.get().toAsyncEvmStateBackend()))
-    else:
-      Opt.none(AsyncEvm)
-
+proc installDebugApiHandlers*(
+    rpcServer: RpcServer, stateNetwork: Opt[StateNetwork], asyncEvm: Opt[AsyncEvm]
+) =
   rpcServer.rpc("debug_getBalanceByStateRoot") do(
     address: Address, stateRoot: Hash32
   ) -> UInt256:

--- a/fluffy/rpc/rpc_eth_api.nim
+++ b/fluffy/rpc/rpc_eth_api.nim
@@ -17,7 +17,7 @@ import
   ../network/history/[history_network, history_content],
   ../network/state/[state_network, state_content, state_endpoints],
   ../network/beacon/beacon_light_client,
-  ../evm/[async_evm, async_evm_portal_backend],
+  ../evm/async_evm,
   ../version
 
 from ../../execution_chain/errors import ValidationError
@@ -137,13 +137,8 @@ proc installEthApiHandlers*(
     historyNetwork: Opt[HistoryNetwork],
     beaconLightClient: Opt[LightClient],
     stateNetwork: Opt[StateNetwork],
+    asyncEvm: Opt[AsyncEvm],
 ) =
-  let asyncEvm =
-    if stateNetwork.isSome():
-      Opt.some(AsyncEvm.init(stateNetwork.get().toAsyncEvmStateBackend()))
-    else:
-      Opt.none(AsyncEvm)
-
   rpcServer.rpc("web3_clientVersion") do() -> string:
     return clientVersion
 

--- a/fluffy/tests/all_fluffy_tests.nim
+++ b/fluffy/tests/all_fluffy_tests.nim
@@ -8,14 +8,10 @@
 {.warning[UnusedImport]: off.}
 
 import
+  ./evm/all_evm_tests,
   ./test_content_db,
   ./wire_protocol_tests/all_wire_protocol_tests,
   ./history_network_tests/all_history_network_tests,
   ./beacon_network_tests/all_beacon_network_tests,
   ./state_network_tests/all_state_network_tests,
   ./rpc_tests/all_rpc_tests
-    # The evm tests are intermittently failing with a SIGSEGV crash.
-    # This appears to be related to this chronos issue which is
-    # not yet fixed: https://github.com/status-im/nim-chronos/issues/518
-    # Leaving this disabled for now to prevent CI test failures.
-    # ./evm/all_evm_tests


### PR DESCRIPTION
Before this change we were creating an AsyncEvm instance for each API handler so if websocket and http servers were enabled with eth and debug APIs then 4 EVMs were being created.

With this change only a single instance is created and shared between all the API handlers.