### PR TITLE
fix: make payload bodies range inclusive in getPayloadBodiesByRange

### DIFF
--- a/execution_chain/beacon/api_handler/api_getbodies.nim
+++ b/execution_chain/beacon/api_handler/api_getbodies.nim
@@ -58,7 +58,7 @@ proc getPayloadBodiesByRange*(ben: BeaconEngineRef,
     last = ben.chain.latestNumber
 
   let base = ben.chain.baseNumber
-  var list = newSeqOfCap[Opt[ExecutionPayloadBodyV1]](last-start)
+  var list = newSeqOfCap[Opt[ExecutionPayloadBodyV1]](last-start+1)
 
   if start < base:
     # get bodies from database.


### PR DESCRIPTION
This commit fixes an off-by-one error in the getPayloadBodiesByRange procedure.
The size of the result list is now calculated as (last - start + 1) instead of (last - start), ensuring that the requested block range is inclusive and no payload bodies are omitted from the result.
This change prevents missing the last element in the specified range and aligns the implementation with expected range semantics.