### PR TITLE
Fluffy: Multiple workers for processing received content in state network

### DIFF
--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -404,6 +404,13 @@ type
       name: "debug-radius-cache-size"
     .}: int
 
+    contentQueueWorkers* {.
+      hidden,
+      desc: "The number of content queue workers to create for concurrent processing of received offers",
+      defaultValue: 25,
+      name: "debug-content-queue-workers"
+    .}: int
+
     case cmd* {.command, defaultValue: noCommand.}: PortalCmd
     of noCommand:
       discard

--- a/fluffy/conf.nim
+++ b/fluffy/conf.nim
@@ -406,8 +406,9 @@ type
 
     contentQueueWorkers* {.
       hidden,
-      desc: "The number of content queue workers to create for concurrent processing of received offers",
-      defaultValue: 25,
+      desc:
+        "The number of content queue workers to create for concurrent processing of received offers",
+      defaultValue: 8,
       name: "debug-content-queue-workers"
     .}: int
 

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -216,6 +216,7 @@ proc run(fluffy: Fluffy, config: PortalConf) {.raises: [CatchableError].} =
       dataDir: string config.dataDir,
       storageCapacity: config.storageCapacityMB * 1_000_000,
       contentRequestRetries: config.contentRequestRetries.int,
+      contentQueueWorkers: config.contentQueueWorkers
     )
 
     node = PortalNode.new(

--- a/fluffy/fluffy.nim
+++ b/fluffy/fluffy.nim
@@ -216,7 +216,7 @@ proc run(fluffy: Fluffy, config: PortalConf) {.raises: [CatchableError].} =
       dataDir: string config.dataDir,
       storageCapacity: config.storageCapacityMB * 1_000_000,
       contentRequestRetries: config.contentRequestRetries.int,
-      contentQueueWorkers: config.contentQueueWorkers
+      contentQueueWorkers: config.contentQueueWorkers,
     )
 
     node = PortalNode.new(

--- a/fluffy/network/state/state_network.nim
+++ b/fluffy/network/state/state_network.nim
@@ -57,11 +57,11 @@ proc new*(
     historyNetwork = Opt.none(HistoryNetwork),
     validateStateIsCanonical = true,
     contentRequestRetries = 1,
-    contentQueueWorkers = 25,
+    contentQueueWorkers = 8,
 ): T =
   doAssert(contentRequestRetries >= 0)
   doAssert(contentQueueWorkers >= 1)
-  
+
   let
     cq = newAsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])](50)
     s = streamManager.registerNewStream(cq)
@@ -85,7 +85,7 @@ proc new*(
     historyNetwork: historyNetwork,
     validateStateIsCanonical: validateStateIsCanonical,
     contentRequestRetries: contentRequestRetries,
-    contentQueueWorkers: contentQueueWorkers
+    contentQueueWorkers: contentQueueWorkers,
   )
 
 proc getContent(

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -1058,6 +1058,7 @@ proc offer(
   ## Main drawback is that content may be deleted from the node database
   ## by the cleanup process before it will be transferred, so this way does not
   ## guarantee content transfer.
+  
   # Fail if no common portal version is found
   let version = ?o.dst.highestCommonPortalVersion(localSupportedVersions)
 
@@ -1790,7 +1791,6 @@ proc neighborhoodGossip*(
           continue
 
       let radius = p.radiusCache.get(node.id).valueOr:
-        # Should only happen if the ping fails, so just skip the node in this case
         continue
 
       # Only send offers to nodes for which the content is in range of their radius

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -1058,7 +1058,7 @@ proc offer(
   ## Main drawback is that content may be deleted from the node database
   ## by the cleanup process before it will be transferred, so this way does not
   ## guarantee content transfer.
-  
+
   # Fail if no common portal version is found
   let version = ?o.dst.highestCommonPortalVersion(localSupportedVersions)
 

--- a/fluffy/portal_node.nim
+++ b/fluffy/portal_node.nim
@@ -33,6 +33,7 @@ type
     dataDir*: string
     storageCapacity*: uint64
     contentRequestRetries*: int
+    contentQueueWorkers*: int
 
   PortalNode* = ref object
     discovery: protocol.Protocol
@@ -154,6 +155,7 @@ proc new*(
             historyNetwork = historyNetwork,
             not config.disableStateRootValidation,
             contentRequestRetries = config.contentRequestRetries,
+            contentQueueWorkers = config.contentQueueWorkers,
           )
         )
       else:


### PR DESCRIPTION
Before this change each Fluffy instance only processes one content/offer from the content queue at a time. In theory we should be able to speed up the process of distributing content across the network by allowing concurrent processing so that each node can process and gossip multiple content offers at once.

It would be nice to have faster distribution across the network so that the Fluffy bridges don't need to be 'smart' and can simply connect to locally running Fluffy nodes which use neighborhoodGossip to send content across the network.

If the distribution across the network is too slow than we might need to build a 'smart' bridge that sends content directly to each node that requires it as this method doesn't rely on the gossip of content between peers as much.
 