### PR TITLE
Update Docker Buildx and Cache Actions

### DIFF
--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -56,10 +56,10 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Cache Docker layers
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION


Updates both docker/setup-buildx-action and actions/cache to their latest stable versions in the Kurtosis workflow configuration.

## Changes:
- Updates `docker/setup-buildx-action@v2` to `docker/setup-buildx-action@v3`
- Updates `actions/cache@v3` to `actions/cache@v4`

## References:
- docker/setup-buildx-action v3.11.1: https://github.com/docker/setup-buildx-action/releases/tag/v3.11.1
- actions/cache v4.2.3: https://github.com/actions/cache/releases/tag/v4.2.3

This update ensures we're using the most recent stable versions of these actions in our Kurtosis workflow, providing better security and performance improvements.