### PR TITLE
Speed up Nimbus shutdown when RPC/HTTP servers are enabled

### DIFF
--- a/execution_chain/nimbus_desc.nim
+++ b/execution_chain/nimbus_desc.nim
@@ -61,9 +61,9 @@ proc stop*(nimbus: NimbusNode, conf: NimbusConf) {.async, gcsafe.} =
   trace "Graceful shutdown"
   var waitedFutures: seq[Future[void]]
   if nimbus.httpServer.isNil.not:
-    waitedFutures.add nimbus.httpServer.stop()
+    discard nimbus.httpServer.stop()
   if nimbus.engineApiServer.isNil.not:
-    waitedFutures.add nimbus.engineApiServer.stop()
+    discard nimbus.engineApiServer.stop()
   if conf.maxPeers > 0:
     waitedFutures.add nimbus.networkLoop.cancelAndWait()
   if nimbus.peerManager.isNil.not:
@@ -71,7 +71,7 @@ proc stop*(nimbus: NimbusNode, conf: NimbusConf) {.async, gcsafe.} =
   if nimbus.beaconSyncRef.isNil.not:
     waitedFutures.add nimbus.beaconSyncRef.stop()
   if nimbus.metricsServer.isNil.not:
-    waitedFutures.add nimbus.metricsServer.stop()
+    discard nimbus.metricsServer.stop()
   if nimbus.wire.isNil.not:
     waitedFutures.add nimbus.wire.stop()
 


### PR DESCRIPTION
I found that Nimbus will hang for a while on shutdown when the RPC server/s are enabled. 

This change speeds up the shutdown process by not bothering to wait for the RPC/HTTP servers to fully stop in the Nimbus `stop` function. I believe this should be safe because the impact of 'killing' these services is low since by the time this stop function is called the database is already closed. There may be more of these services that can be stopped without waiting but I'm not sure which of these if any would be good candidates.
 