### PR TITLE
Fix wire protocol ticker loop and txhash broadcast handling

### DIFF
--- a/execution_chain/sync/wire_protocol/types.nim
+++ b/execution_chain/sync/wire_protocol/types.nim
@@ -131,3 +131,5 @@ type
     actionHeartbeat*: Future[void].Raising([CancelledError])
     actionQueue*: AsyncQueue[ActionHandler]
     gossipEnabled*: bool
+    cleanupTimer*: Future[void].Raising([CancelledError])
+    brUpdateTimer*: Future[void].Raising([CancelledError])


### PR DESCRIPTION
The timer of cleanup and block range update are not recreated properly. Causing one of the longer timer never triggered.

Also improves tx hash receiver robustness against malicious peer.