### PR TITLE
Portal client: Retry failed offers and make content queue size configurable

### DIFF
--- a/portal/client/nimbus_portal_client.nim
+++ b/portal/client/nimbus_portal_client.nim
@@ -249,6 +249,7 @@ proc run(portalClient: PortalClient, config: PortalConf) {.raises: [CatchableErr
       storageCapacity: config.storageCapacityMB * 1_000_000,
       contentRequestRetries: config.contentRequestRetries.int,
       contentQueueWorkers: config.contentQueueWorkers,
+      contentQueueSize: config.contentQueueSize,
     )
 
     node = PortalNode.new(

--- a/portal/client/nimbus_portal_client_conf.nim
+++ b/portal/client/nimbus_portal_client_conf.nim
@@ -431,6 +431,13 @@ type
       name: "debug-content-queue-workers"
     .}: int
 
+    contentQueueSize* {.
+      hidden,
+      desc: "Size of the in memory content queue.",
+      defaultValue: 50,
+      name: "debug-content-queue-size"
+    .}: int
+
     case cmd* {.command, defaultValue: noCommand.}: PortalCmd
     of noCommand:
       discard

--- a/portal/evm/async_evm.nim
+++ b/portal/evm/async_evm.nim
@@ -246,8 +246,10 @@ proc callFetchingState(
           return err("Unable to get code")
         vmState.ledger.setCode(q.address, code)
         fetchedCode.incl(q.address)
+    except CancelledError as e:
+      raise e
     except CatchableError as e:
-      raise newException(CancelledError, e.msg)
+      raiseAssert(e.msg) # Shouldn't happen
 
   evmResult.toCallResult()
 

--- a/portal/network/beacon/beacon_network.nim
+++ b/portal/network/beacon/beacon_network.nim
@@ -200,9 +200,11 @@ proc new*(
     bootstrapRecords: openArray[Record] = [],
     portalConfig: PortalProtocolConfig = defaultPortalProtocolConfig,
     contentQueueWorkers = 8,
+    contentQueueSize = 50,
 ): T =
   let
-    contentQueue = newAsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])](50)
+    contentQueue =
+      newAsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])](contentQueueSize)
 
     stream = streamManager.registerNewStream(contentQueue)
 

--- a/portal/network/history/history_network.nim
+++ b/portal/network/history/history_network.nim
@@ -354,9 +354,11 @@ proc new*(
     portalConfig: PortalProtocolConfig = defaultPortalProtocolConfig,
     contentRequestRetries = 1,
     contentQueueWorkers = 8,
+    contentQueueSize = 50,
 ): T =
   let
-    contentQueue = newAsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])](50)
+    contentQueue =
+      newAsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])](contentQueueSize)
 
     stream = streamManager.registerNewStream(contentQueue)
 

--- a/portal/network/portal_node.nim
+++ b/portal/network/portal_node.nim
@@ -36,6 +36,7 @@ type
     storageCapacity*: uint64
     contentRequestRetries*: int
     contentQueueWorkers*: int
+    contentQueueSize*: int
 
   PortalNode* = ref object
     discovery: protocol.Protocol
@@ -122,6 +123,7 @@ proc new*(
             bootstrapRecords = bootstrapRecords,
             portalConfig = config.portalConfig,
             contentQueueWorkers = config.contentQueueWorkers,
+            contentQueueSize = config.contentQueueSize,
           )
         Opt.some(beaconNetwork)
       else:
@@ -146,6 +148,7 @@ proc new*(
             portalConfig = config.portalConfig,
             contentRequestRetries = config.contentRequestRetries,
             contentQueueWorkers = config.contentQueueWorkers,
+            contentQueueSize = config.contentQueueSize,
           )
         )
       else:
@@ -165,6 +168,7 @@ proc new*(
             not config.disableStateRootValidation,
             contentRequestRetries = config.contentRequestRetries,
             contentQueueWorkers = config.contentQueueWorkers,
+            contentQueueSize = config.contentQueueSize,
           )
         )
       else:

--- a/portal/network/state/state_network.nim
+++ b/portal/network/state/state_network.nim
@@ -58,12 +58,10 @@ proc new*(
     validateStateIsCanonical = true,
     contentRequestRetries = 1,
     contentQueueWorkers = 8,
+    contentQueueSize = 50,
 ): T =
-  doAssert(contentRequestRetries >= 0)
-  doAssert(contentQueueWorkers >= 1)
-
   let
-    cq = newAsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])](50)
+    cq = newAsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])](contentQueueSize)
     s = streamManager.registerNewStream(cq)
     portalProtocol = PortalProtocol.new(
       baseProtocol,

--- a/portal/network/wire/portal_protocol.nim
+++ b/portal/network/wire/portal_protocol.nim
@@ -1238,6 +1238,10 @@ proc offerRateLimited*(
 
   p.offerTokenBucket.replenish(1)
 
+  if res.isErr():
+    # Retry the offer once if it failed for any reason
+    return await p.offerRateLimited(offer)
+
   res
 
 proc lookupWorker(


### PR DESCRIPTION
Changes in this PR:
- We now retry failed offers once just in case they failed due to some transient issue such as network packet drop.
- Add a debug flag to make the content queue size configurable. This will be useful when performance testing to find the optimal size.