### PR TITLE
Avoid using include in DiscoveryV5 implementation

### DIFF
--- a/execution_chain/networking/discoveryv5.nim
+++ b/execution_chain/networking/discoveryv5.nim
@@ -9,10 +9,21 @@
 
 {.push raises: [].}
 
-include
-  eth/p2p/discoveryv5/protocol
+import
+  std/[importutils, tables],
+  metrics,
+  chronicles,
+  eth/p2p/discoveryv5/enr,
+  eth/p2p/discoveryv5/encoding,
+  eth/p2p/discoveryv5/sessions,
+  eth/p2p/discoveryv5/protocol {.all.}
 
+export
+  Protocol, Node, Address, enr, newProtocol, open, close, seedTable, start, queryRandom, closeWait
+  
 proc receiveV5*(d: Protocol, a: Address, packet: openArray[byte]): Result[void, cstring] =
+  privateAccess(Protocol)
+  privateAccess(PendingRequest)
   discv5_network_bytes.inc(packet.len.int64, labelValues = [$Direction.In])
 
   let packet = ?d.codec.decodePacket(a, packet)


### PR DESCRIPTION
This is a workaround to fix https://github.com/status-im/nimbus-eth1/issues/3573. A better fix is to wait for https://github.com/status-im/nim-eth/pull/809.