### PR TITLE
fluffy: pass headers into backend procedures instead of stateroot

### DIFF
--- a/fluffy/evm/async_evm.nim
+++ b/fluffy/evm/async_evm.nim
@@ -215,8 +215,7 @@ proc callFetchingState(
           let slotIdx = (adr, v.storageSlot)
           if slotIdx notin fetchedStorage:
             debug "Fetching storage slot", address = adr, slotKey = v.storageSlot
-            let storageFut =
-              evm.backend.getStorage(header, adr, v.storageSlot)
+            let storageFut = evm.backend.getStorage(header, adr, v.storageSlot)
             if not stateFetchDone:
               storageQueries.add(StorageQuery.init(adr, v.storageSlot, storageFut))
               if not optimisticStateFetch:

--- a/fluffy/evm/async_evm_portal_backend.nim
+++ b/fluffy/evm/async_evm_portal_backend.nim
@@ -12,16 +12,16 @@ import ../network/state/state_endpoints, ./async_evm
 proc toAsyncEvmStateBackend*(stateNetwork: StateNetwork): AsyncEvmStateBackend =
   let
     accProc = proc(
-        stateRoot: Hash32, address: Address
+        header: Header, address: Address
     ): Future[Opt[Account]] {.async: (raw: true, raises: [CancelledError]).} =
-      stateNetwork.getAccount(stateRoot, address)
+      stateNetwork.getAccount(header.stateRoot, address)
     storageProc = proc(
-        stateRoot: Hash32, address: Address, slotKey: UInt256
+        header: Header, address: Address, slotKey: UInt256
     ): Future[Opt[UInt256]] {.async: (raw: true, raises: [CancelledError]).} =
-      stateNetwork.getStorageAtByStateRoot(stateRoot, address, slotKey)
+      stateNetwork.getStorageAtByStateRoot(header.stateRoot, address, slotKey)
     codeProc = proc(
-        stateRoot: Hash32, address: Address
+        header: Header, address: Address
     ): Future[Opt[seq[byte]]] {.async: (raw: true, raises: [CancelledError]).} =
-      stateNetwork.getCodeByStateRoot(stateRoot, address)
+      stateNetwork.getCodeByStateRoot(header.stateRoot, address)
 
   AsyncEvmStateBackend.init(accProc, storageProc, codeProc)

--- a/fluffy/tests/evm/async_evm_test_backend.nim
+++ b/fluffy/tests/evm/async_evm_test_backend.nim
@@ -43,15 +43,15 @@ proc toAsyncEvmStateBackend*(testState: TestEvmState): AsyncEvmStateBackend =
   # State root is ignored because TestEvmState only stores a single state
   let
     accProc = proc(
-        stateRoot: Hash32, address: Address
+        header: Header, address: Address
     ): Future[Opt[Account]] {.async: (raises: [CancelledError]).} =
       Opt.some(testState.getAccount(address))
     storageProc = proc(
-        stateRoot: Hash32, address: Address, slotKey: UInt256
+        header: Header, address: Address, slotKey: UInt256
     ): Future[Opt[UInt256]] {.async: (raises: [CancelledError]).} =
       Opt.some(testState.getStorage(address, slotKey))
     codeProc = proc(
-        stateRoot: Hash32, address: Address
+        header: Header, address: Address
     ): Future[Opt[seq[byte]]] {.async: (raises: [CancelledError]).} =
       Opt.some(testState.getCode(address))
 


### PR DESCRIPTION
Passing headers instead of state roots provides the flexibility of querying the state(accounts, storage slots, code) either using the state root(like for the use case of portal network) or using the block number/hash(like for the use case of nimbus verified proxy).

If the header is not passed, nimbus verified proxy will have to maintain a cache mapping state roots to block numbers. IMO this would be an inefficiency because all calls to the async evm are made against headers which already have all the relevant information required.