### PR TITLE
Stateless: Simplify the witness table data structure

### DIFF
--- a/portal/evm/async_evm.nim
+++ b/portal/evm/async_evm.nim
@@ -180,23 +180,21 @@ proc callFetchingState(
       # state queries are still issued in the background just incase the state is
       # needed in the next iteration.
       var stateFetchDone = false
-      for k, v in witnessKeys:
-        let (adr, _) = k
+      for k, codeTouched in witnessKeys:
+        let (adr, maybeSlot) = k
         if adr == default(Address):
           continue
 
-        if v.storageMode:
-          let slotIdx = (adr, v.storageSlot)
-          if slotIdx notin fetchedStorage:
-            debug "Fetching storage slot", address = adr, slotKey = v.storageSlot
-            let storageFut = evm.backend.getStorage(header, adr, v.storageSlot)
+        if maybeSlot.isSome():
+          let slot = maybeSlot.get()
+          if (adr, slot) notin fetchedStorage:
+            debug "Fetching storage slot", address = adr, slot
+            let storageFut = evm.backend.getStorage(header, adr, slot)
             if not stateFetchDone:
-              storageQueries.add(StorageQuery.init(adr, v.storageSlot, storageFut))
+              storageQueries.add(StorageQuery.init(adr, slot, storageFut))
               if not optimisticStateFetch:
                 stateFetchDone = true
         else:
-          doAssert(adr == v.address)
-
           if adr notin fetchedAccounts:
             debug "Fetching account", address = adr
             let accFut = evm.backend.getAccount(header, adr)
@@ -205,7 +203,7 @@ proc callFetchingState(
               if not optimisticStateFetch:
                 stateFetchDone = true
 
-          if v.codeTouched and adr notin fetchedCode:
+          if codeTouched and adr notin fetchedCode:
             debug "Fetching code", address = adr
             let codeFut = evm.backend.getCode(header, adr)
             if not stateFetchDone:
@@ -336,13 +334,13 @@ proc createAccessList*(
   # returned in the callResult.
 
   var al = access_list.AccessList.init()
-  for lookupKey, witnessKey in witnessKeys:
-    let (adr, _) = lookupKey
+  for k, codeTouched in witnessKeys:
+    let (adr, maybeSlot) = k
     if adr == fromAdr:
       continue
 
-    if witnessKey.storageMode:
-      al.add(adr, witnessKey.storageSlot)
+    if maybeSlot.isSome():
+      al.add(adr, maybeSlot.get())
     else:
       al.add(adr)
 

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -657,11 +657,11 @@ proc runLedgerBasicOperationsTests() =
 
         let
           witnessKeys = ac.getWitnessKeys()
-          keyData = witnessKeys.getOrDefault((addr1, addr1.toAccountKey))
+          key = (addr1, Opt.none(UInt256))
         check:
           witnessKeys.len() == 1
-          keyData.address == addr1
-          keyData.codeTouched == false
+          witnessKeys.contains(key)
+          witnessKeys.getOrDefault(key) == false
 
       test "Witness keys - Get code":
         var
@@ -672,11 +672,11 @@ proc runLedgerBasicOperationsTests() =
 
         let
           witnessKeys = ac.getWitnessKeys()
-          keyData = witnessKeys.getOrDefault((addr1, addr1.toAccountKey))
+          key = (addr1, Opt.none(UInt256))
         check:
           witnessKeys.len() == 1
-          keyData.address == addr1
-          keyData.codeTouched == true
+          witnessKeys.contains(key)
+          witnessKeys.getOrDefault(key) == true
 
       test "Witness keys - Get storage":
         var
@@ -688,10 +688,11 @@ proc runLedgerBasicOperationsTests() =
 
         let
           witnessKeys = ac.getWitnessKeys()
-          keyData = witnessKeys.getOrDefault((addr1, slot1.toSlotKey))
+          key = (addr1, Opt.some(slot1))
         check:
           witnessKeys.len() == 2
-          keyData.storageSlot == slot1
+          witnessKeys.contains(key)
+          witnessKeys.getOrDefault(key) == false
 
       test "Witness keys - Set storage":
         var
@@ -703,10 +704,11 @@ proc runLedgerBasicOperationsTests() =
 
         let
           witnessKeys = ac.getWitnessKeys()
-          keyData = witnessKeys.getOrDefault((addr1, slot1.toSlotKey))
+          key = (addr1, Opt.some(slot1))
         check:
           witnessKeys.len() == 2
-          keyData.storageSlot == slot1
+          witnessKeys.contains(key)
+          witnessKeys.getOrDefault(key) == false
 
       test "Witness keys - Get account, code and storage":
         var
@@ -728,31 +730,30 @@ proc runLedgerBasicOperationsTests() =
         let witnessKeys = ac.getWitnessKeys()
         check witnessKeys.len() == 5
 
-        var keysList = newSeq[(Address, WitnessKey)]()
+        var keysList = newSeq[(WitnessKey, bool)]()
         for k, v in witnessKeys:
-          let (adr, _) = k
-          keysList.add((adr, v))
+          keysList.add((k, v))
 
         check:
-          keysList[0][0] == addr1
-          keysList[0][1].address == addr1
-          keysList[0][1].codeTouched == true
+          keysList[0][0].address == addr1
+          keysList[0][0].slot == Opt.none(UInt256)
+          keysList[0][1] == true
 
-          keysList[1][0] == addr2
-          keysList[1][1].address == addr2
-          keysList[1][1].codeTouched == true
+          keysList[1][0].address == addr2
+          keysList[1][0].slot == Opt.none(UInt256)
+          keysList[1][1] == true
 
-          keysList[2][0] == addr2
-          keysList[2][1].storageSlot == slot1
+          keysList[2][0].address == addr2
+          keysList[2][0].slot == Opt.some(slot1)
+          keysList[2][1] == false
 
-          keysList[3][0] == addr1
-          keysList[3][1].storageSlot == slot1
+          keysList[3][0].address == addr1
+          keysList[3][0].slot == Opt.some(slot1)
+          keysList[3][1] == false
 
-          keysList[4][0] == addr3
-          keysList[4][1].address == addr3
-          keysList[4][1].codeTouched == false
-
-
+          keysList[4][0].address == addr3
+          keysList[4][0].slot == Opt.none(UInt256)
+          keysList[4][1] == false
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
The witness table is used to collect the keys of read state when executing transactions. This PR simplifies the data structure by removing redundant info in order to simplify the code. This witness table is currently used in the Async EVM but will also be used when building execution witnesses for stateless.