### PR TITLE
Fix memory usage regression caused by stateroot mismatch fix

### DIFF
--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -11,7 +11,7 @@ import
   ../execution_chain/compile_info
 
 import
-  std/[os, osproc, strutils, net, options],
+  std/[os, osproc, net, options],
   chronicles,
   eth/net/nat,
   metrics,

--- a/execution_chain/rpc/debug.nim
+++ b/execution_chain/rpc/debug.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import
-  std/json,
+  # std/json,
   json_rpc/rpcserver,
   # ./rpc_utils,
   ./rpc_types,

--- a/tests/test_stateless_witness_generation.nim
+++ b/tests/test_stateless_witness_generation.nim
@@ -12,7 +12,6 @@
 
 import
   stew/byteutils,
-  chronicles,
   unittest2,
   ../execution_chain/common/common,
   ../execution_chain/stateless/witness_generation


### PR DESCRIPTION
Fixes the memory usage issue introduced by the previous state root mismatch fix here: https://github.com/status-im/nimbus-eth1/pull/3527

Instead of copying the updated values from a parent txFrame into the current txFrame in order to prevent losing the updates (when a snapshot is taken), here we just update the shared db LRU caches directly from the snapshot tables which should have the state updates from previous checkpoints which are copied over when the snapshot is moved.

