### PR TITLE
plug a few finalized FCU gaps

### DIFF
--- a/execution_chain/beacon/api_handler/api_forkchoice.nim
+++ b/execution_chain/beacon/api_handler/api_forkchoice.nim
@@ -83,6 +83,7 @@ proc forkchoiceUpdated*(ben: BeaconEngineRef,
     warn "Forkchoice requested update to zero hash"
     return simpleFCU(PayloadExecutionStatus.invalid)
 
+  chain.pendingFCU = update.finalizedBlockHash
   com.resolveFinHash(update.finalizedBlockHash)
 
   # Check whether we have the block yet in our database or not. If not, we'll


### PR DESCRIPTION
* when block is not known, store the finalized hash in `pendingFCU`
* resolve `pendingFCU` from already-processed blocks in FC