### PR TITLE
Fix HistoricalSummaries storage in beacon_db

### DIFF
--- a/fluffy/network/beacon/beacon_network.nim
+++ b/fluffy/network/beacon/beacon_network.nim
@@ -171,11 +171,11 @@ proc getLightClientOptimisticUpdate*(
     Opt.some(decodingResult.value())
 
 proc getHistoricalSummaries*(
-    n: BeaconNetwork, epoch: uint64
+    n: BeaconNetwork, epoch: Epoch
 ): Future[results.Opt[HistoricalSummaries]] {.async: (raises: [CancelledError]).} =
   # Note: when taken from the db, it does not need to verify the proof.
   let
-    contentKey = historicalSummariesContentKey(epoch)
+    contentKey = historicalSummariesContentKey(epoch.distinctBase())
     content = ?await n.getContent(contentKey)
 
     summariesWithProof = decodeSsz(n.forkDigests, content, HistoricalSummariesWithProof).valueOr:

--- a/fluffy/tests/beacon_network_tests/test_beacon_network.nim
+++ b/fluffy/tests/beacon_network_tests/test_beacon_network.nim
@@ -239,13 +239,14 @@ procSuite "Beacon Network":
       (await lcNode2.portalProtocol().ping(lcNode1.localNode())).isOk()
 
     let
-      contentKeyEncoded = historicalSummariesContentKey(0).encode()
+      contentKeyEncoded =
+        historicalSummariesContentKey(epoch(slot).distinctBase()).encode()
       contentId = toContentId(contentKeyEncoded)
 
     lcNode2.portalProtocol().storeContent(contentKeyEncoded, contentId, content)
 
     block:
-      let res = await lcNode1.beaconNetwork.getHistoricalSummaries(0)
+      let res = await lcNode1.beaconNetwork.getHistoricalSummaries(epoch(slot))
       # Should fail as it cannot validate
       check res.isErr()
 
@@ -270,7 +271,7 @@ procSuite "Beacon Network":
       lcNode1.portalProtocol().storeContent(contentKeyEncoded, contentId, content)
 
     block:
-      let res = await lcNode1.beaconNetwork.getHistoricalSummaries(0)
+      let res = await lcNode1.beaconNetwork.getHistoricalSummaries(epoch(slot))
       check:
         res.isOk()
         withState(state[]):


### PR DESCRIPTION
This was being stored in the general kv store, however since this was added the content key was updated to include the epoch. This broke the current logic for overwriting a previously store HistoricalSummary.

Instead create a specific table where we can filter/delete on epoch.