### PR TITLE
Update Actions Cache Version and Minor Documentation Fixes

### DIFF
--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -59,7 +59,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Cache Docker layers
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/hive_integration/README.md
+++ b/hive_integration/README.md
@@ -118,7 +118,7 @@ in a markdown file with the same name with the simulator.
 
 * Problem:<br>
   _hive_ bails out with error when compiling docker compile because
-  it cannot resolve some domain name like _github.com_. It occured with
+  it cannot resolve some domain name like _github.com_. It occurred with
   a locally running DNS resolver (as opposed to a proxy type resolver.)
 
 * Solution:<br>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,7 +24,7 @@ python block-import-stats.py
 * Pass the two CSV files to the script
 
 By default, the script will skip block numbers below 500k since these are mostly
-unintersting.
+uninteresting.
 
 See `-h` for help text on running the script.
 


### PR DESCRIPTION


---



**Description:**
- Upgraded GitHub Actions cache from `v3` to `v4` in workflow for improved reliability.
- Fixed a typo in `hive_integration/README.md` ("occured" → "occurred").
- Minor wording improvement in `scripts/README.md` for clarity.



---