### PR TITLE
eth/69: Disconnect peer when receive invalid blockRangeUpdate

### DIFF
--- a/execution_chain/sync/wire_protocol/responder.nim
+++ b/execution_chain/sync/wire_protocol/responder.nim
@@ -284,7 +284,7 @@ proc blockRangeUpdateUserHandler(peer: Peer; packet: BlockRangeUpdatePacket) {.
       latestHash = packet.latestHash.short
 
   if packet.earliest > packet.latest:
-    trace "Disconnecting peer because of protocol breach",
+    debug "Disconnecting peer because of protocol breach",
       remote = peer.remote, clientId = peer.clientId,
       msg = "blockRangeUpdate must have latest >= earliest"
     await peer.disconnect(BreachOfProtocol)

--- a/execution_chain/sync/wire_protocol/responder.nim
+++ b/execution_chain/sync/wire_protocol/responder.nim
@@ -283,6 +283,10 @@ proc blockRangeUpdateUserHandler(peer: Peer; packet: BlockRangeUpdatePacket) {.
       earliest = packet.earliest, latest = packet.latest,
       latestHash = packet.latestHash.short
 
+  if packet.earliest > packet.latest:
+    await peer.disconnect(BreachOfProtocol)
+    return
+
   peer.state(eth69).earliest = packet.earliest
   peer.state(eth69).latest = packet.latest
   peer.state(eth69).latestHash = packet.latestHash

--- a/execution_chain/sync/wire_protocol/responder.nim
+++ b/execution_chain/sync/wire_protocol/responder.nim
@@ -284,6 +284,9 @@ proc blockRangeUpdateUserHandler(peer: Peer; packet: BlockRangeUpdatePacket) {.
       latestHash = packet.latestHash.short
 
   if packet.earliest > packet.latest:
+    trace "Disconnecting peer because of protocol breach",
+      remote = peer.remote, clientId = peer.clientId,
+      msg = "blockRangeUpdate must have latest >= earliest"
     await peer.disconnect(BreachOfProtocol)
     return
 


### PR DESCRIPTION
Hive test sends an invalid announcement with earliest > latest and expects a disconnect, but Nimbus just keeps the connection open.

fix #3299