### PR TITLE
Stateless: Minor improvement to witness building

### DIFF
--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -179,11 +179,10 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
     processBlock()
 
     let
-      blockHash = header.computeBlockHash()
       preStateLedger = LedgerRef.init(parentTxFrame)
       witness = Witness.build(preStateLedger, vmState.ledger, p.parent, header)
 
-    ?vmState.ledger.txFrame.persistWitness(blockHash, witness)
+    ?vmState.ledger.txFrame.persistWitness(header.computeBlockHash(), witness)
 
   if NoPersistHeader notin p.flags:
     let blockHash = header.computeBlockHash()


### PR DESCRIPTION
Results in a small performance improvement because slots are fetched in batches.

The witness building is still far too slow because the txFrame proofs functions are very slow. Will likely need to implement something custom in the database to collect the witness trie nodes in a more efficient way.