### PR TITLE
Update Dockerfile to supported OS

### DIFF
--- a/docker/dist/base_image/Dockerfile.amd64
+++ b/docker/dist/base_image/Dockerfile.amd64
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -16,7 +16,7 @@
 # it once, upload it to Docker Hub and make sure it's being pulled regularly so
 # it's not deleted after 6 months of inactivity.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/base_image/Dockerfile.arm
+++ b/docker/dist/base_image/Dockerfile.arm
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -16,7 +16,7 @@
 # it once, upload it to Docker Hub and make sure it's being pulled regularly so
 # it's not deleted after 6 months of inactivity.
 
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/base_image/Dockerfile.arm64
+++ b/docker/dist/base_image/Dockerfile.arm64
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -16,7 +16,7 @@
 # it once, upload it to Docker Hub and make sure it's being pulled regularly so
 # it's not deleted after 6 months of inactivity.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/base_image/Dockerfile.macos
+++ b/docker/dist/base_image/Dockerfile.macos
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -16,7 +16,7 @@
 # it once, upload it to Docker Hub and make sure it's being pulled regularly so
 # it's not deleted after 6 months of inactivity.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/base_image/Dockerfile.win64
+++ b/docker/dist/base_image/Dockerfile.win64
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -16,7 +16,7 @@
 # it once, upload it to Docker Hub and make sure it's being pulled regularly so
 # it's not deleted after 6 months of inactivity.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 SHELL ["/bin/bash", "-c"]
 

--- a/hive_integration/nimbus/Dockerfile
+++ b/hive_integration/nimbus/Dockerfile
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at
 #     https://opensource.org/licenses/MIT).
@@ -11,7 +11,7 @@
 
 # Docker container spec for building the master branch of nimbus.
 
-FROM debian:buster-slim AS build
+FROM debian:bullseye-slim AS build
 
 RUN apt-get update \
  && apt-get install -y --fix-missing build-essential make git libpcre3-dev librocksdb-dev \
@@ -32,7 +32,7 @@ RUN cd nimbus-eth1 && \
 # --------------------------------- #
 # Starting new image to reduce size #
 # --------------------------------- #
-FROM debian:buster-slim AS deploy
+FROM debian:bullseye-slim AS deploy
 
 RUN apt-get update \
  && apt-get install -y librocksdb-dev bash curl jq\

--- a/portal/docker/Dockerfile
+++ b/portal/docker/Dockerfile
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-FROM debian:buster-slim AS build
+FROM debian:bullseye-slim AS build
 
 RUN apt-get update \
  && apt-get install -y --fix-missing build-essential make git \
@@ -30,7 +30,7 @@ RUN cd nimbus-eth1 && \
 # --------------------------------- #
 # Starting new image to reduce size #
 # --------------------------------- #
-FROM debian:buster-slim AS deploy
+FROM debian:bullseye-slim AS deploy
 
 COPY --from=build /usr/bin/nimbus_portal_client /usr/bin/nimbus_portal_client
 

--- a/portal/tools/utp_testing/docker/Dockerfile
+++ b/portal/tools/utp_testing/docker/Dockerfile
@@ -1,4 +1,14 @@
-FROM debian:buster-slim AS build
+# Portal
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at
+#     https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at
+#     https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+FROM debian:bullseye-slim AS build
 
 RUN apt-get update \
  && apt-get install -y --fix-missing build-essential make git libpcre3-dev librocksdb-dev \
@@ -18,7 +28,7 @@ RUN cd nimbus-eth1 && \
     make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" utp-test-app && \
     mv build/utp_test_app /bin/
 
-FROM debian:buster-slim AS deploy
+FROM debian:bullseye-slim AS deploy
 
 RUN apt-get update \
  && apt-get install -y ethtool net-tools \


### PR DESCRIPTION
My builds are failing because `buster` upstream repos are now defunct. Change this to `bullseye`, the oldest supported LTS.

While at it, change the base images from Ubuntu 20.04/21.04 to Ubuntu 22.04, the oldest supported LTS.

Docker is used to build release images, as well: That is why this needs to use an older LTS, so glibc in the release binaries is at an older version.