### PR TITLE
Use hash writer for aristo computeKey

### DIFF
--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -14,7 +14,7 @@ import
   std/strformat,
   chronicles,
   eth/rlp,
-  eth/common,
+  eth/common/[accounts_rlp, base_rlp, hashes_rlp],
   results,
   "."/[aristo_desc, aristo_get, aristo_layers],
   ./aristo_desc/desc_backend

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -117,13 +117,13 @@ func clear(self: var AristoTrieWriter) =
   self.twoPassWriter.clear()
   self.hashWriter.clear()
 
-template appendLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: auto) =
+template appendLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: Account | UInt256) =
   w.startList(2)
   w.append(pfx.toHexPrefix(isLeaf = true).data())
   w.wrapEncoding(1)
   w.append(leafData)
 
-template encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: auto): HashKey =
+template encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: Account | UInt256): HashKey =
   w.clear()
   w.tracker.appendLeaf(pfx, leafData)
 

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -113,13 +113,13 @@ func clear(self: var AristoTrieWriter) =
   self.twoPassWriter.clear()
   self.hashWriter.clear()
 
-template appendLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: untyped) =
+template appendLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: auto) =
   w.startList(2)
   w.append(pfx.toHexPrefix(isLeaf = true).data())
   w.wrapEncoding(1)
   w.append(leafData)
 
-template encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: untyped): HashKey =
+template encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: auto): HashKey =
   w.clear()
   w.tracker.appendLeaf(pfx, leafData)
 
@@ -160,7 +160,7 @@ template appendExt(w: var RlpWriter, pfx: NibblesBuf, branchKey: HashKey) =
   w.append(pfx.toHexPrefix(isLeaf = false).data())
   w.append(branchKey)
 
-template encodeExt(w: var AristoTrieWriter, pfx: NibblesBuf, branchKey: untyped): HashKey =
+func encodeExt(w: var AristoTrieWriter, pfx: NibblesBuf, branchKey: HashKey): HashKey =
   w.clear()
   w.tracker.appendExt(pfx, branchKey)
 
@@ -211,9 +211,9 @@ proc computeKeyImpl(
   # empty state
 
   # Top-most level of all the verticies this hash computation depends on
-  var level = level
-
-  var writer = AristoTrieWriter.init()
+  var
+    level = level
+    writer = AristoTrieWriter.init()
 
   let key =
     case vtx.vType
@@ -241,17 +241,17 @@ proc computeKeyImpl(
           else:
             VOID_HASH_KEY
 
-      writer.encodeLeaf(vtx.pfx):
+      writer.encodeLeaf(vtx.pfx,
         Account(
           nonce: vtx.account.nonce,
           balance: vtx.account.balance,
           storageRoot: skey.to(Hash32),
           codeHash: vtx.account.codeHash,
         )
+      )
     of StoLeaf:
       let vtx = StoLeafRef(vtx)
-      writer.encodeLeaf(vtx.pfx):
-        vtx.stoData
+      writer.encodeLeaf(vtx.pfx, vtx.stoData)
     of Branches:
       # For branches, we need to load the vertices before recursing into them
       # to exploit their on-disk order
@@ -320,9 +320,8 @@ proc computeKeyImpl(
 
       if vtx.vType == ExtBranch:
         let vtx = ExtBranchRef(vtx)
-        writer.encodeExt(vtx.pfx):
-          var bwriter = AristoTrieWriter.init()
-          bwriter.writeBranch(vtx)
+        var bwriter = AristoTrieWriter.init()
+        writer.encodeExt(vtx.pfx, bwriter.writeBranch(vtx))
       else:
         writer.writeBranch(vtx)
 

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -19,7 +19,7 @@ import
   "."/[aristo_desc, aristo_get, aristo_layers],
   ./aristo_desc/desc_backend
 
-type 
+type
   WriteBatch = tuple[writer: PutHdlRef, count: int, depth: int, prefix: uint64]
 
   AristoTrieWriter = object
@@ -118,9 +118,6 @@ template appendLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: untyped) =
   w.append(pfx.toHexPrefix(isLeaf = true).data())
   w.wrapEncoding(1)
   w.append(leafData)
-
-  # magical line 
-  discard rlp.encode(leafData)
 
 template encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: untyped): HashKey =
   w.clear()

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -130,20 +130,20 @@ func encodeLeafAccount(pfx: NibblesBuf, acc: Account): HashKey =
   let balanceLen = rlpUInt256EncodedLen(acc.balance)
   const sRootLen = 33  # Hash32 always: 0xa0 prefix + 32 bytes
   const cHashLen = 33
-  let accContent = nonceLen + balanceLen + sRootLen + cHashLen
-  let accListLen = rlpListEncodedLen(accContent)
+  let accContentLen = nonceLen + balanceLen + sRootLen + cHashLen
+  let accTotalLen = rlpListEncodedLen(accContentLen)
 
   # wrapped encoding (rlp encoding a rlp encoded item is now ))))
-  let wrapLen = rlpBlobEncodedLen(accListLen)  # blob-wrap the account list
-  let outerContent = hexPfxBlobLen + wrapLen
-  let outerListLen = rlpListEncodedLen(outerContent)
+  let wrapLen = rlpBlobEncodedLen(accTotalLen)  # blob-wrap the account list
+  let outerContentLen = hexPfxBlobLen + wrapLen
+  let outerTotalLen = rlpListEncodedLen(outerContentLen)
 
   # account leaf nodes are always > 32 bytes encoded, so always use keccak path
   var ctx = Keccak256.init()
-  ctx.rlpHashListHeader(outerContent)
+  ctx.rlpHashListHeader(outerContentLen)
   ctx.rlpHashBlob(hexPfxBuf.data())
-  ctx.rlpHashBlobHeader(accListLen)  # wrap prefix
-  ctx.rlpHashListHeader(accContent)
+  ctx.rlpHashBlobHeader(accTotalLen)  # wrap prefix
+  ctx.rlpHashListHeader(accContentLen)
   ctx.rlpHashInt(acc.nonce)
   ctx.rlpHashUInt256(acc.balance)
   ctx.rlpHashBlobHeader(32); ctx.update(acc.storageRoot.data)
@@ -162,13 +162,13 @@ func encodeLeafStorage(pfx: NibblesBuf, stoData: UInt256): HashKey =
       if isStoSelfEncoding: stoRlpLen  # no wrap prefix: just the raw byte
       else: rlpBlobEncodedLen(stoRlpLen)
 
-    outerContent = hexPfxBlobLen + wrapLen
-    outerListLen = rlpListEncodedLen(outerContent)
+    outerContentLen = hexPfxBlobLen + wrapLen
+    outerTotalLen = rlpListEncodedLen(outerContentLen)
 
-  if outerListLen < 32:
+  if outerTotalLen < 32:
     var output: array[32, byte]
     var pos = 0
-    rlpWriteListHeader(output, pos, outerContent)
+    rlpWriteListHeader(output, pos, outerContentLen)
     rlpWriteBlob(output, pos, hexPfxBuf.data())
     if not isStoSelfEncoding:
       rlpWriteBlobHeader(output, pos, stoRlpLen)
@@ -176,7 +176,7 @@ func encodeLeafStorage(pfx: NibblesBuf, stoData: UInt256): HashKey =
     output.toOpenArray(0, pos - 1).digestTo(HashKey)
   else:
     var ctx = Keccak256.init()
-    ctx.rlpHashListHeader(outerContent)
+    ctx.rlpHashListHeader(outerContentLen)
     ctx.rlpHashBlob(hexPfxBuf.data())
     if not isStoSelfEncoding:
       ctx.rlpHashBlobHeader(stoRlpLen)
@@ -184,15 +184,15 @@ func encodeLeafStorage(pfx: NibblesBuf, stoData: UInt256): HashKey =
     ctx.finish().to(Hash32).to(HashKey)
 
 func encodeBranchStatic(hashKeys: array[16, HashKey]): HashKey =
-  var content = 1  # trailing empty blob (0x80)
+  var contentLen = 1  # trailing empty blob (0x80)
   for key in hashKeys:
-    content += hashKeyEncodedLen(key)
-  let totalLen = rlpListEncodedLen(content)
+    contentLen += hashKeyEncodedLen(key)
+  let totalLen = rlpListEncodedLen(contentLen)
 
   if totalLen < 32:
     var output: array[32, byte]
     var pos = 0
-    rlpWriteListHeader(output, pos, content)
+    rlpWriteListHeader(output, pos, contentLen)
     for key in hashKeys:
       writeHashKey(output, pos, key)
     output[pos] = 0x80
@@ -200,7 +200,7 @@ func encodeBranchStatic(hashKeys: array[16, HashKey]): HashKey =
     output.toOpenArray(0, pos - 1).digestTo(HashKey)
   else:
     var ctx = Keccak256.init()
-    ctx.rlpHashListHeader(content)
+    ctx.rlpHashListHeader(contentLen)
     for key in hashKeys:
       ctx.hashHashKey(key)
     ctx.rlpHashByte(0x80)
@@ -211,19 +211,19 @@ func encodeExtStatic(pfx: NibblesBuf, branchKey: HashKey): HashKey =
 
   let hexPfxBlobLen = rlpBlobEncodedLen(hexPfxBuf.data())
   let branchKeyLen = hashKeyEncodedLen(branchKey)
-  let outerContent = hexPfxBlobLen + branchKeyLen
-  let outerListLen = rlpListEncodedLen(outerContent)
+  let outerContentLen = hexPfxBlobLen + branchKeyLen
+  let outerTotalLen = rlpListEncodedLen(outerContentLen)
 
-  if outerListLen < 32:
+  if outerTotalLen < 32:
     var output: array[32, byte]
     var pos = 0
-    rlpWriteListHeader(output, pos, outerContent)
+    rlpWriteListHeader(output, pos, outerContentLen)
     rlpWriteBlob(output, pos, hexPfxBuf.data())
     writeHashKey(output, pos, branchKey)
     output.toOpenArray(0, pos - 1).digestTo(HashKey)
   else:
     var ctx = Keccak256.init()
-    ctx.rlpHashListHeader(outerContent)
+    ctx.rlpHashListHeader(outerContentLen)
     ctx.rlpHashBlob(hexPfxBuf.data())
     ctx.hashHashKey(branchKey)
     ctx.finish().to(Hash32).to(HashKey)

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -145,7 +145,7 @@ template appendBranch(w: var RlpWriter, vtx: VertexRef, hashKeys: array[16, Hash
   w.append EmptyBlob
 
 template encodeBranch(w: var AristoTrieWriter, rvtx: VertexRef, subKeyForN: untyped): HashKey =
-  var hashKeys: array[16, HashKey]
+  var hashKeys {.noinit.}: array[16, HashKey]
   for (n {.inject.}, subvid {.inject.}) in vtx.allPairs():
     hashKeys[n] = subKeyForN
 

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -119,6 +119,9 @@ template appendLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: untyped) =
   w.wrapEncoding(1)
   w.append(leafData)
 
+  # magical line 
+  discard rlp.encode(leafData)
+
 template encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: untyped): HashKey =
   w.clear()
   w.tracker.appendLeaf(pfx, leafData)

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -95,11 +95,32 @@ proc putKeyAtLevel(
 
   ok()
 
-template encodeLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: untyped): HashKey =
+template appendLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: untyped) =
   w.startList(2)
   w.append(pfx.toHexPrefix(isLeaf = true).data())
+  w.wrapEncoding(1)
   w.append(leafData)
-  w.finish().digestTo(HashKey)
+
+template encodeLeaf(pfx: NibblesBuf, leafData: untyped): HashKey =
+  debugEcho "calling encode Leaf"
+  debugEcho pfx
+  debugEcho leafData
+  var tracker = DynamicRlpLengthTracker()
+  tracker.initLengthTracker()
+  tracker.appendLeaf(pfx, leafData)
+
+  if tracker.totalLength < 32:
+    var writer = initTwoPassWriter(tracker)
+    writer.appendLeaf(pfx, leafData)
+    let buf = HashKey.fromBytes(writer.finish)
+    debugEcho(buf)
+    buf.value
+  else:
+    var writer = initHashWriter(tracker)
+    writer.appendLeaf(pfx, leafData)
+    let buf = writer.finish()
+    debugEcho(buf)
+    buf.to(HashKey)
 
 template encodeBranch(w: var RlpWriter, vtx: VertexRef, subKeyForN: untyped): HashKey =
   w.startList(17)
@@ -152,37 +173,36 @@ proc computeKeyImpl(
   # Top-most level of all the verticies this hash computation depends on
   var level = level
 
-  # TODO this is the same code as when serializing NodeRef, without the NodeRef
   var writer = initRlpWriter()
 
   let key =
     case vtx.vType
     of AccLeaf:
-      let vtx = AccLeafRef(vtx)
-      writer.encodeLeaf(vtx.pfx):
-        let
-          stoID = vtx.stoID
-          skey =
-            if stoID.isValid:
-              let
-                keyvtxl = ?db.getKey((stoID.vid, stoID.vid), skipLayers)
-                (skey, sl) =
-                  if keyvtxl[0][0].isValid:
-                    (keyvtxl[0][0], keyvtxl[1])
-                  else:
-                    ?db.computeKeyImpl(
-                      (stoID.vid, stoID.vid),
-                      batch,
-                      keyvtxl[0][1],
-                      keyvtxl[1],
-                      skipLayers = skipLayers,
-                    )
-              level = max(level, sl)
-              skey
-            else:
-              VOID_HASH_KEY
+      let
+        vtx = AccLeafRef(vtx)
+        stoID = vtx.stoID
+        skey =
+          if stoID.isValid:
+            let
+              keyvtxl = ?db.getKey((stoID.vid, stoID.vid), skipLayers)
+              (skey, sl) =
+                if keyvtxl[0][0].isValid:
+                  (keyvtxl[0][0], keyvtxl[1])
+                else:
+                  ?db.computeKeyImpl(
+                    (stoID.vid, stoID.vid),
+                    batch,
+                    keyvtxl[0][1],
+                    keyvtxl[1],
+                    skipLayers = skipLayers,
+                  )
+            level = max(level, sl)
+            skey
+          else:
+            VOID_HASH_KEY
 
-        rlp.encode Account(
+      encodeLeaf(vtx.pfx):
+        Account(
           nonce: vtx.account.nonce,
           balance: vtx.account.balance,
           storageRoot: skey.to(Hash32),
@@ -190,9 +210,8 @@ proc computeKeyImpl(
         )
     of StoLeaf:
       let vtx = StoLeafRef(vtx)
-      writer.encodeLeaf(vtx.pfx):
-        # TODO avoid memory allocation when encoding storage data
-        rlp.encode(vtx.stoData)
+      encodeLeaf(vtx.pfx):
+        vtx.stoData
     of Branches:
       # For branches, we need to load the vertices before recursing into them
       # to exploit their on-disk order

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -13,12 +13,19 @@
 import
   std/strformat,
   chronicles,
+  eth/rlp,
   eth/common/[accounts_rlp, base_rlp, hashes_rlp],
   results,
   "."/[aristo_desc, aristo_get, aristo_layers],
   ./aristo_desc/desc_backend
 
-type WriteBatch = tuple[writer: PutHdlRef, count: int, depth: int, prefix: uint64]
+type 
+  WriteBatch = tuple[writer: PutHdlRef, count: int, depth: int, prefix: uint64]
+
+  AristoTrieWriter = object
+    tracker: DynamicRlpLengthTracker
+    twoPassWriter: RlpTwoPassWriter
+    hashWriter: RlpHashWriter
 
 # Keep write batch size _around_ 1mb, give or take some overhead - this is a
 # tradeoff between efficiency and memory usage with diminishing returns the
@@ -95,88 +102,79 @@ proc putKeyAtLevel(
 
   ok()
 
+func init(T: type AristoTrieWriter): T =
+  result.tracker = DynamicRlpLengthTracker()
+  result.tracker.initLengthTracker()
+  result.twoPassWriter = initTwoPassWriter(result.tracker)
+  result.hashWriter = initHashWriter(result.tracker)
+
+func clear(self: var AristoTrieWriter) =
+  self.tracker.clear()
+  self.twoPassWriter.clear()
+  self.hashWriter.clear()
+
 template appendLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: untyped) =
   w.startList(2)
   w.append(pfx.toHexPrefix(isLeaf = true).data())
   w.wrapEncoding(1)
   w.append(leafData)
+  discard rlp.encode(leafData)
 
-template encodeLeaf(pfx: NibblesBuf, leafData: untyped): HashKey =
-  debugEcho "calling encode Leaf"
-  debugEcho pfx
-  debugEcho leafData
-  var tracker = DynamicRlpLengthTracker()
-  tracker.initLengthTracker()
-  tracker.appendLeaf(pfx, leafData)
+template encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: untyped): HashKey =
+  w.clear()
+  w.tracker.appendLeaf(pfx, leafData)
 
-  if tracker.totalLength < 32:
-    var writer = initTwoPassWriter(tracker)
-    writer.appendLeaf(pfx, leafData)
-    let buf = HashKey.fromBytes(writer.finish)
-    debugEcho(buf)
+  if w.tracker.totalLength < 32:
+    w.twoPassWriter.reInit(w.tracker)
+    w.twoPassWriter.appendLeaf(pfx, leafData)
+    let buf = HashKey.fromBytes(w.twoPassWriter.finish)
     buf.value
   else:
-    var writer = initHashWriter(tracker)
-    writer.appendLeaf(pfx, leafData)
-    let buf = writer.finish()
-    debugEcho(buf)
+    w.hashWriter.reInit(w.tracker)
+    w.hashWriter.appendLeaf(pfx, leafData)
+    let buf = w.hashWriter.finish()
     buf.to(HashKey)
 
-template encodeBranch(w: var RlpWriter, vtx: VertexRef, subKeyForN: untyped): HashKey =
+template appendBranch(w: var RlpWriter, vtx: VertexRef, subKeyForN: untyped) =
   w.startList(17)
   for (n {.inject.}, subvid {.inject.}) in vtx.allPairs():
     w.append(subKeyForN)
   w.append EmptyBlob
-  w.finish().digestTo(HashKey)
 
-template encodeExt(w: var RlpWriter, pfx: NibblesBuf, branchKey: HashKey): HashKey =
+template encodeBranch(w: var AristoTrieWriter, rvtx: VertexRef, subKeyForN: untyped): HashKey =
+  w.clear()
+  w.tracker.appendBranch(vtx, subKeyForN)
+
+  if w.tracker.totalLength < 32:
+    w.twoPassWriter.reInit(w.tracker)
+    w.twoPassWriter.appendBranch(vtx, subKeyForN)
+    let buf = HashKey.fromBytes(w.twoPassWriter.finish)
+    buf.value
+  else:
+    w.hashWriter.reInit(w.tracker)
+    w.hashWriter.appendBranch(vtx, subKeyForN)
+    let buf = w.hashWriter.finish()
+    buf.to(HashKey)
+
+template appendExt(w: var RlpWriter, pfx: NibblesBuf, branchKey: HashKey) =
   w.startList(2)
   w.append(pfx.toHexPrefix(isLeaf = false).data())
   w.append(branchKey)
-  w.finish().digestTo(HashKey)
 
-# template appendBranch(w: var RlpWriter, vtx: VertexRef, subKeyForN: untyped) =
-#   w.startList(17)
-#   for (n {.inject.}, subvid {.inject.}) in vtx.allPairs():
-#     w.append(subKeyForN)
-#   w.append EmptyBlob
-# 
-# template encodeBranch(vtx: VertexRef, subKeyForN: untyped): HashKey =
-#   var tracker: DynamicRlpLengthTracker
-#   tracker.initLengthTracker()
-#   tracker.appendBranch(vtx, subKeyForN)
-# 
-#   if tracker.totalLength < 32:
-#     var writer = initTwoPassWriter(tracker)
-#     writer.appendBranch(vtx, subKeyForN)
-#     let buf = HashKey.fromBytes(writer.finish)
-#     buf.value
-#   else:
-#     var writer = initHashWriter(tracker)
-#     writer.appendBranch(vtx, subKeyForN)
-#     let buf = writer.finish()
-#     buf.to(HashKey)
-# 
-# template appendExt(w: var RlpWriter, pfx: NibblesBuf, branchKey: HashKey) =
-#   w.startList(2)
-#   w.append(pfx.toHexPrefix(isLeaf = false).data())
-#   w.append(branchKey)
-# 
-# template encodeExt(pfx: NibblesBuf, branchKey: untyped): HashKey =
-#   var tracker: DynamicRlpLengthTracker
-#   tracker.initLengthTracker()
-#   tracker.appendExt(pfx, branchKey)
-# 
-#   if tracker.totalLength < 32:
-#     var writer = initTwoPassWriter(tracker)
-#     writer.appendExt(pfx, branchKey)
-#     let buf = HashKey.fromBytes(writer.finish)
-#     buf.value
-#   else:
-#     var writer = initHashWriter(tracker)
-#     writer.appendExt(pfx, branchKey)
-#     let buf = writer.finish()
-#     buf.to(HashKey)
+template encodeExt(w: var AristoTrieWriter, pfx: NibblesBuf, branchKey: untyped): HashKey =
+  w.clear()
+  w.tracker.appendExt(pfx, branchKey)
+
+  if w.tracker.totalLength < 32:
+    w.twoPassWriter.reInit(w.tracker)
+    w.twoPassWriter.appendExt(pfx, branchKey)
+    let buf = HashKey.fromBytes(w.twoPassWriter.finish)
+    buf.value
+  else:
+    w.hashWriter.reInit(w.tracker)
+    w.hashWriter.appendExt(pfx, branchKey)
+    let buf = w.hashWriter.finish()
+    buf.to(HashKey)
 
 proc getKey(
     db: AristoTxRef, rvid: RootedVertexID, skipLayers: static bool
@@ -216,7 +214,7 @@ proc computeKeyImpl(
   # Top-most level of all the verticies this hash computation depends on
   var level = level
 
-  var writer = initRlpWriter()
+  var writer = AristoTrieWriter.init()
 
   let key =
     case vtx.vType
@@ -244,7 +242,7 @@ proc computeKeyImpl(
           else:
             VOID_HASH_KEY
 
-      encodeLeaf(vtx.pfx):
+      writer.encodeLeaf(vtx.pfx):
         Account(
           nonce: vtx.account.nonce,
           balance: vtx.account.balance,
@@ -253,7 +251,7 @@ proc computeKeyImpl(
         )
     of StoLeaf:
       let vtx = StoLeafRef(vtx)
-      encodeLeaf(vtx.pfx):
+      writer.encodeLeaf(vtx.pfx):
         vtx.stoData
     of Branches:
       # For branches, we need to load the vertices before recursing into them
@@ -313,7 +311,7 @@ proc computeKeyImpl(
             )
           batch.leave(n)
 
-      template writeBranch(w: var RlpWriter, vtx: BranchRef): HashKey =
+      template writeBranch(w: var AristoTrieWriter, vtx: BranchRef): HashKey =
         w.encodeBranch(vtx):
           if subvid.isValid:
             level = max(level, keyvtxs[n][1])
@@ -324,7 +322,7 @@ proc computeKeyImpl(
       if vtx.vType == ExtBranch:
         let vtx = ExtBranchRef(vtx)
         writer.encodeExt(vtx.pfx):
-          var bwriter = initRlpWriter()
+          var bwriter = AristoTrieWriter.init()
           bwriter.writeBranch(vtx)
       else:
         writer.writeBranch(vtx)

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -14,7 +14,7 @@ import
   std/strformat,
   chronicles,
   eth/rlp,
-  eth/common/[accounts_rlp, base_rlp, hashes_rlp],
+  eth/common,
   results,
   "."/[aristo_desc, aristo_get, aristo_layers],
   ./aristo_desc/desc_backend
@@ -118,7 +118,6 @@ template appendLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: untyped) =
   w.append(pfx.toHexPrefix(isLeaf = true).data())
   w.wrapEncoding(1)
   w.append(leafData)
-  discard rlp.encode(leafData)
 
 template encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: untyped): HashKey =
   w.clear()

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -103,10 +103,14 @@ proc putKeyAtLevel(
   ok()
 
 func init(T: type AristoTrieWriter): T =
-  result.tracker = DynamicRlpLengthTracker()
-  result.tracker.initLengthTracker()
-  result.twoPassWriter = initTwoPassWriter(result.tracker)
-  result.hashWriter = initHashWriter(result.tracker)
+  var trk = DynamicRlpLengthTracker()
+  trk.initLengthTracker()
+
+  AristoTrieWriter(
+    tracker: trk,
+    twoPassWriter: initTwoPassWriter(trk),
+    hashWriter: initHashWriter(trk)
+  )
 
 func clear(self: var AristoTrieWriter) =
   self.tracker.clear()

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -123,7 +123,7 @@ template appendLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: Account | UInt2
   w.wrapEncoding(1)
   w.append(leafData)
 
-template encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: Account | UInt256): HashKey =
+func encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: Account | UInt256): HashKey =
   w.clear()
   w.tracker.appendLeaf(pfx, leafData)
 
@@ -138,24 +138,28 @@ template encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: Account 
     let buf = w.hashWriter.finish()
     buf.to(HashKey)
 
-template appendBranch(w: var RlpWriter, vtx: VertexRef, subKeyForN: untyped) =
+template appendBranch(w: var RlpWriter, vtx: VertexRef, hashKeys: array[16, HashKey]) =
   w.startList(17)
-  for (n {.inject.}, subvid {.inject.}) in vtx.allPairs():
-    w.append(subKeyForN)
+  for key in hashKeys:
+    w.append(key)
   w.append EmptyBlob
 
 template encodeBranch(w: var AristoTrieWriter, rvtx: VertexRef, subKeyForN: untyped): HashKey =
+  var hashKeys: array[16, HashKey]
+  for (n {.inject.}, subvid {.inject.}) in vtx.allPairs():
+    hashKeys[n] = subKeyForN
+
   w.clear()
-  w.tracker.appendBranch(vtx, subKeyForN)
+  w.tracker.appendBranch(vtx, hashKeys)
 
   if w.tracker.totalLength < 32:
     w.twoPassWriter.reInit(w.tracker)
-    w.twoPassWriter.appendBranch(vtx, subKeyForN)
+    w.twoPassWriter.appendBranch(vtx, hashKeys)
     let buf = HashKey.fromBytes(w.twoPassWriter.finish)
     buf.value
   else:
     w.hashWriter.reInit(w.tracker)
-    w.hashWriter.appendBranch(vtx, subKeyForN)
+    w.hashWriter.appendBranch(vtx, hashKeys)
     let buf = w.hashWriter.finish()
     buf.to(HashKey)
 

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -135,6 +135,49 @@ template encodeExt(w: var RlpWriter, pfx: NibblesBuf, branchKey: HashKey): HashK
   w.append(branchKey)
   w.finish().digestTo(HashKey)
 
+# template appendBranch(w: var RlpWriter, vtx: VertexRef, subKeyForN: untyped) =
+#   w.startList(17)
+#   for (n {.inject.}, subvid {.inject.}) in vtx.allPairs():
+#     w.append(subKeyForN)
+#   w.append EmptyBlob
+# 
+# template encodeBranch(vtx: VertexRef, subKeyForN: untyped): HashKey =
+#   var tracker: DynamicRlpLengthTracker
+#   tracker.initLengthTracker()
+#   tracker.appendBranch(vtx, subKeyForN)
+# 
+#   if tracker.totalLength < 32:
+#     var writer = initTwoPassWriter(tracker)
+#     writer.appendBranch(vtx, subKeyForN)
+#     let buf = HashKey.fromBytes(writer.finish)
+#     buf.value
+#   else:
+#     var writer = initHashWriter(tracker)
+#     writer.appendBranch(vtx, subKeyForN)
+#     let buf = writer.finish()
+#     buf.to(HashKey)
+# 
+# template appendExt(w: var RlpWriter, pfx: NibblesBuf, branchKey: HashKey) =
+#   w.startList(2)
+#   w.append(pfx.toHexPrefix(isLeaf = false).data())
+#   w.append(branchKey)
+# 
+# template encodeExt(pfx: NibblesBuf, branchKey: untyped): HashKey =
+#   var tracker: DynamicRlpLengthTracker
+#   tracker.initLengthTracker()
+#   tracker.appendExt(pfx, branchKey)
+# 
+#   if tracker.totalLength < 32:
+#     var writer = initTwoPassWriter(tracker)
+#     writer.appendExt(pfx, branchKey)
+#     let buf = HashKey.fromBytes(writer.finish)
+#     buf.value
+#   else:
+#     var writer = initHashWriter(tracker)
+#     writer.appendExt(pfx, branchKey)
+#     let buf = writer.finish()
+#     buf.to(HashKey)
+
 proc getKey(
     db: AristoTxRef, rvid: RootedVertexID, skipLayers: static bool
 ): Result[((HashKey, VertexRef), int), AristoError] =

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -13,19 +13,14 @@
 import
   std/strformat,
   chronicles,
-  eth/rlp,
   eth/common/[accounts_rlp, base_rlp, hashes_rlp],
+  eth/rlp/static_encoder,
   results,
   "."/[aristo_desc, aristo_get, aristo_layers],
   ./aristo_desc/desc_backend
 
 type
   WriteBatch = tuple[writer: PutHdlRef, count: int, depth: int, prefix: uint64]
-
-  AristoTrieWriter = object
-    tracker: DynamicRlpLengthTracker
-    twoPassWriter: RlpTwoPassWriter
-    hashWriter: RlpHashWriter
 
 # Keep write batch size _around_ 1mb, give or take some overhead - this is a
 # tradeoff between efficiency and memory usage with diminishing returns the
@@ -102,86 +97,136 @@ proc putKeyAtLevel(
 
   ok()
 
-func init(T: type AristoTrieWriter): T =
-  var trk = DynamicRlpLengthTracker()
-  trk.initLengthTracker()
+func hashKeyEncodedLen(key: HashKey): int {.inline.} =
+  if key.len == 0: 1
+  elif key.len < 32: key.len
+  else: 33
 
-  AristoTrieWriter(
-    tracker: trk,
-    twoPassWriter: initTwoPassWriter(trk),
-    hashWriter: initHashWriter(trk)
-  )
-
-func clear(self: var AristoTrieWriter) =
-  self.tracker.clear()
-  self.twoPassWriter.clear()
-  self.hashWriter.clear()
-
-template appendLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: Account | UInt256) =
-  w.startList(2)
-  w.append(pfx.toHexPrefix(isLeaf = true).data())
-  w.wrapEncoding(1)
-  w.append(leafData)
-
-func encodeLeaf(w: var AristoTrieWriter, pfx: NibblesBuf, leafData: Account | UInt256): HashKey =
-  w.clear()
-  w.tracker.appendLeaf(pfx, leafData)
-
-  if w.tracker.totalLength < 32:
-    w.twoPassWriter.reInit(w.tracker)
-    w.twoPassWriter.appendLeaf(pfx, leafData)
-    let buf = HashKey.fromBytes(w.twoPassWriter.finish)
-    buf.value
+func writeHashKey(output: var openArray[byte], pos: var int, key: HashKey) {.inline.} =
+  if key.len == 0:
+    output[pos] = 0x80
+    pos += 1
+  elif key.len < 32:
+    rlpWriteRawBytes(output, pos, key.data)
   else:
-    w.hashWriter.reInit(w.tracker)
-    w.hashWriter.appendLeaf(pfx, leafData)
-    let buf = w.hashWriter.finish()
-    buf.to(HashKey)
+    rlpWriteBlobHeader(output, pos, 32)
+    rlpWriteRawBytes(output, pos, key.data)
 
-template appendBranch(w: var RlpWriter, vtx: VertexRef, hashKeys: array[16, HashKey]) =
-  w.startList(17)
+func hashHashKey(ctx: var Keccak256, key: HashKey) {.inline.} =
+  if key.len == 0:
+    ctx.rlpHashByte(0x80)
+  elif key.len < 32:
+    ctx.update(key.data)
+  else:
+    ctx.rlpHashBlobHeader(32)
+    ctx.update(key.data)
+
+func encodeLeafAccount(pfx: NibblesBuf, acc: Account): HashKey =
+  let hexPfxBuf = pfx.toHexPrefix(isLeaf = true)
+
+  # store all lenghts on the stack as local variables (instead of using the length writer)
+  let hexPfxBlobLen = rlpBlobEncodedLen(hexPfxBuf.data())
+  let nonceLen = rlpIntEncodedLen(acc.nonce)
+  let balanceLen = rlpUInt256EncodedLen(acc.balance)
+  const sRootLen = 33  # Hash32 always: 0xa0 prefix + 32 bytes
+  const cHashLen = 33
+  let accContent = nonceLen + balanceLen + sRootLen + cHashLen
+  let accListLen = rlpListEncodedLen(accContent)
+
+  # wrapped encoding (rlp encoding a rlp encoded item is now ))))
+  let wrapLen = rlpBlobEncodedLen(accListLen)  # blob-wrap the account list
+  let outerContent = hexPfxBlobLen + wrapLen
+  let outerListLen = rlpListEncodedLen(outerContent)
+
+  # account leaf nodes are always > 32 bytes encoded, so always use keccak path
+  var ctx = Keccak256.init()
+  ctx.rlpHashListHeader(outerContent)
+  ctx.rlpHashBlob(hexPfxBuf.data())
+  ctx.rlpHashBlobHeader(accListLen)  # wrap prefix
+  ctx.rlpHashListHeader(accContent)
+  ctx.rlpHashInt(acc.nonce)
+  ctx.rlpHashUInt256(acc.balance)
+  ctx.rlpHashBlobHeader(32); ctx.update(acc.storageRoot.data)
+  ctx.rlpHashBlobHeader(32); ctx.update(acc.codeHash.data)
+  ctx.finish().to(Hash32).to(HashKey)
+
+func encodeLeafStorage(pfx: NibblesBuf, stoData: UInt256): HashKey =
+  let
+    hexPfxBuf = pfx.toHexPrefix(isLeaf = true) 
+    hexPfxBlobLen = rlpBlobEncodedLen(hexPfxBuf.data())
+    stoRlpLen = rlpUInt256EncodedLen(stoData)
+
+    # wrapEncoding omits the blob prefix when the inner value is self-encoding
+    isStoSelfEncoding = stoData > 0 and stoData < 128 
+    wrapLen =
+      if isStoSelfEncoding: stoRlpLen  # no wrap prefix: just the raw byte
+      else: rlpBlobEncodedLen(stoRlpLen)
+
+    outerContent = hexPfxBlobLen + wrapLen
+    outerListLen = rlpListEncodedLen(outerContent)
+
+  if outerListLen < 32:
+    var output: array[32, byte]
+    var pos = 0
+    rlpWriteListHeader(output, pos, outerContent)
+    rlpWriteBlob(output, pos, hexPfxBuf.data())
+    if not isStoSelfEncoding:
+      rlpWriteBlobHeader(output, pos, stoRlpLen)
+    rlpWriteUInt256(output, pos, stoData)
+    output.toOpenArray(0, pos - 1).digestTo(HashKey)
+  else:
+    var ctx = Keccak256.init()
+    ctx.rlpHashListHeader(outerContent)
+    ctx.rlpHashBlob(hexPfxBuf.data())
+    if not isStoSelfEncoding:
+      ctx.rlpHashBlobHeader(stoRlpLen)
+    ctx.rlpHashUInt256(stoData)
+    ctx.finish().to(Hash32).to(HashKey)
+
+func encodeBranchStatic(hashKeys: array[16, HashKey]): HashKey =
+  var content = 1  # trailing empty blob (0x80)
   for key in hashKeys:
-    w.append(key)
-  w.append EmptyBlob
+    content += hashKeyEncodedLen(key)
+  let totalLen = rlpListEncodedLen(content)
 
-template encodeBranch(w: var AristoTrieWriter, rvtx: VertexRef, subKeyForN: untyped): HashKey =
-  var hashKeys {.noinit.}: array[16, HashKey]
-  for (n {.inject.}, subvid {.inject.}) in vtx.allPairs():
-    hashKeys[n] = subKeyForN
-
-  w.clear()
-  w.tracker.appendBranch(vtx, hashKeys)
-
-  if w.tracker.totalLength < 32:
-    w.twoPassWriter.reInit(w.tracker)
-    w.twoPassWriter.appendBranch(vtx, hashKeys)
-    let buf = HashKey.fromBytes(w.twoPassWriter.finish)
-    buf.value
+  if totalLen < 32:
+    var output: array[32, byte]
+    var pos = 0
+    rlpWriteListHeader(output, pos, content)
+    for key in hashKeys:
+      writeHashKey(output, pos, key)
+    output[pos] = 0x80
+    pos += 1
+    output.toOpenArray(0, pos - 1).digestTo(HashKey)
   else:
-    w.hashWriter.reInit(w.tracker)
-    w.hashWriter.appendBranch(vtx, hashKeys)
-    let buf = w.hashWriter.finish()
-    buf.to(HashKey)
+    var ctx = Keccak256.init()
+    ctx.rlpHashListHeader(content)
+    for key in hashKeys:
+      ctx.hashHashKey(key)
+    ctx.rlpHashByte(0x80)
+    ctx.finish().to(Hash32).to(HashKey)
 
-template appendExt(w: var RlpWriter, pfx: NibblesBuf, branchKey: HashKey) =
-  w.startList(2)
-  w.append(pfx.toHexPrefix(isLeaf = false).data())
-  w.append(branchKey)
+func encodeExtStatic(pfx: NibblesBuf, branchKey: HashKey): HashKey =
+  let hexPfxBuf = pfx.toHexPrefix(isLeaf = false)
 
-func encodeExt(w: var AristoTrieWriter, pfx: NibblesBuf, branchKey: HashKey): HashKey =
-  w.clear()
-  w.tracker.appendExt(pfx, branchKey)
+  let hexPfxBlobLen = rlpBlobEncodedLen(hexPfxBuf.data())
+  let branchKeyLen = hashKeyEncodedLen(branchKey)
+  let outerContent = hexPfxBlobLen + branchKeyLen
+  let outerListLen = rlpListEncodedLen(outerContent)
 
-  if w.tracker.totalLength < 32:
-    w.twoPassWriter.reInit(w.tracker)
-    w.twoPassWriter.appendExt(pfx, branchKey)
-    let buf = HashKey.fromBytes(w.twoPassWriter.finish)
-    buf.value
+  if outerListLen < 32:
+    var output: array[32, byte]
+    var pos = 0
+    rlpWriteListHeader(output, pos, outerContent)
+    rlpWriteBlob(output, pos, hexPfxBuf.data())
+    writeHashKey(output, pos, branchKey)
+    output.toOpenArray(0, pos - 1).digestTo(HashKey)
   else:
-    w.hashWriter.reInit(w.tracker)
-    w.hashWriter.appendExt(pfx, branchKey)
-    let buf = w.hashWriter.finish()
-    buf.to(HashKey)
+    var ctx = Keccak256.init()
+    ctx.rlpHashListHeader(outerContent)
+    ctx.rlpHashBlob(hexPfxBuf.data())
+    ctx.hashHashKey(branchKey)
+    ctx.finish().to(Hash32).to(HashKey)
 
 proc getKey(
     db: AristoTxRef, rvid: RootedVertexID, skipLayers: static bool
@@ -219,9 +264,7 @@ proc computeKeyImpl(
   # empty state
 
   # Top-most level of all the verticies this hash computation depends on
-  var
-    level = level
-    writer = AristoTrieWriter.init()
+  var level = level
 
   let key =
     case vtx.vType
@@ -249,7 +292,7 @@ proc computeKeyImpl(
           else:
             VOID_HASH_KEY
 
-      writer.encodeLeaf(vtx.pfx,
+      encodeLeafAccount(vtx.pfx,
         Account(
           nonce: vtx.account.nonce,
           balance: vtx.account.balance,
@@ -259,7 +302,7 @@ proc computeKeyImpl(
       )
     of StoLeaf:
       let vtx = StoLeafRef(vtx)
-      writer.encodeLeaf(vtx.pfx, vtx.stoData)
+      encodeLeafStorage(vtx.pfx, vtx.stoData)
     of Branches:
       # For branches, we need to load the vertices before recursing into them
       # to exploit their on-disk order
@@ -318,20 +361,19 @@ proc computeKeyImpl(
             )
           batch.leave(n)
 
-      template writeBranch(w: var AristoTrieWriter, vtx: BranchRef): HashKey =
-        w.encodeBranch(vtx):
-          if subvid.isValid:
-            level = max(level, keyvtxs[n][1])
-            keyvtxs[n][0][0]
-          else:
-            VOID_HASH_KEY
+      var hashKeys {.noinit.}: array[16, HashKey]
+      for (n, subvid) in vtx.allPairs():
+        if subvid.isValid:
+          level = max(level, keyvtxs[n][1])
+          hashKeys[n] = keyvtxs[n][0][0]
+        else:
+          hashKeys[n] = VOID_HASH_KEY
 
       if vtx.vType == ExtBranch:
-        let vtx = ExtBranchRef(vtx)
-        var bwriter = AristoTrieWriter.init()
-        writer.encodeExt(vtx.pfx, bwriter.writeBranch(vtx))
+        let extVtx = ExtBranchRef(vtx)
+        encodeExtStatic(extVtx.pfx, encodeBranchStatic(hashKeys))
       else:
-        writer.writeBranch(vtx)
+        encodeBranchStatic(hashKeys)
 
   # Cache the hash into the same storage layer as the the top-most value that it
   # depends on (recursively) - this could be an ephemeral in-memory layer or the

--- a/tests/test_aristo/test_compute_benchmark.nim
+++ b/tests/test_aristo/test_compute_benchmark.nim
@@ -1,0 +1,70 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+{.used.}
+
+import
+  std/times,
+  unittest2,
+  ../../execution_chain/db/aristo/[
+    aristo_compute,
+    aristo_merge,
+    aristo_desc,
+    aristo_init/memory_only,
+    aristo_tx_frame,
+  ]
+
+suite "Aristo compute benchmark":
+  const 
+    NUM_THREADS = 16
+    NUM_FRAMES = 10
+    NUM_ACCOUNTS_PER_FRAME = 400000
+
+  setup:
+    let db = AristoDbRef.init()
+    var txFrame = db.txRef
+
+    for i in 0 ..< NUM_ACCOUNTS_PER_FRAME:
+      check:
+        txFrame.mergeAccount(
+          cast[Hash32](i), 
+          AristoAccount(balance: i.u256(), codeHash: EMPTY_CODE_HASH)) == Result[bool, AristoError].ok(true)
+    txFrame.checkpoint(1, skipSnapshot = true)
+
+    let batch = db.putBegFn()[]
+    db.persist(batch, txFrame)
+    check db.putEndFn(batch).isOk()
+    
+    txFrame = db.baseTxFrame()
+    
+    for n in 1 .. NUM_FRAMES:
+      txFrame = db.txFrameBegin(txFrame)
+
+      let 
+        startIdx = NUM_ACCOUNTS_PER_FRAME * n
+        endIdx = startIdx + NUM_ACCOUNTS_PER_FRAME
+
+      for i in startIdx ..< endIdx:
+        check:
+          txFrame.mergeAccount(
+            cast[Hash32](i * i), 
+            AristoAccount(balance: i.u256(), codeHash: EMPTY_CODE_HASH)) == Result[bool, AristoError].ok(true)
+      
+      txFrame.checkpoint(1, skipSnapshot = false)
+
+
+  test "Serial benchmark - skipLayers = false":
+    debugEcho "\nSerial benchmark (skipLayers = false) running..."
+
+    let before = cpuTime()
+    check txFrame.computeKey((STATE_ROOT_VID, STATE_ROOT_VID)).isOk()
+    let elapsed = cpuTime() - before
+    
+    debugEcho "Serial benchmark (skipLayers = false) cpu time: ", elapsed


### PR DESCRIPTION
closed duplicate: https://github.com/status-im/nimbus-eth1/pull/3226
fixes: https://github.com/status-im/nimbus-eth1/issues/3164

Uses the rlp hash writer for Aristo DB's `computeKey` implementation