### PR TITLE
Portal Client: Add banOtherClients debug parameter to be used for testing and debugging

### DIFF
--- a/portal/client/nimbus_portal_client.nim
+++ b/portal/client/nimbus_portal_client.nim
@@ -233,7 +233,7 @@ proc run(portalClient: PortalClient, config: PortalConf) {.raises: [CatchableErr
       config.radiusConfig, config.disablePoke, config.maxGossipNodes,
       config.contentCacheSize, config.disableContentCache, config.offerCacheSize,
       config.disableOfferCache, config.maxConcurrentOffers, config.disableBanNodes,
-      config.radiusCacheSize,
+      config.banOtherClients, config.radiusCacheSize,
     )
 
     portalNodeConfig = PortalNodeConfig(

--- a/portal/client/nimbus_portal_client_conf.nim
+++ b/portal/client/nimbus_portal_client_conf.nim
@@ -403,6 +403,15 @@ type
       name: "debug-disable-ban-nodes"
     .}: bool
 
+    banOtherClients* {.
+      hidden,
+      desc:
+        "Ban nodes that don't have a ping capabilities payload client info string matching the value used by Nimbus Portal. " &
+        "This can be useful for testing when we would like to only connect to Nimbus Portal nodes on the network.",
+      defaultValue: $defaultBanOtherClients,
+      name: "debug-ban-other-clients"
+    .}: bool
+
     radiusCacheSize* {.
       hidden,
       desc: "Size of the in memory radius cache.",

--- a/portal/client/nimbus_portal_client_conf.nim
+++ b/portal/client/nimbus_portal_client_conf.nim
@@ -408,7 +408,7 @@ type
       desc:
         "Ban nodes that don't have a ping capabilities payload client info string matching the value used by Nimbus Portal. " &
         "This can be useful for testing when we would like to only connect to Nimbus Portal nodes on the network.",
-      defaultValue: $defaultBanOtherClients,
+      defaultValue: defaultBanOtherClients,
       name: "debug-ban-other-clients"
     .}: bool
 

--- a/portal/network/wire/ping_extensions.nim
+++ b/portal/network/wire/ping_extensions.nim
@@ -21,6 +21,8 @@ const
   MAX_CAPABILITIES_LENGTH* = 400
   MAX_ERROR_BYTE_LENGTH* = 300
 
+  NIMBUS_PORTAL_CLIENT_INFO* = ByteList[MAX_CLIENT_INFO_BYTE_LENGTH].init(@[])
+
 # Different ping extension payloads, TODO: could be moved to each their own file?
 type
   CapabilitiesPayload* = object

--- a/portal/network/wire/portal_protocol_config.nim
+++ b/portal/network/wire/portal_protocol_config.nim
@@ -48,6 +48,7 @@ type
     disableOfferCache*: bool
     maxConcurrentOffers*: int
     disableBanNodes*: bool
+    banOtherClients*: bool
     radiusCacheSize*: int
 
 const
@@ -63,6 +64,7 @@ const
   defaultAlpha* = 3
   revalidationTimeout* = chronos.seconds(30)
   defaultDisableBanNodes* = true
+  defaultBanOtherClients* = false
   defaultRadiusCacheSize* = 512
 
   defaultPortalProtocolConfig* = PortalProtocolConfig(
@@ -78,6 +80,7 @@ const
     disableOfferCache: defaultDisableOfferCache,
     maxConcurrentOffers: defaultMaxConcurrentOffers,
     disableBanNodes: defaultDisableBanNodes,
+    banOtherClients: defaultBanOtherClients,
     radiusCacheSize: defaultRadiusCacheSize,
   )
 
@@ -96,6 +99,7 @@ proc init*(
     disableOfferCache: bool,
     maxConcurrentOffers: int,
     disableBanNodes: bool,
+    banOtherClients: bool,
     radiusCacheSize: int,
 ): T =
   PortalProtocolConfig(
@@ -112,6 +116,7 @@ proc init*(
     disableOfferCache: disableOfferCache,
     maxConcurrentOffers: maxConcurrentOffers,
     disableBanNodes: disableBanNodes,
+    banOtherClients: banOtherClients,
     radiusCacheSize: radiusCacheSize,
   )
 

--- a/portal/tests/wire_protocol_tests/test_portal_wire_protocol.nim
+++ b/portal/tests/wire_protocol_tests/test_portal_wire_protocol.nim
@@ -94,7 +94,7 @@ procSuite "Portal Wire Protocol Tests":
     let pong = await proto1.ping(proto2.localNode)
 
     let customPayload = CapabilitiesPayload(
-      client_info: ByteList[MAX_CLIENT_INFO_BYTE_LENGTH].init(@[]),
+      client_info: NIMBUS_PORTAL_CLIENT_INFO,
       data_radius: UInt256.high(),
       capabilities: List[uint16, MAX_CAPABILITIES_LENGTH].init(
         proto1.pingExtensionCapabilities.toSeq()


### PR DESCRIPTION
This adds a new debug parameter (disabled by default) which can be used to ban all non Nimbus Portal nodes from the routing table. This will be useful when investigating issues on mainnet where we might want to only connect to Nimbus Portal clients for various reasons.

It also might be useful to sometimes run our portal bridges with the local Nimbus Portal client only connecting to other Nimbus Portal nodes.