### PR TITLE
Optimize getPayloadBodiesByHash/ByRange

### DIFF
--- a/execution_chain/beacon/api_handler/api_getbodies.nim
+++ b/execution_chain/beacon/api_handler/api_getbodies.nim
@@ -28,10 +28,10 @@ proc getPayloadBodiesByHash*(ben: BeaconEngineRef,
   var list = newSeqOfCap[Opt[ExecutionPayloadBodyV1]](hashes.len)
 
   for h in hashes:
-    var blk = ben.chain.payloadBodyV1ByHash(h).valueOr:
+    var body = ben.chain.payloadBodyV1ByHash(h).valueOr:
       list.add Opt.none(ExecutionPayloadBodyV1)
       continue
-    list.add Opt.some(move(blk))
+    list.add Opt.some(move(body))
 
   move(list)
 
@@ -51,7 +51,7 @@ proc getPayloadBodiesByRange*(ben: BeaconEngineRef,
     last = start+count-1
 
   if start > ben.chain.latestNumber:
-    # requested range beyond the latest known block
+    # requested range beyond the latest known block.
     return
 
   if last > ben.chain.latestNumber:
@@ -59,13 +59,14 @@ proc getPayloadBodiesByRange*(ben: BeaconEngineRef,
 
   var list = newSeqOfCap[Opt[ExecutionPayloadBodyV1]](last-start)
 
-  # get bodies from database
+  # get bodies from database.
   for bn in start..min(last, ben.chain.baseNumber):
-    var blk = ben.chain.payloadBodyV1ByNumber(bn).valueOr:
+    var body = ben.chain.payloadBodyV1ByNumber(bn).valueOr:
       list.add Opt.none(ExecutionPayloadBodyV1)
       continue
-    list.add Opt.some(move(blk))
+    list.add Opt.some(move(body))
 
+  # get bodies from cache in FC module.
   if last > ben.chain.baseNumber:
     ben.chain.payloadBodyV1FromBaseTo(last, list)
 

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -987,8 +987,9 @@ func payloadBodyV1FromBaseTo*(c: ForkedChainRef,
     branch = branches[i]
     for y in 0..<branch.len:
       let bd = addr branch.blocks[y]
-      if bd.blk.header.number <= last:
-        list.add Opt.some(toPayloadBody(bd.blk))
+      if bd.blk.header.number > last:
+        return
+      list.add Opt.some(toPayloadBody(bd.blk))
 
 func equalOrAncestorOf*(c: ForkedChainRef, blockHash: Hash32, childHash: Hash32): bool =
   if blockHash == childHash:

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -11,12 +11,12 @@
 {.push raises: [].}
 
 import
+  std/[tables, algorithm],
   chronicles,
   results,
   chronos,
-  std/[tables, algorithm],
   ../../common,
-  ../../db/[core_db, fcu_db],
+  ../../db/[core_db, fcu_db, payload_body_db],
   ../../evm/types,
   ../../evm/state,
   ../validate,
@@ -28,6 +28,7 @@ import
     block_quarantine]
 
 from std/sequtils import mapIt
+from web3/engine_api_types import ExecutionPayloadBodyV1
 
 logScope:
   topics = "forked chain"
@@ -892,6 +893,47 @@ proc blockByHash*(c: ForkedChainRef, blockHash: Hash32): Result[Block, string] =
       return c.portal.getBlockByHash(blockHash)
   blk
 
+proc payloadBodyV1ByHash*(c: ForkedChainRef, blockHash: Hash32): Result[ExecutionPayloadBodyV1, string] =
+  c.hashToBlock.withValue(blockHash, loc):
+    return ok(toPayloadBody(loc[].blk))
+
+  let header = ?c.baseTxFrame.getBlockHeader(blockHash)
+  var blk = c.baseTxFrame.getExecutionPayloadBodyV1(header)
+
+  # Serves portal data if block not found in db
+  if blk.isErr or (blk.get.transactions.len == 0 and header.transactionsRoot != zeroHash32):
+    if c.isPortalActive:
+      let blk = ?c.portal.getBlockByHash(blockHash)
+      return ok(toPayloadBody(blk))
+
+  move(blk)
+
+proc payloadBodyV1ByNumber*(c: ForkedChainRef, number: BlockNumber): Result[ExecutionPayloadBodyV1, string] =
+  if number > c.activeBranch.headNumber:
+    return err("Requested block number not exists: " & $number)
+
+  if number <= c.baseBranch.tailNumber:
+    let
+      header = ?c.baseTxFrame.getBlockHeader(number)
+      blk = c.baseTxFrame.getExecutionPayloadBodyV1(header)
+
+    # Txs not there in db - Happens during era1/era import, when we don't store txs and receipts
+    if blk.isErr or (blk.get.transactions.len == 0 and header.transactionsRoot != emptyRoot):
+      # Serves portal data if block not found in database
+      if c.isPortalActive:
+        let blk = ?c.portal.getBlockByNumber(number)
+        return ok(toPayloadBody(blk))
+
+    return blk
+
+  var branch = c.activeBranch
+  while not branch.isNil:
+    if number >= branch.tailNumber:
+      return ok(toPayloadBody(branch.blocks[number - branch.tailNumber].blk))
+    branch = branch.parent
+
+  err("Block not found, number = " & $number)
+
 proc blockByNumber*(c: ForkedChainRef, number: BlockNumber): Result[Block, string] =
   if number > c.activeBranch.headNumber:
     return err("Requested block number not exists: " & $number)
@@ -929,13 +971,24 @@ proc receiptsByBlockHash*(c: ForkedChainRef, blockHash: Hash32): Result[seq[Stor
 
   c.baseTxFrame.getReceipts(header.receiptsRoot)
 
-func blockFromBaseTo*(c: ForkedChainRef, number: BlockNumber): seq[Block] =
+func payloadBodyV1FromBaseTo*(c: ForkedChainRef,
+                              last: BlockNumber,
+                              list: var seq[Opt[ExecutionPayloadBodyV1]]) =
   # return block in reverse order
-  var branch = c.activeBranch
+  var
+    branch = c.activeBranch
+    branches = newSeqOfCap[BranchRef](c.branches.len)
+
   while not branch.isNil:
-    for i in countdown(branch.len-1, 0):
-      result.add(branch.blocks[i].blk)
+    branches.add(branch)
     branch = branch.parent
+
+  for i in countdown(branches.len-1, 0):
+    branch = branches[i]
+    for y in 0..<branch.len:
+      let bd = addr branch.blocks[y]
+      if bd.blk.header.number <= last:
+        list.add Opt.some(toPayloadBody(bd.blk))
 
 func equalOrAncestorOf*(c: ForkedChainRef, blockHash: Hash32, childHash: Hash32): bool =
   if blockHash == childHash:

--- a/execution_chain/db/payload_body_db.nim
+++ b/execution_chain/db/payload_body_db.nim
@@ -1,0 +1,84 @@
+# nimbus-execution-client
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+{.push gcsafe, raises: [].}
+
+import
+  chronicles,
+  web3/engine_api_types,
+  eth/common/blocks_rlp,
+  eth/common/hashes,
+  ./core_db/base,
+  ./core_db/core_apps,
+  ./storage_types,
+  ../constants,
+  ../beacon/web3_eth_conv
+
+# ------------------------------------------------------------------------------
+# Private helpers
+# ------------------------------------------------------------------------------
+
+template wrapRlpException(info: static[string]; code: untyped) =
+  try:
+    code
+  except RlpError as e:
+    return err(info & ": " & e.msg)
+
+proc read(rlp: var Rlp, T: type Quantity): T {.raises: [RlpError].} =
+  rlp.read(uint64).Quantity
+
+# ------------------------------------------------------------------------------
+# Public functions
+# ------------------------------------------------------------------------------
+
+proc getExecutionPayloadBodyV1*(
+    db: CoreDbTxRef;
+    header: Header;
+      ): Result[ExecutionPayloadBodyV1, string] =
+  const info = "getExecutionPayloadBodyV1()"
+  var body: ExecutionPayloadBodyV1
+  
+  for encodedTx in db.getBlockTransactionData(header.txRoot):
+    body.transactions.add TypedTransaction(encodedTx)
+
+  if header.withdrawalsRoot.isSome:
+    let withdrawalsRoot = header.withdrawalsRoot.value
+    if withdrawalsRoot == emptyRoot:
+      var wds: seq[WithdrawalV1]
+      body.withdrawals = Opt.some(wds)
+      return ok(move(body))
+
+    let bytes = db.get(withdrawalsKey(withdrawalsRoot).toOpenArray).valueOr:
+      if error.error != KvtNotFound:
+        warn info, withdrawalsRoot, error=($$error)
+      return ok(move(body))
+
+    wrapRlpException info:
+      var list = rlp.decode(bytes, seq[WithdrawalV1])
+      body.withdrawals = Opt.some(move(list))
+
+  ok(move(body))
+
+func toPayloadBody*(blk: Block): ExecutionPayloadBodyV1 {.raises:[].}  =
+  var wds: seq[WithdrawalV1]
+  if blk.withdrawals.isSome:
+    for w in blk.withdrawals.get:
+      wds.add w3Withdrawal(w)
+
+  ExecutionPayloadBodyV1(
+    transactions: w3Txs(blk.transactions),
+    # pre Shanghai block return null withdrawals
+    # post Shanghai block return at least empty slice
+    withdrawals: if blk.withdrawals.isSome:
+                   Opt.some(wds)
+                 else:
+                   Opt.none(seq[WithdrawalV1])
+  )
+  

--- a/execution_chain/db/storage_types.nim
+++ b/execution_chain/db/storage_types.nim
@@ -27,6 +27,7 @@ type
     fcuNumAndHash = 8
     fcState = 9
     beaconHeader = 10
+    wdKey = 11
 
   DbKey* = object
     # The first byte stores the key type. The rest are key-specific values
@@ -97,6 +98,11 @@ func beaconHeaderKey*(u: BlockNumber): DbKey =
 
 func fcStateKey*(u: uint64): DbKey {.inline.} =
   uint64KeyImpl(fcState)
+
+func withdrawalsKey*(h: Hash32): DbKey {.inline.} =
+  result.data[0] = byte ord(wdKey)
+  result.data[1 .. 32] = h.data
+  result.dataEndPos = uint8 32
 
 template toOpenArray*(k: DbKey): openArray[byte] =
   k.data.toOpenArray(0, int(k.dataEndPos))


### PR DESCRIPTION
Optimization area:
- Optimize withdrawals sequence read and write from database.
- Avoid conversion from rlp to tx to rlp again for TypedTransaction.
- Decode web3 types direcly from rlp instead via nim-eth types for withdrawals.
- Avoid conversion from nim-eth types by using web3 types in FC module if necessary.
- Fix bug found in getPayloadBodiesByRange pulling excessive bodies from FC module.


Combined with #3417, This should improves both getPayloadBodiesByHash and getPayloadBodiesByRange.

fix #3403