### PR TITLE
Portal bridge: fixes and refactor beacon bridge

### DIFF
--- a/portal/tests/beacon_network_tests/test_beacon_network.nim
+++ b/portal/tests/beacon_network_tests/test_beacon_network.nim
@@ -159,8 +159,9 @@ procSuite "Beacon Network":
       update2 = ForkedLightClientUpdate(
         kind: LightClientDataFork.Altair, altairData: altairData2
       )
-      updates = @[update1, update2]
-      content = encodeLightClientUpdatesForked(forkDigests.altair, updates)
+      updates = ForkedLightClientUpdateList.init(@[update1, update2])
+      content =
+        encodeLightClientUpdatesForked(updates, forkDigests, networkData.metadata.cfg)
       startPeriod = altairData1.attested_header.beacon.slot.sync_committee_period
       contentKey = ContentKey(
         contentType: lightClientUpdate,

--- a/portal/tools/eth_data_exporter/cl_data_exporter.nim
+++ b/portal/tools/eth_data_exporter/cl_data_exporter.nim
@@ -142,7 +142,9 @@ proc exportLCUpdates*(
             forkDigests[], epoch(forkyObject.attested_header.beacon.slot), cfg
           )
 
-          content = encodeLightClientUpdatesForked(forkDigest, updates)
+          content = encodeLightClientUpdatesForked(
+            ForkedLightClientUpdateList.init(updates), forkDigests[], cfg
+          )
 
           file = dataDir / fileName
         writePortalContentToYaml(file, contentKey.asSeq().to0xHex(), content.to0xHex())


### PR DESCRIPTION
- Rework bridge result error handling fixing also an invalid res.error access
- Fix bug where List of LC updates would have the wrong fork digest if it would be updates from different forks
- Fix order of injecting LC updates (backfill) to be more likely accepted