### PR TITLE
Stateless: Make collection of witness keys in ledger configurable at runtime

### DIFF
--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -90,6 +90,11 @@ type
     taskpool*: Taskpool
       ## Shared task pool for offloading computation to other threads
 
+    statelessProviderEnabled*: bool
+      ## Enable the stateless provider. This turns on the features required
+      ## by stateless clients such as generation and stored of block witnesses
+      ## and serving these witnesses to peers over the p2p network.
+
 # ------------------------------------------------------------------------------
 # Private helper functions
 # ------------------------------------------------------------------------------
@@ -161,7 +166,8 @@ proc init(com         : CommonRef,
           networkId   : NetworkId,
           config      : ChainConfig,
           genesis     : Genesis,
-          initializeDb: bool) =
+          initializeDb: bool,
+          statelessProviderEnabled: bool) =
 
 
   config.daoCheck()
@@ -199,6 +205,8 @@ proc init(com         : CommonRef,
   if initializeDb:
     com.initializeDb()
 
+  com.statelessProviderEnabled = statelessProviderEnabled
+
 proc isBlockAfterTtd(com: CommonRef, header: Header, txFrame: CoreDbTxRef): bool =
   if com.config.terminalTotalDifficulty.isNone:
     return false
@@ -221,6 +229,7 @@ proc new*(
     networkId: NetworkId = MainNet;
     params = networkParams(MainNet);
     initializeDb = true;
+    statelessProviderEnabled = false
       ): CommonRef =
 
   ## If genesis data is present, the forkIds will be initialized
@@ -232,7 +241,8 @@ proc new*(
     networkId,
     params.config,
     params.genesis,
-    initializeDb)
+    initializeDb,
+    statelessProviderEnabled)
 
 proc new*(
     _: type CommonRef;
@@ -241,6 +251,7 @@ proc new*(
     config: ChainConfig;
     networkId: NetworkId = MainNet;
     initializeDb = true;
+    statelessProviderEnabled = false
       ): CommonRef =
 
   ## There is no genesis data present
@@ -252,7 +263,8 @@ proc new*(
     networkId,
     config,
     nil,
-    initializeDb)
+    initializeDb,
+    statelessProviderEnabled)
 
 func clone*(com: CommonRef, db: CoreDbRef): CommonRef =
   ## clone but replace the db
@@ -265,6 +277,7 @@ func clone*(com: CommonRef, db: CoreDbRef): CommonRef =
     genesisHash  : com.genesisHash,
     genesisHeader: com.genesisHeader,
     networkId    : com.networkId,
+    statelessProviderEnabled: com.statelessProviderEnabled
   )
 
 func clone*(com: CommonRef): CommonRef =

--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -92,7 +92,7 @@ type
 
     statelessProviderEnabled*: bool
       ## Enable the stateless provider. This turns on the features required
-      ## by stateless clients such as generation and stored of block witnesses
+      ## by stateless clients such as generation and storage of block witnesses
       ## and serving these witnesses to peers over the p2p network.
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -410,6 +410,15 @@ type
       desc: "Eagerly check state roots when syncing finalized blocks"
       name: "debug-eager-state-root".}: bool
 
+    statelessProviderEnabled* {.
+      separator: "\pSTATELESS PROVIDER OPTIONS:"
+      hidden
+      desc: "Enable the stateless provider. This turns on the features required" &
+        " by stateless clients such as generation and stored of block witnesses" &
+        " and serving these witnesses to peers over the p2p network."
+      defaultValue: false
+      name: "stateless-provider" }: bool
+
     case cmd* {.
       command
       defaultValue: NimbusCmd.noCommand }: NimbusCmd
@@ -500,15 +509,6 @@ type
           " is auto-generated."
         defaultValueDesc: "\"jwt.hex\" in the data directory (see --data-dir)"
         name: "jwt-secret" .}: Option[InputFile]
-
-      statelessProviderEnabled* {.
-        separator: "\pSTATELESS PROVIDER OPTIONS:"
-        hidden
-        desc: "Enable the stateless provider. This turns on the features required" &
-          " by stateless clients such as generation and stored of block witnesses" &
-          " and serving these witnesses to peers over the p2p network."
-        defaultValue: false
-        name: "stateless-provider" }: bool
 
     of `import`:
       maxBlocks* {.

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -38,19 +38,16 @@ const
     # in greater detail.
   slotsLruSize = 16 * 1024
 
-  statelessEnabled = defined(stateless)
-
-when statelessEnabled:
-  type
-    WitnessKey* = tuple[
-      address: Address,
-      slot: Opt[UInt256]
-    ]
-
-    # Maps witness keys to the codeTouched flag
-    WitnessTable* = OrderedTable[WitnessKey, bool]
 
 type
+  WitnessKey* = tuple[
+    address: Address,
+    slot: Opt[UInt256]
+  ]
+
+  # Maps witness keys to the codeTouched flag
+  WitnessTable* = OrderedTable[WitnessKey, bool]
+
   AccountFlag = enum
     Alive
     IsNew
@@ -95,10 +92,10 @@ type
       ## over and over again to the database to avoid the WAL and compation
       ## write amplification that ensues
 
-    when statelessEnabled:
-      witnessKeys: WitnessTable
-        ## Used to collect the keys of all read accounts, code and storage slots.
-        ## Maps a tuple of address and slot (optional) to the codeTouched flag.
+    collectWitness: bool
+    witnessKeys: WitnessTable
+      ## Used to collect the keys of all read accounts, code and storage slots.
+      ## Maps a tuple of address and slot (optional) to the codeTouched flag.
 
 
   ReadOnlyLedger* = distinct LedgerRef
@@ -169,7 +166,7 @@ proc getAccount(
     address: Address;
     shouldCreate = true;
       ): AccountRef =
-  when statelessEnabled:
+  if ac.collectWitness:
     let lookupKey = (address, Opt.none(UInt256))
     if not ac.witnessKeys.contains(lookupKey):
       ac.witnessKeys[lookupKey] = false
@@ -371,12 +368,13 @@ proc makeDirty(ac: LedgerRef, address: Address, cloneStorage = true): AccountRef
 # ------------------------------------------------------------------------------
 
 # The LedgerRef is modeled after TrieDatabase for it's transaction style
-proc init*(x: typedesc[LedgerRef], db: CoreDbTxRef, storeSlotHash: bool): LedgerRef =
+proc init*(x: typedesc[LedgerRef], db: CoreDbTxRef, storeSlotHash: bool, collectWitness = false): LedgerRef =
   new result
   result.txFrame = db
   result.storeSlotHash = storeSlotHash
   result.code = typeof(result.code).init(codeLruSize)
   result.slots = typeof(result.slots).init(slotsLruSize)
+  result.collectWitness = collectWitness
   discard result.beginSavepoint
 
 proc init*(x: typedesc[LedgerRef], db: CoreDbTxRef): LedgerRef =
@@ -460,7 +458,7 @@ proc getNonce*(ac: LedgerRef, address: Address): AccountNonce =
 proc getCode*(ac: LedgerRef,
               address: Address,
               returnHash: static[bool] = false): auto =
-  when statelessEnabled:
+  if ac.collectWitness:
     let lookupKey = (address, Opt.none(UInt256))
     # We overwrite any existing record here so that codeTouched is always set to
     # true even if an account was previously accessed without touching the code
@@ -524,7 +522,7 @@ proc resolveCode*(ac: LedgerRef, address: Address): CodeBytesRef =
 proc getCommittedStorage*(ac: LedgerRef, address: Address, slot: UInt256): UInt256 =
   let acc = ac.getAccount(address, false)
 
-  when statelessEnabled:
+  if ac.collectWitness:
     let lookupKey = (address, Opt.some(slot))
     if not ac.witnessKeys.contains(lookupKey):
       ac.witnessKeys[lookupKey] = false
@@ -536,7 +534,7 @@ proc getCommittedStorage*(ac: LedgerRef, address: Address, slot: UInt256): UInt2
 proc getStorage*(ac: LedgerRef, address: Address, slot: UInt256): UInt256 =
   let acc = ac.getAccount(address, false)
 
-  when statelessEnabled:
+  if ac.collectWitness:
     let lookupKey = (address, Opt.some(slot))
     if not ac.witnessKeys.contains(lookupKey):
       ac.witnessKeys[lookupKey] = false
@@ -623,7 +621,7 @@ proc setStorage*(ac: LedgerRef, address: Address, slot, value: UInt256) =
   let acc = ac.getAccount(address)
   acc.flags.incl {Alive}
 
-  when statelessEnabled:
+  if ac.collectWitness:
     let lookupKey = (address, Opt.some(slot))
     if not ac.witnessKeys.contains(lookupKey):
       ac.witnessKeys[lookupKey] = false
@@ -880,12 +878,11 @@ proc getStorageProof*(ac: LedgerRef, address: Address, slots: openArray[UInt256]
 
   storageProof
 
-when statelessEnabled:
-  func getWitnessKeys*(ac: LedgerRef): WitnessTable =
-    ac.witnessKeys
+func getWitnessKeys*(ac: LedgerRef): WitnessTable =
+  ac.witnessKeys
 
-  proc clearWitnessKeys*(ac: LedgerRef) =
-    ac.witnessKeys.clear()
+proc clearWitnessKeys*(ac: LedgerRef) =
+  ac.witnessKeys.clear()
 
 # ------------------------------------------------------------------------------
 # Public virtual read-only methods

--- a/execution_chain/evm/state.nim
+++ b/execution_chain/evm/state.nim
@@ -91,7 +91,7 @@ proc new*(
   ## with the `parent` block header.
   new result
   result.init(
-    ac       = LedgerRef.init(txFrame, storeSlotHash),
+    ac       = LedgerRef.init(txFrame, storeSlotHash, com.statelessProviderEnabled),
     parent   = parent,
     blockCtx = blockCtx,
     com      = com,
@@ -158,7 +158,7 @@ proc init*(
   ## It requires the `header` argument properly initalised so that for PoA
   ## networks, the miner address is retrievable via `ecRecover()`.
   self.init(
-    ac       = LedgerRef.init(txFrame, storeSlotHash),
+    ac       = LedgerRef.init(txFrame, storeSlotHash, com.statelessProviderEnabled),
     parent   = parent,
     blockCtx = blockCtx(header),
     com      = com,

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -236,7 +236,8 @@ proc run(nimbus: NimbusNode, conf: NimbusConf) =
     db = coreDB,
     taskpool = taskpool,
     networkId = conf.networkId,
-    params = conf.networkParams)
+    params = conf.networkParams,
+    statelessProviderEnabled = conf.statelessProviderEnabled)
 
   if conf.extraData.len > 32:
     warn "ExtraData exceeds 32 bytes limit, truncate",

--- a/portal/evm/async_evm.nim
+++ b/portal/evm/async_evm.nim
@@ -104,7 +104,7 @@ proc init*(
     taskpool = nil,
     config = chainConfigForNetwork(networkId),
     initializeDb = false,
-    statelessProviderEnabled = true # Enables collection of witness keys
+    statelessProviderEnabled = true, # Enables collection of witness keys
   )
 
   AsyncEvm(com: com, backend: backend)

--- a/portal/evm/async_evm.nim
+++ b/portal/evm/async_evm.nim
@@ -104,6 +104,7 @@ proc init*(
     taskpool = nil,
     config = chainConfigForNetwork(networkId),
     initializeDb = false,
+    statelessProviderEnabled = true # Enables collection of witness keys
   )
 
   AsyncEvm(com: com, backend: backend)

--- a/portal/nim.cfg
+++ b/portal/nim.cfg
@@ -13,5 +13,3 @@
 @end
 
 --hint[Processing]:off
-
--d:"stateless"

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -646,114 +646,113 @@ proc runLedgerBasicOperationsTests() =
       check 2.u256 in vals
       check 3.u256 in vals
 
-    when defined(stateless):
 
-      test "Witness keys - Get account":
-        var
-          ac = LedgerRef.init(memDB.baseTxFrame())
-          addr1 = initAddr(1)
+    test "Witness keys - Get account":
+      var
+        ac = LedgerRef.init(memDB.baseTxFrame(), false, collectWitness = true)
+        addr1 = initAddr(1)
 
-        discard ac.getAccount(addr1)
+      discard ac.getAccount(addr1)
 
-        let
-          witnessKeys = ac.getWitnessKeys()
-          key = (addr1, Opt.none(UInt256))
-        check:
-          witnessKeys.len() == 1
-          witnessKeys.contains(key)
-          witnessKeys.getOrDefault(key) == false
+      let
+        witnessKeys = ac.getWitnessKeys()
+        key = (addr1, Opt.none(UInt256))
+      check:
+        witnessKeys.len() == 1
+        witnessKeys.contains(key)
+        witnessKeys.getOrDefault(key) == false
 
-      test "Witness keys - Get code":
-        var
-          ac = LedgerRef.init(memDB.baseTxFrame())
-          addr1 = initAddr(1)
+    test "Witness keys - Get code":
+      var
+        ac = LedgerRef.init(memDB.baseTxFrame(), false, collectWitness = true)
+        addr1 = initAddr(1)
 
-        discard ac.getCode(addr1)
+      discard ac.getCode(addr1)
 
-        let
-          witnessKeys = ac.getWitnessKeys()
-          key = (addr1, Opt.none(UInt256))
-        check:
-          witnessKeys.len() == 1
-          witnessKeys.contains(key)
-          witnessKeys.getOrDefault(key) == true
+      let
+        witnessKeys = ac.getWitnessKeys()
+        key = (addr1, Opt.none(UInt256))
+      check:
+        witnessKeys.len() == 1
+        witnessKeys.contains(key)
+        witnessKeys.getOrDefault(key) == true
 
-      test "Witness keys - Get storage":
-        var
-          ac = LedgerRef.init(memDB.baseTxFrame())
-          addr1 = initAddr(1)
-          slot1 = 1.u256
+    test "Witness keys - Get storage":
+      var
+        ac = LedgerRef.init(memDB.baseTxFrame(), false, collectWitness = true)
+        addr1 = initAddr(1)
+        slot1 = 1.u256
 
-        discard ac.getStorage(addr1, slot1)
+      discard ac.getStorage(addr1, slot1)
 
-        let
-          witnessKeys = ac.getWitnessKeys()
-          key = (addr1, Opt.some(slot1))
-        check:
-          witnessKeys.len() == 2
-          witnessKeys.contains(key)
-          witnessKeys.getOrDefault(key) == false
+      let
+        witnessKeys = ac.getWitnessKeys()
+        key = (addr1, Opt.some(slot1))
+      check:
+        witnessKeys.len() == 2
+        witnessKeys.contains(key)
+        witnessKeys.getOrDefault(key) == false
 
-      test "Witness keys - Set storage":
-        var
-          ac = LedgerRef.init(memDB.baseTxFrame())
-          addr1 = initAddr(1)
-          slot1 = 1.u256
+    test "Witness keys - Set storage":
+      var
+        ac = LedgerRef.init(memDB.baseTxFrame(), false, collectWitness = true)
+        addr1 = initAddr(1)
+        slot1 = 1.u256
 
-        ac.setStorage(addr1, slot1, slot1)
+      ac.setStorage(addr1, slot1, slot1)
 
-        let
-          witnessKeys = ac.getWitnessKeys()
-          key = (addr1, Opt.some(slot1))
-        check:
-          witnessKeys.len() == 2
-          witnessKeys.contains(key)
-          witnessKeys.getOrDefault(key) == false
+      let
+        witnessKeys = ac.getWitnessKeys()
+        key = (addr1, Opt.some(slot1))
+      check:
+        witnessKeys.len() == 2
+        witnessKeys.contains(key)
+        witnessKeys.getOrDefault(key) == false
 
-      test "Witness keys - Get account, code and storage":
-        var
-          ac = LedgerRef.init(memDB.baseTxFrame())
-          addr1 = initAddr(1)
-          addr2 = initAddr(2)
-          addr3 = initAddr(3)
-          slot1 = 1.u256
+    test "Witness keys - Get account, code and storage":
+      var
+        ac = LedgerRef.init(memDB.baseTxFrame(), false, collectWitness = true)
+        addr1 = initAddr(1)
+        addr2 = initAddr(2)
+        addr3 = initAddr(3)
+        slot1 = 1.u256
 
 
-        discard ac.getAccount(addr1)
-        discard ac.getCode(addr2)
-        discard ac.getCode(addr1)
-        discard ac.getStorage(addr2, slot1)
-        discard ac.getStorage(addr1, slot1)
-        discard ac.getStorage(addr2, slot1)
-        discard ac.getAccount(addr3)
+      discard ac.getAccount(addr1)
+      discard ac.getCode(addr2)
+      discard ac.getCode(addr1)
+      discard ac.getStorage(addr2, slot1)
+      discard ac.getStorage(addr1, slot1)
+      discard ac.getStorage(addr2, slot1)
+      discard ac.getAccount(addr3)
 
-        let witnessKeys = ac.getWitnessKeys()
-        check witnessKeys.len() == 5
+      let witnessKeys = ac.getWitnessKeys()
+      check witnessKeys.len() == 5
 
-        var keysList = newSeq[(WitnessKey, bool)]()
-        for k, v in witnessKeys:
-          keysList.add((k, v))
+      var keysList = newSeq[(WitnessKey, bool)]()
+      for k, v in witnessKeys:
+        keysList.add((k, v))
 
-        check:
-          keysList[0][0].address == addr1
-          keysList[0][0].slot == Opt.none(UInt256)
-          keysList[0][1] == true
+      check:
+        keysList[0][0].address == addr1
+        keysList[0][0].slot == Opt.none(UInt256)
+        keysList[0][1] == true
 
-          keysList[1][0].address == addr2
-          keysList[1][0].slot == Opt.none(UInt256)
-          keysList[1][1] == true
+        keysList[1][0].address == addr2
+        keysList[1][0].slot == Opt.none(UInt256)
+        keysList[1][1] == true
 
-          keysList[2][0].address == addr2
-          keysList[2][0].slot == Opt.some(slot1)
-          keysList[2][1] == false
+        keysList[2][0].address == addr2
+        keysList[2][0].slot == Opt.some(slot1)
+        keysList[2][1] == false
 
-          keysList[3][0].address == addr1
-          keysList[3][0].slot == Opt.some(slot1)
-          keysList[3][1] == false
+        keysList[3][0].address == addr1
+        keysList[3][0].slot == Opt.some(slot1)
+        keysList[3][1] == false
 
-          keysList[4][0].address == addr3
-          keysList[4][0].slot == Opt.none(UInt256)
-          keysList[4][1] == false
+        keysList[4][0].address == addr3
+        keysList[4][0].slot == Opt.none(UInt256)
+        keysList[4][1] == false
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_stateless_witness.nim
+++ b/tests/test_stateless_witness.nim
@@ -21,7 +21,6 @@ suite "Execution Witness Tests":
 
     let witnessBytes = witness.encode()
     check witnessBytes.len() > 0
-    echo witnessBytes
 
     let decodedWitness = ExecutionWitness.decode(witnessBytes)
     check:
@@ -37,7 +36,6 @@ suite "Execution Witness Tests":
 
     let witnessBytes = witness.encode()
     check witnessBytes.len() > 0
-    echo witnessBytes
 
     let decodedWitness = ExecutionWitness.decode(witnessBytes)
     check:


### PR DESCRIPTION
This PR enables the collection of witness keys in the ledger at runtime via the hidden statelessProviderEnabled CLI flag. These witness keys will be used to build the execution witnesses which will be stored in the database for each block when statelessProviderEnabled is true.