### PR TITLE
Revert "defer gc during block processing (#3384)"

### DIFF
--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -280,21 +280,15 @@ proc processBlock*(
     taskpool: Taskpool = nil,
 ): Result[void, string] =
   ## Generalised function to processes `blk` for any network.
+  ?vmState.procBlkPreamble(blk, skipValidation, skipReceipts, skipUncles, taskpool)
 
-  # Processing a block involves making lots and lots of small memory allocations
-  # meaning that GC overhead can make up for 15% of processing time in extreme
-  # cases - since each block is bounded in the amount of memory needed, we can
-  # run collection once per block instead.
-  deferGc:
-    ?vmState.procBlkPreamble(blk, skipValidation, skipReceipts, skipUncles, taskpool)
+  # EIP-3675: no reward for miner in POA/POS
+  if not vmState.com.proofOfStake(blk.header, vmState.ledger.txFrame):
+    vmState.calculateReward(blk.header, blk.uncles)
 
-    # EIP-3675: no reward for miner in POA/POS
-    if not vmState.com.proofOfStake(blk.header, vmState.ledger.txFrame):
-      vmState.calculateReward(blk.header, blk.uncles)
+  ?vmState.procBlkEpilogue(blk, skipValidation, skipReceipts, skipStateRootCheck)
 
-    ?vmState.procBlkEpilogue(blk, skipValidation, skipReceipts, skipStateRootCheck)
-
-    ok()
+  ok()
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/utils/utils.nim
+++ b/execution_chain/utils/utils.nim
@@ -173,18 +173,3 @@ func weiAmount*(w: Withdrawal): UInt256 =
 func isGenesis*(header: Header): bool =
   header.number == 0'u64 and
     header.parentHash == GENESIS_PARENT_HASH
-
-template deferGc*(body: untyped): untyped =
-  when declared(GC_disable):
-    GC_disable()
-
-  when declared(GC_enable):
-    defer:
-      GC_enable()
-      # Perform a small allocation which indirectly runs the garbage collector -
-      # unlike GC_fullCollect, this will use the usual nim heuristic for running
-      # the cycle colllector (which would be extremely expensive to run on each
-      # collection)
-      discard newSeq[int](1)
-
-  body


### PR DESCRIPTION
Deferred GC seemed like a good idea to reduce the amount of work done during block processing, but a side effect of this is that more memory ends up being allocated in certain workloads which in turn causes an overall slowdown, with a long test showing a net performance effect that hovers around 0% and more memory usage.

In particular, the troublesome range around 2M sees a 10-15% slowdown and an ugly memory usage spike.

Reverting for now - it might be worth revisiting in the future under different memory allocation patters, but as usual, it's better to not do work at all (like in #3444) than to do work faster.

This reverts commit 3a009158d3e381562cd4ff855033533dbeadd404.