### PR TITLE
Restore 'make update' and introduce 'make init'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Build Nim and Nimbus-eth1 dependencies
         run: |
-          make -j${ncpu} ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinCache update
+          make -j${ncpu} ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinCache init
 
       - name: Run nimbus-eth1 tests (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/nimbus_verified_proxy.yml
+++ b/.github/workflows/nimbus_verified_proxy.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Build Nim and Nimbus-eth1 dependencies
         run: |
-          make V=1 -j${ncpu} ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinCache update
+          make V=1 -j${ncpu} ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinCache init
 
       - name: Run verified proxy tests (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/portal.yml
+++ b/.github/workflows/portal.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build Nim and Nimbus-eth1 dependencies
         run: |
-          make -j${ncpu} ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinaries update
+          make -j${ncpu} ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinaries init
 
       - name: build uTP test app container
         run: |
@@ -248,7 +248,7 @@ jobs:
         run: |
           # use CC to make sure Nim compiler and subsequent test
           # using the same glibc version.
-          env CC=gcc make -j${ncpu} ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinaries update
+          env CC=gcc make -j${ncpu} ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinaries init
 
       - name: Run Nimbus Portal tests (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/simulators.yml
+++ b/.github/workflows/simulators.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build Nim and deps
         run: |
           ncpu=$(nproc)
-          make -j${ncpu} ARCH_OVERRIDE=x64 CI_CACHE=NimBinaries update
+          make -j${ncpu} ARCH_OVERRIDE=x64 CI_CACHE=NimBinaries init
           make -j${ncpu} deps rocksdb
 
       - name: Run Simulators
@@ -83,7 +83,7 @@ jobs:
       - name: Build Nim and deps
         run: |
           ncpu=$(sysctl -n hw.ncpu)
-          make -j${ncpu} ARCH_OVERRIDE=x64 CI_CACHE=NimBinaries update
+          make -j${ncpu} ARCH_OVERRIDE=x64 CI_CACHE=NimBinaries init
           make -j${ncpu} deps rocksdb
 
       - name: Run Simulators
@@ -148,7 +148,7 @@ jobs:
       - name: Build Nim and deps
         run: |
           ncpu=${NUMBER_OF_PROCESSORS}
-          mingw32-make -j${ncpu} ARCH_OVERRIDE=x64 CI_CACHE=NimBinaries update
+          mingw32-make -j${ncpu} ARCH_OVERRIDE=x64 CI_CACHE=NimBinaries init
           mingw32-make -j${ncpu} deps
 
       - name: Run Simulators

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN ldd --version
 ADD . /root/nimbus-eth1
 
 RUN cd /root/nimbus-eth1 \
- && make -j$(nproc) update \
+ && make -j$(nproc) init \
  && make -j$(nproc) DISABLE_MARCH_NATIVE=1 V=1 nimbus_execution_client
 
 # --------------------------------- #

--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,8 @@ VERIF_PROXY_OUT_PATH ?= build/libverifproxy/
 	rocksdb \
 	dist-amd64 \
 	dist-arm64 \
-	dist-arm \
 	dist-win64 \
 	dist-macos \
-	dist-macos-arm64 \
 	dist
 
 ifeq ($(NIM_PARAMS),)
@@ -194,7 +192,11 @@ endif
 NIM_PARAMS := $(NIM_PARAMS) $(NIM_ETH_PARAMS)
 
 #- deletes and recreates "nimbus.nims" which on Windows is a copy instead of a proper symlink
-update: | sanity-checks update-test
+update: | update-common
+	rm -rf nimbus.nims && \
+		$(MAKE) nimbus.nims $(HANDLE_OUTPUT)
+
+init: | sanity-checks update-test
 	rm -rf nimbus.nims && \
 		$(MAKE) nimbus.nims $(HANDLE_OUTPUT)
 	+ "$(MAKE)" --no-print-directory deps-common

--- a/docker/dist/Dockerfile.arm64
+++ b/docker/dist/Dockerfile.arm64
@@ -24,5 +24,5 @@ USER user
 STOPSIGNAL SIGINT
 
 COPY "entry_point.sh" "/home/user/"
-ENTRYPOINT ["/home/user/entry_point.sh", "linux_arm64v8"]
+ENTRYPOINT ["/home/user/entry_point.sh", "linux_arm64"]
 

--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -85,7 +85,7 @@ if [[ "${PLATFORM}" == "windows_amd64" ]]; then
 
   build_rocksdb TARGET_OS=MINGW CXX="${CXX}"
 
-  make -j$(nproc) update-from-ci
+  make -j$(nproc) init
 
   make \
     -j$(nproc) \
@@ -126,14 +126,14 @@ if [[ "${PLATFORM}" == "windows_amd64" ]]; then
     LOG_LEVEL="TRACE" \
     NIMFLAGS="${NIMFLAGS_COMMON} --os:windows --gcc.exe=${CC} --gcc.linkerexe=${CXX} --passL:'-static -lshlwapi -lrpcrt4' -d:BLSTuseSSSE3=1" \
     ${BINARIES}
-elif [[ "${PLATFORM}" == "linux_arm64v8" ]]; then
+elif [[ "${PLATFORM}" == "linux_arm64" ]]; then
   CC="aarch64-linux-gnu-gcc"
   CXX="aarch64-linux-gnu-g++"
   ${CXX} --version
 
   build_rocksdb TARGET_ARCHITECTURE=arm64 CXX="${CXX}"
 
-  make -j$(nproc) update-from-ci
+  make -j$(nproc) init
 
   make \
     -j$(nproc) \
@@ -162,7 +162,7 @@ elif [[ "${PLATFORM}" == "macOS_arm64" ]]; then
 
   build_rocksdb TARGET_OS=Darwin TARGET_ARCHITECTURE=arm64 CXX="${CXX}" AR="${AR}"
 
-  make -j$(nproc) update-from-ci
+  make -j$(nproc) init
 
   make \
     -j$(nproc) \
@@ -196,7 +196,7 @@ else
 
   build_rocksdb
 
-  make -j$(nproc) update-from-ci
+  make -j$(nproc) init
 
   make \
     -j$(nproc) \


### PR DESCRIPTION
Because of recent changes to 'make update' causing confusion among team members, I decide to restore 'make update' and introduce 'make init' to replace the former 'make update-from-ci'. Now 'make init' also can be used in docker file.

ping @holiman, please use `make init` in your docker file to replace `make update`.