### PR TITLE
Portal Client: Minor improvements to portal docs

### DIFF
--- a/portal/docs/the_fluffy_book/docs/access-content.md
+++ b/portal/docs/the_fluffy_book/docs/access-content.md
@@ -1,6 +1,6 @@
 # Access content on the Portal network
 
-Once you have a Portal node [connected to network](./connect-to-portal.md) with
+Once you have a Portal node [connected to the network](./connect-to-portal.md) with
 the JSON-RPC interface enabled, then you can access the content available on
 the Portal network.
 

--- a/portal/docs/the_fluffy_book/docs/architecture.md
+++ b/portal/docs/the_fluffy_book/docs/architecture.md
@@ -3,7 +3,7 @@
 This section outlines the Nimbus Portal client's architecture and shows the main components in the codebase. The arrows indicate a dependancy relationship between each component.
 
 
-## Nimbus Portal Client high level architecture
+## Nimbus Portal client high level architecture
 
 This diagram outlines the Nimbus Portal client high-level architecture.
 ```mermaid
@@ -18,7 +18,7 @@ graph TD;
     id2(PortalNode) --> id10(Discv5Protocol)
 ```
 
-When `nimbus_portal_client` starts it runs an instance of `PortalNode` which manages the `Discv5Protocol`, `BeaconNetwork`, `HistoryNetwork` and `StateNetwork` instances. There is a single instance of each of these components and each of the subnetwork instances can be enabled/disabled depending on the startup configuration selected. The `PortalNode` instance includes everything needed to participate in the Portal network to enable storage of offered content and serving content requests from other Portal nodes. It may become part of a library in the future which would allow other projects to easily embed an instance of `nimbus_portal_client` in their codebase.
+When the Nimbus Portal client starts it runs an instance of `PortalNode` which manages the `Discv5Protocol`, `BeaconNetwork`, `HistoryNetwork` and `StateNetwork` instances. There is a single instance of each of these components and each of the subnetwork instances can be enabled/disabled depending on the startup configuration selected. The `PortalNode` instance includes everything needed to participate in the Portal network to enable storage of offered content and serving content requests from other Portal nodes. It may become part of a library in the future which would allow other projects to easily embed an instance of the Nimbus Portal client in their codebase.
 
 The `RpcHttpServer` and `RpcWebSocketServer` enable serving JSON-RPC requests from Portal network over HTTP and WebSocket respectively. These RPC servers depend on the Nimbus Portal EVM (`AsyncEvm`) in order to implement the various endpoints which require asyncronous transaction execution while fetching state from the Portal network.
 
@@ -61,7 +61,7 @@ in each of the Portal Wire subprotocols. The `RadiusCache` holds the last known 
 when pinging each node in the routing table periodically. The `OfferCache` caches the content ids of the most recent content successfully offered and stored so that the Portal node can reject content that it already has without doing a database lookup. The `ContentCache` improves the performance of content lookups (used by the JSON-RPC API's) by caching the most recently fetched
 content in a LRU cache.
 
-The `ContentDb` is the main database in `nimbus_portal_client` which internally uses sqlite to store the content data on disk. The `PortalProtocol`
+The `ContentDb` is the main database in the Nimbus Portal client which internally uses sqlite to store the content data on disk. The `PortalProtocol`
 uses the `OfferQueue` to hold pending offer requests which are passed to the `PortalStream` by the concurrent offer workers
 which run as a part of `PortalProtocol`.
 

--- a/portal/docs/the_fluffy_book/docs/beacon-content-bridging.md
+++ b/portal/docs/the_fluffy_book/docs/beacon-content-bridging.md
@@ -8,7 +8,7 @@ Run a Nimbus Portal client with the JSON-RPC API enabled.
 ./build/nimbus_portal_client --rpc
 ```
 
-Build & run the `nimbus_portal_bridge` for the beacon network:
+Build & run the Nimbus Portal bridge for the beacon network:
 ```bash
 make nimbus_portal_bridge
 
@@ -18,7 +18,7 @@ TRUSTED_BLOCK_ROOT=0x12345678901234567890123456789012345678901234567890123456789
 ./build/nimbus_portal_bridge beacon --trusted-block-root:${TRUSTED_BLOCK_ROOT} --rest-url:http://127.0.0.1:5052 --portal-rpc-url:http://127.0.0.1:8545
 ```
 
-The `nimbus_portal_bridge` will connect to Nimbus Portal client over the JSON-RPC
+The Nimbus Portal bridge will connect to the Nimbus Portal client over the JSON-RPC
 interface and start gossiping an `LightClientBootstrap` for
 given trusted block root and gossip backfill `LightClientUpdate`s.
 

--- a/portal/docs/the_fluffy_book/docs/build-from-source.md
+++ b/portal/docs/the_fluffy_book/docs/build-from-source.md
@@ -5,7 +5,7 @@ turned on.
 The build process itself is simple and fully automated, but may take a few minutes.
 
 !!! note "Nim"
-    `nimbus_portal_client` is written in the [Nim](https://nim-lang.org) programming language.
+    The Nimbus Portal client is written in the [Nim](https://nim-lang.org) programming language.
     The correct version will automatically be downloaded as part of the build process!
 
 ## Prerequisites

--- a/portal/docs/the_fluffy_book/docs/calling-a-contract.md
+++ b/portal/docs/the_fluffy_book/docs/calling-a-contract.md
@@ -4,7 +4,7 @@ Once you have a Portal node running and [connected to the network](./connect-to-
 the JSON-RPC interface enabled, then you can call contracts using the `eth_call` JSON-RPC method
 which should be enabled by default.
 
-Note that `eth_call` in `nimbus_portal_client` requires both the history network, state network and the `eth`
+Note that `eth_call` in the Nimbus Portal client requires both the history network, state network and the `eth`
 rpc api to be enabled. These should be enabled by default already but you can also manually
 enable these by running:
 

--- a/portal/docs/the_fluffy_book/docs/history-content-bridging.md
+++ b/portal/docs/the_fluffy_book/docs/history-content-bridging.md
@@ -1,8 +1,8 @@
 # Bridging content into the Portal history network
 
-## Seeding history content with the `nimbus_portal_bridge`
+## Seeding history content with the Nimbus Portal bridge
 
-The `nimbus_portal_bridge` requires `era1` files as source for the block content from before the merge.
+The Nimbus Portal bridge requires `era1` files as source for the block content from before the merge.
 It requires access to a full node with EL JSON-RPC API for seeding the latest (head of the chain) block content.
 Any block content between the merge and the latest is currently not implemented, but will be implemented in the future by usage of `era` files as source.
 
@@ -15,17 +15,16 @@ Run a Portal client with the Portal JSON-RPC API enabled, e.g. Nimbus Portal cli
 ```
 
 > Note: The `--storage-capacity:0` option is not required, but it is added here
-for the use case where the node's only focus is on gossiping content from the
-`nimbus_portal_bridge`.
+for the use case where the node's only focus is on gossiping content from the portal bridge.
 
 ### Step 2: Run an EL client
 
-The `nimbus_portal_bridge` needs access to the EL JSON-RPC API, either through a local
+The Nimbus Portal bridge needs access to the EL JSON-RPC API, either through a local
 Ethereum client or via a web3 provider.
 
 ### Step 3: Run the Portal bridge in history mode
 
-Build & run the `nimbus_portal_bridge`:
+Build & run the Nimbus Portal bridge:
 ```bash
 make nimbus_portal_bridge
 
@@ -33,11 +32,11 @@ WEB3_URL="http://127.0.0.1:8548" # Replace with your provider.
 ./build/nimbus_portal_bridge history --web3-url:${WEB3_URL}
 ```
 
-Default the `nimbus_portal_bridge` will run in `--latest` mode, which means that only the
+By default the Nimbus Portal bridge will run in `--latest` mode, which means that only the
 latest block content will be gossiped into the network.
 
-The `nimbus_portal_bridge` also has a `--backfill` mode which will gossip pre-merge blocks
-from `era1` files into the network. Default the bridge will audit first whether
+It also has a `--backfill` mode which will gossip pre-merge blocks
+from `era1` files into the network. By default the bridge will audit first whether
 the content is available on the network and if not it will gossip it into the
 network.
 
@@ -47,7 +46,7 @@ WEB3_URL="http://127.0.0.1:8548" # Replace with your provider.
 ./build/nimbus_portal_bridge history --latest:true --backfill:true --audit:true --era1-dir:/somedir/era1/ --web3-url:${WEB3_URL}
 ```
 
-## Seeding directly from the nimbus_portal_client
+## Seeding directly from the Nimbus Portal client
 
 This method currently only supports seeding block content from before the merge.
 It uses `era1` files as source for the content.

--- a/portal/docs/the_fluffy_book/docs/index.md
+++ b/portal/docs/the_fluffy_book/docs/index.md
@@ -1,4 +1,4 @@
-# The Nimbus Portal client Guide
+# The Nimbus Portal Client Guide
 
 The Nimbus Portal client is the Nimbus client implementation of the
 [Portal network specifications](https://github.com/ethereum/portal-network-specs).

--- a/portal/docs/the_fluffy_book/docs/state-content-bridging.md
+++ b/portal/docs/the_fluffy_book/docs/state-content-bridging.md
@@ -31,7 +31,7 @@ Currently the portal state bridge requires access to the following EL JSON-RPC A
 `trace_replayBlockTransactions` is a non-standard endpoint that is only implemented
 by some EL clients (e.g. Erigon, Reth and Besu at the time of writing). The bridge uses the
 `stateDiff` trace option parameter to collect the state updates for each block of
-transactions as it syncs and builds the state from genesis onwards. Since access to thef
+transactions as it syncs and builds the state from genesis onwards. Since access to the
 state is required in order to build these state diffs, an EL archive node is required
 to ensure that the state is available for all the historical blocks being synced.
 

--- a/portal/docs/the_fluffy_book/docs/state-content-bridging.md
+++ b/portal/docs/the_fluffy_book/docs/state-content-bridging.md
@@ -2,7 +2,7 @@
 
 ## Seeding from content bridges
 
-### Seeding state data with the `nimbus_portal_bridge`
+### Seeding state data with the Nimbus Portal bridge
 
 
 #### Step 1: Run a Portal client
@@ -14,13 +14,12 @@ Run a Portal client with the Portal JSON-RPC API enabled (e.g. Nimbus Portal cli
 ```
 
 > Note: The `--storage-capacity:0` option is not required, but it is added here
-for the use case where the node's only focus is on gossiping content from the
-`nimbus_portal_bridge`.
+for the use case where the node's only focus is on gossiping content from the portal bridge.
 
 
 #### Step 2: Run an EL client (archive node) that supports `trace_replayBlockTransactions`
 
-The `nimbus_portal_bridge` needs access to the EL JSON-RPC API, either through a local
+The Nimbus Portal bridge needs access to the EL JSON-RPC API, either through a local
 Ethereum client or via a web3 provider.
 
 Currently the portal state bridge requires access to the following EL JSON-RPC APIs:
@@ -32,14 +31,14 @@ Currently the portal state bridge requires access to the following EL JSON-RPC A
 `trace_replayBlockTransactions` is a non-standard endpoint that is only implemented
 by some EL clients (e.g. Erigon, Reth and Besu at the time of writing). The bridge uses the
 `stateDiff` trace option parameter to collect the state updates for each block of
-transactions as it syncs and builds the state from genesis onwards. Since access to the
+transactions as it syncs and builds the state from genesis onwards. Since access to thef
 state is required in order to build these state diffs, an EL archive node is required
 to ensure that the state is available for all the historical blocks being synced.
 
 
 #### Step 3: Run the Portal bridge in state mode
 
-Build & run the `nimbus_portal_bridge`:
+Build & run the Nimbus Portal bridge:
 ```bash
 make nimbus_portal_bridge
 
@@ -60,8 +59,8 @@ The `--gossip-workers` parameter can be used to set the number of workers that w
 gossip the portal state data into the portal state subnetwork. Each worker handles
 gossipping the state for a single block and the workers gossip the data concurrently.
 It is recommended to increase the number of workers in order to increase the speed
-and throughput of the gossiping process up until the point where `nimbus_portal_bridge` is unable
-keep up.
+and throughput of the gossiping process up until the point where the connected portal
+client is unable keep up.
 
 The optional `--verify-gossip` parameter can be used to verify that the state data has
 successfully been gossipped and is available on the portal state network. When this

--- a/portal/docs/the_fluffy_book/docs/upgrade.md
+++ b/portal/docs/the_fluffy_book/docs/upgrade.md
@@ -24,5 +24,5 @@ make -j4 nimbus_portal_client
 Complete the upgrade by restarting the node.
 
 !!! tip
-    To check which version of `nimbus_portal_client` you're currently running, run
+    To check which version of the Nimbus Portal client you're currently running, run
     `./build/nimbus_portal_client --version`


### PR DESCRIPTION
Changes in this PR:
- Replace some places where we refer to the client as `nimbus_portal_client` with 'Nimbus Portal client'.
- Fixed some minor wording typos.
- Fixed capitalization of titles in some places to be more consistent with the rest of the docs.