### PR TITLE
prototype BPO Fork Implementation 

### DIFF
--- a/execution_chain/common/chain_config.nim
+++ b/execution_chain/common/chain_config.nim
@@ -279,30 +279,6 @@ const
     "osaka": Osaka
   }.toTable
 
-# func ofStmt(fork: HardFork, keyName: string, reader: NimNode, value: NimNode): NimNode =
-#   let branchStmt = quote do:
-#     `value`[`fork`] = reader.readValue(Opt[BlobSchedule])
-
-#   nnkOfBranch.newTree(
-#     newLit(keyName),
-#     branchStmt
-#   )
-
-# macro blobScheduleParser(reader, key, value: typed): untyped =
-#   # Automated blob schedule parser generator
-#   var caseStmt = nnkCaseStmt.newTree(
-#     quote do: `key`
-#   )
-
-#   for fork in Cancun..HardFork.high:
-#     let keyName = BlobScheduleTable[fork]
-#     caseStmt.add ofStmt(fork, keyName, reader, value)
-
-#   caseStmt.add nnkElse.newTree(
-#     quote do: discard
-#   )
-#   result = caseStmt
-
 proc readValue(reader: var JsonReader[JGenesis], value: var seq[BpoFork])
     {.gcsafe, raises: [SerializationError, IOError].} =
   wrapError:

--- a/execution_chain/common/chain_config.nim
+++ b/execution_chain/common/chain_config.nim
@@ -514,7 +514,7 @@ proc parseGenesisAlloc*(data: string, ga: var GenesisAlloc): bool
 func defaultBlobSchedule*(): seq[BpoFork] =
   ## Returns a default blob schedule for named forks.
   ## This is used when the blob schedule is not specified in the genesis config.
-  result = @[
+  @[
     BpoFork(
       forkName: Opt.some(Cancun),
       forkTimestamp: Opt.none(EthTime),

--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -408,15 +408,21 @@ func gasLimit*(com: CommonRef): uint64 =
 
 func maxBlobsPerBlock*(com: CommonRef, fork: HardFork): uint64 =
   doAssert(fork >= Cancun)
-  com.config.blobSchedule[fork].expect("blobSchedule initialized").max
+  # Get timestamp from fork 
+  let timestamp = com.forkTransitionTable.timeThresholds[fork]
+  com.config.blobSchedule.getOrDefault($timestamp).max
 
 func targetBlobsPerBlock*(com: CommonRef, fork: HardFork): uint64 =
   doAssert(fork >= Cancun)
-  com.config.blobSchedule[fork].expect("blobSchedule initialized").target
+  # Get timestamp from fork 
+  let timestamp = com.forkTransitionTable.timeThresholds[fork]
+  com.config.blobSchedule.getOrDefault($timestamp).target
 
 func baseFeeUpdateFraction*(com: CommonRef, fork: HardFork): uint64 =
   doAssert(fork >= Cancun)
-  com.config.blobSchedule[fork].expect("blobSchedule initialized").baseFeeUpdateFraction
+  # Get timestamp from fork 
+  let timestamp = com.forkTransitionTable.timeThresholds[fork]
+  com.config.blobSchedule.getOrDefault($timestamp).baseFeeUpdateFraction
 
 # ------------------------------------------------------------------------------
 # Setters

--- a/execution_chain/common/hardforks.nim
+++ b/execution_chain/common/hardforks.nim
@@ -138,6 +138,11 @@ type
     target*: uint64
     max*   : uint64
     baseFeeUpdateFraction*: uint64
+    
+  BpoFork* = object
+    forkName*: Opt[HardFork]
+    forkTimestamp*: Opt[EthTime]
+    blobSchedule*: BlobSchedule
 
   # if you add more fork block
   # please update forkBlockField constant too
@@ -177,7 +182,7 @@ type
 
     terminalTotalDifficulty*: Opt[UInt256]
     depositContractAddress*: Opt[Address]
-    blobSchedule*       : Table[string, BlobSchedule]
+    blobSchedule*       : seq[BpoFork]
 
   # These are used for checking that the values of the fields
   # are in a valid order.

--- a/execution_chain/common/hardforks.nim
+++ b/execution_chain/common/hardforks.nim
@@ -177,7 +177,7 @@ type
 
     terminalTotalDifficulty*: Opt[UInt256]
     depositContractAddress*: Opt[Address]
-    blobSchedule*       : array[Cancun..HardFork.high, Opt[BlobSchedule]]
+    blobSchedule*       : Table[string, BlobSchedule]
 
   # These are used for checking that the values of the fields
   # are in a valid order.

--- a/execution_chain/core/eip4844.nim
+++ b/execution_chain/core/eip4844.nim
@@ -114,9 +114,9 @@ proc getTotalBlobGas*(versionedHashesLen: int): uint64 =
   GAS_PER_BLOB * versionedHashesLen.uint64
 
 # getBlobBaseFee implements get_data_gas_price from EIP-4844
-func getBlobBaseFee*(excessBlobGas: uint64, com: CommonRef, fork: EVMFork): UInt256 =
+func getBlobBaseFee*(excessBlobGas: uint64, com: CommonRef, fork: EVMFork, timestamp: EthTime): UInt256 =
   if fork >= FkCancun:
-    let blobBaseFeeUpdateFraction = com.getBlobBaseFeeUpdateFraction(fork).u256
+    let blobBaseFeeUpdateFraction = com.getBlobBaseFeeUpdateFraction(timestamp).u256
     fakeExponential(
       MIN_BLOB_GASPRICE.u256,
       excessBlobGas.u256,
@@ -127,9 +127,9 @@ func getBlobBaseFee*(excessBlobGas: uint64, com: CommonRef, fork: EVMFork): UInt
 
 proc calcDataFee*(versionedHashesLen: int,
                   excessBlobGas: uint64,
-                  com: CommonRef, fork: EVMFork): UInt256 =
+                  com: CommonRef, fork: EVMFork, timestamp: EthTime): UInt256 =
   getTotalBlobGas(versionedHashesLen).u256 *
-    getBlobBaseFee(excessBlobGas, com, fork)
+    getBlobBaseFee(excessBlobGas, com, fork, timestamp)
 
 func blobGasUsed(txs: openArray[Transaction]): uint64 =
   for tx in txs:

--- a/execution_chain/core/eip7691.nim
+++ b/execution_chain/core/eip7691.nim
@@ -31,10 +31,13 @@ const
     Osaka,
   ]
 
-func getMaxBlobsPerBlock*(com: CommonRef, fork: EVMFork): uint64 =
-  doAssert(fork >= FkCancun)
-  com.maxBlobsPerBlock(EVMForkToFork[fork])
+# Should be based on timestamp and not on Fork after introduction 
+# of BPO forks - EIP-7892 https://eips.ethereum.org/EIPS/eip-7892
 
-func getBlobBaseFeeUpdateFraction*(com: CommonRef, fork: EVMFork): uint64 =
-  doAssert(fork >= FkCancun)
-  com.baseFeeUpdateFraction(EVMForkToFork[fork])
+func getMaxBlobsPerBlock*(com: CommonRef, timestamp: EthTime): uint64 =
+  doAssert(com.isCancunOrLater(timestamp))
+  com.maxBlobsPerBlock(timestamp)
+
+func getBlobBaseFeeUpdateFraction*(com: CommonRef, timestamp: EthTime): uint64 =
+  doAssert(com.isCancunOrLater(timestamp))
+  com.baseFeeUpdateFraction(timestamp)

--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -107,7 +107,7 @@ proc processTransactionImpl(
   # statement, here.
   let
     com = vmState.com
-    txRes = roDB.validateTransaction(tx, sender, header.gasLimit, baseFee256, excessBlobGas, com, fork)
+    txRes = roDB.validateTransaction(tx, sender, header.gasLimit, baseFee256, excessBlobGas, com, fork, header.timestamp)
     res = if txRes.isOk:      
       # Execute the transaction.
       vmState.captureTxStart(tx.gasLimit)

--- a/execution_chain/core/tx_pool/tx_packer.nim
+++ b/execution_chain/core/tx_pool/tx_packer.nim
@@ -74,7 +74,7 @@ proc classifyValidatePacked(vmState: BaseVMState; item: TxItemRef): bool =
     excessBlobGas = calcExcessBlobGas(vmState.parent, fork >= FkPrague)
 
   roDB.validateTransaction(
-    item.tx, item.sender, gasLimit, baseFee, excessBlobGas, vmState.com, fork).isOk
+    item.tx, item.sender, gasLimit, baseFee, excessBlobGas, vmState.com, fork, vmState.blockCtx.timestamp).isOk
 
 proc classifyPacked(vmState: BaseVMState; moreBurned: GasInt): bool =
   ## Classifier for *packing* (i.e. adding up `gasUsed` values after executing
@@ -163,7 +163,7 @@ proc vmExecGrabItem(pst: var TxPacker; item: TxItemRef, xp: TxPoolRef): bool =
 
   # EIP-4844
   if item.tx.txType == TxEip4844:
-    let maxBlobsPerBlock = getMaxBlobsPerBlock(vmState.com, vmState.fork)
+    let maxBlobsPerBlock = getMaxBlobsPerBlock(vmState.com, vmState.blockCtx.timestamp)
     if (pst.numBlobPerBlock + item.tx.versionedHashes.len).uint64 > maxBlobsPerBlock:
       return ContinueWithNextAccount
 

--- a/execution_chain/rpc/rpc_utils.nim
+++ b/execution_chain/rpc/rpc_utils.nim
@@ -236,7 +236,7 @@ proc populateReceipt*(receipt: Receipt, gasUsed: GasInt, tx: Transaction,
 
   if tx.txType == TxEip4844:
     res.blobGasUsed = Opt.some(Quantity(tx.versionedHashes.len.uint64 * GAS_PER_BLOB.uint64))
-    res.blobGasPrice = Opt.some(getBlobBaseFee(header.excessBlobGas.get(0'u64), com, com.toEVMFork(header)))
+    res.blobGasPrice = Opt.some(getBlobBaseFee(header.excessBlobGas.get(0'u64), com, com.toEVMFork(header), header.timestamp))
 
   return res
 

--- a/execution_chain/rpc/server_api.nim
+++ b/execution_chain/rpc/server_api.nim
@@ -661,7 +661,7 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, ctx: EthContext) =
     if header.excessBlobGas.isNone:
       raise newException(ValueError, "excessBlobGas missing from latest header")
     let blobBaseFee =
-      getBlobBaseFee(header.excessBlobGas.get, api.com, api.com.toEVMFork(header)) * header.blobGasUsed.get.u256
+      getBlobBaseFee(header.excessBlobGas.get, api.com, api.com.toEVMFork(header), header.timestamp) * header.blobGasUsed.get.u256
     if blobBaseFee > high(uint64).u256:
       raise newException(ValueError, "blobBaseFee is bigger than uint64.max")
     return w3Qty blobBaseFee.truncate(uint64)

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -118,7 +118,7 @@ proc setupHost(call: CallParams, keepStack: bool): TransactionHost =
     origin         : call.origin.get(call.sender),
     gasPrice       : call.gasPrice,
     versionedHashes: call.versionedHashes,
-    blobBaseFee    : getBlobBaseFee(vmState.blockCtx.excessBlobGas, vmState.com, vmState.fork),
+    blobBaseFee    : getBlobBaseFee(vmState.blockCtx.excessBlobGas, vmState.com, vmState.fork, vmState.blockCtx.timestamp),
   )
 
   # reset global gasRefund counter each time
@@ -192,7 +192,7 @@ proc prepareToRunComputation(host: TransactionHost, call: CallParams) =
       # EIP-4844
       if fork >= FkCancun:
         let blobFee = calcDataFee(call.versionedHashes.len,
-          vmState.blockCtx.excessBlobGas, vmState.com, fork)
+          vmState.blockCtx.excessBlobGas, vmState.com, fork, vmState.blockCtx.timestamp)
         db.subBalance(call.sender, blobFee)
 
 proc calculateAndPossiblyRefundGas(host: TransactionHost, call: CallParams): GasInt =

--- a/tests/customgenesis/blobschedule_bpo.json
+++ b/tests/customgenesis/blobschedule_bpo.json
@@ -1,0 +1,44 @@
+{
+  "config": {
+    "chainId": 7,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip150Hash": "0x5de1ee4135274003348e80b788e5afa4b18b18d320a5622218d5c493fedf5689",
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "prague": {
+        "target": 6,
+        "max": 9,
+        "baseFeeUpdateFraction": 5007716
+      },
+      "osaka": {
+        "target": 6,
+        "max": 9,
+        "baseFeeUpdateFraction": 5007716
+      },
+      "1740693335": {
+        "target": 24,
+        "max": 48,
+        "baseFeeUpdateFraction": 5007716
+      },
+      "1743285335": {
+          "target": 36,
+          "max": 56,
+          "baseFeeUpdateFraction": 5007716
+      }
+    }
+  }
+}

--- a/tests/test_genesis.nim
+++ b/tests/test_genesis.nim
@@ -170,7 +170,6 @@ proc customGenesisTest() =
 
       template validateBlobScheduleTimestamp(cg, timestamp, tgt, mx, fee) =
         var found = false
-        echo cg.config.blobSchedule
         for bpo in cg.config.blobSchedule:
           if bpo.forkTimestamp.isSome and bpo.forkTimestamp.get == timestamp:
             found = true

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -40,6 +40,12 @@ const
 
   nameToFork* = ForkToName.revTable
 
+  EVMForkToFork*: array[FkCancun..FkLatest, HardFork] = [
+    Cancun,
+    Prague,
+    Osaka,
+  ]
+
 func skipNothing*(folder: string, name: string): bool = false
 
 var status = initOrderedTable[string, OrderedTable[string, Status]]()

--- a/tests/test_transaction_json.nim
+++ b/tests/test_transaction_json.nim
@@ -40,8 +40,10 @@ proc testTxByFork(tx: Transaction, forkData: JsonNode, forkName: string, testSta
     config = getChainConfig(forkName)
     memDB  = newCoreDbRef DefaultDbMemory
     com    = CommonRef.new(memDB, nil, config)
+    fork   = nameToFork[forkName]
+    timestamp = com.forkTimestamp(EVMForkToFork[fork]).get()
 
-  validateTxBasic(com, tx, nameToFork[forkName]).isOkOr:
+  validateTxBasic(com, tx, fork, timestamp).isOkOr:
     return
 
   if forkData.len > 0 and "sender" in forkData:

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -652,10 +652,11 @@ proc txPoolMain*() =
       xp.checkAddTx(tx4)
 
       # override current blobSchedule
-      let bs = cc.blobSchedule[Cancun]
-      cc.blobSchedule[Cancun] = Opt.some(
-        BlobSchedule(target: 2, max: 3, baseFeeUpdateFraction: 3338477)
-      )
+      var bs: BlobSchedule
+      for bpo in cc.blobSchedule.mitems:
+        if bpo.forkName.isSome and bpo.forkName.get == Cancun:
+          bs = bpo.blobSchedule
+          bpo.blobSchedule = BlobSchedule(target: 2, max: 3, baseFeeUpdateFraction: 3338477)
 
       # allow 3 blobs
       xp.checkImportBlock(3, 1)
@@ -664,7 +665,9 @@ proc txPoolMain*() =
       xp.checkImportBlock(1, 0)
 
       # restore blobSchedule
-      cc.blobSchedule[Cancun] = bs
+      for bpo in cc.blobSchedule.mitems:
+        if bpo.forkName.isSome and bpo.forkName.get == Cancun:
+          bpo.blobSchedule = bs
 
     test "non blob tx size limit":
       proc dataTx(nonce: AccountNonce, env: TestEnv, btx: BaseTx): (PooledTransaction, PooledTransaction) =

--- a/tools/txparse/txparse.nim
+++ b/tools/txparse/txparse.nim
@@ -18,6 +18,9 @@ import
   ../../execution_chain/common/evmforks,
   ../../execution_chain/common/common
 
+const
+  pragueTimestamp = 1_741_159_776.EthTime
+
 proc parseTx(com: CommonRef, hexLine: string) =
   try:
     let
@@ -25,7 +28,7 @@ proc parseTx(com: CommonRef, hexLine: string) =
       tx = decodeTx(bytes)
       address = tx.recoverSender().expect("valid signature")
 
-    validateTxBasic(com, tx, FkPrague).isOkOr:
+    validateTxBasic(com, tx, FkPrague, pragueTimestamp).isOkOr:
       echo "err: ", error
 
     # everything ok


### PR DESCRIPTION
## EIP-7892: Blob Parameter Only Hard forks
Extends the existing blobSchedule implementation to also add timestamp based blob only forks, for e.g 
```json
"blobSchedule": {
  "cancun": {
    "target": 3,
    "max": 6,
    "baseFeeUpdateFraction": 3338477
  },
  "prague": {
    "target": 6,
    "max": 9,
    "baseFeeUpdateFraction": 5007716
  },
  "1740693335": {
    "target": 24,
    "max": 48,
    "baseFeeUpdateFraction": 5007716
  },
  "1743285335": {
    "target": 36,
    "max": 56,
    "baseFeeUpdateFraction": 5007716
  }
}
```

Considerations made are early participation in fusaka-devnet-0. 
During implementation it was found the current forking logic implemented by `nimbus-eth1` is not efficient and has quite a bit of redundancy. This should be improved in future PRs. ( Will make a detailed issue on this soon )

### TODOs
- [x] Clear unwanted comments and debugging code lines
- [ ] Optimise wherever it seems fit
- [ ] Add more tests 