### PR TITLE
Portal bridge: Use startEra and endEra parameters in history bridge backfill audit

### DIFF
--- a/portal/bridge/history/portal_history_bridge.nim
+++ b/portal/bridge/history/portal_history_bridge.nim
@@ -357,7 +357,6 @@ proc runBackfillLoop(
 proc runBackfillLoopAuditMode(
     bridge: PortalHistoryBridge, era1Dir: string, startEra: uint64, endEra: uint64
 ) {.async: (raises: [CancelledError]).} =
-
   let
     rng = newRng()
     db = Era1DB.new(era1Dir, "mainnet", loadAccumulator())

--- a/portal/bridge/history/portal_history_bridge.nim
+++ b/portal/bridge/history/portal_history_bridge.nim
@@ -357,13 +357,12 @@ proc runBackfillLoop(
 proc runBackfillLoopAuditMode(
     bridge: PortalHistoryBridge, era1Dir: string, startEra: uint64, endEra: uint64
 ) {.async: (raises: [CancelledError]).} =
-  const eraSize = 8192
 
   let
     rng = newRng()
     db = Era1DB.new(era1Dir, "mainnet", loadAccumulator())
-    blockLowerBound = startEra * eraSize # inclusive
-    blockUpperBound = ((endEra + 1) * eraSize) - 1 # inclusive
+    blockLowerBound = startEra * EPOCH_SIZE # inclusive
+    blockUpperBound = ((endEra + 1) * EPOCH_SIZE) - 1 # inclusive
     blockRange = blockUpperBound - blockLowerBound
 
   var blockTuple: BlockTuple


### PR DESCRIPTION
In the Portal history bridge backfill mode we use the `startEra` and `endEra` parameters when `audit=false` but when `audit` is set to true then these parameters are ignored. I think it would be more useful to bound the range of randomly selected block numbers to be within the era parameters. The defaults are still the same so that if no `startEra` and `endEra` parameters are supplied then we should still sample from the same block range as before.