### PR TITLE
aristo: switch to vector memtable

### DIFF
--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_put.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_put.nim
@@ -46,7 +46,7 @@ proc rollback*(rdb: var RdbInst, session: SharedWriteBatchRef) =
 proc commit*(rdb: var RdbInst, session: SharedWriteBatchRef): Result[void,(AristoError,string)] =
   if not session.isClosed():
     defer: session.close()
-    rdb.baseDb.commit(session).isOkOr:
+    rdb.baseDb.commit(session, rdb.vtxCol).isOkOr:
       const errSym = RdbBeDriverWriteError
       when extraTraceMessages:
         trace logTxt "commit", error=errSym, info=error

--- a/execution_chain/db/core_db/backend/aristo_rocksdb.nim
+++ b/execution_chain/db/core_db/backend/aristo_rocksdb.nim
@@ -73,17 +73,22 @@ proc toRocksDb*(
   if opts.writeBufferSize > 0:
     cfOpts.writeBufferSize = opts.writeBufferSize
 
-  # When data is written to rocksdb, it is first put in an in-memory table
-  # whose index is a skip list. Since the mem table holds the most recent data,
-  # all reads must go through this skiplist which results in slow lookups for
-  # already-written data.
-  # We enable a bloom filter on the mem table to avoid this lookup in the cases
-  # where the data is actually on disk already (ie wasn't updated recently).
-  # TODO there's also a hashskiplist that has both a hash index and a skip list
-  #      which maybe could be used - uses more memory, requires a key prefix
-  #      extractor
-  cfOpts.memtableWholeKeyFiltering = true
-  cfOpts.memtablePrefixBloomSizeRatio = 0.1
+  # When data is written to rocksdb, it is first put in an in-memory table. The
+  # default implementation is a skip list whose overhead is quite significant
+  # both when inserting and during lookups - up to 10% CPU time has been
+  # observed in it.
+  # Instead of using a skip list, we'll bulk-load changes into a vector which
+  # immediately is flushed to L0/1 thus avoiding memtables completely (our own
+  # in-memory caches perform a similar task with less serialization).
+  # A downside of this approach is that the memtable *has* to be flushed in the
+  # main thread instead of this operation happening in the background - however,
+  # the time it takes to flush is less than it takes to build the skip list, so
+  # this ends up being a net win regardless.
+  cfOpts.setMemtableVectorRep()
+
+  # L0 files may overlap, so we want to push them down to L1 quickly so as to
+  # not have to read/examine too many files to find data
+  cfOpts.level0FileNumCompactionTrigger = 2
 
   # ZSTD seems to cut database size to 2/3 roughly, at the time of writing
   # Using it for the bottom-most level means it applies to 90% of data but
@@ -96,20 +101,17 @@ proc toRocksDb*(
   # https://github.com/facebook/rocksdb/wiki/Dictionary-Compression
   cfOpts.bottommostCompression = Compression.zstdCompression
 
-  # TODO In the AriVtx table, we don't do lookups that are expected to result
-  #      in misses thus we could avoid the filter cost - this does not apply to
-  #      other tables since their API admit queries that might result in
-  #      not-found - specially the KVT which is exposed to external queries and
-  #      the `HashKey` cache (AriKey)
-  # https://github.com/EighteenZi/rocksdb_wiki/blob/master/Memory-usage-in-RocksDB.md#indexes-and-filter-blocks
-  # https://github.com/facebook/rocksdb/blob/af50823069818fc127438e39fef91d2486d6e76c/include/rocksdb/advanced_options.h#L696
-  # cfOpts.optimizeFiltersForHits = true
-
-  cfOpts.maxBytesForLevelBase = cfOpts.writeBufferSize
+  # With the default options, we end up with 512MB at the base level - a
+  # multiplier of 16 means that we can fit 128GB in the next two levels - the
+  # more levels, the greater the read amplification at an expense of write
+  # amplification - given that we _mostly_ read, this feels like a reasonable
+  # tradeoff.
+  cfOpts.maxBytesForLevelBase = cfOpts.writeBufferSize * 8
+  cfOpts.maxBytesForLevelMultiplier = 16
 
   # Reduce number of files when the database grows
   cfOpts.targetFileSizeBase = cfOpts.writeBufferSize
-  cfOpts.targetFileSizeMultiplier = 6
+  cfOpts.targetFileSizeMultiplier = 4
 
   # We certainly don't want to re-compact historical data over and over
   cfOpts.ttl = 0
@@ -117,6 +119,9 @@ proc toRocksDb*(
 
   let dbOpts = defaultDbOptions(autoClose = true)
   dbOpts.maxOpenFiles = opts.maxOpenFiles
+
+  # Needed for vector memtable
+  dbOpts.allowConcurrentMemtableWrite = false
 
   if opts.rowCacheSize > 0:
     # Good for GET queries, which is what we do most of the time - however,
@@ -126,19 +131,11 @@ proc toRocksDb*(
     # https://github.com/facebook/rocksdb/blob/af50823069818fc127438e39fef91d2486d6e76c/include/rocksdb/options.h#L1276
     dbOpts.rowCache = cacheCreateLRU(opts.rowCacheSize, autoClose = true)
 
-  # Without this option, WAL files might never get removed since a small column
-  # family (like the admin CF) with only tiny writes might keep it open - this
-  # negatively affects startup times since the WAL is replayed on every startup.
-  # https://github.com/facebook/rocksdb/blob/af50823069818fc127438e39fef91d2486d6e76c/include/rocksdb/options.h#L719
-  # Flushing the oldest
-  let writeBufferSize =
-    if opts.writeBufferSize > 0: opts.writeBufferSize else: cfOpts.writeBufferSize
-
-  # The larger the value, the fewer files will be created but the longer the
-  # startup time (because this much data must be replayed)
-  dbOpts.maxTotalWalSize = 3 * writeBufferSize + 1024 * 1024
-
   dbOpts.keepLogFileNum = 16 # No point keeping 1000 log files around...
+
+  # Parallelize L0 -> Ln compaction
+  # https://github.com/facebook/rocksdb/wiki/Subcompaction
+  dbOpts.maxSubcompactions = dbOpts.maxBackgroundJobs
 
   (dbOpts, cfOpts)
 

--- a/execution_chain/db/core_db/backend/rocksdb_desc.nim
+++ b/execution_chain/db/core_db/backend/rocksdb_desc.nim
@@ -10,7 +10,7 @@
 
 {.push raises: [].}
 
-import std/[os, sequtils, sets], rocksdb
+import std/[os, sequtils, sets], rocksdb, chronicles
 
 export rocksdb, sets
 
@@ -30,6 +30,7 @@ type
     refs*: int
     commits*: int
     closes*: int
+    families*: seq[ColFamilyReadWrite]
 
 func dataDir*(baseDir: string): string =
   baseDir / BaseFolder / DataFolder
@@ -56,13 +57,22 @@ proc close*(session: SharedWriteBatchRef) =
     session.commits = 0
     session.closes = 0
 
+
 proc commit*(
-    rdb: RocksDbInstanceRef, session: SharedWriteBatchRef
+    rdb: RocksDbInstanceRef, session: SharedWriteBatchRef, cf: ColFamilyReadWrite
 ): Result[void, string] =
   session.commits += 1
+  session.families.add cf
   if session.commits == session.refs:
     # Write to disk if everyone that opened a session also committed it
     ?rdb.db.write(session.batch)
+    # This flush forces memtables to be written to disk, which is necessary given
+    # the use of vector memtables which have very bad lookup performance.
+    rdb.db.flush(session.families.mapIt(it.handle())).isOkOr:
+      # Not sure what to do here - the commit above worked so it would be strange
+      # to have an error here
+      warn "Could not flush database", error
+
   ok()
 
 proc open*(

--- a/execution_chain/db/kvt/kvt_init/rocks_db/rdb_put.nim
+++ b/execution_chain/db/kvt/kvt_init/rocks_db/rdb_put.nim
@@ -52,7 +52,7 @@ proc rollback*(rdb: var RdbInst, session: SharedWriteBatchRef) =
 proc commit*(rdb: var RdbInst, session: SharedWriteBatchRef): Result[void,(KvtError,string)] =
   if not session.isClosed():
     defer: session.close()
-    rdb.baseDb.commit(session).isOkOr:
+    rdb.baseDb.commit(session, rdb.store[KvtGeneric]).isOkOr:
       const errSym = RdbBeDriverWriteError
       when extraTraceMessages:
         trace logTxt "commit", error=errSym, info=error


### PR DESCRIPTION
Every time we persist, we collect all changes into a batch and write that batch to a memtable which rocksdb lazily will write to disk using a background thread.

The default implementation of the memtable in rocksdb is a skip list which can handle concurrent writes while still allowing lookups. We're not using concurrent inserts and the skip list comes with significant overhead both when writing and when reading.

Here, we switch to a vector memtable which is faster to write but terrible to read. To compensate, we then proceed to flush the memtable eagerly to disk which is a blocking operation.

One would think that the blocking of the main thread this would be bad but it turns out that creating the skip list, also a blocking operation, is even slower, resulting in a net win.

Coupled with this change, we also make the "lower" levels bigger effectively reducing the average number of levels that must be looked at to find recently written data. This could lead to some write amplicification which is offset by making each file smaller and therefore making compactions more targeted.

Taken together, this results in an overall import speed boost of about 3-4%, but above all, it reduces the main thread blocking time during persist.

pre (for 8k blocks persisted around block 11M):
```
DBG 2025-07-03 15:58:14.053+02:00 Core DB persisted
kvtDur=8ms182us947ns mptDur=4s640ms879us492ns endDur=10s50ms862us669ns
stateRoot=none()
```

post:
```
DBG 2025-07-03 14:48:59.426+02:00 Core DB persisted
kvtDur=12ms476us833ns mptDur=4s273ms629us840ns endDur=3s331ms171us989ns
stateRoot=none()
```