### PR TITLE
Fluffy: Use neighboursInRange in neighborhoodGossip and filter out src node in handleFindContent

### DIFF
--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -552,7 +552,7 @@ proc handleFindContent(
   # Node does not have the content, or content is not even in radius,
   # send closest neighbours to the requested content id.
   let
-    closestNodes = p.neighbours(NodeId(contentId), seenOnly = true)
+    closestNodes = p.neighboursInRange(contentId, seenOnly = true)
     enrs = truncateEnrs(closestNodes, maxPayloadSize, enrOverhead)
   portal_content_enrs_packed.observe(enrs.len().int64, labelValues = [$p.protocolId])
 

--- a/fluffy/network/wire/portal_protocol.nim
+++ b/fluffy/network/wire/portal_protocol.nim
@@ -380,8 +380,9 @@ func inRange(
 template inRange*(p: PortalProtocol, contentId: ContentId): bool =
   p.inRange(p.localNode.id, p.dataRadius(), contentId)
 
-proc neighboursInRange*(p: PortalProtocol, id: ContentId, k: int = BUCKET_SIZE, seenOnly = false): seq[Node] =
-
+proc neighboursInRange*(
+    p: PortalProtocol, id: ContentId, k: int = BUCKET_SIZE, seenOnly = false
+): seq[Node] =
   func nodeInRange(nodeId: NodeId): bool =
     let radius = p.radiusCache.get(nodeId).valueOr:
       return false
@@ -1760,8 +1761,7 @@ proc neighborhoodGossip*(
   # table, but at the same time avoid unnecessary node lookups.
   # It might still cause issues in data getting propagated in a wider id range.
 
-  var closestLocalNodes =
-    p.neighboursInRange(contentId, BUCKET_SIZE, seenOnly = true)
+  var closestLocalNodes = p.neighboursInRange(contentId, BUCKET_SIZE, seenOnly = true)
 
   closestLocalNodes.keepItIf(srcNodeId.isNone() or it.id != srcNodeId.get())
 

--- a/fluffy/tests/wire_protocol_tests/test_portal_wire_protocol.nim
+++ b/fluffy/tests/wire_protocol_tests/test_portal_wire_protocol.nim
@@ -174,7 +174,7 @@ procSuite "Portal Wire Protocol Tests":
     let contentKey = ContentKeyByteList.init(@[1'u8])
 
     # content does not exist so this should provide us with the closest nodes
-    # to the content, which should only be node 3 because node 1 and 2 should be excluded
+    # to the content, which should only be node 3 because node 1 should be excluded
     let content = await proto1.findContentImpl(proto2.localNode, contentKey)
 
     check:


### PR DESCRIPTION
Changes in this PR:
- Created new helper function to return nodes which are in range of a content id from the routing table.
- Use the new `neighboursInRange` function in `neighborhoodGossip` which should result in a minor improvement where we should get slightly more in range nodes from the routing table which should reduce the number of node lookups overall.
- Fixed a bug in handleFindContent where we were not correctly filtering out the source node as defined in the portal wire spec.

This change depends on the nim-eth update in this PR: https://github.com/status-im/nim-eth/pull/792

