### PR TITLE
Add Discovery V5 alongside V4

### DIFF
--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -314,7 +314,7 @@ type
         "- None: Disables the peer discovery mechanism (manual peer addition)\n" &
         "- V4  : Node Discovery Protocol v4\n" &
         "- V5  : Node Discovery Protocol v5\n" &
-        "- Both: V4, V5"
+        "- All : V4, V5"
       defaultValue: @["V4", "V5"]
       defaultValueDesc: "V4, V5"
       name: "discovery" .}: seq[string]
@@ -714,7 +714,7 @@ proc getDiscoveryFlags(api: openArray[string]): set[DiscoveryType] =
     of "none": result = {}
     of "v4": result.incl DiscoveryType.V4
     of "v5": result.incl DiscoveryType.V5
-    of "both": result = {DiscoveryType.V4, DiscoveryType.V5}
+    of "all": result = {DiscoveryType.V4, DiscoveryType.V5}
     else:
       error "Unknown discovery type: ", name=item
       quit QuitFailure

--- a/execution_chain/networking/discoveryv4.nim
+++ b/execution_chain/networking/discoveryv4.nim
@@ -373,7 +373,7 @@ proc randomNodes*(d: DiscoveryV4, count: int): seq[Node] =
   d.kademlia.randomNodes(count)
 
 when isMainModule:
-  import stew/byteutils, ../bootnodes
+  import stew/byteutils, ./bootnodes
 
   block:
     let m =

--- a/execution_chain/networking/discoveryv4.nim
+++ b/execution_chain/networking/discoveryv4.nim
@@ -348,16 +348,9 @@ proc lookupRandom*(d: DiscoveryV4): Future[seq[Node]] {.async: (raises: [Cancell
     debug "DiscoveryV4 lookup random error", msg=exc.msg
     return
 
-proc run(d: DiscoveryV4): Future[void] {.async: (raises: [CancelledError]).} =
-  while true:
-    discard await d.lookupRandom()
-    await sleepAsync(chronos.seconds(3))
-    notice "Discovered nodes", nodes = d.kademlia.nodesDiscovered
-
 proc bootstrap*(d: DiscoveryV4): Future[void] {.async: (raises: [CancelledError]).} =
   try:
     await d.kademlia.bootstrap(d.bootstrapNodes)
-    #await d.run()
     discard await d.kademlia.lookupRandom()
   except ValueError as exc:
     debug "DiscoveryV4 bootstrap error", msg=exc.msg

--- a/execution_chain/networking/discoveryv4.nim
+++ b/execution_chain/networking/discoveryv4.nim
@@ -352,12 +352,13 @@ proc run(d: DiscoveryV4): Future[void] {.async: (raises: [CancelledError]).} =
   while true:
     discard await d.lookupRandom()
     await sleepAsync(chronos.seconds(3))
-    trace "Discovered nodes", nodes = d.kademlia.nodesDiscovered
+    notice "Discovered nodes", nodes = d.kademlia.nodesDiscovered
 
 proc bootstrap*(d: DiscoveryV4): Future[void] {.async: (raises: [CancelledError]).} =
   try:
     await d.kademlia.bootstrap(d.bootstrapNodes)
-    discard d.run()
+    #await d.run()
+    discard await d.kademlia.lookupRandom()
   except ValueError as exc:
     debug "DiscoveryV4 bootstrap error", msg=exc.msg
     return

--- a/execution_chain/networking/discoveryv4/kademlia.nim
+++ b/execution_chain/networking/discoveryv4/kademlia.nim
@@ -676,7 +676,7 @@ proc recvFindNode*(k: KademliaProtocol, remote: Node, nodeId: NodeId): Result[vo
     # and thus removed from self.routing, but once it's back online we should accept
     # find_nodes from them.
     trace "Ignoring find_node request from unknown node ", remote
-    return
+    return ok()
   ?k.updateRoutingTable(remote)
   var found = k.routing.neighbours(nodeId)
   found.sort() do(x, y: Node) -> int: cmp(x.id, y.id)

--- a/execution_chain/networking/discoveryv5.nim
+++ b/execution_chain/networking/discoveryv5.nim
@@ -1,0 +1,90 @@
+# nimbus-execution-client
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms
+
+{.push raises: [].}
+
+include
+  eth/p2p/discoveryv5/protocol
+
+proc receiveV5*(d: Protocol, a: Address, packet: openArray[byte]): Result[void, cstring] =
+  discv5_network_bytes.inc(packet.len.int64, labelValues = [$Direction.In])
+
+  let packet = ?d.codec.decodePacket(a, packet)
+
+  case packet.flag
+  of OrdinaryMessage:
+    if d.isBanned(packet.srcId):
+      trace "Ignoring received OrdinaryMessage from banned node", nodeId = packet.srcId
+      return ok()
+
+    if packet.messageOpt.isSome():
+      let message = packet.messageOpt.get()
+      trace "Received message packet", srcId = packet.srcId, address = a,
+        kind = message.kind
+      d.handleMessage(packet.srcId, a, message)
+    else:
+      trace "Not decryptable message packet received",
+        srcId = packet.srcId, address = a
+      d.sendWhoareyou(packet.srcId, a, packet.requestNonce,
+        d.getNode(packet.srcId))
+
+  of Flag.Whoareyou:
+    trace "Received whoareyou packet", address = a
+    var pr: PendingRequest
+    if d.pendingRequests.take(packet.whoareyou.requestNonce, pr):
+      let toNode = pr.node
+      # This is a node we previously contacted and thus must have an address.
+      doAssert(toNode.address.isSome())
+      let address = toNode.address.get()
+      let data = encodeHandshakePacket(d.rng[], d.codec, toNode.id,
+        address, pr.message, packet.whoareyou, toNode.pubkey)
+
+      # Finished setting up the session on our side, so store the ENR of the
+      # peer in the session cache.
+      d.codec.sessions.setEnr(toNode.id, address, toNode.record)
+
+      trace "Send handshake message packet", dstId = toNode.id, address
+      d.send(toNode, data)
+    else:
+      debug "Timed out or unrequested whoareyou packet", address = a
+  of HandshakeMessage:
+    if d.isBanned(packet.srcIdHs):
+      trace "Ignoring received HandshakeMessage from banned node", nodeId = packet.srcIdHs
+      return ok()
+
+    trace "Received handshake message packet", srcId = packet.srcIdHs,
+      address = a, kind = packet.message.kind
+
+    # For a handshake message it is possible that we received an newer ENR.
+    # In that case we can add/update it to the routing table.
+    if packet.node.isSome():
+      let node = packet.node.get()
+      # Lets not add nodes without correct IP in the ENR to the routing table.
+      # The ENR could contain bogus IPs and although they would get removed
+      # on the next revalidation, one could spam these as the handshake
+      # message occurs on (first) incoming messages.
+      if node.address.isSome() and a == node.address.get():
+        if d.addNode(node):
+          trace "Added new node to routing table after handshake", node
+
+      # Received an ENR in the handshake, add it to the session that was just
+      # created in the session cache.
+      d.codec.sessions.setEnr(packet.srcIdHs, a, node.record)
+    else:
+      # Did not receive an ENR in the handshake, this means that the ENR used
+      # is up to date. Get it from the routing table which should normally
+      # be there unless the request was started manually (E.g. from a JSON-RPC call).
+      let node = d.getNode(packet.srcIdHs)
+      if node.isSome():
+        d.codec.sessions.setEnr(packet.srcIdHs, a, node.value().record)
+
+    # The handling of the message needs to be done after adding the ENR.
+    d.handleMessage(packet.srcIdHs, a, packet.message, packet.node)
+
+  ok()

--- a/execution_chain/networking/eth1_discovery.nim
+++ b/execution_chain/networking/eth1_discovery.nim
@@ -94,7 +94,7 @@ proc processClient(
 proc new*(
     _: type Eth1Discovery,
     privKey: PrivateKey,
-    address: discoveryv4.Address,
+    address: AddressV4,
     bootstrapNodes: openArray[ENode],
     bindPort: Port,
     bindIp = IPv6_any(),
@@ -102,7 +102,7 @@ proc new*(
 ): Eth1Discovery =
   let bootnodes = bootstrapNodes.to(enr.Record)
   Eth1Discovery(
-    discv4: newDiscoveryV4(
+    discv4: discoveryv4.newDiscoveryV4(
       privKey = privKey,
       address = address,
       bootstrapNodes = bootstrapNodes,
@@ -110,7 +110,7 @@ proc new*(
       bindIp = bindIp,
       rng = rng
     ),
-    discv5: newProtocol(
+    discv5: discoveryv5.newProtocol(
       privKey = privKey,
       enrIp = Opt.some(address.ip),
       enrTcpPort = Opt.some(address.tcpPort),
@@ -118,6 +118,7 @@ proc new*(
       bootstrapRecords = bootnodes,
       bindPort = bindPort,
       bindIp = bindIp,
+      enrAutoUpdate = true,
       rng = rng
     )
   )

--- a/execution_chain/networking/eth1_discovery.nim
+++ b/execution_chain/networking/eth1_discovery.nim
@@ -127,7 +127,8 @@ proc open*(
 ) {.raises: [TransportOsError].} =
   # TODO: allow binding to both IPv4 and IPv6
 
-  doAssert(enableDiscV4 or enableDiscV5, "must enable of Discovery V4 or V5")
+  if not (enableDiscV4 or enableDiscV5):
+    return
 
   privateAccess(DiscV4)
   privateAccess(DiscV5)
@@ -198,5 +199,5 @@ proc closeWait*(proto: Eth1Discovery) {.async: (raises: []).} =
   # Because UDP transport is shared between DiscV4 and DiscV5,
   # no need for DiscV4 to close it anymore if both enabled.
   # It will be closed by DiscV5.
-  doAssert(proto.discv5.isNil.not)
-  await proto.discv5.closeWait()
+  if proto.discv5.isNil.not:
+    await proto.discv5.closeWait()

--- a/execution_chain/networking/eth1_discovery.nim
+++ b/execution_chain/networking/eth1_discovery.nim
@@ -1,0 +1,199 @@
+# nimbus-execution-client
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms
+
+{.push raises: [].}
+
+import
+  std/[net, importutils, random],
+  chronos,
+  chronicles,
+  results,
+  metrics,
+  ./discoveryv5,
+  ./discoveryv4,
+  ./eth1_enr
+
+export
+  discoveryv4.NodeId,
+  discoveryv4.Node,
+  discoveryv4.ENode
+
+logScope:
+  topics = "p2p"
+
+type
+  DiscV4 = discoveryv4.DiscoveryV4
+  DiscV5 = discoveryv5.Protocol
+
+  NodeV4 = discoveryv4.Node
+  NodeV5 = discoveryv5.Node
+
+  AddressV4 = discoveryv4.Address
+  AddressV5 = discoveryv5.Address
+
+  Eth1Discovery* = ref object
+    discv4: DiscV4
+    discv5: DiscV5
+
+#------------------------------------------------------------------------------
+# Private functions
+#------------------------------------------------------------------------------
+
+func to(raddr: TransportAddress, _: type AddressV4): AddressV4 =
+  AddressV4(
+    ip: raddr.toIpAddress(),
+    udpPort: raddr.port,
+    tcpPort: raddr.port
+  )
+
+func to(raddr: TransportAddress, _: type AddressV5): AddressV5 =
+  AddressV5(ip: raddr.toIpAddress(), port: raddr.port)
+
+func to(node: NodeV5, _: type NodeV4): ENodeResult[NodeV4] =
+  let v4 = NodeV4(
+    id: node.id,
+    node: ?ENode.fromEnr(node.record),
+  )
+  ok(v4)
+
+proc processClient(
+    transp: DatagramTransport, raddr: TransportAddress
+): Future[void] {.async: (raises: []).} =
+  var proto = getUserData[Eth1Discovery](transp)
+  let buf =
+    try:
+      transp.getMessage()
+    except TransportOsError as e:
+      # This is likely to be local network connection issues.
+      warn "Transport getMessage", exception = e.name, msg = e.msg
+      return
+    except TransportError as exc:
+      debug "getMessage error", msg = exc.msg
+      return
+
+  let
+    addrv4 = raddr.to(AddressV4)
+    discv4 = proto.discv4.receive(addrv4, buf)
+
+  if discv4.isErr:
+    # unhandled buf will be handled by discv5
+    let addrv5 = raddr.to(AddressV5)
+    proto.discv5.receiveV5(addrv5, buf).isOkOr:
+      debug "Discovery receive error", discv4=discv4.error, discv5=error
+
+#------------------------------------------------------------------------------
+# Public functions
+#------------------------------------------------------------------------------
+
+proc new*(
+    _: type Eth1Discovery,
+    privKey: PrivateKey,
+    address: discoveryv4.Address,
+    bootstrapNodes: openArray[ENode],
+    bindPort: Port,
+    bindIp = IPv6_any(),
+    rng = newRng()
+): Eth1Discovery =
+  let bootnodes = bootstrapNodes.to(enr.Record)
+  Eth1Discovery(
+    discv4: newDiscoveryV4(
+      privKey = privKey,
+      address = address,
+      bootstrapNodes = bootstrapNodes,
+      bindPort = bindPort,
+      bindIp = bindIp,
+      rng = rng
+    ),
+    discv5: newProtocol(
+      privKey = privKey,
+      enrIp = Opt.some(address.ip),
+      enrTcpPort = Opt.some(address.tcpPort),
+      enrUdpPort = Opt.some(address.udpPort),
+      bootstrapRecords = bootnodes,
+      bindPort = bindPort,
+      bindIp = bindIp,
+      rng = rng
+    )
+  )
+
+proc open*(
+    proto: Eth1Discovery, enableDiscV4: bool, enableDiscV5: bool
+) {.raises: [TransportOsError].} =
+  # TODO: allow binding to both IPv4 and IPv6
+
+  doAssert(enableDiscV4 or enableDiscV5, "must enable of Discovery V4 or V5")
+
+  privateAccess(DiscV4)
+  privateAccess(DiscV5)
+
+  info "Starting discovery node", node = proto.discv4.localNode,
+    bindAddress = proto.discv4.address
+
+  if enableDiscV4 and not enableDiscV5:
+    proto.discv4.open()
+    proto.discv5 = nil
+    return
+
+  if enableDiscV5 and not enableDiscV4:
+    proto.discv5.open()
+    proto.discv4 = nil
+    proto.discv5.seedTable()
+    return
+
+  # Both DiscV4 and DiscV5 share the same transport
+  # Unhandled data from DiscV4 will be handled by DiscV5
+  let ta = initTAddress(proto.discv4.bindIp, proto.discv4.bindPort)
+  proto.discv4.transp = newDatagramTransport(processClient, udata = proto, local = ta)
+  proto.discv5.transp = proto.discv4.transp
+  proto.discv5.seedTable()
+
+proc start*(proto: Eth1Discovery) {.async: (raises: [CancelledError]).} =
+  if proto.discv4.isNil.not:
+    await proto.discv4.bootstrap()
+  if proto.discv5.isNil.not:
+    proto.discv5.start()
+
+proc lookupRandomNode*(proto: Eth1Discovery, queue: AsyncQueue[NodeV4]) {.async: (raises: [CancelledError]).} =
+  if proto.discv4.isNil.not:
+    let nodes = await proto.discv4.lookupRandom()
+    for node in nodes:
+      await queue.addLast(node)
+
+  if proto.discv5.isNil.not:
+    let nodes = await proto.discv5.queryRandom()
+    for node in nodes:
+      let v4 = node.to(NodeV4).valueOr:
+        continue
+      await queue.addLast(v4)
+
+proc getRandomBootnode*(proto: Eth1Discovery): Opt[NodeV4] =
+  if proto.discv4.isNil.not:
+    if proto.discv4.bootstrapNodes.len != 0:
+      return Opt.some(proto.discv4.bootstrapNodes.sample())
+
+  if proto.discv5.isNil.not:
+    if proto.discv5.bootstrapRecords.len != 0:
+      let
+        rec = proto.discv5.bootstrapRecords.sample()
+        enode = ENode.fromEnr(rec).valueOr:
+          return Opt.none(NodeV4)
+      return Opt.some(newNode(enode))
+
+proc closeWait*(proto: Eth1Discovery) {.async: (raises: []).} =
+  privateAccess(DiscV4)
+  if proto.discv4.isNil.not and proto.discv5.isNil:
+    if proto.discv4.transp.isNil.not:
+      await noCancel(proto.discv4.transp.closeWait())
+    return
+
+  # Because UDP transport is shared between DiscV4 and DiscV5,
+  # no need for DiscV4 to close it anymore if both enabled.
+  # It will be closed by DiscV5.
+  doAssert(proto.discv5.isNil.not)
+  await proto.discv5.closeWait()

--- a/execution_chain/networking/eth1_discovery.nim
+++ b/execution_chain/networking/eth1_discovery.nim
@@ -132,8 +132,11 @@ proc open*(
   privateAccess(DiscV4)
   privateAccess(DiscV5)
 
-  info "Starting discovery node", node = proto.discv4.localNode,
-    bindAddress = proto.discv4.address
+  info "Starting discovery node",
+    node = proto.discv4.localNode,
+    bindAddress = proto.discv4.address,
+    discV4 = enableDiscV4,
+    discV5 = enableDiscV5
 
   if enableDiscV4 and not enableDiscV5:
     proto.discv4.open()

--- a/execution_chain/networking/eth1_enr.nim
+++ b/execution_chain/networking/eth1_enr.nim
@@ -1,0 +1,67 @@
+# nimbus-execution-client
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms
+
+{.push raises: [].}
+
+import
+  std/importutils,
+  ./discoveryv4/enode,
+  eth/net/utils,
+  eth/p2p/discoveryv5/enr {.all.}
+
+export
+  enr.Record, enr.fromURI, enode
+
+func to*(enode: ENode, _: type enr.Record): enr.Record =
+  privateAccess(enr.Field)
+
+  var record = enr.Record(
+    seqNum: 1'u64,
+    publicKey: enode.pubkey,
+  )
+
+  record.pairs.insert(("id", Field(kind: kString, str: "v4")))
+  record.pairs.insert(("secp256k1",
+    Field(kind: kBytes, bytes: @(enode.pubkey.toRawCompressed()))))
+  record.pairs.insertAddress(
+    ip = Opt.some(enode.address.ip),
+    tcpPort = Opt.some(enode.address.tcpPort),
+    udpPort = Opt.some(enode.address.udpPort)
+  )
+
+  record
+
+func to*(enodes: openArray[ENode], _: type enr.Record): seq[enr.Record] =
+  result = newSeqOfCap[enr.Record](enodes.len)
+  for enode in enodes:
+    result.add enode.to(enr.Record)
+
+func fromEnr*(T: type ENode, r: enr.Record): ENodeResult[ENode] =
+  let
+    # TODO: there must always be a public key, else no signature verification
+    # could have been done and no Record would exist here.
+    # TypedRecord should be reworked not to have public key as an option.
+    pk = r.get(PublicKey).get()
+    tr = TypedRecord.fromRecord(r)#.expect("id in valid record")
+
+  if tr.ip.isNone():
+    return err(IncorrectIP)
+  if tr.udp.isNone():
+    return err(IncorrectDiscPort)
+  if tr.tcp.isNone():
+    return err(IncorrectPort)
+
+  ok(ENode(
+    pubkey: pk,
+    address: enode.Address(
+      ip: utils.ipv4(tr.ip.get()),
+      udpPort: Port(tr.udp.get()),
+      tcpPort: Port(tr.tcp.get())
+    )
+  ))

--- a/execution_chain/networking/p2p.nim
+++ b/execution_chain/networking/p2p.nim
@@ -10,14 +10,16 @@
 {.push raises: [].}
 
 import
-  std/[tables, algorithm, random, typetraits, strutils, net],
+  std/[tables, algorithm, typetraits, strutils, net],
   chronos, chronos/timer, chronicles,
   eth/common/keys,
   results,
-  ./[discoveryv4, peer_pool, rlpx, p2p_types]
+  ./[peer_pool, rlpx, p2p_types],
+  ./discoveryv4/enode,
+  ./eth1_discovery
 
 export
-  p2p_types, rlpx, enode, kademlia
+  p2p_types, rlpx, enode
 
 logScope:
   topics = "p2p"
@@ -37,23 +39,22 @@ proc newEthereumNode*(
   if rng == nil: # newRng could fail
     raiseAssert "Cannot initialize RNG"
 
-  new result
-  result.keys = keys
-  result.networkId = networkId
-  result.clientId = clientId
-  result.protocols.newSeq 0
-  result.capabilities.newSeq 0
-  result.address = address
-  result.connectionState = ConnectionState.None
-  result.bindIp = bindIp
-  result.bindPort = bindTcpPort
-  result.rng = rng
-
-  let discv4 = newDiscoveryV4(
-    keys.seckey, address, bootstrapNodes, bindUdpPort, bindIp, rng)
-
-  result.peerPool = newPeerPool[EthereumNode](
-    result, discv4, minPeers = minPeers)
+  let
+    discovery = Eth1Discovery.new(
+      keys.seckey, address, bootstrapNodes, bindUdpPort, bindIp, rng)
+    node = EthereumNode(
+      keys: keys,
+      networkId: networkId,
+      clientId: clientId,
+      address: address,
+      connectionState: ConnectionState.None,
+      bindIp: bindIp,
+      bindPort: bindTcpPort,
+      rng: rng,
+    )
+  node.peerPool = newPeerPool[EthereumNode](
+    node, discovery, minPeers = minPeers)
+  node
 
 proc processIncoming(server: StreamServer,
                      remote: StreamTransport): Future[void] {.async: (raises: []).} =
@@ -82,28 +83,30 @@ proc startListening*(node: EthereumNode) {.raises: [CatchableError].} =
   info "RLPx listener up", self = node.listeningAddress
 
 proc connectToNetwork*(
-    node: EthereumNode, startListening = true,
-    enableDiscovery = true, waitForPeers = true) {.async.} =
+    node: EthereumNode,
+    startListening = true,
+    enableDiscV4 = true,
+    enableDiscV5 = true) =
   doAssert node.connectionState == ConnectionState.None
 
   node.connectionState = Connecting
 
   if startListening:
-    p2p.startListening(node)
+    try:
+      p2p.startListening(node)
+    except CatchableError as exc:
+      error "Cannot start listening server", msg=exc.msg
 
-  if enableDiscovery:
-    node.peerPool.discv4.open()
-    await node.peerPool.discv4.bootstrap()
-    node.peerPool.start()
+  if enableDiscV4 or enableDiscV5:
+    node.peerPool.start(enableDiscV4, enableDiscV5)
   else:
     info "Discovery disabled"
 
-  while node.peerPool.connectedNodes.len == 0 and waitForPeers:
-    trace "Waiting for more peers", peers = node.peerPool.connectedNodes.len
-    await sleepAsync(500.milliseconds)
-
-proc stopListening*(node: EthereumNode) {.raises: [CatchableError].} =
-  node.listeningServer.stop()
+proc stopListening*(node: EthereumNode) =
+  try:
+    node.listeningServer.stop()
+  except TransportOsError as exc:
+    error "Cannot stop listening server", msg=exc.msg
 
 iterator peers*(node: EthereumNode): Peer =
   for peer in node.peerPool.peers:
@@ -113,18 +116,19 @@ iterator peers*(node: EthereumNode, Protocol: type): Peer =
   for peer in node.peerPool.peers(Protocol):
     yield peer
 
-proc connectToNode*(node: EthereumNode, n: Node) {.async.} =
+proc connectToNode*(node: EthereumNode, n: Node) {.async: (raises: [CancelledError]).} =
   await node.peerPool.connectToNode(n)
 
-proc connectToNode*(node: EthereumNode, n: ENode) {.async.} =
+proc connectToNode*(node: EthereumNode, n: ENode) {.async: (raises: [CancelledError]).} =
   await node.peerPool.connectToNode(n)
 
 func numPeers*(node: EthereumNode): int =
   node.peerPool.numPeers
 
-proc closeWait*(node: EthereumNode) {.async.} =
+proc closeWait*(node: EthereumNode) {.async: (raises: []).} =
   node.stopListening()
   await node.listeningServer.closeWait()
+  await node.peerPool.closeWait()
 
 proc addCapability*(node: EthereumNode,
                     p: ProtocolInfo,

--- a/execution_chain/networking/p2p_types.nim
+++ b/execution_chain/networking/p2p_types.nim
@@ -12,7 +12,6 @@
 import
   chronos,
   eth/common/[base, keys],
-  ./discoveryv4,
   ./rlpx/rlpxtransport,
   ./discoveryv4/[enode, kademlia],
   ./p2p_peers,

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -137,10 +137,11 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf,
 
   # Start Eth node
   if conf.maxPeers > 0:
-    nimbus.networkLoop = nimbus.ethNode.connectToNetwork(
-      enableDiscovery = conf.discovery != DiscoveryType.None,
-      waitForPeers = true)
-
+    let discovery = conf.getDiscoveryFlags()
+    nimbus.ethNode.connectToNetwork(
+      enableDiscV4 = DiscoveryType.V4 in discovery,
+      enableDiscV5 = DiscoveryType.V5 in discovery,
+    )
 
 proc setupMetrics(nimbus: NimbusNode, conf: NimbusConf)
     {.raises: [CancelledError, MetricsError].} =
@@ -294,7 +295,7 @@ proc run(nimbus: NimbusNode, conf: NimbusConf) =
         discard e # silence warning when chronicles not activated
 
     # Stop loop
-    waitFor nimbus.stop(conf)
+    waitFor nimbus.closeWait()
 
 when isMainModule:
   var nimbus = NimbusNode(state: NimbusState.Starting, ctx: newEthContext())

--- a/tests/networking/fuzzing/discoveryv4/fuzz.nim
+++ b/tests/networking/fuzzing/discoveryv4/fuzz.nim
@@ -10,7 +10,8 @@
 import
   std/net,
   testutils/fuzzing, chronicles, nimcrypto/keccak,
-  eth/[common/keys, rlp],
+  eth/[common/keys],
+  results,
   ../../../../execution_chain/networking/discoveryv4,
   ../../p2p_test_helper
 
@@ -46,11 +47,5 @@ test:
   msg = packData(payload, nodeKey)
   address = localAddress(DefaultListeningPort + 1)
 
-  try:
-    targetNode.receive(address, msg)
-  # These errors are also caught in `processClient` in discovery.nim
-  # TODO: move them a layer down in discovery so we can do a cleaner test there?
-  except RlpError as e:
-    debug "Receive failed", err = e.msg
-  except DiscProtocolError as e:
-    debug "Receive failed", err = e.msg
+  targetNode.receive(address, msg).isOkOr:
+    debug "Receive failed", msg=error

--- a/tests/networking/test_discoveryv4.nim
+++ b/tests/networking/test_discoveryv4.nim
@@ -138,9 +138,8 @@ procSuite "Discovery Tests":
     for data in invalidRlpData:
       check bootNode.receive(address, packData(hexToSeqByte(data), nodeKey)).isErr
 
-    # empty msg id and payload, doesn't raise, just fails and prints wrong
-    # msg mac
-    check bootNode.receive(address, packData(@[], nodeKey)) == Result[void, cstring].ok()
+    # empty msg id and payload, wrong msg mac
+    check bootNode.receive(address, packData(@[], nodeKey)).isErr
 
 
   asyncTest "Two findNode calls for the same peer in rapid succession":

--- a/tests/networking/test_discoveryv4.nim
+++ b/tests/networking/test_discoveryv4.nim
@@ -16,7 +16,6 @@ import
   nimcrypto/keccak,
   testutils/unittests,
   eth/common/keys,
-  eth/rlp,
   ./stubloglevel,
   ../../execution_chain/networking/discoveryv4
 
@@ -101,7 +100,7 @@ procSuite "Discovery Tests":
 
     for data in validProtocolData:
       # none of these may raise
-      bootNode.receive(address, packData(hexToSeqByte(data), nodeKey))
+      check bootNode.receive(address, packData(hexToSeqByte(data), nodeKey)) == Result[void, cstring].ok()
 
   test "Invalid protocol data":
     let invalidProtocolData = [
@@ -134,16 +133,15 @@ procSuite "Discovery Tests":
         "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a618")[]
 
     for data in invalidProtocolData:
-      expect DiscProtocolError:
-        bootNode.receive(address, packData(hexToSeqByte(data), nodeKey))
+      check bootNode.receive(address, packData(hexToSeqByte(data), nodeKey)).isErr
 
     for data in invalidRlpData:
-      expect RlpError:
-        bootNode.receive(address, packData(hexToSeqByte(data), nodeKey))
+      check bootNode.receive(address, packData(hexToSeqByte(data), nodeKey)).isErr
 
     # empty msg id and payload, doesn't raise, just fails and prints wrong
     # msg mac
-    bootNode.receive(address, packData(@[], nodeKey))
+    check bootNode.receive(address, packData(@[], nodeKey)) == Result[void, cstring].ok()
+
 
   asyncTest "Two findNode calls for the same peer in rapid succession":
     let targetKey = PrivateKey.fromHex(


### PR DESCRIPTION
Also cleanup peer pool and EthereumNode async start and termination. Async raises in Discovery V4 also refactored.
There is no algorithm changes, only modify error handling of both receiver proc. So when discovery V4 cannot handle incoming message, there is discovery V5 waiting to handle it.
If both of them error, the error will be logged with two error message.

And this is test result from hive, some test cases are failing. But other clients also have no perfect score:

```
jangko@Jangko-MSI:~/hive$ ./hive --sim devp2p --sim.limit discv5 --client nimbus-el
Jul 19 22:16:03.463 INF building image image=hive/hiveproxy nocache=false pull=false
Jul 19 22:16:03.491 INF building 1 clients...
Jul 19 22:16:03.491 INF building image image=hive/clients/nimbus-el:latest dir=clients/nimbus-el nocache=false pull=false
Jul 19 22:16:04.062 INF building 1 simulators...
Jul 19 22:16:04.062 INF building image image=hive/simulators/devp2p:latest dir=simulators/devp2p nocache=false pull=false
Jul 19 22:16:04.123 INF running simulation: devp2p
Jul 19 22:16:04.332 INF hiveproxy started container=2b7ab4068cb6 addr=172.17.0.4:8081
Jul 19 22:16:04.552 INF API: suite started suite=0 name=discv5
Jul 19 22:16:04.554 INF API: test started suite=0 test=1 name=nimbus-el
Jul 19 22:16:04.854 INF API: client nimbus-el started suite=0 test=1 container=5fe0323c
Jul 19 22:16:04.884 INF API: network created name=network1
Jul 19 22:16:04.979 INF API: container connected to network network=network1 container=simulation
Jul 19 22:16:04.981 INF API: container IP requested network=bridge container=simulation ip=172.17.0.5
Jul 19 22:16:04.983 INF API: container IP requested network=network1 container=simulation ip=172.20.0.2
Jul 19 22:16:05.078 INF API: container connected to network network=network1 container=5fe0323c
Jul 19 22:16:05.135 INF API: container IP requested network=bridge container=5fe0323c ip=172.17.0.6
Jul 19 22:16:05.451 INF API: test started suite=0 test=2 name="Ping (nimbus-el)"
Jul 19 22:16:05.452 INF API: test ended suite=0 test=2 pass=true
Jul 19 22:16:05.756 INF API: test started suite=0 test=3 name="PingLargeRequestID (nimbus-el)"
Jul 19 22:16:05.758 INF API: test ended suite=0 test=3 pass=true
Jul 19 22:16:06.061 INF API: test started suite=0 test=4 name="PingMultiIP (nimbus-el)"
Jul 19 22:16:06.062 INF API: test ended suite=0 test=4 pass=false
Jul 19 22:16:06.068 INF API: test started suite=0 test=5 name="PingHandshakeInterrupted (nimbus-el)"
Jul 19 22:16:06.069 INF API: test ended suite=0 test=5 pass=false
Jul 19 22:16:06.072 INF API: test started suite=0 test=6 name="TalkRequest (nimbus-el)"
Jul 19 22:16:06.073 INF API: test ended suite=0 test=6 pass=true
Jul 19 22:17:06.078 INF API: test started suite=0 test=7 name="FindnodeZeroDistance (nimbus-el)"
Jul 19 22:17:06.079 INF API: test ended suite=0 test=7 pass=true
Jul 19 22:17:06.082 INF API: test started suite=0 test=8 name="FindnodeResults (nimbus-el)"
Jul 19 22:17:06.084 INF API: test ended suite=0 test=8 pass=false
Jul 19 22:17:06.405 INF API: test ended suite=0 test=1 pass=false
Jul 19 22:17:06.408 INF removing docker network name=network1
Jul 19 22:17:06.599 INF API: suite ended suite=0
Jul 19 22:17:06.964 INF simulation devp2p finished suites=1 tests=8 failed=4
4 tests failed
```

fix #2799