### PR TITLE
Rename fluffy refs now that hive and docker image are updated

### DIFF
--- a/portal/docs/the_fluffy_book/docs/nimbus-portal-with-hive.md
+++ b/portal/docs/the_fluffy_book/docs/nimbus-portal-with-hive.md
@@ -18,13 +18,13 @@ Example commands for running test suites:
 
 ```sh
 # Run the portal hive tests with only the Nimbus Portal client
-./hive --sim portal --client fluffy
+./hive --sim portal --client nimbus-portal
 
 # Run the portal hive tests with different clients
-./hive --sim portal --client fluffy,trin,ultralight,shisui
+./hive --sim portal --client nimbus-portal,trin,ultralight,shisui
 
 # Run portal hive tests from a specific portal hive simulator
-./hive --sim portal --client fluffy --sim.limit history-interop
+./hive --sim portal --client nimbus-portal --sim.limit history-interop
 ```
 
 Access the results through web-ui:
@@ -48,11 +48,11 @@ To do that follow next steps:
 
 2) Build the local development Docker image using the following command:
 ```
-docker build --tag fluffy-dev --file ./portal/docker/Dockerfile.debug .
+docker build --tag nimbus-portal-dev --file ./portal/docker/Dockerfile.debug .
 ```
 
-3) Modify the `FROM` tag in the portal-hive `Dockerfile` of fluffy at
-`./hive/clients/fluffy/Dockerfile` to use the image that was build in step 2.
+3) Modify the `FROM` tag in the portal-hive `Dockerfile` of Nimbus Portal client at
+`./hive/clients/nimbus-portal/Dockerfile` to use the image that was build in step 2.
 
 4) Run the tests as [usual](nimbus-portal-with-portal-hive.md/#run-the-hive-tests-locally).
 
@@ -62,4 +62,4 @@ docker build --tag fluffy-dev --file ./portal/docker/Dockerfile.debug .
     `vendors/` from `./portal/docker/Dockerfile.debug.dockerignore`.
 
 !!! note
-    When developing on Linux the `./portal/docker/Dockerfile.debug.linux` Dockerfile can also be used instead. It does require to manually build fluffy first as it copies over this binary.
+    When developing on Linux the `./portal/docker/Dockerfile.debug.linux` Dockerfile can also be used instead. It does require to manually build `nimbus_portal_client` first as it copies over this binary.

--- a/portal/docs/the_fluffy_book/docs/quick-start-docker.md
+++ b/portal/docs/the_fluffy_book/docs/quick-start-docker.md
@@ -1,7 +1,7 @@
 # Quick start - Docker
 
 This page takes you through the steps of getting the Nimbus Portal client running
-on the public network by use of the [public Docker image](https://hub.docker.com/r/statusim/nimbus-fluffy/tags).
+on the public network by use of the [public Docker image](https://hub.docker.com/r/statusim/nimbus-portal-client/tags).
 
 The Docker image gets rebuild from latest master every night and only `amd64` is supported currently.
 
@@ -14,7 +14,7 @@ The Docker image gets rebuild from latest master every night and only `amd64` is
 
 ```bash
 # Connect to the Portal bootstrap nodes and enable the JSON-RPC APIs.
-docker container run -p 8545:8545 statusim/nimbus-fluffy:amd64-master-latest --rpc --rpc-address:0.0.0.0
+docker container run -p 8545:8545 statusim/nimbus-portal-client:amd64-master-latest --rpc --rpc-address:0.0.0.0
 ```
 !!! note
     Port 8545 is published and `rpc-address` is set to the `ANY` address in this command to allow access to the JSON-RPC API from outside the Docker image. You might want to adjust that depending on the use case & security model.


### PR DESCRIPTION
- Hive has been updated from fluffy to nimbus-portal
- Docker hub repo nimbus-portal-client has been created and latest build has been added there