### PR TITLE
fix: correct fork transition logic in lastFork function

### DIFF
--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -319,7 +319,7 @@ func nextFork*(com: CommonRef, currentFork: HardFork): Opt[HardFork] =
 func lastFork*(com: CommonRef, currentFork: HardFork): Opt[HardFork] =
   ## Returns the last hard fork before the given one
   for fork in countdown(HardFork.high, currentFork):
-    if fork > currentFork and com.forkTransitionTable.timeThresholds[fork].isSome:
+    if fork < currentFork and com.forkTransitionTable.timeThresholds[fork].isSome:
       return Opt.some(HardFork(fork))
   return Opt.none(HardFork)
 


### PR DESCRIPTION
Fix the logical impossibility in lastFork function where the condition
fork > currentFork was used in a countdown loop, making it impossible
to find previous forks. Changed to fork < currentFork to correctly
identify the last hard fork before the current one.