### PR TITLE
CI using shared workflow to generate matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,34 +41,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  matrix_config:
+    uses: ./.github/workflows/matrix_config.yml
+
   build:
+    needs: matrix_config
+
     strategy:
       fail-fast: false
-      max-parallel: 20
-      matrix:
-        target:
-          - os: linux
-            cpu: amd64
-          - os: windows
-            cpu: amd64
-          - os: macos
-            cpu: arm64
-        include:
-          - target:
-              os: linux
-            builder: ubuntu-22.04
-          - target:
-              os: macos
-            builder: macos-13
-          - target:
-              os: windows
-            builder: windows-latest
+      matrix: ${{ fromJSON(needs.matrix_config.outputs.matrix) }}
 
     defaults:
       run:
         shell: bash
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}'
+    name: '${{ matrix.os }}-${{ matrix.cpu }}'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout nimbus-eth1
@@ -76,10 +63,10 @@ jobs:
 
       - name: Derive environment variables
         run: |
-          if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
+          if [[ '${{ matrix.cpu }}' == 'amd64' ]]; then
             PLATFORM=x64
             GOARCH=amd64
-          elif [[ '${{ matrix.target.cpu }}' == 'arm64' ]]; then
+          elif [[ '${{ matrix.cpu }}' == 'arm64' ]]; then
             PLATFORM=arm64
             GOARCH=arm64
           else
@@ -128,8 +115,8 @@ jobs:
         id: windows-mingw-cache
         uses: actions/cache@v4
         with:
-          path: external/mingw-${{ matrix.target.cpu }}
-          key: 'mingw-llvm-17-${{ matrix.target.cpu }}'
+          path: external/mingw-${{ matrix.cpu }}
+          key: 'mingw-llvm-17-${{ matrix.cpu }}'
 
       - name: Install llvm-mingw dependency (Windows)
         if: >
@@ -139,22 +126,22 @@ jobs:
           mkdir -p external
           LLVM_VERSION="20250730"
           MINGW_BASE="https://github.com/mstorsjo/llvm-mingw/releases/download/$LLVM_VERSION"
-          if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
+          if [[ '${{ matrix.cpu }}' == 'amd64' ]]; then
             MINGW_URL="$MINGW_BASE/llvm-mingw-$LLVM_VERSION-ucrt-x86_64.zip"
             ARCH=64
           else
             MINGW_URL="$MINGW_BASE/llvm-mingw-$LLVM_VERSION-ucrt-i686.zip"
             ARCH=32
           fi
-          curl -L "$MINGW_URL" -o "external/mingw-${{ matrix.target.cpu }}.zip"
-          7z x -y "external/mingw-${{ matrix.target.cpu }}.zip" -oexternal/mingw-${{ matrix.target.cpu }}/
-          mv external/mingw-${{ matrix.target.cpu }}/**/* ./external/mingw-${{ matrix.target.cpu }}
+          curl -L "$MINGW_URL" -o "external/mingw-${{ matrix.cpu }}.zip"
+          7z x -y "external/mingw-${{ matrix.cpu }}.zip" -oexternal/mingw-${{ matrix.cpu }}/
+          mv external/mingw-${{ matrix.cpu }}/**/* ./external/mingw-${{ matrix.cpu }}
 
       - name: Path to cached dependencies (Windows)
         if: >
           runner.os == 'Windows'
         run: |
-          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.target.cpu }}/bin" >> $GITHUB_PATH
+          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.cpu }}/bin" >> $GITHUB_PATH
 
       - name: Get latest nimbus-build-system commit hash
         id: versions
@@ -170,7 +157,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: NimBinCache
-          key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}'
+          key: 'nim-${{ matrix.os }}-${{ matrix.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}'
 
       - name: Get latest nim-rocksdb commit hash
         id: rocksdb-versions
@@ -186,7 +173,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: RocksBinCache
-          key: 'rocks-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.rocksdb-versions.outputs.nim_rocksdb }}'
+          key: 'rocks-${{ matrix.os }}-${{ matrix.cpu }}-${{ steps.rocksdb-versions.outputs.nim_rocksdb }}'
 
       - name: Build Nim and Nimbus-eth1 dependencies
         run: |

--- a/.github/workflows/nimbus_verified_proxy.yml
+++ b/.github/workflows/nimbus_verified_proxy.yml
@@ -33,36 +33,21 @@ on:
       - 'nimbus.nimble'
 
 jobs:
+  matrix_config:
+    uses: ./.github/workflows/matrix_config.yml
+
   build:
+    needs: matrix_config
+
     strategy:
       fail-fast: false
-      max-parallel: 20
-      matrix:
-        target:
-          - os: linux
-            cpu: amd64
-          # - os: linux
-          #   cpu: i386
-          - os: macos
-            cpu: arm64
-          - os: windows
-            cpu: amd64
-        include:
-          - target:
-              os: linux
-            builder: ubuntu-22.04
-          - target:
-              os: macos
-            builder: macos-13
-          - target:
-              os: windows
-            builder: windows-latest
+      matrix: ${{ fromJSON(needs.matrix_config.outputs.matrix) }}
 
     defaults:
       run:
         shell: bash
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}'
+    name: '${{ matrix.os }}-${{ matrix.cpu }}'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout nimbus-eth1
@@ -70,9 +55,9 @@ jobs:
 
       - name: Derive environment variables
         run: |
-          if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
+          if [[ '${{ matrix.cpu }}' == 'amd64' ]]; then
             PLATFORM=x64
-          elif [[ '${{ matrix.target.cpu }}' == 'arm64' ]]; then
+          elif [[ '${{ matrix.cpu }}' == 'arm64' ]]; then
             PLATFORM=arm64
           else
             PLATFORM=x86
@@ -80,7 +65,7 @@ jobs:
           echo "PLATFORM=${PLATFORM}" >> $GITHUB_ENV
 
           # libminiupnp / natpmp
-          if [[ '${{ runner.os }}' == 'Linux' && '${{ matrix.target.cpu }}' == 'i386' ]]; then
+          if [[ '${{ runner.os }}' == 'Linux' && '${{ matrix.cpu }}' == 'i386' ]]; then
             export CFLAGS="${CFLAGS} -m32 -mno-adx"
             echo "CFLAGS=${CFLAGS}" >> $GITHUB_ENV
           fi
@@ -100,26 +85,6 @@ jobs:
           [[ -z "$ncpu" || $ncpu -le 0 ]] && ncpu=1
           echo "ncpu=${ncpu}" >> $GITHUB_ENV
 
-      - name: Install build dependencies (Linux i386)
-        if: runner.os == 'Linux' && matrix.target.cpu == 'i386'
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
-            --no-install-recommends -yq gcc-multilib g++-multilib \
-            libz-dev:i386 libbz2-dev:i386 libssl-dev:i386 libpcre3-dev:i386
-          mkdir -p external/bin
-          cat << EOF > external/bin/gcc
-          #!/bin/bash
-          exec $(which gcc) -m32 "\$@"
-          EOF
-          cat << EOF > external/bin/g++
-          #!/bin/bash
-          exec $(which g++) -m32 "\$@"
-          EOF
-          chmod 755 external/bin/gcc external/bin/g++
-          echo '${{ github.workspace }}/external/bin' >> $GITHUB_PATH
-
       - name: Install build dependencies (Macos)
         # Some home brew modules were reported missing
         if: runner.os == 'Macos'
@@ -132,8 +97,8 @@ jobs:
         id: windows-mingw-cache
         uses: actions/cache@v4
         with:
-          path: external/mingw-${{ matrix.target.cpu }}
-          key: 'mingw-llvm-17-${{ matrix.target.cpu }}'
+          path: external/mingw-${{ matrix.cpu }}
+          key: 'mingw-llvm-17-${{ matrix.cpu }}'
 
       - name: Install llvm-mingw dependency (Windows)
         if: >
@@ -143,22 +108,22 @@ jobs:
           mkdir -p external
           LLVM_VERSION="20250730"
           MINGW_BASE="https://github.com/mstorsjo/llvm-mingw/releases/download/$LLVM_VERSION"
-          if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
+          if [[ '${{ matrix.cpu }}' == 'amd64' ]]; then
             MINGW_URL="$MINGW_BASE/llvm-mingw-$LLVM_VERSION-ucrt-x86_64.zip"
             ARCH=64
           else
             MINGW_URL="$MINGW_BASE/llvm-mingw-$LLVM_VERSION-ucrt-i686.zip"
             ARCH=32
           fi
-          curl -L "$MINGW_URL" -o "external/mingw-${{ matrix.target.cpu }}.zip"
-          7z x -y "external/mingw-${{ matrix.target.cpu }}.zip" -oexternal/mingw-${{ matrix.target.cpu }}/
-          mv external/mingw-${{ matrix.target.cpu }}/**/* ./external/mingw-${{ matrix.target.cpu }}
+          curl -L "$MINGW_URL" -o "external/mingw-${{ matrix.cpu }}.zip"
+          7z x -y "external/mingw-${{ matrix.cpu }}.zip" -oexternal/mingw-${{ matrix.cpu }}/
+          mv external/mingw-${{ matrix.cpu }}/**/* ./external/mingw-${{ matrix.cpu }}
 
       - name: Path to cached dependencies (Windows)
         if: >
           runner.os == 'Windows'
         run: |
-          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.target.cpu }}/bin" >> $GITHUB_PATH
+          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.cpu }}/bin" >> $GITHUB_PATH
 
       - name: Get latest nimbus-build-system commit hash
         id: versions
@@ -174,7 +139,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: NimBinCache
-          key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}-verified-proxy'
+          key: 'nim-${{ matrix.os }}-${{ matrix.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}-verified-proxy'
 
       - name: Build Nim and Nimbus-eth1 dependencies
         run: |

--- a/.github/workflows/portal.yml
+++ b/.github/workflows/portal.yml
@@ -107,34 +107,21 @@ jobs:
           PATH=$PATH$(find /usr/libexec/docker -name docker-compose -printf ":%h")
           docker-compose -f portal/tools/utp_testing/docker/docker-compose.yml down
 
+  matrix_config:
+    uses: ./.github/workflows/matrix_config.yml
+
   build:
+    needs: matrix_config
+
     strategy:
       fail-fast: false
-      max-parallel: 20
-      matrix:
-        target:
-          - os: linux
-            cpu: amd64
-          - os: macos
-            cpu: arm64
-          - os: windows
-            cpu: amd64
-        include:
-          - target:
-              os: linux
-            builder: ubuntu-22.04
-          - target:
-              os: macos
-            builder: macos-13
-          - target:
-              os: windows
-            builder: windows-latest
+      matrix: ${{ fromJSON(needs.matrix_config.outputs.matrix) }}
 
     defaults:
       run:
         shell: bash
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}'
+    name: '${{ matrix.os }}-${{ matrix.cpu }}'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout nimbus-eth1
@@ -142,9 +129,9 @@ jobs:
 
       - name: Derive environment variables
         run: |
-          if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
+          if [[ '${{ matrix.cpu }}' == 'amd64' ]]; then
             PLATFORM=x64
-          elif [[ '${{ matrix.target.cpu }}' == 'arm64' ]]; then
+          elif [[ '${{ matrix.cpu }}' == 'arm64' ]]; then
             PLATFORM=arm64
           else
             PLATFORM=x86
@@ -152,7 +139,7 @@ jobs:
           echo "PLATFORM=${PLATFORM}" >> $GITHUB_ENV
 
           # libminiupnp / natpmp
-          if [[ '${{ runner.os }}' == 'Linux' && '${{ matrix.target.cpu }}' == 'i386' ]]; then
+          if [[ '${{ runner.os }}' == 'Linux' && '${{ matrix.cpu }}' == 'i386' ]]; then
             export CFLAGS="${CFLAGS} -m32 -mno-adx"
             echo "CFLAGS=${CFLAGS}" >> $GITHUB_ENV
           fi
@@ -172,25 +159,6 @@ jobs:
           [[ -z "$ncpu" || $ncpu -le 0 ]] && ncpu=1
           echo "ncpu=${ncpu}" >> $GITHUB_ENV
 
-      - name: Install build dependencies (Linux i386)
-        if: runner.os == 'Linux' && matrix.target.cpu == 'i386'
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt-fast update -qq
-          sudo DEBIAN_FRONTEND='noninteractive' apt-fast install \
-            --no-install-recommends -yq gcc-multilib g++-multilib
-          mkdir -p external/bin
-          cat << EOF > external/bin/gcc
-          #!/bin/bash
-          exec $(which gcc) -m32 -mno-adx "\$@"
-          EOF
-          cat << EOF > external/bin/g++
-          #!/bin/bash
-          exec $(which g++) -m32 -mno-adx "\$@"
-          EOF
-          chmod 755 external/bin/gcc external/bin/g++
-          echo "${{ github.workspace }}/external/bin" >> $GITHUB_PATH
-
       # Required for running the local testnet script
       - name: Install build dependencies (MacOS)
         if: runner.os == 'macOS'
@@ -203,8 +171,8 @@ jobs:
         id: windows-mingw-cache
         uses: actions/cache@v4
         with:
-          path: external/mingw-${{ matrix.target.cpu }}
-          key: 'mingw-llvm-17-${{ matrix.target.cpu }}'
+          path: external/mingw-${{ matrix.cpu }}
+          key: 'mingw-llvm-17-${{ matrix.cpu }}'
 
       - name: Install llvm-mingw dependency (Windows)
         if: >
@@ -214,22 +182,22 @@ jobs:
           mkdir -p external
           LLVM_VERSION="20250730"
           MINGW_BASE="https://github.com/mstorsjo/llvm-mingw/releases/download/$LLVM_VERSION"
-          if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then
+          if [[ '${{ matrix.cpu }}' == 'amd64' ]]; then
             MINGW_URL="$MINGW_BASE/llvm-mingw-$LLVM_VERSION-ucrt-x86_64.zip"
             ARCH=64
           else
             MINGW_URL="$MINGW_BASE/llvm-mingw-$LLVM_VERSION-ucrt-x86_64.zip"
             ARCH=32
           fi
-          curl -L "$MINGW_URL" -o "external/mingw-${{ matrix.target.cpu }}.zip"
-          7z x -y "external/mingw-${{ matrix.target.cpu }}.zip" -oexternal/mingw-${{ matrix.target.cpu }}/
-          mv external/mingw-${{ matrix.target.cpu }}/**/* ./external/mingw-${{ matrix.target.cpu }}
+          curl -L "$MINGW_URL" -o "external/mingw-${{ matrix.cpu }}.zip"
+          7z x -y "external/mingw-${{ matrix.cpu }}.zip" -oexternal/mingw-${{ matrix.cpu }}/
+          mv external/mingw-${{ matrix.cpu }}/**/* ./external/mingw-${{ matrix.cpu }}
 
       - name: Path to cached dependencies (Windows)
         if: >
           runner.os == 'Windows'
         run: |
-          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.target.cpu }}/bin" >> $GITHUB_PATH
+          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.cpu }}/bin" >> $GITHUB_PATH
 
       - name: Get latest nimbus-build-system commit hash
         id: versions
@@ -245,7 +213,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: NimBinaries
-          key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}-portal'
+          key: 'nim-${{ matrix.os }}-${{ matrix.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}-portal'
 
       - name: Get latest nim-rocksdb commit hash
         id: rocksdb-versions
@@ -261,7 +229,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: RocksBinCache
-          key: 'rocks-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.rocksdb-versions.outputs.nim_rocksdb }}'
+          key: 'rocks-${{ matrix.os }}-${{ matrix.cpu }}-${{ steps.rocksdb-versions.outputs.nim_rocksdb }}'
 
       - name: Build Nim and Nimbus-eth1 dependencies
         run: |

--- a/.github/workflows/simulators.yml
+++ b/.github/workflows/simulators.yml
@@ -16,43 +16,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  matrix_config:
+    uses: ./.github/workflows/matrix_config.yml
+
   build:
+    needs: matrix_config
+
     strategy:
       fail-fast: false
-      max-parallel: 20
-      matrix:
-        target:
-          - os: linux
-            cpu: amd64
-          - os: windows
-            cpu: amd64
-          - os: macos
-            cpu: arm64
-        include:
-          - target:
-              os: linux
-            builder: ubuntu-22.04
-          - target:
-              os: macos
-            builder: macos-13
-          - target:
-              os: windows
-            builder: windows-latest
+      matrix: ${{ fromJSON(needs.matrix_config.outputs.matrix) }}
 
     defaults:
       run:
         shell: bash
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}'
+    name: '${{ matrix.os }}-${{ matrix.cpu }}'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Initialize
-        if: runner.os == 'linux'
-        run: |
-          sudo apt-get -q update
 
       - name: Restore llvm-mingw from cache
         if: runner.os == 'windows'
@@ -93,7 +75,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: NimBinaries
-          key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}-sim'
+          key: 'nim-${{ matrix.os }}-${{ matrix.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}-sim'
 
       - name: Get latest nim-rocksdb commit hash
         id: rocksdb-versions
@@ -109,13 +91,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: RocksBinCache
-          key: 'rocks-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.rocksdb-versions.outputs.nim_rocksdb }}'
+          key: 'rocks-${{ matrix.os }}-${{ matrix.cpu }}-${{ steps.rocksdb-versions.outputs.nim_rocksdb }}'
 
       - name: Build Nim and deps
         run: |
-          if [[ '${{ matrix.target.os }}' == 'windows' ]]; then
+          if [[ '${{ matrix.os }}' == 'windows' ]]; then
             ncpu=${NUMBER_OF_PROCESSORS}
-          elif [[ '${{ matrix.target.os }}' == 'macos' ]]; then
+          elif [[ '${{ matrix.os }}' == 'macos' ]]; then
             ncpu=$(sysctl -n hw.ncpu)
           else
             ncpu=$(nproc)
@@ -126,12 +108,12 @@ jobs:
       - name: Run Simulators
         run: |
           SIM_SCRIPT="hive_integration/nodocker/build_sims.sh"
-          bash ${SIM_SCRIPT} "${{ matrix.target.os }}-${{ matrix.target.cpu }}"
+          bash ${SIM_SCRIPT} "${{ matrix.os }}-${{ matrix.cpu }}"
 
       - name: Upload artefact
         uses: actions/upload-artifact@v4
         with:
-          name: '${{ matrix.target.os }}_${{ matrix.target.cpu }}_stat'
+          name: '${{ matrix.os }}_${{ matrix.cpu }}_stat'
           path: ./simulators.md
           retention-days: 2
 


### PR DESCRIPTION
We advertise our macos CI as macos-arm64, using macos-13.
But when I try to fix the docker base images and nightly build using macos arm64 binaries, turns out macos-13 is a github hosted runner runs on intel machine. All sort of incompatible caches and binaries pops up.

And the github docs confirm it. https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories. Only macos-14 and newer really runs on arm64 machine.

So this shared workflow ensure all our CI matrix in this repo using the same configuration. same matrices for consistency.

Later, a following PR will addressing shared steps in CI jobs using composite workflow to ease maintenance instead each CI script using their own recipes. All CI will use the same basic configuration, e.g. nim compiler, c/c++ compilers, cache keys, cached binaries, test vector, docker things, etc will use shared composite workflow.

Right now we support linux-amd64, linux-arm64, windows-amd64, and macos-arm64(now the label and the binaries are correct).

Later if we want to add windows-arm64 for example, we don't have to go through all CI files, only need to modify one place, and all CI will enjoy the same benefits.

