### PR TITLE
Re-activate historical summaries test vector tests

### DIFF
--- a/fluffy/tests/beacon_network_tests/all_beacon_network_tests.nim
+++ b/fluffy/tests/beacon_network_tests/all_beacon_network_tests.nim
@@ -11,7 +11,6 @@ import
   ./test_beacon_content,
   ./test_beacon_historical_roots,
   ./test_beacon_historical_summaries,
-  # TODO: enable again after implementing for Electra.
-  # ./test_beacon_historical_summaries_vectors,
+  ./test_beacon_historical_summaries_vectors,
   ./test_beacon_network,
   ./test_beacon_light_client


### PR DESCRIPTION
Bump portal-spec-tests repo for new historical summaries test vectors and re-activate relevant historical summaries test that uses those test vectors.