### PR TITLE
Portal: default disable the Portal state network

### DIFF
--- a/execution_chain/evm/interpreter/op_handlers/oph_helpers.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_helpers.nim
@@ -15,7 +15,6 @@
 {.push raises: [].}
 
 import
-  ../../../core/eip7702,
   ../../evm_errors,
   ../../types,
   ../gas_costs,

--- a/portal/client/nimbus_portal_client_conf.nim
+++ b/portal/client/nimbus_portal_client_conf.nim
@@ -106,8 +106,7 @@ type
 
     portalSubnetworks* {.
       desc: "Select which networks (Portal sub-protocols) to enable",
-      defaultValue:
-        {PortalSubnetwork.history, PortalSubnetwork.state, PortalSubnetwork.beacon},
+      defaultValue: {PortalSubnetwork.history, PortalSubnetwork.beacon},
       name: "portal-subnetworks"
     .}: set[PortalSubnetwork]
 


### PR DESCRIPTION
Portal state network will no longer receive support from EF for the foreseeable future. 

It is currently in a development state that is not sufficiently finished to be of any use other than testing the ongoing R&D of itself. That means it is of no use for an end user, thus disabling this by default.