### PR TITLE
Stateless: Implement debug_executionWitness and debug_executionWitnessByBlockHash RPC endpoints

### DIFF
--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -187,7 +187,6 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
 
     var witness = Witness.build(witnessKeys, preStateLedger.ReadOnlyLedger)
     witness.addHeaderHash(header.parentHash)
-    witness.addHeaderHash(blockHash)
 
     ?vmState.ledger.txFrame.persistWitness(blockHash, witness)
     vmState.ledger.clearWitnessKeys()

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -634,6 +634,12 @@ proc getWitness*(db: CoreDbTxRef, blockHash: Hash32): Result[Witness, string] =
 
   Witness.decode(witnessBytes)
 
+proc getCodeByHash*(db: CoreDbTxRef, codeHash: Hash32): Result[seq[byte], string] =
+  let code = db.get(contractHashKey(codeHash).toOpenArray).valueOr:
+    return err("getCodeByHash: " & $$error)
+
+  ok(code)
+
 # ------------------------------------------------------------------------------
 # End
 # ------------------------------------------------------------------------------

--- a/execution_chain/rpc.nim
+++ b/execution_chain/rpc.nim
@@ -12,7 +12,7 @@ import
   websock/websock,
   json_rpc/rpcserver,
   ./rpc/common,
-  #./rpc/debug,
+  ./rpc/debug,
   ./rpc/engine_api,
   ./rpc/jwt_auth,
   ./rpc/cors,
@@ -56,9 +56,8 @@ func installRPC(server: RpcServer,
   if RpcFlag.Admin in flags:
     setupAdminRpc(nimbus, conf, server)
 
-  #  # Tracer is currently disabled
-  # if RpcFlag.Debug in flags:
-  #   setupDebugRpc(com, nimbus.txPool, server)
+  if RpcFlag.Debug in flags:
+    setupDebugRpc(com, nimbus.txPool, server)
 
 
 proc newRpcWebsocketHandler(): RpcWebSocketHandler =

--- a/execution_chain/rpc/debug.nim
+++ b/execution_chain/rpc/debug.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -7,162 +7,218 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [].}
+
 import
   std/json,
   json_rpc/rpcserver,
-  ./rpc_utils,
+  # ./rpc_utils,
   ./rpc_types,
-  ../tracer, ../evm/types,
+  #../tracer,
+  #../evm/types,
   ../common/common,
   ../beacon/web3_eth_conv,
   ../core/tx_pool,
+  ../core/chain/forked_chain,
+  ../stateless/witness_types,
   web3/conversions
 
-{.push raises: [].}
+# type
+#   TraceOptions = object
+#     disableStorage: Opt[bool]
+#     disableMemory: Opt[bool]
+#     disableStack: Opt[bool]
+#     disableState: Opt[bool]
+#     disableStateDiff: Opt[bool]
 
-type
-  TraceOptions = object
-    disableStorage: Opt[bool]
-    disableMemory: Opt[bool]
-    disableStack: Opt[bool]
-    disableState: Opt[bool]
-    disableStateDiff: Opt[bool]
+# TraceOptions.useDefaultSerializationIn JrpcConv
+ExecutionWitness.useDefaultSerializationIn JrpcConv
 
-TraceOptions.useDefaultSerializationIn JrpcConv
+# proc isTrue(x: Opt[bool]): bool =
+#   result = x.isSome and x.get() == true
 
-proc isTrue(x: Opt[bool]): bool =
-  result = x.isSome and x.get() == true
+# proc traceOptionsToFlags(options: Opt[TraceOptions]): set[TracerFlags] =
+#   if options.isSome:
+#     let opts = options.get
+#     if opts.disableStorage.isTrue: result.incl TracerFlags.DisableStorage
+#     if opts.disableMemory.isTrue : result.incl TracerFlags.DisableMemory
+#     if opts.disableStack.isTrue  : result.incl TracerFlags.DisableStack
+#     if opts.disableState.isTrue  : result.incl TracerFlags.DisableState
+#     if opts.disableStateDiff.isTrue: result.incl TracerFlags.DisableStateDiff
 
-proc traceOptionsToFlags(options: Opt[TraceOptions]): set[TracerFlags] =
-  if options.isSome:
-    let opts = options.get
-    if opts.disableStorage.isTrue: result.incl TracerFlags.DisableStorage
-    if opts.disableMemory.isTrue : result.incl TracerFlags.DisableMemory
-    if opts.disableStack.isTrue  : result.incl TracerFlags.DisableStack
-    if opts.disableState.isTrue  : result.incl TracerFlags.DisableState
-    if opts.disableStateDiff.isTrue: result.incl TracerFlags.DisableStateDiff
+proc headerFromTag(chain: ForkedChainRef, blockTag: BlockTag): Result[Header, string] =
+  if blockTag.kind == bidAlias:
+    let tag = blockTag.alias.toLowerAscii
+    case tag
+    of "latest":
+      return ok(chain.latestHeader)
+    of "finalized":
+      return ok(chain.finalizedHeader)
+    of "safe":
+      return ok(chain.safeHeader)
+    else:
+      return err("Unsupported block tag " & tag)
+  else:
+    let blockNum = base.BlockNumber blockTag.number
+    return chain.headerByNumber(blockNum)
 
-proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, rpcsrv: RpcServer) =
-  let chainDB = com.db
+proc getExecutionWitness*(db: CoreDbRef, blockHash: Hash32): Result[ExecutionWitness, string] =
+  let txFrame = db.baseTxFrame.txFrameBegin()
+  defer:
+    txFrame.dispose()
 
-  rpcsrv.rpc("debug_traceTransaction") do(data: Hash32, options: Opt[TraceOptions]) -> JsonNode:
-    ## The traceTransaction debugging method will attempt to run the transaction in the exact
-    ## same manner as it was executed on the network. It will replay any transaction that may
-    ## have been executed prior to this one before it will finally attempt to execute the
-    ## transaction that corresponds to the given hash.
-    ##
-    ## In addition to the hash of the transaction you may give it a secondary optional argument,
-    ## which specifies the options for this specific call. The possible options are:
-    ##
-    ## * disableStorage: BOOL. Setting this to true will disable storage capture (default = false).
-    ## * disableMemory: BOOL. Setting this to true will disable memory capture (default = false).
-    ## * disableStack: BOOL. Setting this to true will disable stack capture (default = false).
-    ## * disableState: BOOL. Setting this to true will disable state trie capture (default = false).
-    let
-      txHash = data
-      txDetails = chainDB.getTransactionKey(txHash)
-      header = chainDB.getBlockHeader(txDetails.blockNumber)
-      transactions = chainDB.getTransactions(header.txRoot)
-      flags = traceOptionsToFlags(options)
+  let witness = txFrame.getWitness(blockHash).valueOr:
+    return err("Witness not found")
 
-    traceTransaction(com, header, transactions, txDetails.index, flags)
+  var executionWitness = ExecutionWitness.init(state = witness.state, keys = witness.keys)
+  for codeHash in witness.codeHashes:
+    let code = txFrame.getCodeByHash(codeHash).valueOr:
+      return err("Code not found")
+    executionWitness.addCode(code)
 
-  rpcsrv.rpc("debug_dumpBlockStateByNumber") do(quantityTag: BlockTag) -> JsonNode:
-    ## Retrieves the state that corresponds to the block number and returns
-    ## a list of accounts (including storage and code).
-    ##
-    ## quantityTag: integer of a block number, or the string "earliest",
-    ## "latest" or "pending", as in the default block parameter.
-    var
-      header = chainDB.headerFromTag(quantityTag)
-      blockHash = chainDB.getBlockHash(header.number)
-      body = chainDB.getBlockBody(blockHash)
+  for headerHash in witness.headerHashes:
+    let header = txFrame.getBlockHeader(headerHash).valueOr:
+      return err("Header not found")
+    executionWitness.addHeader(rlp.encode(header))
 
-    dumpBlockState(com, EthBlock.init(move(header), move(body)))
+  ok(executionWitness)
 
-  rpcsrv.rpc("debug_dumpBlockStateByHash") do(data: Hash32) -> JsonNode:
-    ## Retrieves the state that corresponds to the block number and returns
-    ## a list of accounts (including storage and code).
-    ##
-    ## data: Hash of a block.
-    var
-      h = data
-      blk = chainDB.getEthBlock(h)
+proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
+  let
+    chainDB = com.db
+    chain = txPool.chain
 
-    dumpBlockState(com, blk)
+  # server.rpc("debug_traceTransaction") do(data: Hash32, options: Opt[TraceOptions]) -> JsonNode:
+  #   ## The traceTransaction debugging method will attempt to run the transaction in the exact
+  #   ## same manner as it was executed on the network. It will replay any transaction that may
+  #   ## have been executed prior to this one before it will finally attempt to execute the
+  #   ## transaction that corresponds to the given hash.
+  #   ##
+  #   ## In addition to the hash of the transaction you may give it a secondary optional argument,
+  #   ## which specifies the options for this specific call. The possible options are:
+  #   ##
+  #   ## * disableStorage: BOOL. Setting this to true will disable storage capture (default = false).
+  #   ## * disableMemory: BOOL. Setting this to true will disable memory capture (default = false).
+  #   ## * disableStack: BOOL. Setting this to true will disable stack capture (default = false).
+  #   ## * disableState: BOOL. Setting this to true will disable state trie capture (default = false).
+  #   let
+  #     txHash = data
+  #     txDetails = chainDB.getTransactionKey(txHash)
+  #     header = chainDB.getBlockHeader(txDetails.blockNumber)
+  #     transactions = chainDB.getTransactions(header.txRoot)
+  #     flags = traceOptionsToFlags(options)
 
-  rpcsrv.rpc("debug_traceBlockByNumber") do(quantityTag: BlockTag, options: Opt[TraceOptions]) -> JsonNode:
-    ## The traceBlock method will return a full stack trace of all invoked opcodes of all transaction
-    ## that were included included in this block.
-    ##
-    ## quantityTag: integer of a block number, or the string "earliest",
-    ## "latest" or "pending", as in the default block parameter.
-    ## options: see debug_traceTransaction
-    var
-      header = chainDB.headerFromTag(quantityTag)
-      blockHash = chainDB.getBlockHash(header.number)
-      body = chainDB.getBlockBody(blockHash)
-      flags = traceOptionsToFlags(options)
+  #   traceTransaction(com, header, transactions, txDetails.index, flags)
 
-    traceBlock(com, EthBlock.init(move(header), move(body)), flags)
+  # server.rpc("debug_dumpBlockStateByNumber") do(quantityTag: BlockTag) -> JsonNode:
+  #   ## Retrieves the state that corresponds to the block number and returns
+  #   ## a list of accounts (including storage and code).
+  #   ##
+  #   ## quantityTag: integer of a block number, or the string "earliest",
+  #   ## "latest" or "pending", as in the default block parameter.
+  #   var
+  #     header = chainDB.headerFromTag(quantityTag)
+  #     blockHash = chainDB.getBlockHash(header.number)
+  #     body = chainDB.getBlockBody(blockHash)
 
-  rpcsrv.rpc("debug_traceBlockByHash") do(data: Hash32, options: Opt[TraceOptions]) -> JsonNode:
-    ## The traceBlock method will return a full stack trace of all invoked opcodes of all transaction
-    ## that were included included in this block.
-    ##
-    ## data: Hash of a block.
-    ## options: see debug_traceTransaction
-    var
-      h = data
-      header = chainDB.getBlockHeader(h)
-      blockHash = chainDB.getBlockHash(header.number)
-      body = chainDB.getBlockBody(blockHash)
-      flags = traceOptionsToFlags(options)
+  #   dumpBlockState(com, EthBlock.init(move(header), move(body)))
 
-    traceBlock(com, EthBlock.init(move(header), move(body)), flags)
+  # server.rpc("debug_dumpBlockStateByHash") do(data: Hash32) -> JsonNode:
+  #   ## Retrieves the state that corresponds to the block number and returns
+  #   ## a list of accounts (including storage and code).
+  #   ##
+  #   ## data: Hash of a block.
+  #   var
+  #     h = data
+  #     blk = chainDB.getEthBlock(h)
 
-  rpcsrv.rpc("debug_setHead") do(quantityTag: BlockTag) -> bool:
-    ## Sets the current head of the local chain by block number.
-    ## Note, this is a destructive action and may severely damage your chain.
-    ## Use with extreme caution.
-    let
-      header = chainDB.headerFromTag(quantityTag)
-    chainDB.setHead(header)
+  #   dumpBlockState(com, blk)
 
-  rpcsrv.rpc("debug_getRawBlock") do(quantityTag: BlockTag) -> seq[byte]:
-    ## Returns an RLP-encoded block.
-    var
-      header = chainDB.headerFromTag(quantityTag)
-      blockHash = chainDB.getBlockHash(header.number)
-      body = chainDB.getBlockBody(blockHash)
+  # server.rpc("debug_traceBlockByNumber") do(quantityTag: BlockTag, options: Opt[TraceOptions]) -> JsonNode:
+  #   ## The traceBlock method will return a full stack trace of all invoked opcodes of all transaction
+  #   ## that were included included in this block.
+  #   ##
+  #   ## quantityTag: integer of a block number, or the string "earliest",
+  #   ## "latest" or "pending", as in the default block parameter.
+  #   ## options: see debug_traceTransaction
+  #   var
+  #     header = chainDB.headerFromTag(quantityTag)
+  #     blockHash = chainDB.getBlockHash(header.number)
+  #     body = chainDB.getBlockBody(blockHash)
+  #     flags = traceOptionsToFlags(options)
 
-    rlp.encode(EthBlock.init(move(header), move(body)))
+  #   traceBlock(com, EthBlock.init(move(header), move(body)), flags)
 
-  rpcsrv.rpc("debug_getRawHeader") do(quantityTag: BlockTag) -> seq[byte]:
-    ## Returns an RLP-encoded header.
-    let header = chainDB.headerFromTag(quantityTag)
-    rlp.encode(header)
+  # server.rpc("debug_traceBlockByHash") do(data: Hash32, options: Opt[TraceOptions]) -> JsonNode:
+  #   ## The traceBlock method will return a full stack trace of all invoked opcodes of all transaction
+  #   ## that were included included in this block.
+  #   ##
+  #   ## data: Hash of a block.
+  #   ## options: see debug_traceTransaction
+  #   var
+  #     h = data
+  #     header = chainDB.getBlockHeader(h)
+  #     blockHash = chainDB.getBlockHash(header.number)
+  #     body = chainDB.getBlockBody(blockHash)
+  #     flags = traceOptionsToFlags(options)
 
-  rpcsrv.rpc("debug_getRawReceipts") do(quantityTag: BlockTag) -> seq[seq[byte]]:
-    ## Returns an array of EIP-2718 binary-encoded receipts.
-    let header = chainDB.headerFromTag(quantityTag)
-    for receipt in chainDB.getReceipts(header.receiptsRoot):
-      result.add rlp.encode(receipt)
+  #   traceBlock(com, EthBlock.init(move(header), move(body)), flags)
 
-  rpcsrv.rpc("debug_getRawTransaction") do(data: Hash32) -> seq[byte]:
-    ## Returns an EIP-2718 binary-encoded transaction.
-    let txHash = data
-    let res = txPool.getItem(txHash)
-    if res.isOk:
-      return rlp.encode(res.get().tx)
+  # server.rpc("debug_setHead") do(quantityTag: BlockTag) -> bool:
+  #   ## Sets the current head of the local chain by block number.
+  #   ## Note, this is a destructive action and may severely damage your chain.
+  #   ## Use with extreme caution.
+  #   let
+  #     header = chainDB.headerFromTag(quantityTag)
+  #   chainDB.setHead(header)
 
-    let txDetails = chainDB.getTransactionKey(txHash)
-    if txDetails.index < 0:
-      raise newException(ValueError, "Transaction not found " & data.toHex)
+  # server.rpc("debug_getRawBlock") do(quantityTag: BlockTag) -> seq[byte]:
+  #   ## Returns an RLP-encoded block.
+  #   var
+  #     header = chainDB.headerFromTag(quantityTag)
+  #     blockHash = chainDB.getBlockHash(header.number)
+  #     body = chainDB.getBlockBody(blockHash)
 
-    let header = chainDB.getBlockHeader(txDetails.blockNumber)
-    var tx: Transaction
-    if chainDB.getTransaction(header.txRoot, txDetails.index, tx):
-      return rlp.encode(tx)
+  #   rlp.encode(EthBlock.init(move(header), move(body)))
 
-    raise newException(ValueError, "Transaction not found " & data.toHex)
+  # server.rpc("debug_getRawHeader") do(quantityTag: BlockTag) -> seq[byte]:
+  #   ## Returns an RLP-encoded header.
+  #   let header = chainDB.headerFromTag(quantityTag)
+  #   rlp.encode(header)
+
+  # server.rpc("debug_getRawReceipts") do(quantityTag: BlockTag) -> seq[seq[byte]]:
+  #   ## Returns an array of EIP-2718 binary-encoded receipts.
+  #   let header = chainDB.headerFromTag(quantityTag)
+  #   for receipt in chainDB.getReceipts(header.receiptsRoot):
+  #     result.add rlp.encode(receipt)
+
+  # server.rpc("debug_getRawTransaction") do(data: Hash32) -> seq[byte]:
+  #   ## Returns an EIP-2718 binary-encoded transaction.
+  #   let txHash = data
+  #   let res = txPool.getItem(txHash)
+  #   if res.isOk:
+  #     return rlp.encode(res.get().tx)
+
+  #   let txDetails = chainDB.getTransactionKey(txHash)
+  #   if txDetails.index < 0:
+  #     raise newException(ValueError, "Transaction not found " & data.toHex)
+
+  #   let header = chainDB.getBlockHeader(txDetails.blockNumber)
+  #   var tx: Transaction
+  #   if chainDB.getTransaction(header.txRoot, txDetails.index, tx):
+  #     return rlp.encode(tx)
+
+  #   raise newException(ValueError, "Transaction not found " & data.toHex)
+
+  server.rpc("debug_executionWitness") do(quantityTag: BlockTag) -> ExecutionWitness:
+    ## Returns an execution witness for the given block number.
+    let header = chain.headerFromTag(quantityTag).valueOr:
+      raise newException(ValueError, "Header not found")
+
+    chainDB.getExecutionWitness(header.computeBlockHash()).valueOr:
+      raise newException(ValueError, error)
+
+  server.rpc("debug_executionWitnessByBlockHash") do(blockHash: Hash32) -> ExecutionWitness:
+    ## Returns an execution witness for the given block hash.
+    chainDB.getExecutionWitness(blockHash).valueOr:
+      raise newException(ValueError, error)

--- a/execution_chain/stateless/witness_types.nim
+++ b/execution_chain/stateless/witness_types.nim
@@ -21,34 +21,34 @@ export
 type
   Witness* = object
     state*: seq[seq[byte]] # MPT trie nodes accessed while executing the block.
-    keys*: seq[seq[byte]] # Ordered list of access keys (address bytes or storage slots bytes).
     codeHashes*: seq[Hash32] # Code hashes of the bytecode required by the witness.
+    keys*: seq[seq[byte]] # Ordered list of access keys (address bytes or storage slots bytes).
     headerHashes*: seq[Hash32] # Hashes of block headers which are required by the witness.
 
   ExecutionWitness* = object
     state*: seq[seq[byte]] # MPT trie nodes accessed while executing the block.
-    keys*: seq[seq[byte]] # Ordered list of access keys (address bytes or storage slots bytes).
     codes*: seq[seq[byte]] # Contract bytecodes read while executing the block.
-    headers*: seq[Header] # Block headers required for proving correctness of stateless execution.
+    keys*: seq[seq[byte]] # Ordered list of access keys (address bytes or storage slots bytes).
+    headers*: seq[seq[byte]] # Block headers required for proving correctness of stateless execution.
       # Stores the parent block headers needed to verify that the state reads are correct with respect
       # to the pre-state root.
 
 func init*(
     T: type Witness,
     state = newSeq[seq[byte]](),
-    keys = newSeq[seq[byte]](),
     codeHashes = newSeq[Hash32](),
+    keys = newSeq[seq[byte]](),
     headerHashes = newSeq[Hash32]()): T =
-  Witness(state: state, keys: keys, headerHashes: headerHashes)
+  Witness(state: state, codeHashes: codeHashes, keys: keys, headerHashes: headerHashes)
 
 template addState*(witness: var Witness, trieNode: seq[byte]) =
   witness.state.add(trieNode)
 
-template addKey*(witness: var Witness, key: openArray[byte]) =
-  witness.keys.add(@key)
-
 template addCodeHash*(witness: var Witness, codeHash: Hash32) =
   witness.codeHashes.add(codeHash)
+
+template addKey*(witness: var Witness, key: openArray[byte]) =
+  witness.keys.add(@key)
 
 template addHeaderHash*(witness: var Witness, headerHash: Hash32) =
   witness.headerHashes.add(headerHash)
@@ -65,10 +65,10 @@ func decode*(T: type Witness, witnessBytes: openArray[byte]): Result[T, string] 
 func init*(
     T: type ExecutionWitness,
     state = newSeq[seq[byte]](),
-    keys = newSeq[seq[byte]](),
     codes = newSeq[seq[byte]](),
-    headers = newSeq[Header]()): T =
-  ExecutionWitness(state: state, keys: keys, codes: codes, headers: headers)
+    keys = newSeq[seq[byte]](),
+    headers = newSeq[seq[byte]]()): T =
+  ExecutionWitness(state: state, codes: codes, keys: keys, headers: headers)
 
 template addState*(witness: var ExecutionWitness, trieNode: seq[byte]) =
   witness.state.add(trieNode)
@@ -79,7 +79,7 @@ template addCode*(witness: var ExecutionWitness, code: seq[byte]) =
 template addKey*(witness: var ExecutionWitness, key: seq[byte]) =
   witness.keys.add(key)
 
-template addHeader*(witness: var ExecutionWitness, header: Header) =
+template addHeader*(witness: var ExecutionWitness, header: seq[byte]) =
   witness.headers.add(header)
 
 func encode*(witness: ExecutionWitness): seq[byte] =

--- a/tests/test_stateless_witness_types.nim
+++ b/tests/test_stateless_witness_types.nim
@@ -58,7 +58,7 @@ suite "Stateless: Witness Types":
     witness.addState(@[0x1.byte, 0x2, 0x3])
     witness.addKey(@[0x7.byte, 0x8, 0x9])
     witness.addCode(@[0x4.byte, 0x5, 0x6])
-    witness.addHeader(Header())
+    witness.addHeader(@[0x10.byte, 0x11, 0x12])
 
     let witnessBytes = witness.encode()
     check witnessBytes.len() > 0


### PR DESCRIPTION
This PR implements `debug_executionWitness` and `debug_executionWitnessByBlockHash` RPC endpoints which return the MPT block witnesses which are stored in the database while syncing.

The RPC debug code has some out of date tracer code which was not being built with Nimbus and therefore needs to be commented out for now until it can be worked on in a separate PR, because this code no longer compiles as is.

Unit tests for these RPC endpoints will come later in a separate PR.