### PR TITLE
reduce sync error threshold

### DIFF
--- a/execution_chain/sync/beacon/worker_const.nim
+++ b/execution_chain/sync/beacon/worker_const.nim
@@ -48,7 +48,7 @@ const
 
   # ----------------------
 
-  nFetchHeadersFailedInitialPeersThreshold* = 30
+  nFetchHeadersFailedInitialPeersThreshold* = 17
     ## If there are more failing peers than this threshold right at the
     ## begining of a header chain download scrum (before any data received),
     ## then this session (scrum or sprint) is discarded and the suncer is


### PR DESCRIPTION
As per testing in devnet, the ideal failing peers seems to be something in between 16-20