### PR TITLE
fix some Nim 2.2 warnings

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -84,8 +84,8 @@ if defined(windows):
 if defined(disableMarchNative):
   if defined(i386) or defined(amd64):
     if defined(macosx):
-      # https://support.apple.com/en-us/102861
-      # "macOS Ventura is compatible with these computers" lists current oldest
+      # https://support.apple.com/en-us/105113
+      # "macOS Sonoma is compatible with these computers" lists current oldest
       # supported x86 models, all of which have Kaby Lake or newer CPUs.
       switch("passC", "-march=skylake -mtune=generic")
       switch("passL", "-march=skylake -mtune=generic")

--- a/execution_chain/makefile
+++ b/execution_chain/makefile
@@ -1,5 +1,15 @@
 #! /usr/bin/make -f
 
+# Nimbus
+# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
 SAVED_PATH := $(PATH)
 PWD        := $(shell pwd)
 

--- a/execution_chain/makefile
+++ b/execution_chain/makefile
@@ -52,7 +52,7 @@ NIMDOC_FLAGS += -d:debug -d:disable_libbacktrace
 NIMDOC_FLAGS += $(NIMFLAGS)
 
 # Nim check flags
-NIMCHK_FLAGS := c -r --verbosity:0 --hints:off --warnings:off
+NIMCHK_FLAGS := c -r --verbosity:0 --warnings:off
 
 # Markdown compiler (test for discount tool with tables support)
 MD_CMD     := markdown

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -18,7 +18,6 @@ import
   ../execution_chain/[constants, transaction, config, version],
   ../execution_chain/db/[ledger, storage_types],
   ../execution_chain/sync/wire_protocol,
-  ../execution_chain/portal/portal,
   ../execution_chain/core/[tx_pool, chain, pow/difficulty],
   ../execution_chain/utils/utils,
   ../execution_chain/[common, rpc],
@@ -30,8 +29,6 @@ import
    ./test_block_fixture
 
 type
-  Hash32 = common.Hash32
-
   TestEnv = object
     conf     : NimbusConf
     com      : CommonRef


### PR DESCRIPTION
`../execution_chain/portal/portal` is an `UnusedImport`, and `type Hash32 = common.Hash32` triggers:
```
nimbus-eth1/tests/test_rpc.nim(49, 20) template/generic instantiation of `hash32` from here
nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(75, 8) Warning: a new symbol 'Hash32' has been injected during template or generic instantiation, however hashes.Hash32 [type declared in nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(22, 3)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
nimbus-eth1/tests/test_rpc.nim(49, 20) template/generic instantiation of `hash32` from here
nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(75, 4) template/generic instantiation of `to` from here
nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(71, 16) Warning: a new symbol 'Hash32' has been injected during template or generic instantiation, however hashes.Hash32 [type declared in nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(22, 3)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
nimbus-eth1/tests/test_rpc.nim(50, 25) template/generic instantiation of `hash32` from here
nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(75, 8) Warning: a new symbol 'Hash32' has been injected during template or generic instantiation, however hashes.Hash32 [type declared in nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(22, 3)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
nimbus-eth1/tests/test_rpc.nim(50, 25) template/generic instantiation of `hash32` from here
nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(75, 4) template/generic instantiation of `to` from here
nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(71, 16) Warning: a new symbol 'Hash32' has been injected during template or generic instantiation, however hashes.Hash32 [type declared in nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(22, 3)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
nimbus-eth1/tests/test_rpc.nim(51, 28) template/generic instantiation of `hash32` from here
nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(75, 8) Warning: a new symbol 'Hash32' has been injected during template or generic instantiation, however hashes.Hash32 [type declared in nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(22, 3)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
nimbus-eth1/tests/test_rpc.nim(51, 28) template/generic instantiation of `hash32` from here
nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(75, 4) template/generic instantiation of `to` from here
nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(71, 16) Warning: a new symbol 'Hash32' has been injected during template or generic instantiation, however hashes.Hash32 [type declared in nimbus-eth1/vendor/nim-eth/eth/common/hashes.nim(22, 3)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
```