### PR TITLE
Synchronize FC block processing using asyncQueue

### DIFF
--- a/execution_chain/beacon/api_handler/api_forkchoice.nim
+++ b/execution_chain/beacon/api_handler/api_forkchoice.nim
@@ -188,7 +188,7 @@ proc forkchoiceUpdated*(ben: BeaconEngineRef,
       raise invalidForkChoiceState("safe block not in canonical tree")
     # similar to headHash, safeBlockHash is saved by FC module
 
-  (await chain.forkChoice(headHash, finalizedBlockHash, safeBlockHash)).isOkOr:
+  (await chain.queueForkChoice(headHash, finalizedBlockHash, safeBlockHash)).isOkOr:
     return invalidFCU(error, chain, header)
 
   # If payload generation was requested, create a new block to be potentially

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -233,7 +233,7 @@ proc newPayload*(ben: BeaconEngineRef,
   trace "Importing block without sethead",
     hash = blockHash, number = header.number
 
-  let vres = await chain.importBlock(blk, finalized = false)
+  let vres = await chain.queueImportBlock(blk, finalized = false)
   if vres.isErr:
     warn "Error importing block",
       number = header.number,

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -41,6 +41,7 @@ export
 const
   BaseDistance = 128'u64
   PersistBatchSize = 32'u64
+  MaxQueueSize = 9
 
 # ------------------------------------------------------------------------------
 # Forward declarations
@@ -490,6 +491,26 @@ proc updateBase(c: ForkedChainRef, newBase: BlockPos):
       pendingFCU = c.pendingFCU.short,
       resolvedFin= c.latestFinalizedBlockNumber
 
+proc processQueue(c: ForkedChainRef) {.async: (raises: [CancelledError]).} =
+  while true:
+    # Cooperative concurrency: one block per loop iteration - because
+    # we run both networking and CPU-heavy things like block processing
+    # on the same thread, we need to make sure that there is steady progress
+    # on the networking side or we get long lockups that lead to timeouts.
+    const
+      # We cap waiting for an idle slot in case there's a lot of network traffic
+      # taking up all CPU - we don't want to _completely_ stop processing blocks
+      # in this case - doing so also allows us to benefit from more batching /
+      # larger network reads when under load.
+      idleTimeout = 10.milliseconds
+
+    discard await idleAsync().withTimeout(idleTimeout)
+    let
+      item = await c.queue.popFirst()
+      res = await item.handler()
+    if not item.responseFut.finished:
+      item.responseFut.complete res
+
 # ------------------------------------------------------------------------------
 # Public functions
 # ------------------------------------------------------------------------------
@@ -500,6 +521,7 @@ proc init*(
     baseDistance = BaseDistance;
     persistBatchSize = PersistBatchSize;
     eagerStateRoot = false;
+    enableQueue = false;
       ): T =
   ## Constructor that uses the current database ledger state for initialising.
   ## This state coincides with the canonical head that would be used for
@@ -523,18 +545,24 @@ proc init*(
       FcuHashAndNumber(hash: baseHash, number: baseHeader.number)
     fcuSafe = baseTxFrame.fcuSafe().valueOr:
       FcuHashAndNumber(hash: baseHash, number: baseHeader.number)
+    fc = T(com:             com,
+      baseBranch:      baseBranch,
+      activeBranch:    baseBranch,
+      branches:        @[baseBranch],
+      hashToBlock:     {baseHash: baseBranch.lastBlockPos}.toTable,
+      baseTxFrame:     baseTxFrame,
+      baseDistance:    baseDistance,
+      persistBatchSize:persistBatchSize,
+      quarantine:      Quarantine.init(),
+      fcuHead:         fcuHead,
+      fcuSafe:         fcuSafe,
+    )
 
-  T(com:             com,
-    baseBranch:      baseBranch,
-    activeBranch:    baseBranch,
-    branches:        @[baseBranch],
-    hashToBlock:     {baseHash: baseBranch.lastBlockPos}.toTable,
-    baseTxFrame:     baseTxFrame,
-    baseDistance:    baseDistance,
-    persistBatchSize:persistBatchSize,
-    quarantine:      Quarantine.init(),
-    fcuHead:         fcuHead,
-    fcuSafe:         fcuSafe)
+  if enableQueue:
+   fc.queue = newAsyncQueue[QueueItem](maxsize = MaxQueueSize)
+   fc.processingQueueLoop = fc.processQueue()
+
+  fc
 
 proc importBlock*(c: ForkedChainRef, blk: Block, finalized = false):
        Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
@@ -652,6 +680,35 @@ proc forkChoice*(c: ForkedChainRef,
   await c.updateBase(newBase)
 
   ok()
+
+proc stopProcessingQueue*(c: ForkedChainRef) {.async: (raises: [CancelledError]).} =
+  doAssert(c.processingQueueLoop.isNil.not, "Please set enableQueue=true when constructing FC")
+  await c.processingQueueLoop.cancelAndWait()
+
+template queueImportBlock*(c: ForkedChainRef, blk: Block, finalized = false): auto =
+  proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
+    await c.importBlock(blk, finalized)
+
+  let item = QueueItem(
+    responseFut: Future[Result[void, string]].Raising([CancelledError]).init(),
+    handler: asyncHandler
+  )
+  await c.queue.addLast(item)
+  item.responseFut
+
+template queueForkChoice*(c: ForkedChainRef,
+                 headHash: Hash32,
+                 finalizedHash: Hash32,
+                 safeHash: Hash32 = zeroHash32): auto =
+  proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
+    await c.forkChoice(headHash, finalizedHash, safeHash)
+
+  let item = QueueItem(
+    responseFut: Future[Result[void, string]].Raising([CancelledError]).init(),
+    handler: asyncHandler
+  )
+  await c.queue.addLast(item)
+  item.responseFut
 
 func finHash*(c: ForkedChainRef): Hash32 =
   c.pendingFCU

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -559,8 +559,8 @@ proc init*(
     )
 
   if enableQueue:
-   fc.queue = newAsyncQueue[QueueItem](maxsize = MaxQueueSize)
-   fc.processingQueueLoop = fc.processQueue()
+    fc.queue = newAsyncQueue[QueueItem](maxsize = MaxQueueSize)
+    fc.processingQueueLoop = fc.processQueue()
 
   fc
 

--- a/execution_chain/nimbus_desc.nim
+++ b/execution_chain/nimbus_desc.nim
@@ -8,7 +8,9 @@
 # those terms.
 
 import
+  std/sequtils,
   chronos,
+  chronicles,
   ./networking/p2p,
   metrics/chronos_httpserver,
   ./rpc/rpc_server,

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -44,7 +44,8 @@ proc basicServices(nimbus: NimbusNode,
   # Setup the chain
   let fc = ForkedChainRef.init(com,
     eagerStateRoot = conf.eagerStateRootCheck,
-    persistBatchSize=conf.persistBatchSize)
+    persistBatchSize=conf.persistBatchSize,
+    enableQueue = true)
   fc.deserialize().isOkOr:
     warn "Loading block DAG from database", msg=error
 

--- a/execution_chain/sync/beacon/worker/blocks_staged/staged_blocks.nim
+++ b/execution_chain/sync/beacon/worker/blocks_staged/staged_blocks.nim
@@ -175,7 +175,7 @@ proc blocksImport*(
         continue
 
       try:
-        (await ctx.chain.importBlock(blocks[n])).isOkOr:
+        (await ctx.chain.queueImportBlock(blocks[n])).isOkOr:
           # The way out here is simply to re-compile the block queue. At any
           # point, the `FC` module data area might have been moved to a new
           # canonical branch.
@@ -196,7 +196,7 @@ proc blocksImport*(
       # Allow pseudo/async thread switch.
       (await ctx.updateAsyncTasks()).isOkOr:
         break loop
-      
+
   info "Imported blocks", iv=(if iv.minPt <= ctx.blk.topImported:
     (iv.minPt, ctx.blk.topImported).bnStr else: "n/a"),
     nBlocks=(ctx.blk.topImported - iv.minPt + 1),

--- a/hive_integration/nodocker/engine/engine_env.nim
+++ b/hive_integration/nodocker/engine/engine_env.nim
@@ -82,7 +82,7 @@ proc newEngineEnv*(conf: var NimbusConf, chainFile: string, enableAuth: bool): E
   let
     node   = setupEthNode(conf, ctx)
     com    = makeCom(conf)
-    chain  = ForkedChainRef.init(com)
+    chain  = ForkedChainRef.init(com, enableQueue = true)
     txPool = TxPoolRef.new(chain)
 
   node.addEthHandlerCapability(txPool)
@@ -133,6 +133,7 @@ proc close*(env: EngineEnv) =
   waitFor env.node.closeWait()
   waitFor env.client.close()
   waitFor env.server.closeWait()
+  waitFor env.chain.stopProcessingQueue()
 
 proc setRealTTD*(env: EngineEnv) =
   let genesis = env.com.genesisHeader

--- a/tests/test_engine_api.nim
+++ b/tests/test_engine_api.nim
@@ -89,7 +89,7 @@ proc setupEnv(envFork: HardFork = MergeFork,
 
   let
     com   = setupCom(conf)
-    chain = ForkedChainRef.init(com)
+    chain = ForkedChainRef.init(com, enableQueue = true)
     txPool = TxPoolRef.new(chain)
 
   let
@@ -117,6 +117,7 @@ proc setupEnv(envFork: HardFork = MergeFork,
 proc close(env: TestEnv) =
   waitFor env.client.close()
   waitFor env.server.closeWait()
+  waitFor env.chain.stopProcessingQueue()
 
 proc runBasicCycleTest(env: TestEnv): Result[void, string] =
   let


### PR DESCRIPTION
Tested with hoodi, both during syncing and chain following.

fix #3294

https://github.com/status-im/nimbus-eth1/pull/3259 introduce asynchronous block import and fork choice to FC module.
And because it is called from 3 places:
1. engine_newPayload
2. engine_forkChoiceUpdated
3. beacon syncer

The interaction causing FC state corruption. Most visible problem is state root mismatch error.