### PR TITLE
feat: add admin_peers and admin ns

### DIFF
--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -96,6 +96,7 @@ type
     ## RPC flags
     Eth                           ## enable eth_ set of RPC API
     Debug                         ## enable debug_ set of RPC API
+    Admin                         ## enable admin_ set of RPC API
 
   DiscoveryType* {.pure.} = enum
     None
@@ -433,7 +434,7 @@ type
         name: "rpc" }: bool
 
       rpcApi {.
-        desc: "Enable specific set of RPC API (available: eth, debug)"
+        desc: "Enable specific set of RPC API (available: eth, debug, admin)"
         defaultValue: @[]
         defaultValueDesc: $RpcFlag.Eth
         name: "rpc-api" }: seq[string]
@@ -444,7 +445,7 @@ type
         name: "ws" }: bool
 
       wsApi {.
-        desc: "Enable specific set of Websocket RPC API (available: eth, debug)"
+        desc: "Enable specific set of Websocket RPC API (available: eth, debug, admin)"
         defaultValue: @[]
         defaultValueDesc: $RpcFlag.Eth
         name: "ws-api" }: seq[string]
@@ -684,6 +685,7 @@ proc getRpcFlags(api: openArray[string]): set[RpcFlag] =
     case item.toLowerAscii()
     of "eth": result.incl RpcFlag.Eth
     of "debug": result.incl RpcFlag.Debug
+    of "admin": result.incl RpcFlag.Admin
     else:
       error "Unknown RPC API: ", name=item
       quit QuitFailure

--- a/execution_chain/networking/p2p_types.nim
+++ b/execution_chain/networking/p2p_types.nim
@@ -54,6 +54,7 @@ type
     awaitedMessages*: seq[FutureBase] # per `msgId` table
     snappyEnabled*: bool
     clientId*: string
+    inbound*: bool  # true if connection was initiated by remote peer
 
   SeenNode* = object
     nodeId*: NodeId

--- a/execution_chain/networking/rlpx.nim
+++ b/execution_chain/networking/rlpx.nim
@@ -1223,7 +1223,7 @@ proc rlpxConnect*(
   trace "Connecting to peer"
 
   let
-    peer = Peer(remote: remote, network: node)
+    peer = Peer(remote: remote, network: node, inbound: false)
     deadline = sleepAsync(connectionTimeout)
 
   var error = true
@@ -1320,7 +1320,7 @@ proc rlpxAccept*(
   initTracing(devp2pInfo, node.protocols)
 
   let
-    peer = Peer(network: node)
+    peer = Peer(network: node, inbound: true)
     deadline = sleepAsync(connectionTimeout)
 
   var error = true

--- a/execution_chain/rpc.nim
+++ b/execution_chain/rpc.nim
@@ -54,8 +54,7 @@ func installRPC(server: RpcServer,
     setupServerAPI(serverApi, server, nimbus.ctx)
 
   if RpcFlag.Admin in flags:
-    setupAdminRpc(nimbus.ethNode, conf, server)
-    setupAdminQuitRpc(server, nimbus)
+    setupAdminRpc(nimbus.ethNode, conf, server, nimbus)
 
   #  # Tracer is currently disabled
   # if RpcFlag.Debug in flags:

--- a/execution_chain/rpc.nim
+++ b/execution_chain/rpc.nim
@@ -53,14 +53,14 @@ func installRPC(server: RpcServer,
   if RpcFlag.Eth in flags:
     setupServerAPI(serverApi, server, nimbus.ctx)
 
+  if RpcFlag.Admin in flags:
+    setupAdminRpc(nimbus.ethNode, conf, server)
+    setupAdminQuitRpc(server, nimbus)
+
   #  # Tracer is currently disabled
   # if RpcFlag.Debug in flags:
   #   setupDebugRpc(com, nimbus.txPool, server)
 
-  server.rpc("admin_quit") do() -> string:
-    {.gcsafe.}:
-      nimbus.state = NimbusState.Stopping
-    result = "EXITING"
 
 proc newRpcWebsocketHandler(): RpcWebSocketHandler =
   let rng = HmacDrbgContext.new()

--- a/execution_chain/rpc/common.nim
+++ b/execution_chain/rpc/common.nim
@@ -68,7 +68,7 @@ proc setupCommonRpc*(node: EthereumNode, conf: NimbusConf, server: RpcServer) =
     let peerCount = uint node.numPeers
     result = w3Qty(peerCount)
 
-proc setupAdminRpc*(node: EthereumNode, conf: NimbusConf, server: RpcServer) =
+proc setupAdminRpc*(node: EthereumNode, conf: NimbusConf, server: RpcServer, nimbus: auto) =
   server.rpc("admin_nodeInfo") do() -> NodeInfo:
     let
       enode = toENode(node)
@@ -131,7 +131,6 @@ proc setupAdminRpc*(node: EthereumNode, conf: NimbusConf, server: RpcServer) =
     
     return peers
 
-proc setupAdminQuitRpc*(server: RpcServer, nimbus: auto) =
   server.rpc("admin_quit") do() -> string:
     {.gcsafe.}:
       nimbus.state = NimbusState.Stopping

--- a/execution_chain/rpc/common.nim
+++ b/execution_chain/rpc/common.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard library imports are prefixed with `std/`
-  std/json,
+  std/[json, sequtils],
   stint, json_rpc/server, json_rpc/errors,
   ../networking/[p2p, discoveryv4/enode, peer_pool, p2p_types],
   ../config,
@@ -91,7 +91,7 @@ proc setupAdminRpc*(node: EthereumNode, conf: NimbusConf, server: RpcServer, nim
     if res.isOk:
       asyncSpawn node.connectToNode(res.get())
       return true
-    raise (ref InvalidRequest)(code: -32602, msg: "Invalid ENode")
+    return false
 
   server.rpc("admin_peers") do() -> seq[PeerInfo]:
     var peers: seq[PeerInfo]

--- a/execution_chain/rpc/common.nim
+++ b/execution_chain/rpc/common.nim
@@ -8,12 +8,13 @@
 # those terms.
 
 import
+  # Standard library imports are prefixed with `std/`
+  std/json,
   stint, json_rpc/server, json_rpc/errors,
   ../networking/[p2p, discoveryv4/enode, peer_pool, p2p_types],
   ../config,
   ../beacon/web3_eth_conv,
-  web3/conversions,
-  json
+  web3/conversions
 
 {.push raises: [].}
 
@@ -106,9 +107,7 @@ proc setupAdminRpc*(node: EthereumNode, conf: NimbusConf, server: RpcServer) =
           localIp = $localEnode.address.ip
           localTcpPort = $localEnode.address.tcpPort
           
-        var caps: seq[string]
-        for capability in node.capabilities:
-          caps.add(capability.name & "/" & $capability.version)
+        let caps = node.capabilities.mapIt(it.name & "/" & $it.version)
         
         # Create protocols object with version info
         var protocolsObj = newJObject()

--- a/execution_chain/rpc/common.nim
+++ b/execution_chain/rpc/common.nim
@@ -106,8 +106,7 @@ proc setupAdminRpc*(node: EthereumNode, conf: NimbusConf, server: RpcServer) =
           localEnode = toENode(node)
           localIp = $localEnode.address.ip
           localTcpPort = $localEnode.address.tcpPort
-          
-        let caps = node.capabilities.mapIt(it.name & "/" & $it.version)
+          caps = node.capabilities.mapIt(it.name & "/" & $it.version)
         
         # Create protocols object with version info
         var protocolsObj = newJObject()

--- a/tests/test_configuration.nim
+++ b/tests/test_configuration.nim
@@ -104,6 +104,14 @@ proc configurationMain*() =
       let cx = cc.getRpcFlags()
       check { RpcFlag.Eth, RpcFlag.Debug } == cx
 
+      let dd = makeConfig(@["--rpc-api:admin"])
+      let dx = dd.getRpcFlags()
+      check { RpcFlag.Admin } == dx
+
+      let ee = makeConfig(@["--rpc-api:eth,admin"])
+      let ex = ee.getRpcFlags()
+      check { RpcFlag.Eth, RpcFlag.Admin } == ex
+
     test "ws-api":
       let conf = makeTestConfig()
       let flags = conf.getWsFlags()

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -24,7 +24,7 @@ import
   ../execution_chain/core/eip4844,
   ../execution_chain/utils/utils,
   ../execution_chain/[common, rpc],
-  ../execution_chain/rpc/rpc_types,
+  ../execution_chain/rpc/[rpc_types, common as rpc_common],
   ../execution_chain/beacon/web3_eth_conv,
   ../execution_chain/networking/p2p,
    ./test_helpers,
@@ -244,6 +244,7 @@ proc setupEnv(envFork: HardFork = MergeFork): TestEnv =
 
   setupServerAPI(serverApi, server, ctx)
   setupCommonRpc(node, conf, server)
+  setupAdminRpc(node, conf, server)
   server.start()
 
   TestEnv(
@@ -303,6 +304,8 @@ createRpcSigsFromNim(RpcClient):
   proc net_version(): string
   proc net_listening(): bool
   proc net_peerCount(): Quantity
+  proc admin_nodeInfo(): NodeInfo
+  proc admin_peers(): seq[PeerInfo]
 
 proc rpcMain*() =
   suite "Remote Procedure Calls":
@@ -336,6 +339,34 @@ proc rpcMain*() =
       let res = await client.net_peerCount()
       let peerCount = node.peerPool.connectedNodes.len
       check res == w3Qty(peerCount)
+
+    test "admin_nodeInfo":
+      let res = await client.admin_nodeInfo()
+      check:
+        res.id.len > 0
+        res.name == env.conf.agentString
+        res.enode.startsWith("enode://")
+        res.ip.len > 0
+        res.ports.discovery.len > 0
+        res.ports.listener.len > 0
+
+    test "admin_peers":
+      let peers = await client.admin_peers()
+      check peers.len == node.peerPool.connectedNodes.len
+      
+      # If there are peers, verify the structure matches Geth specification
+      for peer in peers:
+        check:
+          peer.caps.len > 0
+          peer.enode.startsWith("enode://")
+          peer.id.len > 0
+          peer.name.len > 0
+          peer.network.localAddress.len > 0
+          peer.network.remoteAddress.len > 0
+          # inbound field should be boolean (either true or false)
+          peer.network.inbound in [true, false]
+          peer.network.`static` in [true, false]
+          peer.network.trusted in [true, false]
 
     test "eth_chainId":
       let res = await client.eth_chainId()

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -363,10 +363,6 @@ proc rpcMain*() =
           peer.name.len > 0
           peer.network.localAddress.len > 0
           peer.network.remoteAddress.len > 0
-          # inbound field should be boolean (either true or false)
-          peer.network.inbound in [true, false]
-          peer.network.`static` in [true, false]
-          peer.network.trusted in [true, false]
 
     test "eth_chainId":
       let res = await client.eth_chainId()


### PR DESCRIPTION
fix #2780

Example output:
```sh
curl -L '127.0.0.1:36694' \
-H 'Content-Type: application/json' \
-H 'Accept: application/json' \
-d '{
  "method": "admin_peers",
  "id": 1,
  "jsonrpc": "2.0",
  "params": []
}'  | jq .
```
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": [
    {
      "caps": [
        "eth/69",
        "eth/68"
      ],
      "enode": "enode://b1de553bf833a47481d5ad9ab5b49802f6e52b42d8f63c7eba278f5c0f23763a98ab8502f140291d46bcd87e47d7a74454d404d647a083560d89f5e34b5bebc7@172.16.0.12:30303",
      "id": "d790e150ad02dfb526d7e9ba2210915d9631e563c4930a1789d058240c22980f",
      "name": "Geth/v1.15.12-unstable-78b60593-20250623/linux-arm64/go1.24.4",
      "network": {
        "inbound": false,
        "localAddress": "172.16.0.13:30303",
        "remoteAddress": "172.16.0.12:30303",
        "static": false,
        "trusted": false
      },
      "protocols": {
        "eth": {
          "version": 68
        }
      }
    },
    {
      "caps": [
        "eth/69",
        "eth/68"
      ],
      "enode": "enode://3c063c1d8d7b316215d526d654a48dd19834ed851aaaf17abd435393324f6dcb1804bf0e3cdaa15b19a388ffc4db6199b98c5ba1be61daf88591ea91f07f760a@172.16.0.14:30303",
      "id": "efe5b759e874523d0dc5d7bcd26a5989c6808b9fecedecfddd11f89c1ffd1de8",
      "name": "nimbus-eth1/v0.1.0-25ad87b5/linux-arm64/Nim-2.2.4",
      "network": {
        "inbound": false,
        "localAddress": "172.16.0.13:30303",
        "remoteAddress": "172.16.0.14:30303",
        "static": false,
        "trusted": false
      },
      "protocols": {
        "eth": {
          "version": 68
        }
      }
    }
  ]
}
```