### PR TITLE
Set the default rocksdb cache location to the build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ libbacktrace:
 	+ $(MAKE) -C vendor/nim-libbacktrace --no-print-directory BUILD_CXX_LIB=0
 
 # nim-rocksdb
-ROCKSDB_CI_CACHE := /usr/rocksdb
+ROCKSDB_CI_CACHE := build
 
 ifneq ($(USE_SYSTEM_ROCKSDB), 0)
 rocksdb:


### PR DESCRIPTION
When I run `make nimbus_execution_client` I get this:
```
Building: install/usr/lib/libbacktracenim.a
RocksDb static libraries already built. Skipping build.
mkdir: cannot create directory ‘/usr/rocksdb’: Permission denied
make: *** [Makefile:230: rocksdb] Error 1
```

The default cache directory is `/usr/rocksdb`. We should probably change it to use the build directory or something else inside the repo. It looks like the CI already manual sets the `ROCKSDB_CI_CACHE` variable so this should be fine I think.