### PR TITLE
Async EVM: Return ok when error message exists so that call output can be returned 

### DIFF
--- a/portal/evm/async_evm.nim
+++ b/portal/evm/async_evm.nim
@@ -311,10 +311,7 @@ proc call*(
     callResult =
       ?(await evm.callFetchingState(vmState, header, tx, optimisticStateFetch))
 
-  if callResult.error.len() > 0:
-    err("EVM execution failed: " & callResult.error)
-  else:
-    ok(callResult)
+  ok(callResult)
 
 proc createAccessList*(
     evm: AsyncEvm, header: Header, tx: TransactionArgs, optimisticStateFetch = true

--- a/portal/rpc/rpc_eth_api.nim
+++ b/portal/rpc/rpc_eth_api.nim
@@ -9,6 +9,7 @@
 
 import
   std/sequtils,
+  stew/byteutils,
   json_rpc/rpcserver,
   chronicles,
   web3/[eth_api_types, conversions],
@@ -462,6 +463,13 @@ proc installEthApiHandlers*(
 
     let callResult = (await evm.call(header, tx, optimisticStateFetch)).valueOr:
       raise newException(ValueError, error)
+
+    if callResult.error.len() > 0:
+      raise (ref ApplicationError)(
+        code: 3,
+        msg: callResult.error,
+        data: Opt.some(JsonString("\"" & callResult.output.to0xHex() & "\"")),
+      )
 
     return callResult.output
 


### PR DESCRIPTION
This is a minor fix to allow displaying the call result data when an EVM call execution reverts. Also updates the portal `eth_call` RPC to return the correct error message and data in the response. The nimbus verified proxy can use the same pattern as well later on.