### PR TITLE
portal: cleanup of block proof tests

### DIFF
--- a/portal/tests/all_portal_tests.nim
+++ b/portal/tests/all_portal_tests.nim
@@ -13,4 +13,5 @@ import
   ./legacy_history_network_tests/all_history_network_tests,
   ./history_network_tests/all_history_network_tests,
   ./beacon_network_tests/all_beacon_network_tests,
+  ./eth_history_tests/all_eth_history_tests,
   ./rpc_tests/all_rpc_tests

--- a/portal/tests/eth_history_tests/test_block_proof_historical_roots.nim
+++ b/portal/tests/eth_history_tests/test_block_proof_historical_roots.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -12,96 +12,56 @@
 import
   unittest2,
   beacon_chain/spec/forks,
-  beacon_chain/spec/datatypes/bellatrix,
-  beacon_chain /../ tests/testblockutil,
   # Mock helpers
+  beacon_chain /../ tests/testblockutil,
   beacon_chain /../ tests/mocking/mock_genesis,
   ../../eth_history/block_proofs/block_proof_historical_roots
 
-# Test suite for the proofs:
-# - HistoricalRootsProof
-# - BeaconBlockProof
-# and:
-# - the chain of both proofs, BeaconChainBlockProof:
-# BlockHash
-# -> BeaconBlockProof
-# -> HistoricalRootsProof
-# historical_roots
+# Test suite for the chain of proofs BlockProofHistoricalRoots:
+# -> BeaconBlockProofHistoricalRoots
+# -> ExecutionBlockProof
 #
-# Note: The last test makes the others redundant, but keeping them all around
-# for now as it might be sufficient to go with just HistoricalRootsProof (and
-# perhaps BeaconBlockHeaderProof), see comments in beacon_chain_proofs.nim.
-#
-# TODO: Add more blocks to reach 1+ historical roots, to make sure that indexing
-# is properly tested.
+# Note: Only the full chain of proofs is tested here. The setup takes a lot of time
+# and testing the individual proofs is redundant.
 
 suite "History Block Proofs - Historical Roots":
-  let
-    cfg = block:
-      var res = defaultRuntimeConfig
-      res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
-      res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
-      res
-    state = newClone(initGenesisState(cfg = cfg))
-  var cache = StateCache()
-
-  var blocks: seq[bellatrix.SignedBeaconBlock]
-  # Note:
-  # Adding 8192 blocks. First block is genesis block and not one of these.
-  # Then one extra block is needed to get the historical roots, block
-  # roots and state roots processed.
-  # index i = 0 is second block.
-  # index i = 8190 is 8192th block and last one that is part of the first
-  # historical root
-  for i in 0 ..< SLOTS_PER_HISTORICAL_ROOT:
-    blocks.add(addTestBlock(state[], cache, cfg = cfg).bellatrixData)
-
-  # Starts from the block after genesis.
-  const blocksToTest = [
-    0'u64,
-    1,
-    2,
-    3,
-    SLOTS_PER_HISTORICAL_ROOT div 2,
-    SLOTS_PER_HISTORICAL_ROOT - 3,
-    SLOTS_PER_HISTORICAL_ROOT - 2,
-  ]
-
-  test "BeaconBlockProofHistoricalRoots for BeaconBlock":
+  setup:
     let
-      # Historical batch of first historical root
-      batch = HistoricalBatch(
-        block_roots: getStateField(state[], block_roots).data,
-        state_roots: getStateField(state[], state_roots).data,
-      )
-      historical_roots = getStateField(state[], historical_roots)
+      cfg = block:
+        var res = defaultRuntimeConfig
+        res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
+        res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
+        res
+      state = newClone(initGenesisState(cfg = cfg))
+    var cache = StateCache()
 
-    # for i in 0..<(SLOTS_PER_HISTORICAL_ROOT - 1): # Test all blocks
-    for i in blocksToTest:
-      let
-        beaconBlock = blocks[i].message
-        historicalRootsIndex = getHistoricalRootsIndex(beaconBlock.slot)
-        blockRootIndex = getBlockRootsIndex(beaconBlock.slot)
+    var blocks: seq[bellatrix.SignedBeaconBlock]
+    # Note:
+    # Adding 8192 blocks. First block is genesis block and not one of these.
+    # Then one extra block is needed to get the historical roots, block
+    # roots and state roots processed.
+    # index i = 0 is second block.
+    # index i = 8190 is 8192th block and last one that is part of the first
+    # historical root
 
-      let res = buildProof(batch, blockRootIndex)
-      check res.isOk()
-      let proof = res.get()
+    # genesis + 8191 slots
+    for i in 0 ..< SLOTS_PER_HISTORICAL_ROOT - 1:
+      blocks.add(addTestBlock(state[], cache, cfg = cfg).bellatrixData)
 
-      check verifyProof(
-        blocks[i].root, proof, historical_roots[historicalRootsIndex], blockRootIndex
-      )
+    # One more slot to hit second SLOTS_PER_HISTORICAL_ROOT, hitting first
+    # historical root.
+    discard addTestBlock(state[], cache, cfg = cfg)
 
-  test "ExecutionBlockProof for Execution BlockHeader":
-    # for i in 0..<(SLOTS_PER_HISTORICAL_ROOT - 1): # Test all blocks
-    for i in blocksToTest:
-      let beaconBlock = blocks[i].message
-
-      let res = buildProof(beaconBlock)
-      check res.isOk()
-      let proof = res.get()
-
-      let leave = beaconBlock.body.execution_payload.block_hash
-      check verifyProof(leave, proof, blocks[i].root)
+    # Starts from the block after genesis.
+    const blocksToTest = [
+      0'u64,
+      1,
+      2,
+      3,
+      SLOTS_PER_HISTORICAL_ROOT div 2,
+      SLOTS_PER_HISTORICAL_ROOT - 3,
+      SLOTS_PER_HISTORICAL_ROOT - 2,
+    ]
 
   test "BlockProofHistoricalRoots for Execution BlockHeader":
     let

--- a/portal/tests/eth_history_tests/test_block_proof_historical_summaries_deneb.nim
+++ b/portal/tests/eth_history_tests/test_block_proof_historical_summaries_deneb.nim
@@ -12,91 +12,61 @@
 import
   unittest2,
   beacon_chain/spec/forks,
-  beacon_chain/spec/datatypes/deneb,
-  beacon_chain /../ tests/testblockutil,
   # Mock helpers
+  beacon_chain /../ tests/testblockutil,
   beacon_chain /../ tests/mocking/mock_genesis,
   ../../eth_history/block_proofs/block_proof_historical_summaries
 
+# Test suite for the chain of proofs BlockProofHistoricalSummariesDeneb:
+# -> BeaconBlockProofHistoricalSummaries
+# -> ExecutionBlockProofDeneb
+#
+# Note: Only the full chain of proofs is tested here. The setup takes a lot of time
+# and testing the individual proofs is redundant.
+
 suite "History Block Proofs - Historical Summaries - Deneb":
-  let
-    cfg = block:
-      var res = defaultRuntimeConfig
-      res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
-      res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
-      res.CAPELLA_FORK_EPOCH = GENESIS_EPOCH
-      res.DENEB_FORK_EPOCH = GENESIS_EPOCH
-      res
-    state = newClone(initGenesisState(cfg = cfg))
-  var cache = StateCache()
+  setup:
+    let
+      cfg = block:
+        var res = defaultRuntimeConfig
+        res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
+        res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
+        res.CAPELLA_FORK_EPOCH = GENESIS_EPOCH
+        res.DENEB_FORK_EPOCH = GENESIS_EPOCH
+        res
+      state = newClone(initGenesisState(cfg = cfg))
+    var cache = StateCache()
 
-  var blocks: seq[deneb.SignedBeaconBlock]
+    var blocks: seq[deneb.SignedBeaconBlock]
 
-  # Note:
-  # Adding 8192*2 blocks. First block is genesis block and not one of these.
-  # Then one extra block is needed to get the historical roots, block
-  # roots and state roots processed.
-  # index i = 0 is second block.
-  # index i = 8190 is 8192th block and last one that is part of the first
-  # historical root
+    # Note:
+    # Adding 8192 blocks. First block is genesis block and not one of these.
+    # Then one extra block is needed to get the historical summaries, block
+    # roots and state roots processed.
+    # index i = 0 is second block.
+    # index i = 8190 is 8192th block and last one that is part of the first
+    # historical summaries root
 
-  # genesis + 8191 slots, next one will be capella fork
-  for i in 0 ..< SLOTS_PER_HISTORICAL_ROOT - 1:
-    blocks.add(addTestBlock(state[], cache, cfg = cfg).denebData)
+    # genesis + 8191 slots
+    for i in 0 ..< SLOTS_PER_HISTORICAL_ROOT - 1:
+      blocks.add(addTestBlock(state[], cache, cfg = cfg).denebData)
 
-  # One more slot to hit second SLOTS_PER_HISTORICAL_ROOT, hitting first
-  # historical_summary.
-  discard addTestBlock(state[], cache, cfg = cfg)
+    # One more slot to hit second SLOTS_PER_HISTORICAL_ROOT, hitting first
+    # historical_summary root.
+    discard addTestBlock(state[], cache, cfg = cfg)
 
-  # Starts from the block after genesis.
-  const blocksToTest = [
-    0'u64,
-    1,
-    2,
-    3,
-    SLOTS_PER_HISTORICAL_ROOT div 2,
-    SLOTS_PER_HISTORICAL_ROOT - 3,
-    SLOTS_PER_HISTORICAL_ROOT - 2,
-  ]
+    # Starts from the block after genesis.
+    const blocksToTest = [
+      0'u64,
+      1,
+      2,
+      3,
+      SLOTS_PER_HISTORICAL_ROOT div 2,
+      SLOTS_PER_HISTORICAL_ROOT - 3,
+      SLOTS_PER_HISTORICAL_ROOT - 2,
+    ]
 
-  test "BeaconBlockProofHistoricalSummaries for BeaconBlock":
-    let blockRoots = getStateField(state[], block_roots).data
-
-    withState(state[]):
-      when consensusFork >= ConsensusFork.Capella:
-        let historical_summaries = forkyState.data.historical_summaries
-
-        # for i in 0..<(SLOTS_PER_HISTORICAL_ROOT - 1): # Test all blocks
-        for i in blocksToTest:
-          let
-            beaconBlock = blocks[i].message
-            historicalRootsIndex = getHistoricalSummariesIndex(beaconBlock.slot, cfg)
-            blockRootIndex = getBlockRootsIndex(beaconBlock.slot)
-
-          let res = buildProof(blockRoots, blockRootIndex)
-          check res.isOk()
-          let proof = res.get()
-
-          check verifyProof(
-            blocks[i].root,
-            proof,
-            historical_summaries[historicalRootsIndex].block_summary_root,
-            blockRootIndex,
-          )
-
-  test "ExecutionBlockProof for Execution BlockHeader":
-    # for i in 0..<(SLOTS_PER_HISTORICAL_ROOT - 1): # Test all blocks
-    for i in blocksToTest:
-      let beaconBlock = blocks[i].message
-
-      let res = block_proof_historical_summaries.buildProof(beaconBlock)
-      check res.isOk()
-      let proof = res.get()
-
-      let leave = beaconBlock.body.execution_payload.block_hash
-      check verifyProof(leave, proof, blocks[i].root)
-
-  test "BlockProofHistoricalSummaries for Execution BlockHeader":
+  test "BlockProofHistoricalSummariesDeneb for Execution BlockHeader":
     let blockRoots = getStateField(state[], block_roots).data
 
     withState(state[]):


### PR DESCRIPTION
- Use setup for prepration of test (blocks creation)
- Remove intermediate proof testing as is redudant and would take up too much time with setup
- Start immediatly from Capella fork for historical summaries test to win some time
- Cleanup comments