### PR TITLE
Update default rocksdb cache dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ libbacktrace:
 	+ $(MAKE) -C vendor/nim-libbacktrace --no-print-directory BUILD_CXX_LIB=0
 
 # nim-rocksdb
-ROCKSDB_CI_CACHE := build
+ROCKSDB_CI_CACHE := build/rocksdb
 
 ifneq ($(USE_SYSTEM_ROCKSDB), 0)
 rocksdb:


### PR DESCRIPTION
I found that using the `build/` directory here had the effect of copying all the binaries into the `vendor/nim-rocksdb/build/` directory which isn't what we want. Creating a `build/rocksdb/` subfolder solves the problem.