### PR TITLE
Fix hoodi chain config

### DIFF
--- a/execution_chain/common/chain_config.nim
+++ b/execution_chain/common/chain_config.nim
@@ -609,7 +609,12 @@ func chainConfigForNetwork*(id: NetworkId): ChainConfig =
   else:
     ChainConfig()
 
-  doAssert validateChainConfig(result)
+  {.cast(noSideEffect).}:
+    # Obviously we lie about no side effect.
+    # If chonicles enabled and there is something bad with
+    # the chain config values, `validateChainConfig` will print something.
+    # But it is very rare and must immediately fixed anyway.
+    doAssert validateChainConfig(result)
 
 func genesisBlockForNetwork*(id: NetworkId): Genesis
     {.gcsafe, raises: [ValueError, RlpError].} =


### PR DESCRIPTION
Somehow, when inputting shanghai time for hoodi, an extra `1` is inserted.