### PR TITLE
rm useless windeps.dll downloading; make syncer batch size --debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,12 +106,6 @@ jobs:
           [[ -z "$ncpu" || $ncpu -le 0 ]] && ncpu=1
           echo "ncpu=${ncpu}" >> $GITHUB_ENV
 
-          if [[ '${{ matrix.target.evmc }}' == 'evmc' ]]; then
-            echo "ENABLE_EVMC=1" >> $GITHUB_ENV
-          else
-            echo "ENABLE_EVMC=0" >> $GITHUB_ENV
-          fi
-
       - name: Install build dependencies (Macos)
         # Some home brew modules were reported missing
         if: runner.os == 'Macos'
@@ -126,16 +120,6 @@ jobs:
         with:
           path: external/mingw-${{ matrix.target.cpu }}
           key: 'mingw-llvm-17-${{ matrix.target.cpu }}'
-
-      - name: Restore Nim DLLs dependencies (Windows) from cache
-        if: runner.os == 'Windows'
-        id: windows-dlls-cache
-        uses: actions/cache@v4
-        with:
-          path: external/dlls-${{ matrix.target.cpu }}
-          # according to docu, idle caches are kept for up to 7 days
-          # so change dlls# to force new cache contents (for some number #)
-          key: dlls1-${{ matrix.target.cpu }}
 
       - name: Install llvm-mingw dependency (Windows)
         if: >
@@ -155,22 +139,11 @@ jobs:
           7z x -y "external/mingw-${{ matrix.target.cpu }}.zip" -oexternal/mingw-${{ matrix.target.cpu }}/
           mv external/mingw-${{ matrix.target.cpu }}/**/* ./external/mingw-${{ matrix.target.cpu }}
 
-      - name: Install DLLs dependencies (Windows)
-        if: >
-          steps.windows-dlls-cache.outputs.cache-hit != 'true' &&
-          runner.os == 'Windows'
-        run: |
-          DLLPATH=external/dlls-${{ matrix.target.cpu }}
-          mkdir -p external
-          curl -L "https://nim-lang.org/download/windeps.zip" -o external/windeps.zip
-          7z x -y external/windeps.zip -o"$DLLPATH"
-
       - name: Path to cached dependencies (Windows)
         if: >
           runner.os == 'Windows'
         run: |
           echo '${{ github.workspace }}'"/external/mingw-${{ matrix.target.cpu }}/bin" >> $GITHUB_PATH
-          echo '${{ github.workspace }}'"/external/dlls-${{ matrix.target.cpu }}" >> $GITHUB_PATH
 
       - name: Get latest nimbus-build-system commit hash
         id: versions

--- a/.github/workflows/nimbus_verified_proxy.yml
+++ b/.github/workflows/nimbus_verified_proxy.yml
@@ -72,6 +72,8 @@ jobs:
         run: |
           if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
             PLATFORM=x64
+          elif [[ '${{ matrix.target.cpu }}' == 'arm64' ]]; then
+            PLATFORM=arm64
           else
             PLATFORM=x86
           fi

--- a/.github/workflows/nimbus_verified_proxy.yml
+++ b/.github/workflows/nimbus_verified_proxy.yml
@@ -44,7 +44,7 @@ jobs:
           # - os: linux
           #   cpu: i386
           - os: macos
-            cpu: amd64
+            cpu: arm64
           - os: windows
             cpu: amd64
         include:
@@ -133,14 +133,6 @@ jobs:
           path: external/mingw-${{ matrix.target.cpu }}
           key: 'mingw-llvm-17-${{ matrix.target.cpu }}'
 
-      - name: Restore Nim DLLs dependencies (Windows) from cache
-        if: runner.os == 'Windows'
-        id: windows-dlls-cache
-        uses: actions/cache@v4
-        with:
-          path: external/dlls-${{ matrix.target.cpu }}
-          key: 'dlls-${{ matrix.target.cpu }}-verified-proxy'
-
       - name: Install llvm-mingw dependency (Windows)
         if: >
           steps.windows-mingw-cache.outputs.cache-hit != 'true' &&
@@ -159,22 +151,11 @@ jobs:
           7z x -y "external/mingw-${{ matrix.target.cpu }}.zip" -oexternal/mingw-${{ matrix.target.cpu }}/
           mv external/mingw-${{ matrix.target.cpu }}/**/* ./external/mingw-${{ matrix.target.cpu }}
 
-      - name: Install DLLs dependencies (Windows)
-        if: >
-          steps.windows-dlls-cache.outputs.cache-hit != 'true' &&
-          runner.os == 'Windows'
-        run: |
-          DLLPATH=external/dlls-${{ matrix.target.cpu }}
-          mkdir -p external
-          curl -L "https://nim-lang.org/download/windeps.zip" -o external/windeps.zip
-          7z x -y external/windeps.zip -o"$DLLPATH"
-
       - name: Path to cached dependencies (Windows)
         if: >
           runner.os == 'Windows'
         run: |
           echo '${{ github.workspace }}'"/external/mingw-${{ matrix.target.cpu }}/bin" >> $GITHUB_PATH
-          echo '${{ github.workspace }}'"/external/dlls-${{ matrix.target.cpu }}" >> $GITHUB_PATH
 
       - name: Get latest nimbus-build-system commit hash
         id: versions

--- a/.github/workflows/portal.yml
+++ b/.github/workflows/portal.yml
@@ -113,7 +113,7 @@ jobs:
           - os: linux
             cpu: amd64
           - os: macos
-            cpu: amd64
+            cpu: arm64
           - os: windows
             cpu: amd64
         include:
@@ -201,14 +201,6 @@ jobs:
           path: external/mingw-${{ matrix.target.cpu }}
           key: 'mingw-llvm-17-${{ matrix.target.cpu }}'
 
-      - name: Restore Nim DLLs dependencies (Windows) from cache
-        if: runner.os == 'Windows'
-        id: windows-dlls-cache
-        uses: actions/cache@v4
-        with:
-          path: external/dlls-${{ matrix.target.cpu }}
-          key: 'dlls-${{ matrix.target.cpu }}-portal'
-
       - name: Install llvm-mingw dependency (Windows)
         if: >
           steps.windows-mingw-cache.outputs.cache-hit != 'true' &&
@@ -227,22 +219,11 @@ jobs:
           7z x -y "external/mingw-${{ matrix.target.cpu }}.zip" -oexternal/mingw-${{ matrix.target.cpu }}/
           mv external/mingw-${{ matrix.target.cpu }}/**/* ./external/mingw-${{ matrix.target.cpu }}
 
-      - name: Install DLLs dependencies (Windows)
-        if: >
-          steps.windows-dlls-cache.outputs.cache-hit != 'true' &&
-          runner.os == 'Windows'
-        run: |
-          DLLPATH=external/dlls-${{ matrix.target.cpu }}
-          mkdir -p external
-          curl -L "https://nim-lang.org/download/windeps.zip" -o external/windeps.zip
-          7z x -y external/windeps.zip -o"$DLLPATH"
-
       - name: Path to cached dependencies (Windows)
         if: >
           runner.os == 'Windows'
         run: |
           echo '${{ github.workspace }}'"/external/mingw-${{ matrix.target.cpu }}/bin" >> $GITHUB_PATH
-          echo '${{ github.workspace }}'"/external/dlls-${{ matrix.target.cpu }}" >> $GITHUB_PATH
 
       - name: Get latest nimbus-build-system commit hash
         id: versions

--- a/.github/workflows/portal.yml
+++ b/.github/workflows/portal.yml
@@ -141,6 +141,8 @@ jobs:
         run: |
           if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
             PLATFORM=x64
+          elif [[ '${{ matrix.target.cpu }}' == 'arm64' ]]; then
+            PLATFORM=arm64
           else
             PLATFORM=x86
           fi

--- a/.github/workflows/simulators.yml
+++ b/.github/workflows/simulators.yml
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -109,23 +109,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Restore Nim DLLs dependencies from cache
-        id: windows-dlls-cache
-        uses: actions/cache@v4
-        with:
-          path: external/dlls
-          # according to docu, idle caches are kept for up to 7 days
-          # so change dlls# to force new cache contents (for some number #)
-          key: dlls1
-
-      - name: Install DLLs dependencies
-        if: steps.windows-dlls-cache.outputs.cache-hit != 'true'
-        run: |
-          DLLPATH=external/dlls
-          mkdir -p external
-          curl -L "https://nim-lang.org/download/windeps.zip" -o external/windeps.zip
-          7z x -y external/windeps.zip -o"$DLLPATH"
-
       - name: Restore llvm-mingw from cache
         id: windows-mingw-cache
         uses: actions/cache@v4
@@ -146,7 +129,6 @@ jobs:
       - name: Path to cached dependencies
         run: |
           echo '${{ github.workspace }}'"/external/mingw-amd64/bin" >> $GITHUB_PATH
-          echo '${{ github.workspace }}'"/external/dlls" >> $GITHUB_PATH
 
       - name: Get latest nimbus-build-system commit hash
         id: versions

--- a/config.nims
+++ b/config.nims
@@ -164,6 +164,8 @@ if canEnableDebuggingSymbols:
 
 --define:nimOldCaseObjects # https://github.com/status-im/nim-confutils/issues/9
 
+switch("warningAsError", "BareExcept:on")
+
 # `switch("warning[CaseTransition]", "off")` fails with "Error: invalid command line option: '--warning[CaseTransition]'"
 switch("warning", "CaseTransition:off")
 

--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -340,9 +340,9 @@ type
       name: "num-threads" .}: int
 
     persistBatchSize* {.
-      desc: ""
+      hidden
       defaultValue: 32'u64
-      name: "persist-batch-size" .}: uint64
+      name: "debug-persist-batch-size" .}: uint64
 
     beaconSyncTargetFile* {.
       hidden


### PR DESCRIPTION
The reasons for removing windeps.zip downloading are primarily twofold:
- it's a useless/unused network fetch which could fail; and
- given that, that it contains an EOL OpenSSL 1.1 DLL makes it potential attack surface to leave in the CI path.

There's no point (at least initially for sure, but probably ever) in supporting x86 macOS. It's rapidly fading. If nothing else, the defaults should be switched to ARM macOS, and if x86 really needs to be re-added, that can be looked at later. But right now the CI should be focusing on testing ARM.

`--persist-batch-size` looks very much like a debugging option we probably won't want to ship/document as an end-user supported command-line flag, so signal that appropriately. As with x86 macOS, this can be reviewed later, but as we approach an initial alpha release, it's better to err on the side of not having command-line options which are/were largely debugging artifacts enshrined in the supported set.