### PR TITLE
Portal client: Increase the default number of content queue workers

### DIFF
--- a/portal/client/nimbus_portal_client_conf.nim
+++ b/portal/client/nimbus_portal_client_conf.nim
@@ -427,7 +427,7 @@ type
       hidden,
       desc:
         "The number of content queue workers to create for concurrent processing of received offers",
-      defaultValue: 8,
+      defaultValue: 50,
       name: "debug-content-queue-workers"
     .}: int
 

--- a/portal/network/beacon/beacon_network.nim
+++ b/portal/network/beacon/beacon_network.nim
@@ -199,7 +199,7 @@ proc new*(
     trustedBlockRoot: Opt[Eth2Digest],
     bootstrapRecords: openArray[Record] = [],
     portalConfig: PortalProtocolConfig = defaultPortalProtocolConfig,
-    contentQueueWorkers = 8,
+    contentQueueWorkers = 50,
     contentQueueSize = 50,
 ): T =
   let

--- a/portal/network/history/history_network.nim
+++ b/portal/network/history/history_network.nim
@@ -353,7 +353,7 @@ proc new*(
     bootstrapRecords: openArray[Record] = [],
     portalConfig: PortalProtocolConfig = defaultPortalProtocolConfig,
     contentRequestRetries = 1,
-    contentQueueWorkers = 8,
+    contentQueueWorkers = 50,
     contentQueueSize = 50,
 ): T =
   let

--- a/portal/network/state/state_network.nim
+++ b/portal/network/state/state_network.nim
@@ -57,7 +57,7 @@ proc new*(
     historyNetwork = Opt.none(HistoryNetwork),
     validateStateIsCanonical = true,
     contentRequestRetries = 1,
-    contentQueueWorkers = 8,
+    contentQueueWorkers = 50,
     contentQueueSize = 50,
 ): T =
   let


### PR DESCRIPTION
After testing more using a local testnet I found that increasing the content queue workers significantly increases the throughput of content processing and reduces the number of `DeclinedRateLimited` accept codes received from peers while not causing any additional timeouts or errors.