### PR TITLE
Stateless: Speed up witness building by caching nodes when fetching proofs

### DIFF
--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -61,17 +61,17 @@ type
     ## `sTab[]` tables must correspond to a hash entry held on the `kMap[]`
     ## tables. So a corresponding zero value or missing entry produces an
     ## inconsistent state that must be resolved.
-    db*: AristoDbRef                       ## Database descriptor
-    parent*: AristoTxRef                   ## Previous transaction
+    db*: AristoDbRef                        ## Database descriptor
+    parent*: AristoTxRef                    ## Previous transaction
 
-    sTab*: Table[RootedVertexID,VertexRef] ## Structural vertex table
-    kMap*: Table[RootedVertexID,HashKey]   ## Merkle hash key mapping
-    vTop*: VertexID                        ## Last used vertex ID
+    sTab*: Table[RootedVertexID, VertexRef] ## Structural vertex table
+    kMap*: Table[RootedVertexID, HashKey]   ## Merkle hash key mapping
+    vTop*: VertexID                         ## Last used vertex ID
 
-    accLeaves*: Table[Hash32, AccLeafRef]  ## Account path -> VertexRef
-    stoLeaves*: Table[Hash32, StoLeafRef]  ## Storage path -> VertexRef
+    accLeaves*: Table[Hash32, AccLeafRef]   ## Account path -> VertexRef
+    stoLeaves*: Table[Hash32, StoLeafRef]   ## Storage path -> VertexRef
 
-    blockNumber*: Opt[uint64]              ## Block number set when checkpointing the frame
+    blockNumber*: Opt[uint64]               ## Block number set when checkpointing the frame
 
     snapshot*: Snapshot
       ## Optional snapshot containing the cumulative changes from ancestors and

--- a/execution_chain/db/aristo/aristo_desc/desc_structural.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_structural.nim
@@ -70,7 +70,7 @@ type
     ## Combined record for a *traditional* ``Merkle Patricia Tree` node merged
     ## with a structural `VertexRef` type object.
     vtx*: VertexRef
-    key*: array[16,HashKey]          ## Merkle hash/es for vertices
+    key*: array[16, HashKey]          ## Merkle hash/es for vertices
 
   # ----------------------
 

--- a/execution_chain/db/aristo/aristo_proof.nim
+++ b/execution_chain/db/aristo/aristo_proof.nim
@@ -11,6 +11,7 @@
 ## Aristo DB -- Create and verify MPT proofs
 ## ===========================================================
 ##
+
 {.push raises: [].}
 
 import
@@ -33,20 +34,29 @@ const
     ## This is the opposite of `ChainRlpNodesNoEntry` when verifying that a
     ## node does not exist.
 
+type
+  NodesCache = Table[RootedVertexID, seq[seq[byte]]]
+    ## Caches up to two rlp encoded trie nodes in each value
+
 proc chainRlpNodes(
-    db: AristoTxRef;
-    rvid: RootedVertexID;
+    db: AristoTxRef,
+    rvid: RootedVertexID,
     path: NibblesBuf,
-    chain: var seq[seq[byte]];
-      ): Result[void,AristoError] =
+    chain: var seq[seq[byte]],
+    nodesCache: var NodesCache): Result[void, AristoError] =
   ## Inspired by the `getBranchAux()` function from `hexary.nim`
-  let
-    (vtx,_) = ? db.getVtxRc rvid
-    node = vtx.toNode(rvid.root, db).valueOr:
+  let (vtx, _) = ?db.getVtxRc(rvid)
+
+  nodesCache.withValue(rvid, value):
+    chain &= value[]
+  do:
+    let node = vtx.toNode(rvid.root, db).valueOr:
       return err(PartChnNodeConvError)
 
-  # Save rpl encoded node(s)
-  node.appendRlpBytesTo(chain)
+    # Save rpl encoded node(s)
+    let rlpNodes = node.to(seq[seq[byte]])
+    nodesCache[rvid] = rlpNodes
+    chain &= rlpNodes
 
   # Follow up child node
   case vtx.vType:
@@ -70,7 +80,7 @@ proc chainRlpNodes(
       if not vtx.bVid(nibble).isValid:
         return err(PartChnBranchVoidEdge)
       # Recursion!
-      db.chainRlpNodes((rvid.root,vtx.bVid(nibble)), rest, chain)
+      db.chainRlpNodes((rvid.root,vtx.bVid(nibble)), rest, chain, nodesCache)
 
 
 proc trackRlpNodes(
@@ -78,7 +88,7 @@ proc trackRlpNodes(
     topKey: HashKey;
     path: NibblesBuf;
     start = false;
-     ): Result[seq[byte],AristoError]
+     ): Result[seq[byte], AristoError]
      {.gcsafe, raises: [RlpError]} =
   ## Verify rlp-encoded node chain created by `chainRlpNodes()`.
   if path.len == 0:
@@ -126,7 +136,8 @@ proc makeProof(
     db: AristoTxRef;
     root: VertexID;
     path: NibblesBuf;
-      ): Result[(seq[seq[byte]],bool), AristoError] =
+    nodesCache: var NodesCache;
+      ): Result[(seq[seq[byte]], bool), AristoError] =
   ## This function returns a chain of rlp-encoded nodes along the argument
   ## path `(root,path)` followed by a `true` value if the `path` argument
   ## exists in the database. If the argument `path` is not on the database,
@@ -135,7 +146,7 @@ proc makeProof(
   ## Errors will only be returned for invalid paths.
   ##
   var chain: seq[seq[byte]]
-  let rc = db.chainRlpNodes((root,root), path, chain)
+  let rc = db.chainRlpNodes((root,root), path, chain, nodesCache)
   if rc.isOk:
     ok((chain, true))
   elif rc.error in ChainRlpNodesNoEntry:
@@ -146,21 +157,46 @@ proc makeProof(
 proc makeAccountProof*(
     db: AristoTxRef;
     accPath: Hash32;
-      ): Result[(seq[seq[byte]],bool), AristoError] =
-  db.makeProof(STATE_ROOT_VID, NibblesBuf.fromBytes accPath.data)
+      ): Result[(seq[seq[byte]], bool), AristoError] =
+  var nodesCache: NodesCache
+  db.makeProof(STATE_ROOT_VID, NibblesBuf.fromBytes accPath.data, nodesCache)
 
 proc makeStorageProof*(
     db: AristoTxRef;
     accPath: Hash32;
     stoPath: Hash32;
-      ): Result[(seq[seq[byte]],bool), AristoError] =
+      ): Result[(seq[seq[byte]], bool), AristoError] =
   ## Note that the function returns an error unless
   ## the argument `accPath` is valid.
   let vid = db.fetchStorageID(accPath).valueOr:
     if error == FetchPathStoRootMissing:
       return ok((@[],false))
     return err(error)
-  db.makeProof(vid, NibblesBuf.fromBytes stoPath.data)
+  var nodesCache: NodesCache
+  db.makeProof(vid, NibblesBuf.fromBytes stoPath.data, nodesCache)
+
+proc makeStorageProofs*(
+    db: AristoTxRef;
+    accPath: Hash32;
+    stoPaths: openArray[Hash32];
+      ): Result[seq[seq[seq[byte]]], AristoError] =
+  ## Note that the function returns an error unless
+  ## the argument `accPath` is valid.
+  let vid = db.fetchStorageID(accPath).valueOr:
+    if error == FetchPathStoRootMissing:
+      let emptyProofs = newSeq[seq[seq[byte]]](stoPaths.len())
+      return ok(emptyProofs)
+    return err(error)
+
+  var
+    nodesCache: NodesCache
+    proofs = newSeqOfCap[seq[seq[byte]]](stoPaths.len())
+
+  for stoPath in stoPaths:
+    let (proof, _) = ?db.makeProof(vid, NibblesBuf.fromBytes stoPath.data, nodesCache)
+    proofs.add(proof)
+
+  ok(proofs)
 
 # ----------
 
@@ -168,7 +204,7 @@ proc verifyProof*(
     chain: openArray[seq[byte]];
     root: Hash32;
     path: Hash32;
-      ): Result[Opt[seq[byte]],AristoError] =
+      ): Result[Opt[seq[byte]], AristoError] =
   ## Variant of `partUntwigGeneric()`.
   try:
     let

--- a/execution_chain/db/aristo/aristo_proof.nim
+++ b/execution_chain/db/aristo/aristo_proof.nim
@@ -46,7 +46,7 @@ proc chainRlpNodes(
       return err(PartChnNodeConvError)
 
   # Save rpl encoded node(s)
-  chain &= node.to(seq[seq[byte]])
+  node.appendRlpBytesTo(chain)
 
   # Follow up child node
   case vtx.vType:

--- a/execution_chain/db/aristo/aristo_serialise.nim
+++ b/execution_chain/db/aristo/aristo_serialise.nim
@@ -27,7 +27,7 @@ proc toRlpBytes*(acc: AristoAccount, key: HashKey): seq[byte] =
     codeHash: acc.codeHash,
   )
 
-proc to*(node: NodeRef, T: type seq[seq[byte]]): T =
+proc to*(node: NodeRef, T: type array[2, seq[byte]]): T =
   ## Convert the argument pait `w` to a single or a double item list item of
   ## `<rlp-encoded-node>` type entries. Only in case of a combined extension
   ## and branch vertex argument, there will be a double item list result.
@@ -51,11 +51,10 @@ proc to*(node: NodeRef, T: type seq[seq[byte]]): T =
       wrx.append node.vtx.pfx.toHexPrefix(isleaf = false).data()
       wrx.append brHash
 
-      result.add wrx.finish()
-      result.add brData
+      [wrx.finish(), brData]
     else:
       # Do for pure branch node
-      result.add brData
+      [brData, @[]]
   of AccLeaf:
     let vtx = AccLeafRef(node.vtx)
     var wr = initRlpWriter()
@@ -63,7 +62,7 @@ proc to*(node: NodeRef, T: type seq[seq[byte]]): T =
     wr.append vtx.pfx.toHexPrefix(isleaf = true).data()
     wr.append vtx.account.toRlpBytes(node.key[0])
 
-    result.add (wr.finish())
+    [wr.finish(), @[]]
   of StoLeaf:
     let vtx = StoLeafRef(node.vtx)
     var wr = initRlpWriter()
@@ -71,7 +70,7 @@ proc to*(node: NodeRef, T: type seq[seq[byte]]): T =
     wr.append vtx.pfx.toHexPrefix(isleaf = true).data()
     wr.append rlp.encode vtx.stoData
 
-    result.add (wr.finish())
+    [wr.finish(), @[]]
 
 proc digestTo*(node: NodeRef; T: type HashKey): T =
   ## Convert the argument `node` to the corresponding Merkle hash key. Note

--- a/execution_chain/db/aristo/aristo_serialise.nim
+++ b/execution_chain/db/aristo/aristo_serialise.nim
@@ -27,7 +27,7 @@ proc toRlpBytes*(acc: AristoAccount, key: HashKey): seq[byte] =
     codeHash: acc.codeHash,
   )
 
-proc appendRlpBytesTo*(node: NodeRef, chain: var seq[seq[byte]]) =
+proc to*(node: NodeRef, T: type seq[seq[byte]]): T =
   ## Convert the argument pait `w` to a single or a double item list item of
   ## `<rlp-encoded-node>` type entries. Only in case of a combined extension
   ## and branch vertex argument, there will be a double item list result.
@@ -51,11 +51,11 @@ proc appendRlpBytesTo*(node: NodeRef, chain: var seq[seq[byte]]) =
       wrx.append node.vtx.pfx.toHexPrefix(isleaf = false).data()
       wrx.append brHash
 
-      chain.add wrx.finish()
-      chain.add brData
+      result.add wrx.finish()
+      result.add brData
     else:
       # Do for pure branch node
-      chain.add brData
+      result.add brData
   of AccLeaf:
     let vtx = AccLeafRef(node.vtx)
     var wr = initRlpWriter()
@@ -63,7 +63,7 @@ proc appendRlpBytesTo*(node: NodeRef, chain: var seq[seq[byte]]) =
     wr.append vtx.pfx.toHexPrefix(isleaf = true).data()
     wr.append vtx.account.toRlpBytes(node.key[0])
 
-    chain.add (wr.finish())
+    result.add (wr.finish())
   of StoLeaf:
     let vtx = StoLeafRef(node.vtx)
     var wr = initRlpWriter()
@@ -71,7 +71,7 @@ proc appendRlpBytesTo*(node: NodeRef, chain: var seq[seq[byte]]) =
     wr.append vtx.pfx.toHexPrefix(isleaf = true).data()
     wr.append rlp.encode vtx.stoData
 
-    chain.add (wr.finish())
+    result.add (wr.finish())
 
 proc digestTo*(node: NodeRef; T: type HashKey): T =
   ## Convert the argument `node` to the corresponding Merkle hash key. Note

--- a/execution_chain/db/aristo/aristo_serialise.nim
+++ b/execution_chain/db/aristo/aristo_serialise.nim
@@ -27,7 +27,7 @@ proc toRlpBytes*(acc: AristoAccount, key: HashKey): seq[byte] =
     codeHash: acc.codeHash,
   )
 
-proc to*(node: NodeRef, T: type seq[seq[byte]]): T =
+proc appendRlpBytesTo*(node: NodeRef, chain: var seq[seq[byte]]) =
   ## Convert the argument pait `w` to a single or a double item list item of
   ## `<rlp-encoded-node>` type entries. Only in case of a combined extension
   ## and branch vertex argument, there will be a double item list result.
@@ -51,11 +51,11 @@ proc to*(node: NodeRef, T: type seq[seq[byte]]): T =
       wrx.append node.vtx.pfx.toHexPrefix(isleaf = false).data()
       wrx.append brHash
 
-      result.add wrx.finish()
-      result.add brData
+      chain.add wrx.finish()
+      chain.add brData
     else:
       # Do for pure branch node
-      result.add brData
+      chain.add brData
   of AccLeaf:
     let vtx = AccLeafRef(node.vtx)
     var wr = initRlpWriter()
@@ -63,7 +63,7 @@ proc to*(node: NodeRef, T: type seq[seq[byte]]): T =
     wr.append vtx.pfx.toHexPrefix(isleaf = true).data()
     wr.append vtx.account.toRlpBytes(node.key[0])
 
-    result.add (wr.finish())
+    chain.add (wr.finish())
   of StoLeaf:
     let vtx = StoLeafRef(node.vtx)
     var wr = initRlpWriter()
@@ -71,7 +71,7 @@ proc to*(node: NodeRef, T: type seq[seq[byte]]): T =
     wr.append vtx.pfx.toHexPrefix(isleaf = true).data()
     wr.append rlp.encode vtx.stoData
 
-    result.add (wr.finish())
+    chain.add (wr.finish())
 
 proc digestTo*(node: NodeRef; T: type HashKey): T =
   ## Convert the argument `node` to the corresponding Merkle hash key. Note

--- a/execution_chain/db/aristo/aristo_utils.nim
+++ b/execution_chain/db/aristo/aristo_utils.nim
@@ -25,7 +25,7 @@ proc toNode*(
     vtx: VertexRef;                    # Vertex to convert
     root: VertexID;                    # Sub-tree root the `vtx` belongs to
     db: AristoTxRef;                   # Database
-      ): Result[NodeRef,seq[VertexID]] =
+      ): Result[NodeRef, seq[VertexID]] =
   ## Convert argument the vertex `vtx` to a node type. Missing Merkle hash
   ## keys are searched for on the argument database `db`.
   ##

--- a/execution_chain/db/core_db/base.nim
+++ b/execution_chain/db/core_db/base.nim
@@ -309,11 +309,11 @@ proc getStateRoot*(acc: CoreDbTxRef): CoreDbRc[Hash32] =
 
 # ------------ storage ---------------
 
-proc slotProof*(
+proc slotProofs*(
     acc: CoreDbTxRef;
     accPath: Hash32;
-    stoPath: Hash32;
-      ): CoreDbRc[(seq[seq[byte]],bool)] =
+    stoPaths: openArray[Hash32];
+      ): CoreDbRc[seq[seq[seq[byte]]]] =
   ## On the storage MPT related to the argument account `acPath`, collect the
   ## nodes along the `stoPath` interpreted as path. Return these path nodes as
   ## a chain of rlp-encoded blobs followed by a bool value which is `true` if
@@ -324,7 +324,7 @@ proc slotProof*(
   ## Note that the function always returns an error unless the `accPath` is
   ## valid.
   ##
-  let rc = acc.aTx.makeStorageProof(accPath, stoPath).valueOr:
+  let rc = acc.aTx.makeStorageProofs(accPath, stoPaths).valueOr:
     return err(error.toError("", ProofCreate))
 
   ok(rc)

--- a/execution_chain/stateless/witness_generation.nim
+++ b/execution_chain/stateless/witness_generation.nim
@@ -80,9 +80,10 @@ proc build*(
     preStateLedger: LedgerRef,
     ledger: LedgerRef,
     parent: Header,
-    header: Header): T =
+    header: Header,
+    validateStateRoot = false): T =
 
-  if parent.number > 0:
+  if validateStateRoot and parent.number > 0:
     doAssert preStateLedger.getStateRoot() == parent.stateRoot
 
   var witness = Witness.build(ledger.getWitnessKeys(), preStateLedger)


### PR DESCRIPTION
Building the block witnesses relies on fetching proofs from the database. 

I found that the slowest sections of code when building proofs were the call to `toNode` to get the `NodeRef` and the rlp encoding but these calls would be repeated multiple times for the same nodes when fetching multiple slots from the same account. Catching the result of these expensive calls results in at least a 2x speed up when fetching multiple slot proofs at once in a batch.

This PR also disables the state root checks in the witness building for an additional speed up. 

I'm planning to use the nodes cache when fetching multiple account proofs in a batch in a future PR when I implement a multiproof function. This should further improve the performance of building witnesses.