### PR TITLE
fix: queueUpdateBase batching to iterate from base to prevQueuedBase

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -396,8 +396,8 @@ proc queueUpdateBase(c: ForkedChainRef, base: BlockRef)
 
   var
     number = base.number - min(base.number, PersistBatchSize)
-    steps  = newSeqOfCap[BlockRef]((base.number-c.base.number) div PersistBatchSize + 1)
-    it = prevQueuedBase
+    steps  = newSeqOfCap[BlockRef]((base.number - prevQueuedBase.number) div PersistBatchSize + 1)
+    it = base
 
   steps.add base
 


### PR DESCRIPTION
- Iterate from new base target back toward prevQueuedBase for correct step scheduling
- Pre-allocate steps capacity based on (base.number - prevQueuedBase.number)
- Keeps batch size semantics via PersistBatchSize; no behavior changes elsewhere