### PR TITLE
Fix verify proof function in aristo proof module

### DIFF
--- a/execution_chain/db/aristo/aristo_desc/desc_error.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_error.nim
@@ -87,6 +87,7 @@ type
     PartChnLeafPathMismatch
     PartChnNodeConvError
     PartTrkEmptyPath
+    PartTrkEmptyProof
     PartTrkFollowUpKeyMismatch
     PartTrkGarbledNode
     PartTrkLeafPfxMismatch

--- a/execution_chain/db/aristo/aristo_proof.nim
+++ b/execution_chain/db/aristo/aristo_proof.nim
@@ -94,6 +94,8 @@ proc trackRlpNodes(
   ## Verify rlp-encoded node chain created by `chainRlpNodes()`.
   if path.len == 0:
     return err(PartTrkEmptyPath)
+  if chain.len() == 0:
+    return err(PartTrkEmptyProof)
 
   # Verify key against rlp-node
   let digest = chain[0].digestTo(HashKey)

--- a/execution_chain/db/aristo/aristo_proof.nim
+++ b/execution_chain/db/aristo/aristo_proof.nim
@@ -127,7 +127,11 @@ proc trackRlpNodes(
 
   let nextKey = HashKey.fromBytes(link).valueOr:
     return err(PartTrkLinkExpected)
-  chain.toOpenArray(1,chain.len-1).trackRlpNodes(nextKey, path.slice nChewOff)
+
+  if chain.len() > 1:
+    chain.toOpenArray(1, chain.len() - 1).trackRlpNodes(nextKey, path.slice nChewOff)
+  else:
+    err(PartTrkLinkExpected)
 
 proc makeProof(
     db: AristoTxRef;

--- a/execution_chain/db/core_db/base.nim
+++ b/execution_chain/db/core_db/base.nim
@@ -130,7 +130,7 @@ proc stateBlockNumber*(db: CoreDbTxRef): BlockNumber =
 
   rc.BlockNumber
 
-proc verify*(
+proc verifyProof*(
     db: CoreDbRef;
     proof: openArray[seq[byte]];
     root: Hash32;
@@ -221,21 +221,6 @@ proc hasKey*(kvt: CoreDbTxRef; key: openArray[byte]): bool =
 
 # ----------- accounts ---------------
 
-proc proof*(
-    acc: CoreDbTxRef;
-    accPath: Hash32;
-      ): CoreDbRc[(seq[seq[byte]],bool)] =
-  ## On the accounts MPT, collect the nodes along the `accPath` interpreted as
-  ## path. Return these path nodes as a chain of rlp-encoded blobs followed
-  ## by a bool value which is `true` if the `key` path exists in the database,
-  ## and `false` otherwise. In the latter case, the chain of rlp-encoded blobs
-  ## are the nodes proving that the `key` path does not exist.
-  ##
-  let rc = acc.aTx.makeAccountProof(accPath).valueOr:
-    return err(error.toError("", ProofCreate))
-
-  ok(rc)
-
 proc fetch*(
     acc: CoreDbTxRef;
     accPath: Hash32;
@@ -304,6 +289,21 @@ proc getStateRoot*(acc: CoreDbTxRef): CoreDbRc[Hash32] =
   ## column (if available.)
   let rc = acc.aTx.fetchStateRoot().valueOr:
     return err(error.toError(""))
+
+  ok(rc)
+
+proc proof*(
+    acc: CoreDbTxRef;
+    accPath: Hash32;
+      ): CoreDbRc[(seq[seq[byte]],bool)] =
+  ## On the accounts MPT, collect the nodes along the `accPath` interpreted as
+  ## path. Return these path nodes as a chain of rlp-encoded blobs followed
+  ## by a bool value which is `true` if the `key` path exists in the database,
+  ## and `false` otherwise. In the latter case, the chain of rlp-encoded blobs
+  ## are the nodes proving that the `key` path does not exist.
+  ##
+  let rc = acc.aTx.makeAccountProof(accPath).valueOr:
+    return err(error.toError("", ProofCreate))
 
   ok(rc)
 

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -22,6 +22,7 @@ import
     test_forkid,
     test_genesis,
     test_getproof_json,
+    test_aristo_proof,
     test_jwt_auth,
     test_kvt,
     test_ledger,

--- a/tests/proof_helpers.nim
+++ b/tests/proof_helpers.nim
@@ -1,0 +1,56 @@
+# Nimbus
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  stew/byteutils,
+  eth/rlp,
+  eth/common/keys,
+  web3/eth_api,
+  ../execution_chain/db/aristo/aristo_proof
+
+template toHash32*(hash: untyped): Hash32 =
+  fromHex(Hash32, hash.toHex())
+
+proc verifyAccountLeafExists*(trustedStateRoot: Hash32, res: ProofResponse): bool =
+  let
+    accPath = keccak256(res.address.data)
+    value = rlp.encode(Account(
+        nonce: res.nonce.uint64,
+        balance: res.balance,
+        storageRoot: res.storageHash.toHash32(),
+        codeHash: res.codeHash.toHash32()))
+
+  let accLeaf = verifyProof(seq[seq[byte]](res.accountProof), trustedStateRoot, accPath).expect("valid proof")
+  accLeaf.isSome() and accLeaf.get() == value
+
+proc verifyAccountLeafMissing*(trustedStateRoot: Hash32, res: ProofResponse): bool =
+  let
+    accPath = keccak256(res.address.data)
+    value = rlp.encode(Account(
+        nonce: res.nonce.uint64,
+        balance: res.balance,
+        storageRoot: res.storageHash.toHash32(),
+        codeHash: res.codeHash.toHash32()))
+
+  let accLeaf = verifyProof(seq[seq[byte]](res.accountProof), trustedStateRoot, accPath).expect("valid proof")
+  accLeaf.isNone()
+
+proc verifySlotLeafExists*(trustedStorageRoot: Hash32, slot: StorageProof): bool =
+  let
+    slotPath = keccak256(toBytesBE(slot.key))
+    value = rlp.encode(slot.value)
+
+  let slotLeaf = verifyProof(seq[seq[byte]](slot.proof), trustedStorageRoot, slotPath).expect("valid proof")
+  slotLeaf.isSome() and slotLeaf.get() == value
+
+proc verifySlotLeafMissing*(trustedStorageRoot: Hash32, slot: StorageProof): bool =
+  let
+    slotPath = keccak256(toBytesBE(slot.key))
+    value = rlp.encode(slot.value)
+
+  let slotLeaf = verifyProof(seq[seq[byte]](slot.proof), trustedStorageRoot, slotPath).expect("valid proof")
+  slotLeaf.isNone()

--- a/tests/test_aristo_proof.nim
+++ b/tests/test_aristo_proof.nim
@@ -1,0 +1,140 @@
+# proof verification
+# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+{.push raises: [].}
+
+import
+  std/sequtils,
+  unittest2,
+  stint,
+  results,
+  stew/byteutils,
+  eth/trie/[hexary, db, trie_defs],
+  ../execution_chain/db/aristo/aristo_proof
+
+proc getKeyBytes(i: int): seq[byte] =
+  @(u256(i).toBytesBE())
+
+suite "Aristo proof verification":
+
+  test "Validate proof for existing value":
+    let numValues = 1000
+
+    var db = newMemoryDB()
+    var trie = initHexaryTrie(db)
+
+    for i in 1..numValues:
+      let
+        key = getKeyBytes(i).keccak256()
+        value = getKeyBytes(i)
+      trie.put(key.data, value)
+
+    for i in 1..numValues:
+      let
+        key = getKeyBytes(i).keccak256()
+        value = getKeyBytes(i)
+        proof = trie.getBranch(key.data)
+        root = trie.rootHash()
+
+      let proofRes = verifyProof(proof, root, key).expect("valid proof")
+      check:
+        proofRes.isSome()
+        proofRes.get() == value
+
+  test "Validate proof for non-existing value":
+    let numValues = 1000
+    var db = newMemoryDB()
+    var trie = initHexaryTrie(db)
+
+    for i in 1..numValues:
+      let
+        key = getKeyBytes(i).keccak256()
+        value = getKeyBytes(i)
+      trie.put(key.data, value)
+
+    let
+      nonExistingKey = toSeq(toBytesBE(u256(numValues + 1))).keccak256()
+      proof = trie.getBranch(nonExistingKey.data)
+      root = trie.rootHash()
+
+    let proofRes = verifyProof(proof, root, nonExistingKey).expect("valid proof")
+    check:
+      proofRes.isNone()
+
+  # The following test cases were copied from the Rust hexary trie implementation.
+  # See here: https://github.com/citahub/cita_trie/blob/master/src/tests/mod.rs#L554
+  test "Validate proof for empty trie":
+    let db = newMemoryDB()
+    var trie = initHexaryTrie(db)
+
+    let
+      proof = trie.getBranch("not-exist".toBytes.keccak256().data)
+      res = verifyProof(proof, trie.rootHash, "not-exist".toBytes.keccak256())
+
+    check:
+      trie.rootHash == keccak256(emptyRlp)
+      proof.len() == 1 # Note that the Rust implementation returns an empty list for this scenario
+      proof == @[emptyRlp]
+      res.isErr()
+
+  test "Validate proof for one element trie":
+    let db = newMemoryDB()
+    var trie = initHexaryTrie(db)
+
+    trie.put("k".toBytes.keccak256().data, "v".toBytes)
+
+    let
+      rootHash = trie.rootHash
+      proof = trie.getBranch("k".toBytes.keccak256().data)
+      res = verifyProof(proof, rootHash, "k".toBytes.keccak256()).expect("valid proof")
+
+    check:
+      proof.len() == 1
+      res.isSome()
+      res.get() == "v".toBytes
+
+  test "Validate proof bytes":
+    let db = newMemoryDB()
+    var trie = initHexaryTrie(db)
+
+    trie.put("doe".toBytes.keccak256().data, "reindeer".toBytes)
+    trie.put("dog".toBytes.keccak256().data, "puppy".toBytes)
+    trie.put("dogglesworth".toBytes.keccak256().data, "cat".toBytes)
+
+    block:
+      let
+        rootHash = trie.rootHash
+        proof = trie.getBranch("doe".toBytes.keccak256().data)
+        res = verifyProof(proof, rootHash, "doe".toBytes.keccak256()).expect("valid proof")
+
+      check:
+        res.isSome()
+        res.get() == "reindeer".toBytes
+
+    block:
+      let
+        rootHash = trie.rootHash
+        proof = trie.getBranch("dogg".toBytes.keccak256().data)
+        res = verifyProof(proof, rootHash, "dogg".toBytes.keccak256()).expect("valid proof")
+
+      check res.isNone()
+
+    block:
+      let
+        proof = newSeq[seq[byte]]()
+        res = verifyProof(proof, trie.rootHash, "doe".toBytes.keccak256())
+
+      check res.isErr()
+
+    block:
+      let
+        proof = @["aaa".toBytes, "ccc".toBytes]
+        res = verifyProof(proof, trie.rootHash, "doe".toBytes.keccak256())
+
+      check res.isErr()

--- a/tests/test_aristo_proof.nim
+++ b/tests/test_aristo_proof.nim
@@ -1,5 +1,5 @@
 # proof verification
-# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Copyright (c) 2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -12,7 +12,7 @@ import
   web3/eth_api,
   stew/byteutils,
   json_rpc/[rpcserver, rpcclient],
-  eth/[rlp, trie/hexary_proof_verification],
+  eth/rlp,
   eth/common/[transaction_utils, addresses],
   ../hive_integration/nodocker/engine/engine_client,
   ../execution_chain/[constants, transaction, config, version],
@@ -30,7 +30,8 @@ import
   ../execution_chain/nimbus_desc,
    ./test_helpers,
    ./macro_assembler,
-   ./test_block_fixture
+   ./test_block_fixture,
+   ./proof_helpers
 
 type
   TestEnv = object
@@ -69,32 +70,6 @@ const
   feeRecipient = address"0000000000000000000000000000000000000212"
   prevRandao = Bytes32 EMPTY_UNCLE_HASH # it can be any valid hash
   oneETH = 1.u256 * 1_000_000_000.u256 * 1_000_000_000.u256
-
-proc verifyAccountProof(trustedStateRoot: Hash32, res: ProofResponse): MptProofVerificationResult =
-  let
-    key = keccak256(res.address.data).data
-    value = rlp.encode(Account(
-        nonce: res.nonce.uint64,
-        balance: res.balance,
-        storageRoot: res.storageHash,
-        codeHash: res.codeHash))
-
-  verifyMptProof(
-    seq[seq[byte]](res.accountProof),
-    trustedStateRoot,
-    key,
-    value)
-
-proc verifySlotProof(trustedStorageRoot: Hash32, slot: StorageProof): MptProofVerificationResult =
-  let
-    key = keccak256(toBytesBE(slot.key)).data
-    value = rlp.encode(slot.value)
-
-  verifyMptProof(
-    seq[seq[byte]](slot.proof),
-    trustedStorageRoot,
-    key,
-    value)
 
 proc persistFixtureBlock(chainDB: CoreDbTxRef) =
   let header = getBlockHeader4514995()
@@ -688,7 +663,7 @@ proc rpcMain*() =
 
         check:
           proofResponse.address == address
-          verifyAccountProof(blockData.stateRoot, proofResponse).isMissing()
+          verifyAccountLeafMissing(blockData.stateRoot, proofResponse)
           proofResponse.balance == 0.u256
           proofResponse.codeHash == zeroHash
           proofResponse.nonce == w3Qty(0.uint64)
@@ -706,7 +681,7 @@ proc rpcMain*() =
 
         check:
           proofResponse.address == address
-          verifyAccountProof(blockData.stateRoot, proofResponse).isValid()
+          verifyAccountLeafExists(blockData.stateRoot, proofResponse)
           proofResponse.balance == 2_000_000_000.u256
           proofResponse.codeHash == emptyCodeHash
           proofResponse.nonce == w3Qty(1.uint64)
@@ -729,7 +704,7 @@ proc rpcMain*() =
 
         check:
           proofResponse.address == address
-          verifyAccountProof(blockData.stateRoot, proofResponse).isValid()
+          verifyAccountLeafExists(blockData.stateRoot, proofResponse)
           proofResponse.balance == 0.u256
           proofResponse.codeHash == hash32"0x09044b55d7aba83cb8ac3d2c9c8d8bcadbfc33f06f1be65e8cc1e4ddab5f3074"
           proofResponse.nonce == w3Qty(0.uint64)
@@ -754,7 +729,7 @@ proc rpcMain*() =
 
         check:
           proofResponse.address == address
-          verifyAccountProof(blockData.stateRoot, proofResponse).isValid()
+          verifyAccountLeafExists(blockData.stateRoot, proofResponse)
           proofResponse.balance == 1_000_000_000.u256
           proofResponse.codeHash == hash32"0x09044b55d7aba83cb8ac3d2c9c8d8bcadbfc33f06f1be65e8cc1e4ddab5f3074"
           proofResponse.nonce == w3Qty(2.uint64)
@@ -769,9 +744,9 @@ proc rpcMain*() =
           storageProof[2].key == slot3Key
           storageProof[2].proof.len() > 0
           storageProof[2].value == 0.u256
-          verifySlotProof(proofResponse.storageHash, storageProof[0]).isValid()
-          verifySlotProof(proofResponse.storageHash, storageProof[1]).isValid()
-          verifySlotProof(proofResponse.storageHash, storageProof[2]).isMissing()
+          verifySlotLeafExists(proofResponse.storageHash, storageProof[0])
+          verifySlotLeafExists(proofResponse.storageHash, storageProof[1])
+          verifySlotLeafMissing(proofResponse.storageHash, storageProof[2])
 
       block:
         # externally owned account
@@ -782,7 +757,7 @@ proc rpcMain*() =
 
         check:
           proofResponse.address == address
-          verifyAccountProof(blockData.stateRoot, proofResponse).isValid()
+          verifyAccountLeafExists(blockData.stateRoot, proofResponse)
           proofResponse.balance == 2_000_000_000.u256
           proofResponse.codeHash == emptyCodeHash
           proofResponse.nonce == w3Qty(1.uint64)
@@ -802,13 +777,13 @@ proc rpcMain*() =
 
         check:
           proofResponse.address == address
-          verifyAccountProof(blockData.stateRoot, proofResponse).isValid()
+          verifyAccountLeafExists(blockData.stateRoot, proofResponse)
           proofResponse.balance == 1_000_000_000.u256
           proofResponse.codeHash == hash32"0x09044b55d7aba83cb8ac3d2c9c8d8bcadbfc33f06f1be65e8cc1e4ddab5f3074"
           proofResponse.nonce == w3Qty(2.uint64)
           proofResponse.storageHash == hash32"0x2ed06ec37dad4cd8c8fc1a1172d633a8973987fa6995b14a7c0a50c0e8d1a9c3"
           storageProof.len() == 1
-          verifySlotProof(proofResponse.storageHash, storageProof[0]).isValid()
+          verifySlotLeafExists(proofResponse.storageHash, storageProof[0])
 
     env.close()
 


### PR DESCRIPTION
This fixes the `verifyProof` function in the aristo_proof module and removes usages of the eth/trie proof verification library in the tests. Under certain conditions the aristo `verifyProof` function was throwing a index out of bounds when the proof doesn't contain the requested path. Also updated to handle empty proofs without crashing.

A modified version of the `verifyProof` function will be useful for validating execution witnesses. Each key in the execution witnesses needs to be checked against the pre-state root and so the modified version will support passing in an in memory db/table of nodes that can be used to walk down the trie. Currently only passing in a branch of trie nodes  is supported.