### PR TITLE
Add command line option for marking a manual sync target finalised

### DIFF
--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -507,19 +507,20 @@ type
         name: "jwt-secret" .}: Option[InputFile]
 
       beaconSyncTarget* {.
-        separator: "\pBEACON SYNC OPTIONS:"
+        hidden
         desc: "Manually set the initial sync target specified by its 32 byte" &
               " block hash (e.g. as found on etherscan.io) represented by a" &
               " hex string"
-        name: "beacon-sync-target" .}: Option[string]
+        name: "debug-beacon-sync-target" .}: Option[string]
 
       beaconSyncTargetIsFinal* {.
+        hidden
         defaultValue: false
         desc: "If the sync taget is finalised (e.g. as stated on" &
               " etherscan.io) this can be set here. For a non-finalised" &
               " manual sync target it is advisable to run this EL against a" &
               " CL which will result in a smaller memory footprint"
-        name: "beacon-sync-target-is-final".}: bool
+        name: "debug-beacon-sync-target-is-final".}: bool
 
     of `import`:
       maxBlocks* {.

--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -508,11 +508,18 @@ type
 
       beaconSyncTarget* {.
         separator: "\pBEACON SYNC OPTIONS:"
-        desc: "Set the initial sync target specified by its 32 byte block" &
-              " hash (e.g. as found on etherscan.io) represented by a" &
-              " hex string. With this option, it is advisable to run this EL" &
-              " against a CL which will result in a smaller memory footprint"
+        desc: "Manually set the initial sync target specified by its 32 byte" &
+              " block hash (e.g. as found on etherscan.io) represented by a" &
+              " hex string"
         name: "beacon-sync-target" .}: Option[string]
+
+      beaconSyncTargetIsFinal* {.
+        defaultValue: false
+        desc: "If the sync taget is finalised (e.g. as stated on" &
+              " etherscan.io) this can be set here. For a non-finalised" &
+              " manual sync target it is advisable to run this EL against a" &
+              " CL which will result in a smaller memory footprint"
+        name: "beacon-sync-target-is-final".}: bool
 
     of `import`:
       maxBlocks* {.

--- a/execution_chain/core/chain/header_chain_cache.nim
+++ b/execution_chain/core/chain/header_chain_cache.nim
@@ -324,8 +324,12 @@ proc headUpdateFromCL(hc: HeaderChainRef; h: Header; f: Hash32) =
       hc.kvt.putHeader(h)
       metrics.set(nec_sync_dangling, h.number.int64)
 
-      # Inform client app about that a new session has started.
+      # Update `FC` module
       hc.chain.pendingFCU = f
+      if f == hc.session.headHash:
+        discard hc.chain.tryUpdatePendingFCU(f, h.number)
+
+      # Inform client app about that a new session has started.
       hc.notify()
 
     # For logging and metrics

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -123,7 +123,7 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf,
   # Optional for pre-setting the sync target (i.e. debugging)
   if conf.beaconSyncTarget.isSome():
     let hex = conf.beaconSyncTarget.unsafeGet
-    if not nimbus.beaconSyncRef.targetInit hex:
+    if not nimbus.beaconSyncRef.targetInit(hex, conf.beaconSyncTargetIsFinal):
       fatal "Error parsing --beacon-sync-target hash32 argument", hash32=hex
       quit QuitFailure
 

--- a/execution_chain/sync/beacon.nim
+++ b/execution_chain/sync/beacon.nim
@@ -69,10 +69,10 @@ proc init*(
   desc.ctx.pool.chain = chain
   desc
 
-proc targetInit*(desc: BeaconSyncRef; hex: string): bool =
+proc targetInit*(desc: BeaconSyncRef; hex: string; isFinal: bool): bool =
   ## Set up inital target sprint (if any, mainly for debugging)
   try:
-    desc.ctx.headersTargetRequest(Hash32.fromHex(hex), "init")
+    desc.ctx.headersTargetRequest(Hash32.fromHex(hex), isFinal, "init")
     return true
   except ValueError:
     discard

--- a/execution_chain/sync/beacon/README.md
+++ b/execution_chain/sync/beacon/README.md
@@ -204,14 +204,14 @@ command line without need to be requested by the consensus layer. In fact,
 this allows for single run synchronisation tests without the need of a
 consensus layer. The command line option needed here is
 
-       --beacon-sync-target=<hash32>
+       --debug-beacon-sync-target=<hash32>
 
 where *&lt;hash32&gt;* is a hexadecimal ASCII representation of a block
 header. The hashes for particular blocks can be looked up at *etherscan.io*.
 For testing, only finalised hblock headers should be referred to in which
 case the option
 
-       --beacon-sync-target-is-final
+       --debug-beacon-sync-target-is-final
 
 should be set. This reduces the potential memory footprint when running
 without a CL.

--- a/execution_chain/sync/beacon/README.md
+++ b/execution_chain/sync/beacon/README.md
@@ -208,9 +208,13 @@ consensus layer. The command line option needed here is
 
 where *&lt;hash32&gt;* is a hexadecimal ASCII representation of a block
 header. The hashes for particular blocks can be looked up at *etherscan.io*.
-This works well for short sync sprints (i.e. number of blocks to import.)
-For longer sync sprints the consensus layer should be availale as it reduces
-the memory footprint (by updating the finalised block.)
+For testing, only finalised hblock headers should be referred to in which
+case the option
+
+       --beacon-sync-target-is-final
+
+should be set. This reduces the potential memory footprint when running
+without a CL.
 
 ### Syncing on a low memory machine
 

--- a/execution_chain/sync/beacon/worker/update.nim
+++ b/execution_chain/sync/beacon/worker/update.nim
@@ -16,7 +16,6 @@ import
   pkg/eth/common,
   ../worker_desc,
   ./blocks/blocks_unproc,
-  ./headers/headers_target,
   ./headers
 
 logScope:

--- a/execution_chain/sync/beacon/worker_desc.nim
+++ b/execution_chain/sync/beacon/worker_desc.nim
@@ -120,6 +120,10 @@ type
     ## Local descriptor data extension
     nRespErrors*: BuddyError         ## Number of errors/slow responses in a row
 
+  InitTarget* = tuple
+    hash: Hash32                     ## Some block hash to sync towards to
+    isFinal: bool                    ## The `hash` belongs to a finalised block
+
   BeaconCtxData* = object
     ## Globally shared data extension
     nBuddies*: int                   ## Number of active workers
@@ -138,7 +142,7 @@ type
     lastSlowPeer*: Opt[Hash]         ## Register slow peer when the last one
     failedPeers*: HashSet[Hash]      ## Detect dead end sync by collecting peers
     seenData*: bool                  ## Set `true` if data were fetched, already
-    initTarget*: Opt[Hash32]         ## Optionally set up first target
+    initTarget*: Opt[InitTarget]     ## Optionally set up first target
 
     when enableTicker:
       ticker*: RootRef               ## Logger ticker


### PR DESCRIPTION
why
  If it is known to be finalised, it can be set. The implications are
  that with the given sync target no CL is needed to keep the memory footprint
  small.