### PR TITLE
fix slow startup during sync

### DIFF
--- a/execution_chain/db/core_db/backend/aristo_rocksdb.nim
+++ b/execution_chain/db/core_db/backend/aristo_rocksdb.nim
@@ -21,15 +21,35 @@ import
   ../../aristo/aristo_compute,
   ../../opts
 
-proc toRocksDb*(
-    opts: DbOptions
-): tuple[dbOpts: DbOptionsRef, cfOpts: ColFamilyOptionsRef] =
-  # TODO the configuration options below have not been tuned but are rather
-  #      based on gut feeling, guesses and by looking at other clients - it
-  #      would make sense to test different settings and combinations once the
-  #      data model itself has settled down as their optimal values will depend
-  #      on the shape of the data - it'll also be different per column family..
+# TODO the configuration options below have not been tuned but are rather
+#      based on gut feeling, guesses and by looking at other clients - it
+#      would make sense to test different settings and combinations once the
+#      data model itself has settled down as their optimal values will depend
+#      on the shape of the data - it'll also be different per column family..
 
+proc toDbOpts*(opts: DbOptions): DbOptionsRef =
+  let dbOpts = defaultDbOptions(autoClose = true)
+  dbOpts.maxOpenFiles = opts.maxOpenFiles
+
+  # Needed for vector memtable
+  dbOpts.allowConcurrentMemtableWrite = false
+
+  if opts.rowCacheSize > 0:
+    # Good for GET queries, which is what we do most of the time - however,
+    # because we have other similar caches at different abstraction levels in
+    # the codebase, this cache ends up being less impactful than the block cache
+    # even though it is faster to access.
+    # https://github.com/facebook/rocksdb/blob/af50823069818fc127438e39fef91d2486d6e76c/include/rocksdb/options.h#L1276
+    dbOpts.rowCache = cacheCreateLRU(opts.rowCacheSize, autoClose = true)
+
+  dbOpts.keepLogFileNum = 16 # No point keeping 1000 log files around...
+
+  # Parallelize L0 -> Ln compaction
+  # https://github.com/facebook/rocksdb/wiki/Subcompaction
+  dbOpts.maxSubcompactions = dbOpts.maxBackgroundJobs
+  dbOpts
+
+proc toCfOpts*(opts: DbOptions, cache: CacheRef, bulk: bool): ColFamilyOptionsRef =
   let tableOpts = defaultTableOptions(autoClose = true)
   # This bloom filter helps avoid having to read multiple SST files when looking
   # for a value.
@@ -40,15 +60,8 @@ proc toRocksDb*(
   # https://github.com/facebook/rocksdb/blob/d64eac28d32a025770cba641ea04e697f475cdd6/include/rocksdb/filter_policy.h#L208
   tableOpts.filterPolicy = createRibbonHybrid(9.9)
 
-  if opts.blockCacheSize > 0:
-    # The block cache holds uncompressed data blocks that each contain multiple
-    # key-value pairs - it helps in particular when loading sort-adjacent values
-    # such as when the storage of each account is prefixed by a value unique to
-    # that account - it is best that this cache is large enough to hold a
-    # significant portion of the inner trie nodes!
-    # This code sets up a single block cache to be shared, a strategy that
-    # plausibly can be refined in the future.
-    tableOpts.blockCache = cacheCreateLRU(opts.blockCacheSize, autoClose = true)
+  if cache != nil:
+    tableOpts.blockCache = cache
 
   # Single-level indices might cause long stalls due to their large size -
   # two-level indexing allows the first level to be kept in memory at all times
@@ -77,14 +90,27 @@ proc toRocksDb*(
   # default implementation is a skip list whose overhead is quite significant
   # both when inserting and during lookups - up to 10% CPU time has been
   # observed in it.
-  # Instead of using a skip list, we'll bulk-load changes into a vector which
-  # immediately is flushed to L0/1 thus avoiding memtables completely (our own
-  # in-memory caches perform a similar task with less serialization).
-  # A downside of this approach is that the memtable *has* to be flushed in the
-  # main thread instead of this operation happening in the background - however,
-  # the time it takes to flush is less than it takes to build the skip list, so
-  # this ends up being a net win regardless.
-  cfOpts.setMemtableVectorRep()
+  # Depending on whether the database is bulk-written or not, we'll use a vector
+  # representation instead.
+  if bulk:
+    # Bulk-load changes into a vector which immediately is flushed to L0/1 thus
+    # avoiding memtable reads completely (our own in-memory caches perform a
+    # similar task with less serialization).
+    # A downside of this approach is that the memtable *has* to be flushed in the
+    # main thread instead of this operation happening in the background - however,
+    # the time it takes to flush is less than it takes to build the skip list, so
+    # this ends up being a net win regardless.
+    cfOpts.setMemtableVectorRep()
+  else:
+    # Since the mem table holds the most recent data, all reads must go through
+    # this skiplist which results in slow lookups for already-written data.
+    # We enable a bloom filter on the mem table to avoid this lookup in the cases
+    # where the data is actually on disk already (ie wasn't updated recently).
+    # TODO there's also a hashskiplist that has both a hash index and a skip list
+    #      which maybe could be used - uses more memory, requires a key prefix
+    #      extractor
+    cfOpts.memtableWholeKeyFiltering = true
+    cfOpts.memtablePrefixBloomSizeRatio = 0.1
 
   # L0 files may overlap, so we want to push them down to L1 quickly so as to
   # not have to read/examine too many files to find data
@@ -117,27 +143,7 @@ proc toRocksDb*(
   cfOpts.ttl = 0
   cfOpts.periodicCompactionSeconds = 0
 
-  let dbOpts = defaultDbOptions(autoClose = true)
-  dbOpts.maxOpenFiles = opts.maxOpenFiles
-
-  # Needed for vector memtable
-  dbOpts.allowConcurrentMemtableWrite = false
-
-  if opts.rowCacheSize > 0:
-    # Good for GET queries, which is what we do most of the time - however,
-    # because we have other similar caches at different abstraction levels in
-    # the codebase, this cache ends up being less impactful than the block cache
-    # even though it is faster to access.
-    # https://github.com/facebook/rocksdb/blob/af50823069818fc127438e39fef91d2486d6e76c/include/rocksdb/options.h#L1276
-    dbOpts.rowCache = cacheCreateLRU(opts.rowCacheSize, autoClose = true)
-
-  dbOpts.keepLogFileNum = 16 # No point keeping 1000 log files around...
-
-  # Parallelize L0 -> Ln compaction
-  # https://github.com/facebook/rocksdb/wiki/Subcompaction
-  dbOpts.maxSubcompactions = dbOpts.maxBackgroundJobs
-
-  (dbOpts, cfOpts)
+  cfOpts
 
 # ------------------------------------------------------------------------------
 # Public constructor
@@ -151,11 +157,28 @@ proc newRocksDbCoreDbRef*(basePath: string, opts: DbOptions): CoreDbRef =
   # of what's stored in there - there's room for improvement here!
 
   # Legacy support: adm CF, if it exists
-
   let
-    (dbOpts, cfOpts) = opts.toRocksDb()
-    cfDescs = @[$AristoCFs.VtxCF] & KvtCFs.items().toSeq().mapIt($it)
-    baseDb = RocksDbInstanceRef.open(basePath, dbOpts, cfOpts, cfDescs).expect(
+    cache =
+      if opts.blockCacheSize > 0:
+        # The block cache holds uncompressed data blocks that each contain multiple
+        # key-value pairs - it helps in particular when loading sort-adjacent values
+        # such as when the storage of each account is prefixed by a value unique to
+        # that account - it is best that this cache is large enough to hold a
+        # significant portion of the inner trie nodes!
+        # This code sets up a single block cache to be shared, a strategy that
+        # plausibly can be refined in the future.
+        cacheCreateLRU(opts.blockCacheSize, autoClose = true)
+      else:
+        nil
+    dbOpts = opts.toDbOpts()
+    acfOpts = opts.toCfOpts(cache, true)
+    # The KVT is is not bulk-flushed so we have to use a skiplist memtable for
+    # it
+    kcfOpts = opts.toCfOpts(cache, false)
+
+    cfDescs =
+      @[($AristoCFs.VtxCF, acfOpts)] & KvtCFs.items().toSeq().mapIt(($it, kcfOpts))
+    baseDb = RocksDbInstanceRef.open(basePath, dbOpts, cfDescs).expect(
         "Open database from " & basePath
       )
 


### PR DESCRIPTION
Unlike the rest of the database code, sync does not bulk-flush what it writes and therefore runs into a pathologically slow case when a vector memtable is used and it tries to read from it in a loop mingled with writes.

This can cause the application to freeze for several seconds  - keep vector for state database but otherwise use the skiplist.