### PR TITLE
bump nimbus-eth2 and remove old fulu field in Portal beacon test

### DIFF
--- a/portal/tests/beacon_network_tests/test_beacon_content.nim
+++ b/portal/tests/beacon_network_tests/test_beacon_content.nim
@@ -198,7 +198,6 @@ suite "Beacon Content Keys and Values":
     capella: ForkDigest([0'u8, 0, 0, 4]),
     deneb: ForkDigest([0'u8, 0, 0, 5]),
     electra: ForkDigest([0'u8, 0, 0, 6]),
-    fulu: ForkDigest([0'u8, 0, 0, 7]),
   )
 
   test "LightClientBootstrap":


### PR DESCRIPTION
Those old beacon tests only test with altair test data and the digest fields are arbitrary.