### PR TITLE
Add access from History network to historical summaries

### DIFF
--- a/fluffy/network/beacon/beacon_network.nim
+++ b/fluffy/network/beacon/beacon_network.nim
@@ -225,6 +225,9 @@ proc new*(
     else:
       trustedBlockRoot
 
+  # load from db to cache
+  beaconDb.loadHistoricalSummariesCache()
+
   BeaconNetwork(
     portalProtocol: portalProtocol,
     beaconDb: beaconDb,
@@ -339,6 +342,9 @@ proc validateContent(
   of beacon_content.ContentType.historicalSummaries:
     let summariesWithProof =
       ?decodeSsz(n.forkDigests, content, HistoricalSummariesWithProof)
+
+    if key.historicalSummariesKey.epoch != summariesWithProof.epoch:
+      return err("Epoch mismatch in historical_summaries")
 
     n.validateHistoricalSummaries(summariesWithProof)
 

--- a/fluffy/portal_node.nim
+++ b/fluffy/portal_node.nim
@@ -134,6 +134,11 @@ proc new*(
             streamManager,
             networkData.metadata.cfg,
             accumulator,
+            beaconDbCache =
+              if beaconNetwork.isSome():
+                beaconNetwork.value().beaconDb.beaconDbCache
+              else:
+                BeaconDbCache(),
             bootstrapRecords = bootstrapRecords,
             portalConfig = config.portalConfig,
             contentRequestRetries = config.contentRequestRetries,

--- a/fluffy/tests/beacon_network_tests/test_beacon_network.nim
+++ b/fluffy/tests/beacon_network_tests/test_beacon_network.nim
@@ -220,6 +220,12 @@ procSuite "Beacon Network":
             historical_summaries: historical_summaries,
             proof: proof,
           )
+
+          # Note that this is not the slot deduced forkDigest, as that one would
+          # cause issues for this custom chain.
+          # TODO: If we were to encode the historical summaries in the db code
+          # it would fail due to slot based fork digest until we allow for
+          # custom networks.
           forkDigest = atConsensusFork(forkDigests, consensusFork)
 
           content = encodeSsz(historicalSummariesWithProof, forkDigest)


### PR DESCRIPTION
Add access from History network to historical summaries for the verification of Capella and onwards block proofs.

Access is provided by adding the BeaconDbCache to the history network, more specifical to the HeaderVerifier (before called Accumulators). This approach is taken, over providing callbacks,
 as it is more in sync with how StateNetwork accesses the
HistoryNetwork. It might be still be considered to move to callbacks in the future though as that could provide a more "oracle" agnostic way of providing this data.

The BeaconDbCache is created because for Ephemeral headers verification we will also need access to the Light client updates. Aside from the Light client updates, the historical summaries are also added to the cache in its decoded form for easy and fast access on block verification.

Some changes are likely to be still required to avoid to many copies of the summaries, TBI.