### PR TITLE
txFrame HashKeys (kMap) memory optimization 

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -441,7 +441,7 @@ proc validateBlock(c: ForkedChainRef,
     # parent txFrame to the new txFrame unless the block number is one
     # greater than a block which is expected to be persisted based on the
     # persistBatchSize
-    moveParentHashKeys = (blk.header.number mod c.persistBatchSize) != 1
+    moveParentHashKeys = c.persistBatchSize > 1 and (blk.header.number mod c.persistBatchSize) != 1
     parentFrame = parent.txFrame
     txFrame = parentFrame.txFrameBegin(moveParentHashKeys)
 

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -437,8 +437,13 @@ proc validateBlock(c: ForkedChainRef,
       c.latestFinalizedBlockNumber)
 
   let
+    # As a memory optimization we move the HashKeys (kMap) stored in the
+    # parent txFrame to the new txFrame unless the block number is one
+    # greater than a block which is expected to be persisted based on the
+    # persistBatchSize
+    moveParentHashKeys = (blk.header.number mod c.persistBatchSize) != 1
     parentFrame = parent.txFrame
-    txFrame = parentFrame.txFrameBegin
+    txFrame = parentFrame.txFrameBegin(moveParentHashKeys)
 
   # TODO shortLog-equivalent for eth types
   debug "Validating block",

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -91,9 +91,15 @@ proc buildSnapshot(txFrame: AristoTxRef, minLevel: int) =
 
   txFrame.snapshot.level = Opt.some(minLevel)
 
-proc txFrameBegin*(db: AristoDbRef, parent: AristoTxRef): AristoTxRef =
+proc txFrameBegin*(db: AristoDbRef, parent: AristoTxRef, moveParentHashKeys: bool): AristoTxRef =
   let parent = if parent == nil: db.txRef else: parent
-  AristoTxRef(db: db, parent: parent, vTop: parent.vTop, level: parent.level + 1)
+
+  AristoTxRef(
+    db: db,
+    parent: parent,
+    kMap: if moveParentHashKeys: move(parent.kMap) else: default(parent.kMap.type),
+    vTop: parent.vTop,
+    level: parent.level + 1)
 
 proc dispose*(tx: AristoTxRef) =
   tx[].reset()

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -91,7 +91,7 @@ proc buildSnapshot(txFrame: AristoTxRef, minLevel: int) =
 
   txFrame.snapshot.level = Opt.some(minLevel)
 
-proc txFrameBegin*(db: AristoDbRef, parent: AristoTxRef, moveParentHashKeys: bool): AristoTxRef =
+proc txFrameBegin*(db: AristoDbRef, parent: AristoTxRef, moveParentHashKeys = false): AristoTxRef =
   let parent = if parent == nil: db.txRef else: parent
 
   AristoTxRef(

--- a/execution_chain/db/core_db/base.nim
+++ b/execution_chain/db/core_db/base.nim
@@ -455,16 +455,19 @@ proc txFrameBegin*(db: CoreDbRef): CoreDbTxRef =
   ##
   let
     kTx = db.kvt.txFrameBegin(nil)
-    aTx = db.mpt.txFrameBegin(nil)
+    aTx = db.mpt.txFrameBegin(nil, false)
 
   CoreDbTxRef(kTx: kTx, aTx: aTx)
 
-proc txFrameBegin*(parent: CoreDbTxRef): CoreDbTxRef =
+proc txFrameBegin*(
+    parent: CoreDbTxRef,
+    moveParentHashKeys = false
+  ): CoreDbTxRef =
   ## Constructor
   ##
   let
     kTx = parent.kTx.db.txFrameBegin(parent.kTx)
-    aTx = parent.aTx.db.txFrameBegin(parent.aTx)
+    aTx = parent.aTx.db.txFrameBegin(parent.aTx, moveParentHashKeys)
 
   CoreDbTxRef(kTx: kTx, aTx: aTx)
 

--- a/tests/test_aristo/test_tx_frame.nim
+++ b/tests/test_aristo/test_tx_frame.nim
@@ -108,3 +108,25 @@ suite "Aristo TxFrame":
       check:
         tx.fetchAccountRecord(acc1[0]).isOk()
         tx.fetchAccountRecord(acc2[0]).isErr() # Doesn't exist in tx2
+
+  test "Frames using moveParentHashKeys parameter":
+    let
+      tx0 = db.txFrameBegin(db.baseTxFrame())
+      tx1 = db.txFrameBegin(tx0)
+
+    check:
+      tx0.mergeAccountRecord(acc1[0], acc1[1]).isOk()
+      tx1.mergeAccountRecord(acc2[0], acc2[1]).isOk()
+      tx0.fetchStateRoot() != tx1.fetchStateRoot()
+      tx0.kMap.len() == 0
+      tx1.kMap.len() == 1
+
+    let tx2 = db.txFrameBegin(tx1, moveParentHashKeys = true)
+    check:
+      tx1.kMap.len() == 0
+      tx2.kMap.len() == 1
+
+    let tx3 = db.txFrameBegin(tx2, moveParentHashKeys = false)
+    check:
+      tx2.kMap.len() == 1
+      tx3.kMap.len() == 0


### PR DESCRIPTION
This PR adds a flag to `txFrameBegin` which enables moving the kMap from the parent to the new frame. In the ForkedChain we always move the kMap unless the `block number = block expected to be persisted + 1` or the `persistBatchSize < 2`.

This should have the effect of keeping the kMap entries only for the txFrames of the blocks which will be persisted. These blocks benefit the most from having the kMap entries available for the state root computation.