### PR TITLE
Delete stale values from the shared database LRU caches in persist

### DIFF
--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -214,29 +214,29 @@ with --debug-eager-state-root."""
 
   # Copy cached values from the snapshot
   for accPath, v in txFrame.snapshot.acc:
-    if v[0] == nil:
-      db.accLeaves.del(accPath)
-    else:
-      discard db.accLeaves.update(accPath, v[0])
+    # if v[0] == nil:
+    db.accLeaves.del(accPath)
+    # else:
+    #   discard db.accLeaves.update(accPath, v[0])
 
   for mixPath, v in txFrame.snapshot.sto:
-    if v[0] == nil:
-      db.stoLeaves.del(mixPath)
-    else:
-      discard db.stoLeaves.update(mixPath, v[0])
+    # if v[0] == nil:
+    db.stoLeaves.del(mixPath)
+    # else:
+    #   discard db.stoLeaves.update(mixPath, v[0])
 
   # Copy cached values from the txFrame
   for accPath, vtx in txFrame.accLeaves:
-    if vtx == nil:
-      db.accLeaves.del(accPath)
-    else:
-      discard db.accLeaves.update(accPath, vtx)
+    # if vtx == nil:
+    db.accLeaves.del(accPath)
+    # else:
+    #   discard db.accLeaves.update(accPath, vtx)
 
   for mixPath, vtx in txFrame.stoLeaves:
-    if vtx == nil:
-      db.stoLeaves.del(mixPath)
-    else:
-      discard db.stoLeaves.update(mixPath, vtx)
+    # if vtx == nil:
+    db.stoLeaves.del(mixPath)
+    # else:
+    #   discard db.stoLeaves.update(mixPath, vtx)
 
   txFrame.snapshot.vtx.clear()
   txFrame.snapshot.acc.clear()

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -210,33 +210,18 @@ with --debug-eager-state-root."""
   #      really run after things have been written (to maintain sync betweeen
   #      in-memory and on-disk state)
 
-  # Copy back updated payloads into the shared database LRU caches.
+  # Updated values in the txFrame caches are now stale so remove them from the
+  # shared database LRU caches.
 
-  # Copy cached values from the snapshot
   for accPath, v in txFrame.snapshot.acc:
-    # if v[0] == nil:
     db.accLeaves.del(accPath)
-    # else:
-    #   discard db.accLeaves.update(accPath, v[0])
-
   for mixPath, v in txFrame.snapshot.sto:
-    # if v[0] == nil:
     db.stoLeaves.del(mixPath)
-    # else:
-    #   discard db.stoLeaves.update(mixPath, v[0])
 
-  # Copy cached values from the txFrame
   for accPath, vtx in txFrame.accLeaves:
-    # if vtx == nil:
     db.accLeaves.del(accPath)
-    # else:
-    #   discard db.accLeaves.update(accPath, vtx)
-
   for mixPath, vtx in txFrame.stoLeaves:
-    # if vtx == nil:
     db.stoLeaves.del(mixPath)
-    # else:
-    #   discard db.stoLeaves.update(mixPath, vtx)
 
   txFrame.snapshot.vtx.clear()
   txFrame.snapshot.acc.clear()


### PR DESCRIPTION
This change appears to improve performance by a few percent.

I ran block imports over the first 3 million blocks and here are the results:
```
baseline.csv vs delete-all.csv
                       bps_x     bps_y      tps_x      tps_y  time_x time_y    bpsd    tpsd   timed
block_number                                                                                       
(499713, 777522]    8,865.48  9,614.48  14,682.15  15,934.45     43s    38s  19.58%  19.58%  -6.28%
(777522, 1055332]   5,903.32  6,185.96  16,865.01  17,907.18     54s    48s  16.38%  16.38%  -1.28%
(1055332, 1333142]  5,053.96  5,622.88  25,792.41  28,775.77     57s    51s  13.32%  13.32%  -9.20%
(1333142, 1610952]  4,413.58  4,895.69  28,765.84  32,123.93   1m16s   1m1s  29.46%  29.46%  -7.68%
(1610952, 1888761]  3,657.44  4,053.78  25,510.86  28,090.79   1m56s  1m43s  22.56%  22.56%  -7.77%
(1888761, 2166571]  4,393.58  4,397.60  32,989.25  33,007.81    1m8s  1m14s   1.30%   1.30%   9.25%
(2166571, 2444381]  2,009.52  2,368.80  15,735.87  18,544.95  13m40s  13m6s  14.76%  14.76%  -8.79%
(2444381, 2722191]  3,229.39  3,008.85  22,540.26  20,985.28   8m19s  8m28s   0.99%   0.99%   8.00%
(2722191, 3000001]  4,370.49  4,319.19  30,905.05  30,375.02   1m11s  1m11s   9.10%   9.10%   8.76%

blocks: 2492096, baseline: 30m7s, contender: 29m3s
Time (total): -1m3s, -3.54%

bpsd = blocks per sec diff (+), tpsd = txs per sec diff, timed = time to process diff (-)
+ = more is better, - = less is better
```