### PR TITLE
Fix race condition between FC.processingQueue and FC.serialize

### DIFF
--- a/execution_chain/core/chain/forked_chain/chain_serialize.nim
+++ b/execution_chain/core/chain/forked_chain/chain_serialize.nim
@@ -283,7 +283,8 @@ proc deserialize*(fc: ForkedChainRef): Result[void, string] =
 
   # All blocks should have replayed
   for b in blocks:
-    doAssert(b.txFrame.isNil.not, "deserialized node should have txFrame")
+    if b.txFrame.isNil:
+      return err("corrupted FC serialization: deserialized node should have txFrame")
 
   fc.hashToBlock.withValue(fc.fcuHead.hash, val) do:
     let txFrame = val[].txFrame


### PR DESCRIPTION
This in theory should fix both problem of FC crash during termination and restart.

cc @advaita-saha 