### PR TITLE
Portal: Fix beacon lc bootstrap validation

### DIFF
--- a/portal/network/beacon/beacon_network.nim
+++ b/portal/network/beacon/beacon_network.nim
@@ -286,7 +286,7 @@ proc validateContent(
                   forkyBootstrap.header.beacon:
                 return err("Bootstrap header does not match recent finalized header")
 
-              if forkyBootstrap.isValidBootstrap(n.beaconDb.cfg):
+              if forkyBootstrap.isValidBootstrap(lcDataFork, n.beaconDb.cfg):
                 ok()
               else:
                 err("Error validating LC bootstrap")
@@ -298,7 +298,7 @@ proc validateContent(
           if blockRoot != n.trustedBlockRoot.get():
             return err("Bootstrap header does not match trusted block root")
 
-          if forkyBootstrap.isValidBootstrap(n.beaconDb.cfg):
+          if forkyBootstrap.isValidBootstrap(lcDataFork, n.beaconDb.cfg):
             ok()
           else:
             err("Error validating LC bootstrap")

--- a/portal/network/beacon/beacon_validation.nim
+++ b/portal/network/beacon/beacon_validation.nim
@@ -13,14 +13,18 @@ import
   beacon_chain/spec/forks,
   beacon_chain/spec/forks_light_client
 
-func isValidBootstrap*(bootstrap: ForkyLightClientBootstrap, cfg: RuntimeConfig): bool =
+func isValidBootstrap*(
+    bootstrap: ForkyLightClientBootstrap,
+    kind: static LightClientDataFork,
+    cfg: RuntimeConfig,
+): bool =
   ## Verify if the bootstrap is valid. This does not verify if the header is
   ## part of the canonical chain.
   is_valid_light_client_header(bootstrap.header, cfg) and
     is_valid_merkle_branch(
       hash_tree_root(bootstrap.current_sync_committee),
       bootstrap.current_sync_committee_branch,
-      log2trunc(altair.CURRENT_SYNC_COMMITTEE_GINDEX),
-      get_subtree_index(altair.CURRENT_SYNC_COMMITTEE_GINDEX),
+      log2trunc(current_sync_committee_gindex(kind)),
+      get_subtree_index(current_sync_committee_gindex(kind)),
       bootstrap.header.beacon.state_root,
     )


### PR DESCRIPTION
The current_sync_committee_gindex is fork dependant, this causes bootstrap validation issue since electra.