### PR TITLE
Set parent header when starting block import

### DIFF
--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -69,6 +69,7 @@ proc getVmState(
     doAssert txFrame.getSavedStateBlockNumber() == parent.number
     vmState.init(parent, header, p.com, txFrame, storeSlotHash = storeSlotHash)
     p.vmState = vmState
+    assign(p.parent, parent)
   else:
     if header.number != p.parent.number + 1:
       return err("Only linear histories supported by Persister")


### PR DESCRIPTION
This fixes a minor bug in the block import where on startup the parent header in the `Persister` object was not assigned to when constructing the vmState instance. 

This didn't cause any problems because the parent header was correctly passed into the vmState and it was not used in other locations. Having the correct parent header stored in the `Persister` object is needed when building the witnesses when running the import with the stateless provider enabled.