### PR TITLE
Fluffy: Add min gossip peers parameter to state bridge and other improvements

### DIFF
--- a/fluffy/tools/portal_bridge/portal_bridge_conf.nim
+++ b/fluffy/tools/portal_bridge/portal_bridge_conf.nim
@@ -210,9 +210,17 @@ type
 
       gossipWorkers* {.
         desc:
-          "The number of workers to use for gossiping the state into the portal network",
+          "The number of concurrent workers to use for gossiping the state into the portal network",
         defaultValue: 2,
         name: "gossip-workers"
+      .}: uint
+
+      minGossipPeers* {.
+        desc:
+          "The minimum number of peers to which we gossip each piece of content. " &
+          "The gossip is retried until this target number of peers is reached.",
+        defaultValue: 1,
+        name: "min-gossip-peers"
       .}: uint
 
 func parseCmdArg*(T: type TrustedDigest, input: string): T {.raises: [ValueError].} =


### PR DESCRIPTION
Changes in this PR:
- Improved logging.
- Fixed an issue when stopping the concurrent workers. 
- Added a `--min-gossip-peers` parameter which can be used to configure the desired number of peers to which the content should be gossiped. If the number of peers is less then the minGossipPeers target then the gossip is retried.