### PR TITLE
Fix WAL file buildup

### DIFF
--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_put.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_put.nim
@@ -46,7 +46,7 @@ proc rollback*(rdb: var RdbInst, session: SharedWriteBatchRef) =
 proc commit*(rdb: var RdbInst, session: SharedWriteBatchRef): Result[void,(AristoError,string)] =
   if not session.isClosed():
     defer: session.close()
-    rdb.baseDb.commit(session, rdb.vtxCol).isOkOr:
+    rdb.baseDb.commit(session, rdb.vtxCol, true).isOkOr:
       const errSym = RdbBeDriverWriteError
       when extraTraceMessages:
         trace logTxt "commit", error=errSym, info=error

--- a/execution_chain/db/kvt/kvt_init/rocks_db.nim
+++ b/execution_chain/db/kvt/kvt_init/rocks_db.nim
@@ -122,7 +122,7 @@ proc putKvpFn(db: RdbBackendRef, cf: static[KvtCFs]): PutKvpFn =
           return
 
 
-proc putEndFn(db: RdbBackendRef): PutEndFn =
+proc putEndFn(db: RdbBackendRef, cf: static[KvtCFs]): PutEndFn =
   result =
     proc(hdl: PutHdlRef): Result[void,KvtError] =
       let hdl = hdl.endSession db
@@ -133,7 +133,7 @@ proc putEndFn(db: RdbBackendRef): PutEndFn =
         return err(hdl.error)
 
       # Commit session
-      db.rdb.commit(hdl.session).isOkOr:
+      db.rdb.commit(hdl.session, cf).isOkOr:
         when extraTraceMessages:
           trace "putEndFn: failed", error=($error[0]), info=error[1]
           return err(error[0])
@@ -170,7 +170,7 @@ proc rocksDbKvtBackend*(baseDb: RocksDbInstanceRef, cf: static[KvtCFs]): KvtDbRe
 
   db.putBegFn = putBegFn be
   db.putKvpFn = putKvpFn(be, cf)
-  db.putEndFn = putEndFn be
+  db.putEndFn = putEndFn(be, cf)
 
   db.closeFn = closeFn be
   db.getBackendFn = getBackendFn be

--- a/execution_chain/db/kvt/kvt_init/rocks_db/rdb_put.nim
+++ b/execution_chain/db/kvt/kvt_init/rocks_db/rdb_put.nim
@@ -49,10 +49,12 @@ proc rollback*(rdb: var RdbInst, session: SharedWriteBatchRef) =
   if not session.isClosed():
     session.close()
 
-proc commit*(rdb: var RdbInst, session: SharedWriteBatchRef): Result[void,(KvtError,string)] =
+proc commit*(
+    rdb: var RdbInst, session: SharedWriteBatchRef, cf: static[KvtCFs]
+): Result[void, (KvtError, string)] =
   if not session.isClosed():
     defer: session.close()
-    rdb.baseDb.commit(session, rdb.store[KvtGeneric]).isOkOr:
+    rdb.baseDb.commit(session, rdb.store[cf], false).isOkOr:
       const errSym = RdbBeDriverWriteError
       when extraTraceMessages:
         trace logTxt "commit", error=errSym, info=error


### PR DESCRIPTION
Due to the wrong CF being passed to the database flush mechanism during sync, the sync KVT would remain unflushed as a memtable and thus prevent the WAL from being released - given that a new wal is created for every flush, this would lead to a buildup of small WAL files (50k and counting on my hoodi node) after a sync.

At the same time, we don't really need to flush the KVT at every commit since the skiplist permits efficient lookups (unlike the vector memtable used for bulk updates to the state).