### PR TITLE
Portal client: Drop remaining offer content after first validation failure in state network

### DIFF
--- a/portal/metrics/grafana/portal_grafana_dashboard.json
+++ b/portal/metrics/grafana/portal_grafana_dashboard.json
@@ -2151,7 +2151,7 @@
           "exemplar": false,
           "expr": "rate(portal_offer_accept_codes_total{instance=\"${instance}\",container=\"${container}\"}[$__rate_interval])",
           "interval": "",
-          "legendFormat": "portal_offer_accept_codes[protocol_id={{protocol_id}, accept_code={{accept_code}}]",
+          "legendFormat": "portal_offer_accept_codes[protocol_id={{protocol_id}}, accept_code={{accept_code}}]",
           "refId": "A"
         },
         {
@@ -2163,11 +2163,11 @@
           "expr": "rate(portal_handle_offer_accept_codes_total{instance=\"${instance}\",container=\"${container}\"}[$__rate_interval])",
           "hide": false,
           "interval": "",
-          "legendFormat": "portal_handle_offer_accept_codes[protocol_id={{protocol_id}, accept_code={{accept_code}}]",
+          "legendFormat": "portal_handle_offer_accept_codes[protocol_id={{protocol_id}}, accept_code={{accept_code}}]",
           "refId": "B"
         }
       ],
-      "title": "",
+      "title": "Neighborhood gossip content offer accept codes",
       "type": "timeseries"
     },
     {

--- a/portal/network/beacon/beacon_network.nim
+++ b/portal/network/beacon/beacon_network.nim
@@ -453,9 +453,8 @@ proc contentQueueWorker(n: BeaconNetwork) {.async: (raises: []).} =
       # TODO: Differentiate between failures due to invalid data and failures
       # due to missing network data for validation.
       if await n.validateContent(srcNodeId, contentKeys, contentItems):
-        discard await n.portalProtocol.randomGossip(
-          srcNodeId, contentKeys, contentItems
-        )
+        discard
+          await n.portalProtocol.randomGossip(srcNodeId, contentKeys, contentItems)
   except CancelledError:
     trace "contentQueueWorker canceled"
 

--- a/portal/network/beacon/beacon_network.nim
+++ b/portal/network/beacon/beacon_network.nim
@@ -453,7 +453,7 @@ proc contentQueueWorker(n: BeaconNetwork) {.async: (raises: []).} =
       # TODO: Differentiate between failures due to invalid data and failures
       # due to missing network data for validation.
       if await n.validateContent(srcNodeId, contentKeys, contentItems):
-        await n.portalProtocol.randomGossipDiscardPeers(
+        discard await n.portalProtocol.randomGossip(
           srcNodeId, contentKeys, contentItems
         )
   except CancelledError:

--- a/portal/network/history/history_network.nim
+++ b/portal/network/history/history_network.nim
@@ -428,7 +428,7 @@ proc contentQueueWorker(n: HistoryNetwork) {.async: (raises: []).} =
       # TODO: Differentiate between failures due to invalid data and failures
       # due to missing network data for validation.
       if await n.validateContent(srcNodeId, contentKeys, contentItems):
-        await n.portalProtocol.neighborhoodGossipDiscardPeers(
+        discard await n.portalProtocol.neighborhoodGossip(
           srcNodeId, contentKeys, contentItems
         )
   except CancelledError:

--- a/portal/network/state/state_network.nim
+++ b/portal/network/state/state_network.nim
@@ -262,6 +262,11 @@ proc contentQueueWorker(n: StateNetwork) {.async: (raises: []).} =
           state_network_offers_failed.inc(labelValues = [$n.portalProtocol.protocolId])
           error "Received offered content failed validation",
             srcNodeId, contentKeyBytes, error = offerRes.error()
+
+          # The content validation failed so drop the remaining content (if any) from
+          # this offer, because the remainly content is also likely to fail validation.
+          break
+
   except CancelledError:
     trace "contentQueueWorker canceled"
 

--- a/portal/network/state/state_network.nim
+++ b/portal/network/state/state_network.nim
@@ -266,7 +266,6 @@ proc contentQueueWorker(n: StateNetwork) {.async: (raises: []).} =
           # The content validation failed so drop the remaining content (if any) from
           # this offer, because the remainly content is also likely to fail validation.
           break
-
   except CancelledError:
     trace "contentQueueWorker canceled"
 

--- a/portal/network/wire/ping_extensions.nim
+++ b/portal/network/wire/ping_extensions.nim
@@ -21,6 +21,8 @@ const
   MAX_CAPABILITIES_LENGTH* = 400
   MAX_ERROR_BYTE_LENGTH* = 300
 
+  NIMBUS_PORTAL_CLIENT_INFO* = ByteList[MAX_CLIENT_INFO_BYTE_LENGTH].init(@[])
+
 # Different ping extension payloads, TODO: could be moved to each their own file?
 type
   CapabilitiesPayload* = object

--- a/portal/network/wire/portal_protocol.nim
+++ b/portal/network/wire/portal_protocol.nim
@@ -440,7 +440,7 @@ proc handlePingExtension(
       payloadType,
       encodePayload(
         CapabilitiesPayload(
-          client_info: ByteList[MAX_CLIENT_INFO_BYTE_LENGTH].init(@[]),
+          client_info: NIMBUS_PORTAL_CLIENT_INFO,
           data_radius: p.dataRadius(),
           capabilities: List[uint16, MAX_CAPABILITIES_LENGTH].init(
             p.pingExtensionCapabilities.toSeq()
@@ -849,7 +849,7 @@ proc pingImpl*(
 ): Future[PortalResult[PongMessage]] {.async: (raises: [CancelledError]).} =
   let pingPayload = encodePayload(
     CapabilitiesPayload(
-      client_info: ByteList[MAX_CLIENT_INFO_BYTE_LENGTH].init(@[]),
+      client_info: NIMBUS_PORTAL_CLIENT_INFO,
       data_radius: p.dataRadius(),
       capabilities:
         List[uint16, MAX_CAPABILITIES_LENGTH].init(p.pingExtensionCapabilities.toSeq()),
@@ -1846,15 +1846,6 @@ proc neighborhoodGossip*(
 
   await p.offerBatchGetPeerCount(offers)
 
-proc neighborhoodGossipDiscardPeers*(
-    p: PortalProtocol,
-    srcNodeId: Opt[NodeId],
-    contentKeys: ContentKeysList,
-    content: seq[seq[byte]],
-    enableNodeLookup = false,
-): Future[void] {.async: (raises: [CancelledError]).} =
-  discard await p.neighborhoodGossip(srcNodeId, contentKeys, content, enableNodeLookup)
-
 proc randomGossip*(
     p: PortalProtocol,
     srcNodeId: Opt[NodeId],
@@ -1876,14 +1867,6 @@ proc randomGossip*(
     offers = nodes.mapIt(OfferRequest(dst: it, kind: Direct, contentList: contentList))
 
   await p.offerBatchGetPeerCount(offers)
-
-proc randomGossipDiscardPeers*(
-    p: PortalProtocol,
-    srcNodeId: Opt[NodeId],
-    contentKeys: ContentKeysList,
-    content: seq[seq[byte]],
-): Future[void] {.async: (raises: [CancelledError]).} =
-  discard await p.randomGossip(srcNodeId, contentKeys, content)
 
 proc storeContent*(
     p: PortalProtocol,

--- a/portal/tests/wire_protocol_tests/test_portal_wire_protocol.nim
+++ b/portal/tests/wire_protocol_tests/test_portal_wire_protocol.nim
@@ -94,7 +94,7 @@ procSuite "Portal Wire Protocol Tests":
     let pong = await proto1.ping(proto2.localNode)
 
     let customPayload = CapabilitiesPayload(
-      client_info: ByteList[MAX_CLIENT_INFO_BYTE_LENGTH].init(@[]),
+      client_info: NIMBUS_PORTAL_CLIENT_INFO,
       data_radius: UInt256.high(),
       capabilities: List[uint16, MAX_CAPABILITIES_LENGTH].init(
         proto1.pingExtensionCapabilities.toSeq()


### PR DESCRIPTION
Changes in this PR:
- State network now drops the remaining content in an offer as soon as any of the validations fail. This is already the behavior in the beacon and history networks.
- Remove the `*DiscardPeers` functions from `PortalProtocol`. These are unneeded and introduce an additional and unneeded await. We could also use the discardable pragma to achieve a similar result.
- Added a NIMBUS_PORTAL_CLIENT_INFO const type so that we define it in one place and also don't construct these empty objects each time at the point of usage.