### PR TITLE
Increase rpc http server chunk size to 1 MBytes

### DIFF
--- a/execution_chain/rpc.nim
+++ b/execution_chain/rpc.nim
@@ -31,7 +31,7 @@ export
 
 {.push gcsafe, raises: [].}
 
-const DefaultChunkSize = 8192
+const DefaultChunkSize = 1024*1024
 
 func serverEnabled(conf: NimbusConf): bool =
   conf.httpServerEnabled or


### PR DESCRIPTION
This will reduce engine api traffic. But don't know if this can help with the overall slowness mentioned in #3403

ping @advaita-saha 