### PR TITLE
Portal Client: Improve node status log

### DIFF
--- a/portal/network/portal_node.nim
+++ b/portal/network/portal_node.nim
@@ -209,14 +209,12 @@ proc statusLogLoop(n: PortalNode) {.async: (raises: []).} =
         radius = n.contentDB.dataRadius
         radiusPercentage = radius div (UInt256.high() div u256(100))
         logRadius = logDistance(radius, u256(0))
-        logRadiusPercentage = (logRadius * 100) div 256
 
       info "Portal node status",
-        dbSize = $(n.contentDB.size() div 1_000_000) & "MB",
-        logRadiusPercentage = $logRadiusPercentage & "%",
-        logRadius,
+        dbSize = $(n.contentDB.size() div 1_000_000) & "mb",
         radiusPercentage = radiusPercentage.toString(10) & "%",
-        radius = radius.toHex()
+        radius = radius.toHex(),
+        logRadius = logRadius & " / 256"
 
       await sleepAsync(60.seconds)
   except CancelledError:

--- a/portal/network/portal_node.nim
+++ b/portal/network/portal_node.nim
@@ -212,7 +212,7 @@ proc statusLogLoop(n: PortalNode) {.async: (raises: []).} =
         logRadiusPercentage = (logRadius * 100) div 256
 
       info "Portal node status",
-        dbSize = $(n.contentDB.size() div 1_000_000) & " MB",
+        dbSize = $(n.contentDB.size() div 1_000_000) & "MB",
         logRadiusPercentage = $logRadiusPercentage & "%",
         logRadius,
         radiusPercentage = radiusPercentage.toString(10) & "%",

--- a/portal/network/portal_node.nim
+++ b/portal/network/portal_node.nim
@@ -212,11 +212,12 @@ proc statusLogLoop(n: PortalNode) {.async: (raises: []).} =
         logRadiusPercentage = (logRadius * 100) div 256
 
       info "Portal node status",
+        dbSize = $(n.contentDB.size() div 1_000_000) & "MB"
         logRadiusPercentage = $logRadiusPercentage & "%",
         logRadius,
         radiusPercentage = radiusPercentage.toString(10) & "%",
         radius = radius.toHex(),
-        dbSize = $(n.contentDB.size() div 1_000_000) & "MB"
+
 
       await sleepAsync(60.seconds)
   except CancelledError:

--- a/portal/network/portal_node.nim
+++ b/portal/network/portal_node.nim
@@ -214,7 +214,7 @@ proc statusLogLoop(n: PortalNode) {.async: (raises: []).} =
         dbSize = $(n.contentDB.size() div 1_000_000) & "mb",
         radiusPercentage = radiusPercentage.toString(10) & "%",
         radius = radius.toHex(),
-        logRadius = logRadius & " / 256"
+        logRadius = $logRadius & " / 256"
 
       await sleepAsync(60.seconds)
   except CancelledError:

--- a/portal/network/portal_node.nim
+++ b/portal/network/portal_node.nim
@@ -214,7 +214,7 @@ proc statusLogLoop(n: PortalNode) {.async: (raises: []).} =
         dbSize = $(n.contentDB.size() div 1_000_000) & "mb",
         radiusPercentage = radiusPercentage.toString(10) & "%",
         radius = radius.toHex(),
-        logRadius = $logRadius & " / 256"
+        logRadius
 
       await sleepAsync(60.seconds)
   except CancelledError:

--- a/portal/network/portal_node.nim
+++ b/portal/network/portal_node.nim
@@ -212,12 +212,11 @@ proc statusLogLoop(n: PortalNode) {.async: (raises: []).} =
         logRadiusPercentage = (logRadius * 100) div 256
 
       info "Portal node status",
-        dbSize = $(n.contentDB.size() div 1_000_000) & "MB"
+        dbSize = $(n.contentDB.size() div 1_000_000) & " MB",
         logRadiusPercentage = $logRadiusPercentage & "%",
         logRadius,
         radiusPercentage = radiusPercentage.toString(10) & "%",
-        radius = radius.toHex(),
-
+        radius = radius.toHex()
 
       await sleepAsync(60.seconds)
   except CancelledError:


### PR DESCRIPTION
I noticed that in the Nimbus Portal fleet logs the Portal node status looks like this for the 2GB nodes:
```
INF 2025-05-24 14:34:21.128+00:00 Portal node status                         radiusPercentage=0% radius=4beec975f622c1fd982e0cbef253deb9762ad0e437106ab1ca5f1b5a268139 dbSize=2000236kb
```

And like this for the 35G nodes:
```
INF 2025-05-24 14:34:20.341+00:00 Portal node status                         radiusPercentage=1% radius=383355a2cc74296f8485be9e5e43df32638ec2db05c9cd99a365bb2384cdc93 dbSize=35000209kb
```

Using the default storage size of 2G the `radiusPercentage` shows as 0%. This isn't very useful information for the user and the radius is actually likely to get smaller as the amount of data in the network grows.

To improve the logs I suggest we use log radius and log radius percent which will be a better way to represent the information. We could either show both the `radiusPercentage` and `logRadiusPercentage` or just show the log radius named as radiusPercentage (log base 2).

Also now showing the storage in MB instead of KB.

The updated log looks like this:
```
INF 2025-05-24 22:30:51.773+08:00 Portal node status                         dbSize=0MB logRadiusPercentage=50% logRadius=128 radiusPercentage=0% radius=ffffffffffffffffffffffffffffffff
```

Alternatively we could show something like:
```
INF 2025-05-24 22:30:51.773+08:00 Portal node status                         dbSize=0MB logRadius=128/256 radiusPercentage=0% radius=ffffffffffffffffffffffffffffffff
```