### PR TITLE
Track missing vertex lookups in metrics

### DIFF
--- a/execution_chain/db/aristo/aristo_desc/desc_structural.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_structural.nim
@@ -90,8 +90,9 @@ type
       ## unfriendly to caches
 
 const
-  Leaves* = {AccLeaf, StoLeaf}
-  Branches* = {Branch, ExtBranch}
+  Leaves* = {VertexType.AccLeaf, VertexType.StoLeaf}
+  Branches* = {VertexType.Branch, VertexType.ExtBranch}
+  VertexTypes* = Leaves + Branches
 
 # ------------------------------------------------------------------------------
 # Public helpers (misc)

--- a/execution_chain/db/aristo/aristo_init/memory_db.nim
+++ b/execution_chain/db/aristo/aristo_init/memory_db.nim
@@ -208,7 +208,7 @@ func memoryBackend*(): AristoDbRef =
 
 iterator walkVtx*(
     be: MemBackendRef;
-    kinds = {Branch, ExtBranch, AccLeaf, StoLeaf};
+    kinds = VertexTypes;
       ): tuple[rvid: RootedVertexID, vtx: VertexRef] =
   ##  Iteration over the vertex sub-table.
   for n,rvid in be.sTab.keys.toSeq.sorted:

--- a/execution_chain/db/aristo/aristo_init/rocks_db.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db.nim
@@ -245,7 +245,7 @@ proc rocksDbBackend*(
 
 iterator walkVtx*(
     be: RdbBackendRef;
-    kinds = {Branch, ExtBranch, AccLeaf, StoLeaf};
+    kinds = VertexTypes;
       ): tuple[evid: RootedVertexID, vtx: VertexRef] =
   ## Variant of `walk()` iteration over the vertex sub-table.
   for (rvid, vtx) in be.rdb.walkVtx(kinds):

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -73,6 +73,12 @@ type
     Account
     World
 
+  RdbVertexType* = enum
+    Empty
+    Leaf
+    Branch
+    ExtBranch
+
 var
   # Hit/miss counters for LRU cache - global so as to integrate easily with
   # nim-metrics and `uint64` to ensure that increasing them is fast - collection
@@ -80,7 +86,7 @@ var
   # TODO maybe turn this into more general framework for LRU reporting since
   #      we have lots of caches of this sort
   rdbBranchLruStats*: array[RdbStateType, RdbLruCounter]
-  rdbVtxLruStats*: array[RdbStateType, array[VertexType, RdbLruCounter]]
+  rdbVtxLruStats*: array[RdbStateType, array[RdbVertexType, RdbLruCounter]]
   rdbKeyLruStats*: array[RdbStateType, RdbLruCounter]
 
 # ------------------------------------------------------------------------------
@@ -92,6 +98,12 @@ template toOpenArray*(xid: AdminTabID): openArray[byte] =
 
 template to*(v: RootedVertexID, T: type RdbStateType): RdbStateType =
   if v.root == VertexID(1): RdbStateType.World else: RdbStateType.Account
+
+template to*(v: VertexType, T: type RdbVertexType): RdbVertexType =
+  case v
+  of VertexType.AccLeaf, VertexType.StoLeaf: RdbVertexType.Leaf
+  of VertexType.Branch: RdbVertexType.Branch
+  of VertexType.ExtBranch: RdbVertexType.ExtBranch
 
 template inc*(v: var RdbLruCounter, hit: bool) =
   discard v[hit].fetchAdd(1, moRelaxed)

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_init.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_init.nim
@@ -27,7 +27,7 @@ proc dumpCacheStats(keySize, vtxSize, branchSize: int) =
     echo "vtxLru(", vtxSize, ")"
     echo "   state    vtype       miss        hit      total hitrate"
     for state in RdbStateType:
-      for vtype in VertexType:
+      for vtype in RdbVertexType:
         let
           (miss, hit) = (
             rdbVtxLruStats[state][vtype].get(false),

--- a/execution_chain/db/aristo/aristo_walk/memory_only.nim
+++ b/execution_chain/db/aristo/aristo_walk/memory_only.nim
@@ -29,7 +29,7 @@ export
 iterator walkVtxBe*[T: MemBackendRef](
    _: type T;
    db: AristoDbRef;
-   kinds = {Branch, ExtBranch, AccLeaf, StoLeaf};
+   kinds = VertexTypes;
      ): tuple[rvid: RootedVertexID, vtx: VertexRef] =
   ## Iterate over filtered memory backend or backend-less vertices. This
   ## function depends on the particular backend type name which must match

--- a/execution_chain/db/aristo/aristo_walk/persistent.nim
+++ b/execution_chain/db/aristo/aristo_walk/persistent.nim
@@ -34,7 +34,7 @@ export
 iterator walkVtxBe*[T: RdbBackendRef](
    _: type T;
    db: AristoDbRef;
-   kinds = {Branch, ExtBranch, AccLeaf, StoLeaf};
+   kinds = VertexTypes;
      ): tuple[rvid: RootedVertexID, vtx: VertexRef] =
   ## Iterate over RocksDB backend vertices. This function depends on
   ## the particular backend type name which must match the backend descriptor.


### PR DESCRIPTION
When looking up a VertexID, the entry might not be present in the database - this is currently not tracked since the functionality is not commonly used - with path-based vertex id generation, we'll be making guesses however where empty lookups become "normal" - the same would happen for incomplete databases as well.