### PR TITLE
Quit when address + port is already in use for listening server and discovery

### DIFF
--- a/execution_chain/networking/p2p.nim
+++ b/execution_chain/networking/p2p.nim
@@ -97,7 +97,8 @@ proc connectToNetwork*(
     try:
       p2p.startListening(node)
     except TransportOsError as exc:
-      error "Cannot start listening server", msg=exc.msg
+      fatal "Cannot start listening server", msg=exc.msg
+      quit(QuitFailure)
 
   if enableDiscV4 or enableDiscV5:
     node.peerPool.start(enableDiscV4, enableDiscV5)

--- a/execution_chain/networking/peer_pool.nim
+++ b/execution_chain/networking/peer_pool.nim
@@ -282,8 +282,8 @@ proc start*(p: PeerPoolRef, enableDiscV4: bool, enableDiscV5: bool) =
   try:
     p.discovery.open(enableDiscV4, enableDiscV5)
   except TransportOsError as exc:
-    error "Cannot start discovery protocol", msg=exc.msg
-    return
+    fatal "Cannot start discovery protocol", msg=exc.msg
+    quit(QuitFailure)
 
   var workers = newSeqOfCap[WorkerFuture](maxConcurrentConnectionRequests+1)
   for i in 0 ..< maxConcurrentConnectionRequests:


### PR DESCRIPTION
Before this change if the tcp or udp port used for the p2p networking/discovery services were already in use then these services wouldn't start up but the node would still be running. 

We should instead shutdown if the p2p network services fail to start (like other EL clients).