### PR TITLE
Stateless: Create snapshots before building witness during block import

### DIFF
--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -165,6 +165,11 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
     let parentTxFrame = vmState.ledger.txFrame
     vmState.ledger.txFrame = parentTxFrame.txFrameBegin()
 
+    # Creating a snapshot here significantly improves the performance of building
+    # the witness from the prestate, especially when the import batch size is
+    # set to a larger value.
+    parentTxFrame.checkpoint(p.parent.number, skipSnapshot = false)
+
     # Clear the caches before executing the block to ensure we collect the correct
     # witness keys and block hashes when processing the block as these will be used
     # when building the witness.


### PR DESCRIPTION
Now that the state root mismatch issue is fixed we can safely take multiple snapshots (one per txFrame/block) before persisting to the database. 

This change updates the block import so that when the stateless provider flag is enabled we take a snapshot of the `parentTxFrame` before building the witness. This significantly improves the performance of the import. 

Before implementing this change, I found that the slowest section of code was fetching the proofs from the database especially when setting a larger batch size for the import. This is likely because it has to search through all the txFrames in memory when snapshots are not in use.
