### PR TITLE
Increase rpc server request body limit to 26MB

### DIFF
--- a/execution_chain/rpc/rpc_server.nim
+++ b/execution_chain/rpc/rpc_server.nim
@@ -72,7 +72,7 @@ func defaultRpcHttpServerParams(): RpcHttpServerParams =
     httpHeadersTimeout: 10.seconds,
     maxHeadersSize: 64 * 1024,
     # Needs to accomodate a large block and all its blobs, with json overhead
-    maxRequestBodySize: 16 * 1024 * 1024,
+    maxRequestBodySize: 26 * 1024 * 1024,
   )
 
 proc resolvedAddress(address: string): Result[TransportAddress, string] =


### PR DESCRIPTION
Fusaka devnet 2 hive test result:
https://hive.ethpandaops.io/fusaka-devnet-2/suite.html?suiteid=1752413594-b21943fd6f355a950e220bcdd81b90e8.json&suitename=eest%2Fconsume-engine

Shows the error message:
```
requests.exceptions.HTTPError: 413 Client Error: Request Entity Too Large for url: http://172.17.0.6:8551/
```

And with this PR, pass the test:
```
Successfully built 09617484b788
Successfully tagged hive/simulators/ethereum/eest/consume-engine:latest
Jul 14 19:46:24.693 INF running simulation: ethereum/eest/consume-engine
Jul 14 19:46:24.936 INF hiveproxy started container=dd659da8b893 addr=172.17.0.4:8081
Jul 14 19:46:27.956 INF API: hive info requested
Jul 14 19:46:28.145 INF API: suite started suite=0 name=eest/consume-engine
Jul 14 19:46:29.112 INF API: hive info requested
Jul 14 19:46:29.114 INF API: test started suite=0 test=1 name=tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py::test_block_at_rlp_size_limit_boundary[fork_Osaka-blockchain_test_engine-max_rlp_size]-nimbus-el
Jul 14 19:46:29.564 INF API: client nimbus-el started suite=0 test=1 container=efcc3a21
Jul 14 19:46:30.218 INF API: test ended suite=0 test=1 pass=true
Jul 14 19:46:30.220 INF API: suite ended suite=0
Jul 14 19:46:30.853 INF simulation ethereum/eest/consume-engine finished suites=1 tests=1 failed=0
```


