### PR TITLE
aristo: fold Adm column family into Vtx

### DIFF
--- a/execution_chain/db/aristo/aristo_blobify.nim
+++ b/execution_chain/db/aristo/aristo_blobify.nim
@@ -224,7 +224,7 @@ proc blobify*(vtx: VertexRef, key: HashKey): seq[byte] =
 
 proc blobifyTo*(lSst: SavedState; data: var seq[byte]) =
   ## Serialise a last saved state record
-  data.add lSst.key.data
+  data.add lSst.vTop.uint64.toBytesBE
   data.add lSst.serial.toBytesBE
   data.add @[0x7fu8]
 
@@ -340,8 +340,8 @@ proc deblobify*(record: openArray[byte], T: type HashKey): Opt[HashKey] =
 
 proc deblobify*(
     data: openArray[byte];
-    T: type SavedState;
-      ): Result[SavedState,AristoError] =
+    T: type SavedStateV0;
+      ): Result[SavedStateV0,AristoError] =
   ## De-serialise the last saved state data record previously encoded with
   ## `blobify()`.
   if data.len != 41:
@@ -349,9 +349,25 @@ proc deblobify*(
   if data[^1] != 0x7f:
     return err(DeblobWrongType)
 
-  ok(SavedState(
+  ok(SavedStateV0(
     key: Hash32(array[32, byte].initCopyFrom(data.toOpenArray(0, 31))),
     serial: uint64.fromBytesBE data.toOpenArray(32, 39)))
+
+proc deblobify*(
+    data: openArray[byte];
+    T: type SavedState;
+      ): Result[SavedState,AristoError] =
+  ## De-serialise the last saved state data record previously encoded with
+  ## `blobify()`.
+  if data.len != 17:
+    debugEcho "data ", data.len
+    return err(DeblobWrongSize)
+  if data[^1] != 0x7f:
+    return err(DeblobWrongType)
+
+  ok(SavedState(
+    vTop: VertexID(uint64.fromBytesBE data.toOpenArray(0, 7)),
+    serial: uint64.fromBytesBE data.toOpenArray(8, 15)))
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -97,12 +97,10 @@ type
     ## Backend interface.
     getVtxFn*: GetVtxFn              ## Read vertex record
     getKeyFn*: GetKeyFn              ## Read Merkle hash/key
-    getTuvFn*: GetTuvFn              ## Read top used vertex ID
     getLstFn*: GetLstFn              ## Read saved state
 
     putBegFn*: PutBegFn              ## Start bulk store session
     putVtxFn*: PutVtxFn              ## Bulk store vertex records
-    putTuvFn*: PutTuvFn              ## Store top used vertex ID
     putLstFn*: PutLstFn              ## Store saved state
     putEndFn*: PutEndFn              ## Commit bulk store session
 

--- a/execution_chain/db/aristo/aristo_desc/desc_backend.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_backend.nim
@@ -57,12 +57,6 @@ type
         ## Generic backend database bulk storage function, `VertexRef(nil)`
         ## values indicate that records should be deleted.
 
-  PutTuvFn* =
-    proc(hdl: PutHdlRef; vs: VertexID)
-      {.gcsafe, raises: [].}
-        ## Generic backend database ID generator storage function for the
-        ## top used vertex ID.
-
   PutLstFn* =
     proc(hdl: PutHdlRef; lst: SavedState)
       {.gcsafe, raises: [].}

--- a/execution_chain/db/aristo/aristo_desc/desc_structural.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_structural.nim
@@ -79,9 +79,15 @@ type
     vid*: VertexID                   ## Table lookup vertex ID (if any)
     vtx*: VertexRef                  ## Reference to vertex
 
+  SavedStateV0* = object
+    ## Legacy saved state from when state lived in separate column family
+    ## TODO remove before beta
+    key*: Hash32                     ## Some state hash (if any)
+    serial*: uint64                  ## Generic identifier from application
+
   SavedState* = object
     ## Last saved state
-    key*: Hash32                     ## Some state hash (if any)
+    vTop*: VertexID                   ## Top used VertexID
     serial*: uint64                  ## Generic identifier from application
 
   GetVtxFlag* = enum

--- a/execution_chain/db/aristo/aristo_get.nim
+++ b/execution_chain/db/aristo/aristo_get.nim
@@ -21,18 +21,12 @@ import
 # Public functions
 # ------------------------------------------------------------------------------
 
-proc getTuvBe*(
-    db: AristoDbRef;
-      ): Result[VertexID,AristoError] =
-  ## Get the ID generator state from the backened if available.
-  db.getTuvFn()
-  
 proc getLstBe*(
     db: AristoDbRef;
       ): Result[SavedState,AristoError] =
   ## Get the last saved state
   db.getLstFn()
-  
+
 proc getVtxBe*(
     db: AristoDbRef;
     rvid: RootedVertexID;

--- a/execution_chain/db/aristo/aristo_init/init_common.nim
+++ b/execution_chain/db/aristo/aristo_init/init_common.nim
@@ -82,7 +82,7 @@ proc finishSession*(hdl: TypedPutHdlRef; db: TypedBackendRef) =
     db.txId = 0
 
 proc initInstance*(db: AristoDbRef): Result[void, AristoError] =
-  let vTop = ?db.getTuvFn()
+  let vTop = (?db.getLstFn()).vTop
   db.txRef = AristoTxRef(db: db, vTop: vTop, snapshot: Snapshot(level: Opt.some(0)))
   db.accLeaves = LruCache[Hash32, AccLeafRef].init(ACC_LRU_SIZE)
   db.stoLeaves = LruCache[Hash32, StoLeafRef].init(ACC_LRU_SIZE)

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -24,6 +24,8 @@ import
 
 export minilru, rocksdb_desc
 
+const AdmKey* = default(seq[byte])
+
 type
   RdbWriteEventCb* =
     proc(session: WriteBatchRef): bool {.gcsafe, raises: [].}
@@ -38,7 +40,7 @@ type
 
   RdbInst* = object
     baseDb*: RocksDbInstanceRef
-    admCol*: ColFamilyReadWrite        ## Admin column family handler
+    admCol*: ColFamilyReadWrite        ## Legacy column family for administrative data
     vtxCol*: ColFamilyReadWrite        ## Vertex column family handler
 
     # Note that the key type `VertexID` for LRU caches requires that there is
@@ -64,7 +66,7 @@ type
 
   AristoCFs* = enum
     ## Column family symbols/handles and names used on the database
-    AdmCF = "AriAdm"                   ## Admin column family name
+    AdmCF = "AriAdm"                   ## Admin column family name (deprecated)
     VtxCF = "AriVtx"                   ## Vertex column family name
 
   RdbLruCounter* = array[bool, Atomic[uint64]]

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_init.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_init.nim
@@ -114,8 +114,8 @@ proc init*(rdb: var RdbInst, opts: DbOptions, baseDb: RocksDbInstanceRef) =
     )
 
   # Initialise column handlers (this stores implicitely `baseDb`)
-  rdb.admCol = baseDb.db.getColFamily($AdmCF).valueOr:
-    raiseAssert "Cannot initialise AdmCF descriptor: " & error
+  rdb.admCol = baseDb.db.getColFamily($AdmCF).valueOr(default(ColFamilyReadWrite))
+
   rdb.vtxCol = baseDb.db.getColFamily($VtxCF).valueOr:
     raiseAssert "Cannot initialise VtxCF descriptor: " & error
 

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_put.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_put.nim
@@ -17,7 +17,6 @@ import
   rocksdb,
   results,
   ../../[aristo_blobify, aristo_desc],
-  ../init_common,
   ./rdb_desc
 
 const
@@ -56,22 +55,21 @@ proc commit*(rdb: var RdbInst, session: SharedWriteBatchRef): Result[void,(Arist
 
 proc putAdm*(
     rdb: var RdbInst; session: SharedWriteBatchRef,
-    xid: AdminTabID;
     data: openArray[byte];
-      ): Result[void,(AdminTabID,AristoError,string)] =
+      ): Result[void,(AristoError,string)] =
   let dsc = session.batch
   if data.len == 0:
-    dsc.delete(xid.toOpenArray, rdb.admCol.handle()).isOkOr:
+    dsc.delete(AdmKey, rdb.vtxCol.handle()).isOkOr:
       const errSym = RdbBeDriverDelAdmError
       when extraTraceMessages:
         trace logTxt "putAdm()", xid, error=errSym, info=error
-      return err((xid,errSym,error))
+      return err((errSym,error))
   else:
-    dsc.put(xid.toOpenArray, data, rdb.admCol.handle()).isOkOr:
+    dsc.put(AdmKey, data, rdb.vtxCol.handle()).isOkOr:
       const errSym = RdbBeDriverPutAdmError
       when extraTraceMessages:
         trace logTxt "putAdm()", xid, error=errSym, info=error
-      return err((xid,errSym,error))
+      return err((errSym,error))
   ok()
 
 proc putVtx*(

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -118,7 +118,7 @@ proc persist*(
     return
 
   let lSst = SavedState(
-    key: emptyRoot, # placeholder for more
+    vTop: txFrame.vTop,
     serial: txFrame.blockNumber.expect("`checkpoint` before persisting frame"),
   )
 
@@ -203,7 +203,6 @@ with --debug-eager-state-root."""
     do:
       db.putVtxFn(batch, rvid, vtx, default(HashKey))
 
-  db.putTuvFn(batch, txFrame.vTop)
   db.putLstFn(batch, lSst)
 
   # TODO above, we only prepare the changes to the database but don't actually

--- a/execution_chain/db/core_db/backend/aristo_rocksdb.nim
+++ b/execution_chain/db/core_db/backend/aristo_rocksdb.nim
@@ -152,9 +152,12 @@ proc newRocksDbCoreDbRef*(basePath: string, opts: DbOptions): CoreDbRef =
   # The same column family options are used for all column families meaning that
   # the options are a compromise between the various write and access patterns
   # of what's stored in there - there's room for improvement here!
+
+  # Legacy support: adm CF, if it exists
+
   let
     (dbOpts, cfOpts) = opts.toRocksDb()
-    cfDescs = (AristoCFs.items().toSeq().mapIt($it) & KvtCFs.items().toSeq().mapIt($it))
+    cfDescs = @[$AristoCFs.VtxCF] & KvtCFs.items().toSeq().mapIt($it)
     baseDb = RocksDbInstanceRef.open(basePath, dbOpts, cfOpts, cfDescs).expect(
         "Open database from " & basePath
       )


### PR DESCRIPTION
Each column family in rocksdb requires its own set of SST files that must be kept open, cached etc. Further, wal files are [deleted]() only once all column families referencing them have been flushed meaning that low-volume families like Adm can keep them around far longer than makes sense.

Adm contains only two useful metadata entries and therefore it doesn't really make sense to allocate an entire CF for it.

Consolidating Adm into Vtx also makes it easier to reason about the internal consistency of the Vtx table - even though rocksdb ensures atomic cross-cf writes via the wal, it requires using a special batch write API that introduces its own overhead. With this change, don't need to rely on this particular rocksdb feature to maintain atomic consistency within Vtx.

Databases using the old schema are supported but rollback is not (ie the old metadata format/CF is read but not written)