### PR TITLE
Update Nimbus README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,11 +291,11 @@ portal-test-reproducibility:
 # Portal tests
 all_history_network_custom_chain_tests: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
-	$(ENV_SCRIPT) nim c -r $(NIM_PARAMS) -d:chronicles_log_level=ERROR -d:mergeBlockNumber:38130 -d:nimbus_db_backend=sqlite -o:build/$@ "portal/tests/history_network_tests/$@.nim"
+	$(ENV_SCRIPT) nim c -r $(NIM_PARAMS) -d:chronicles_log_level=ERROR -d:mergeBlockNumber:38130 -o:build/$@ "portal/tests/history_network_tests/$@.nim"
 
 all_portal_tests: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
-	$(ENV_SCRIPT) nim c -r $(NIM_PARAMS) -d:chronicles_log_level=ERROR -d:nimbus_db_backend=sqlite -o:build/$@ "portal/tests/$@.nim"
+	$(ENV_SCRIPT) nim c -r $(NIM_PARAMS) -d:chronicles_log_level=ERROR -o:build/$@ "portal/tests/$@.nim"
 
 # builds and runs the Portal test suite
 portal-test: | all_portal_tests all_history_network_custom_chain_tests

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ All consensus-layer client development is happening in parallel in the
 
 ## Development Updates
 
-Monthly development updates are shared
-[here](https://hackmd.io/jRpxY4WBQJ-hnsKaPDYqTw).
-
 For more detailed write-ups on the development progress, follow the
 [Nimbus blog](https://blog.nimbus.team/).
 
@@ -53,18 +50,18 @@ nix-shell default.nix
 # You'll run `make update` after each `git pull`, in the future, to keep those submodules up to date.
 # Assuming you have 4 CPU cores available, you can ask Make to run 4 parallel jobs, with "-j4".
 
-make -j4 nimbus
+make -j4 nimbus_execution_client
 
 # See available command line options
-build/nimbus --help
+build/nimbus_execution_client --help
 
 # Start syncing with mainnet
-build/nimbus
+build/nimbus_execution_client
 
 # Update to latest version
 git pull && make update
 # Build the newly downloaded version
-make -j4 nimbus
+make -j4 nimbus_execution_client
 
 # Run tests
 make test
@@ -112,7 +109,7 @@ ln -s mingw32-make.exe make.exe
 You can now follow those instructions in the previous section. For example:
 
 ```bash
-make nimbus # build the Nimbus execution client binary
+make nimbus_execution_client # build the Nimbus execution client binary
 make test # run the test suite
 # etc.
 ```
@@ -144,9 +141,9 @@ cd status
 # Raspberry pi doesn't include /usr/local/lib in library search path - need to add
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
-git clone https://github.com/status-im/nimbus.git
+git clone https://github.com/status-im/nimbus-eth1.git
 
-cd nimbus
+cd nimbus-eth1
 
 # Follow instructions above!
 ```
@@ -168,15 +165,15 @@ Note, the Ubuntu PRoot is known to contain all Nimbus prerequisites compiled on 
 apt install git make gcc
 
 # Clone repo and build Nimbus just like above
-git clone https://github.com/status-im/nimbus.git
+git clone https://github.com/status-im/nimbus-eth1.git
 
-cd nimbus
+cd nimbus_execution_client
 
-make
+make update
 
-make nimbus
+make nimbus_execution_client
 
-build/nimbus
+build/nimbus_execution_client
 ```
 ### <a name="make-xvars"></a>Experimental make variables
 
@@ -201,12 +198,6 @@ has the same effect as &lt;variable&gt;=1 (ditto for other numbers.)
 
 Interesting Make variables and targets are documented in the [nimbus-build-system](https://github.com/status-im/nimbus-build-system) repo.
 
-- you can switch the DB backend with a Nim compiler define:
-  `-d:nimbus_db_backend=...` where the (case-insensitive) value is one of
-  "rocksdb" (the default), "sqlite", "lmdb"
-
-- the Premix debugging tools are [documented separately](premix/readme.md)
-
 - you can control the Makefile's verbosity with the V variable (defaults to 0):
 
 ```bash
@@ -217,8 +208,8 @@ make V=2 test # even more verbose
 - same for the [Chronicles log level](https://github.com/status-im/nim-chronicles#chronicles_log_level):
 
 ```bash
-make LOG_LEVEL=DEBUG nimbus # this is the default
-make LOG_LEVEL=TRACE nimbus # log everything
+make LOG_LEVEL=DEBUG nimbus_execution_client # this is the default
+make LOG_LEVEL=TRACE nimbus_execution_client # log everything
 ```
 
 - pass arbitrary parameters to the Nim compiler:
@@ -315,7 +306,7 @@ Install Prometheus and Grafana. On Gentoo, it's `emerge prometheus grafana-bin`.
 
 ```bash
 # build Nimbus execution client
-make nimbus
+make nimbus_execution_client
 # the Prometheus daemon will create its data dir in the current dir, so give it its own directory
 mkdir ../my_metrics
 # copy the basic config file over there
@@ -349,7 +340,7 @@ to the combined view. To edit a panel, click on its title and select "Edit".
 
 ### Troubleshooting
 
-Report any errors you encounter, please, if not [already documented](https://github.com/status-im/nimbus/issues)!
+Report any errors you encounter, please, if not [already documented](https://github.com/status-im/nimbus-eth1/issues)!
 
 * Turn it off and on again:
 

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -102,13 +102,11 @@ task nimbus_portal_client, "Build nimbus_portal_client":
   buildBinary "nimbus_portal_client", "portal/client/", "-d:chronicles_log_level=TRACE"
 
 task portal_test, "Run Portal tests":
-  # Need the nimbus_db_backend in state network tests as we need a Hexary to
-  # start from, even though it only uses the MemoryDb.
-  test "portal/tests/history_network_tests/", "all_history_network_custom_chain_tests", "-d:chronicles_log_level=ERROR -d:nimbus_db_backend=sqlite"
+  test "portal/tests/history_network_tests/", "all_history_network_custom_chain_tests", "-d:chronicles_log_level=ERROR
   # Seperate build for these tests as they are run with a low `mergeBlockNumber`
   # to make the tests faster. Using the real mainnet merge block number is not
   # realistic for these tests.
-  test "portal/tests", "all_portal_tests", "-d:chronicles_log_level=ERROR -d:nimbus_db_backend=sqlite -d:mergeBlockNumber:38130"
+  test "portal/tests", "all_portal_tests", "-d:chronicles_log_level=ERROR -d:mergeBlockNumber:38130"
 
 task utp_test_app, "Build uTP test app":
   buildBinary "utp_test_app", "portal/tools/utp_testing/", "-d:chronicles_log_level=TRACE"
@@ -125,7 +123,7 @@ task nimbus_verified_proxy, "Build Nimbus verified proxy":
   buildBinary "nimbus_verified_proxy", "nimbus_verified_proxy/", "-d:chronicles_log_level=TRACE"
 
 task nimbus_verified_proxy_test, "Run Nimbus verified proxy tests":
-  test "nimbus_verified_proxy/tests", "all_proxy_tests", "-d:chronicles_log_level=ERROR -d:nimbus_db_backend=sqlite"
+  test "nimbus_verified_proxy/tests", "all_proxy_tests", "-d:chronicles_log_level=ERROR
 
 task build_fuzzers, "Build fuzzer test cases":
   # This file is there to be able to quickly build the fuzzer test cases in

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -102,7 +102,7 @@ task nimbus_portal_client, "Build nimbus_portal_client":
   buildBinary "nimbus_portal_client", "portal/client/", "-d:chronicles_log_level=TRACE"
 
 task portal_test, "Run Portal tests":
-  test "portal/tests/history_network_tests/", "all_history_network_custom_chain_tests", "-d:chronicles_log_level=ERROR
+  test "portal/tests/history_network_tests/", "all_history_network_custom_chain_tests", "-d:chronicles_log_level=ERROR"
   # Seperate build for these tests as they are run with a low `mergeBlockNumber`
   # to make the tests faster. Using the real mainnet merge block number is not
   # realistic for these tests.
@@ -123,7 +123,7 @@ task nimbus_verified_proxy, "Build Nimbus verified proxy":
   buildBinary "nimbus_verified_proxy", "nimbus_verified_proxy/", "-d:chronicles_log_level=TRACE"
 
 task nimbus_verified_proxy_test, "Run Nimbus verified proxy tests":
-  test "nimbus_verified_proxy/tests", "all_proxy_tests", "-d:chronicles_log_level=ERROR
+  test "nimbus_verified_proxy/tests", "all_proxy_tests", "-d:chronicles_log_level=ERROR"
 
 task build_fuzzers, "Build fuzzer test cases":
   # This file is there to be able to quickly build the fuzzer test cases in


### PR DESCRIPTION
The `make nimbus` make target is deprecated so this PR updates the references in the readme to use the new target `make nimbus_execution_client`.

Also removes some broken links and outdated information and removes the unused `nimbus_db_backend` flag from the build and docs.