### PR TITLE
Discovery: Filter out non 'eth' nodes and regularly update 'eth' field.

### DIFF
--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -362,6 +362,9 @@ func forkId*(com: CommonRef, head: BlockNumber, time: EthTime): ForkID {.gcsafe.
   ## EIP 2364/2124
   com.forkIdCalculator.newID(head, time.uint64)
 
+func compatibleForkId*(com: CommonRef, id: ForkID): bool =
+  com.forkIdCalculator.compatible(id)
+
 func isEIP155*(com: CommonRef, number: BlockNumber): bool =
   com.config.eip155Block.isSome and number >= com.config.eip155Block.value
 

--- a/execution_chain/networking/discoveryv5.nim
+++ b/execution_chain/networking/discoveryv5.nim
@@ -19,8 +19,9 @@ import
   eth/p2p/discoveryv5/protocol {.all.}
 
 export
-  Protocol, Node, Address, enr, newProtocol, open, close, seedTable, start, queryRandom, closeWait
-  
+  Protocol, Node, Address, enr, newProtocol, open, close, seedTable, start, queryRandom, closeWait,
+  updateRecord
+
 proc receiveV5*(d: Protocol, a: Address, packet: openArray[byte]): Result[void, cstring] =
   privateAccess(Protocol)
   privateAccess(PendingRequest)

--- a/execution_chain/networking/p2p.nim
+++ b/execution_chain/networking/p2p.nim
@@ -19,7 +19,7 @@ import
   ./eth1_discovery
 
 export
-  p2p_types, rlpx, enode
+  p2p_types, rlpx, enode, UpdaterHook
 
 logScope:
   topics = "p2p"
@@ -34,14 +34,15 @@ proc newEthereumNode*(
     bindUdpPort: Port,
     bindTcpPort: Port,
     bindIp = IPv6_any(),
-    rng = newRng()): EthereumNode =
+    rng = newRng(),
+    hook = UpdaterHook()): EthereumNode =
 
   if rng == nil: # newRng could fail
     raiseAssert "Cannot initialize RNG"
 
   let
     discovery = Eth1Discovery.new(
-      keys.seckey, address, bootstrapNodes, bindUdpPort, bindIp, rng)
+      keys.seckey, address, bootstrapNodes, bindUdpPort, bindIp, rng, hook)
     node = EthereumNode(
       keys: keys,
       networkId: networkId,
@@ -53,7 +54,7 @@ proc newEthereumNode*(
       rng: rng,
     )
   node.peerPool = newPeerPool[EthereumNode](
-    node, discovery, minPeers = minPeers)
+    node, discovery, minPeers = minPeers, hook = hook)
   node
 
 proc processIncoming(server: StreamServer,

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -103,7 +103,21 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf,
       if extPorts.isSome:
         (address.tcpPort, address.udpPort) = extPorts.get()
 
-  let bootstrapNodes = conf.getBootNodes()
+  let
+    bootstrapNodes = conf.getBootNodes()
+    fc = nimbus.fc
+
+  func forkIdHook(): ForkID {.raises: [].} =
+    let header = fc.latestHeader()
+    com.forkId(header.number, header.timestamp)
+
+  func compatibleForkIdHook(id: ForkID): bool {.raises: [].} =
+    com.compatibleForkId(id)
+    
+  let hook = UpdaterHook(
+    forkId: forkIdHook,
+    compatibleForkId: compatibleForkIdHook,
+  )
 
   nimbus.ethNode = newEthereumNode(
     keypair, address, conf.networkId, conf.agentString,
@@ -111,7 +125,8 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf,
     bootstrapNodes = bootstrapNodes,
     bindUdpPort = conf.udpPort, bindTcpPort = conf.tcpPort,
     bindIp = conf.listenAddress,
-    rng = nimbus.ctx.rng)
+    rng = nimbus.ctx.rng,
+    hook = hook)
 
   # Add protocol capabilities
   nimbus.wire = nimbus.ethNode.addEthHandlerCapability(nimbus.txPool)

--- a/execution_chain/stateless/witness_verification.nim
+++ b/execution_chain/stateless/witness_verification.nim
@@ -36,7 +36,7 @@ func putAll(
   for key in keysToAdd:
     if key.isAddress():
       currentAddress = Address.copyFrom(key)
-      keys.withValue(currentAddress, v):
+      keys.withValue(currentAddress, _):
         discard
       do:
         keys[currentAddress] = default(HashSet[UInt256])
@@ -105,7 +105,7 @@ func verify*(witness: ExecutionWitness, preStateRoot: Hash32): Result[void, stri
       try:
         rlp.decode(accLeaf, Account)
       except RlpError as e:
-        return err("Failed to decode account leaf from witness state")
+        return err("Failed to decode account leaf from witness state: " & e.msg)
     codeHashes.incl(account.codeHash)
 
     # No point in verifying slot proofs against an empty root hash
@@ -132,7 +132,7 @@ func verify*(witness: ExecutionWitness, preStateRoot: Hash32): Result[void, stri
     try:
       headers.add(rlp.decode(header, Header))
     except RlpError as e:
-      return err("Failed to decode header in witness")
+      return err("Failed to decode header in witness: " & e.msg)
 
   func compareByNumber(a, b: Header): int =
     if a.number == b.number:


### PR DESCRIPTION
This should fix #3557 

The async worker will regularly update `localNode` enr with `("eth", forkId)` every 15 secs if there is changes in the `forkId`.
It will make other easier for other node to peer with nimbus-eth1.

And the returned node by discovery V5 also get filtered by "eth" field and compatible `forkId`.
This will filter out e.g. `eth2` nodes,  and nodes with different chain in advance before actually using rlpx to connect them.