### PR TITLE
Disable testutp CI job until it gets fixed

### DIFF
--- a/.github/workflows/portal.yml
+++ b/.github/workflows/portal.yml
@@ -40,7 +40,8 @@ jobs:
     runs-on: ubuntu-22.04
     # TODO: for now only push event as this way it is easier to get branch name
     # to build container
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
+    if: false
     steps:
       - name: Checkout nimbus-eth1
         uses: actions/checkout@v4


### PR DESCRIPTION
Tried previous commits (before it first started failing) and those also fails, which would indicate that it is an issue caused by a change in the testing env. Can reproduce locally so will be further investigated but disabled in CI to not block other PRs by this recurrent failure.