### PR TITLE
NimbusVersion in one place for all version related code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,4 @@ jobs:
         if: ${{ !cancelled() }} && github.event_name == 'pull_request'
         run: |
           bash scripts/check_copyright_year.sh
+          bash scripts/check_version.sh

--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -14,7 +14,7 @@ import
   logging,
   ../db/[core_db, ledger, storage_types, fcu_db],
   ../utils/[utils],
-  ".."/[constants, errors, version],
+  ".."/[constants, errors, version_info],
   "."/[chain_config, evmforks, genesis, hardforks],
   taskpools
 

--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -29,7 +29,7 @@ import
   ],
   eth/[common, net/nat],
   ./networking/[bootnodes, eth1_enr as enr],
-  ./[constants, compile_info, version],
+  ./[constants, compile_info, version_info],
   ./common/chain_config,
   ./db/opts
 

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -18,7 +18,7 @@ import
   metrics/chronicles_support,
   stew/byteutils,
   ./rpc,
-  ./version,
+  ./version_info,
   ./constants,
   ./nimbus_desc,
   ./nimbus_import,
@@ -96,7 +96,7 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf,
 
   func compatibleForkIdProc(id: ForkID): bool {.raises: [].} =
     com.compatibleForkId(id)
-    
+
   let forkIdProcs = ForkIdProcs(
     forkId: forkIdProc,
     compatibleForkId: compatibleForkIdProc,

--- a/execution_chain/rpc/engine_api.nim
+++ b/execution_chain/rpc/engine_api.nim
@@ -13,7 +13,7 @@ import
   web3/[conversions, execution_types],
   ../beacon/api_handler,
   ../beacon/beacon_engine,
-  ../version
+  ../version_info
 
 from ../beacon/web3_eth_conv import Hash32
 

--- a/execution_chain/version.nim
+++ b/execution_chain/version.nim
@@ -14,7 +14,6 @@
 # break some scripts. Users of this file:
 # - ./version_info.nim > used by compiled binaries.
 # - ../scripts/print_version.nims > used by docker files.
-# - ../nimbus.nimble > nimble file package version.
 #------------------------------------------------------------------------------
 
 const

--- a/execution_chain/version.nim
+++ b/execution_chain/version.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -8,30 +8,24 @@
 
 {.push raises: [].}
 
-import
-  std/[strformat],
-  stew/byteutils, ./compile_info, beacon_chain/buildinfo
+#------------------------------------------------------------------------------
+# The only place where NimbusVersion is declared.
+# Please do not put nim vm unfriendly stuff in this file, otherwise it will
+# break some scripts. Users of this file:
+# - ./version_info.nim > used by compiled binaries.
+# - ../scripts/print_version.nims > used by docker files.
+# - ../nimbus.nimble > nimble file package version.
+#------------------------------------------------------------------------------
 
 const
-  NimbusName* = "nimbus-eth1"
-  ## project name string
-
-  NimbusMajor*: int = 0
+  NimbusMajor* = 0
   ## is the major number of Nimbus' version.
 
-  NimbusMinor*: int = 1
+  NimbusMinor* = 1
   ## is the minor number of Nimbus' version.
 
-  NimbusPatch*: int = 0
+  NimbusPatch* = 0
   ## is the patch number of Nimbus' version.
 
   NimbusVersion* = $NimbusMajor & "." & $NimbusMinor & "." & $NimbusPatch
   ## is the version of Nimbus as a string.
-
-  GitRevisionBytes* = hexToByteArray[4](GitRevision)
-
-  FullVersionStr* = "v" & NimbusVersion & "-" & GitRevision
-
-  ClientId* = &"{NimbusName}/{FullVersionStr}/{hostOS}-{hostCPU}/Nim-{NimVersion}"
-
-  ShortClientId* = NimbusName & "/" & FullVersionStr

--- a/execution_chain/version_info.nim
+++ b/execution_chain/version_info.nim
@@ -1,0 +1,29 @@
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [].}
+
+import
+  std/[strformat],
+  stew/byteutils, ./compile_info, beacon_chain/buildinfo,
+  ./version
+
+export
+  version
+
+const
+  NimbusName* = "nimbus-eth1"
+  ## project name string
+
+  GitRevisionBytes* = hexToByteArray[4](GitRevision)
+
+  FullVersionStr* = "v" & NimbusVersion & "-" & GitRevision
+
+  ClientId* = &"{NimbusName}/{FullVersionStr}/{hostOS}-{hostCPU}/Nim-{NimVersion}"
+
+  ShortClientId* = NimbusName & "/" & FullVersionStr

--- a/execution_chain/version_info.nim
+++ b/execution_chain/version_info.nim
@@ -20,6 +20,8 @@ const
   NimbusName* = "nimbus-eth1"
   ## project name string
 
+  # Please keep it 4 bytes long, used in `engine_ClientVersionV1`
+  # https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#clientversionv1
   GitRevisionBytes* = hexToByteArray[4](GitRevision)
 
   FullVersionStr* = "v" & NimbusVersion & "-" & GitRevision

--- a/execution_chain/version_info.nim
+++ b/execution_chain/version_info.nim
@@ -21,7 +21,7 @@ const
   ## project name string
 
   # Please keep it 4 bytes long, used in `engine_ClientVersionV1`
-  # https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#clientversionv1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/identification.md#clientversionv1
   GitRevisionBytes* = hexToByteArray[4](GitRevision)
 
   FullVersionStr* = "v" & NimbusVersion & "-" & GitRevision

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -7,8 +7,11 @@
 
 mode = ScriptMode.Verbose
 
+# Get the version from one location
+include ./execution_chain/version
+
 packageName   = "nimbus"
-version       = "0.1.0"
+version       = NimbusVersion
 author        = "Status Research & Development GmbH"
 description   = "An Ethereum 2.0 Sharding Client for Resource-Restricted Devices"
 license       = "Apache License 2.0"

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -8,7 +8,7 @@
 mode = ScriptMode.Verbose
 
 # Get the version from one location
-import ./execution_chain/version
+import ./execution_chain/version as ver
 
 packageName   = "nimbus"
 version       = NimbusVersion

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -8,7 +8,7 @@
 mode = ScriptMode.Verbose
 
 # Get the version from one location
-include ./execution_chain/version
+import ./execution_chain/version
 
 packageName   = "nimbus"
 version       = NimbusVersion

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -7,11 +7,8 @@
 
 mode = ScriptMode.Verbose
 
-# Get the version from one location
-import ./execution_chain/version as ver
-
 packageName   = "nimbus"
-version       = NimbusVersion
+version       = "0.1.0"
 author        = "Status Research & Development GmbH"
 description   = "An Ethereum 2.0 Sharding Client for Resource-Restricted Devices"
 license       = "Apache License 2.0"

--- a/scripts/check_version.sh
+++ b/scripts/check_version.sh
@@ -7,24 +7,22 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-remove_quotes() {
+remove_quotes_spaces() {
   local str="$1"
   # Remove any quotes
   str="${str//\"/}"
-  # Remove any spaces
-  str="${str// /}"
-  echo "$str"
+  echo "$str" | sed 's/[[:space:]]//g'
 }
 
 while read -r line; do
   if [[ "$line" == *"NimbusMajor*"* ]]; then
-    NIMBUS_MAJOR=$(remove_quotes ${line##*=})
+    NIMBUS_MAJOR=$(remove_quotes_spaces ${line##*=})
   fi
   if [[ "$line" == *"NimbusMinor*"* ]]; then
-    NIMBUS_MINOR=$(remove_quotes ${line##*=})
+    NIMBUS_MINOR=$(remove_quotes_spaces ${line##*=})
   fi
   if [[ "$line" == *"NimbusPatch*"* ]]; then
-    NIMBUS_PATCH=$(remove_quotes ${line##*=})
+    NIMBUS_PATCH=$(remove_quotes_spaces ${line##*=})
     break
   fi
 done < execution_chain/version.nim
@@ -32,7 +30,7 @@ done < execution_chain/version.nim
 # Search 'version' from 'nimbus.nimble'
 while read -r line; do
   if [[ "$line" == "version"* ]]; then
-    VERSION_IN_NIMBLE_FILE=$(remove_quotes ${line##*=})
+    VERSION_IN_NIMBLE_FILE=$(remove_quotes_spaces ${line##*=})
     break
   fi
 done < nimbus.nimble

--- a/scripts/check_version.sh
+++ b/scripts/check_version.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2025 Status Research & Development GmbH. Licensed under
+# either of:
+# - Apache License, version 2.0
+# - MIT license
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+remove_quotes() {
+  local str="$1"
+  # Remove any quotes
+  str="${str//\"/}"
+  # Remove any spaces
+  str="${str// /}"
+  echo "$str"
+}
+
+while read -r line; do
+  if [[ "$line" == *"NimbusMajor*"* ]]; then
+    NIMBUS_MAJOR=$(remove_quotes ${line##*=})
+  fi
+  if [[ "$line" == *"NimbusMinor*"* ]]; then
+    NIMBUS_MINOR=$(remove_quotes ${line##*=})
+  fi
+  if [[ "$line" == *"NimbusPatch*"* ]]; then
+    NIMBUS_PATCH=$(remove_quotes ${line##*=})
+    break
+  fi
+done < execution_chain/version.nim
+
+# Search 'version' from 'nimbus.nimble'
+while read -r line; do
+  if [[ "$line" == "version"* ]]; then
+    VERSION_IN_NIMBLE_FILE=$(remove_quotes ${line##*=})
+    break
+  fi
+done < nimbus.nimble
+
+NIMBUS_VERSION=$NIMBUS_MAJOR.$NIMBUS_MINOR.$NIMBUS_PATCH
+
+if [[ "$NIMBUS_VERSION" != "$VERSION_IN_NIMBLE_FILE" ]]; then
+  echo "NimbusVersion($NIMBUS_VERSION) doesn't match version in .nimble file($VERSION_IN_NIMBLE_FILE)"
+  exit 2
+fi

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -15,7 +15,7 @@ import
   eth/rlp,
   eth/common/[transaction_utils, addresses],
   ../hive_integration/nodocker/engine/engine_client,
-  ../execution_chain/[constants, transaction, config, version],
+  ../execution_chain/[constants, transaction, config, version_info],
   ../execution_chain/db/[ledger, storage_types],
   ../execution_chain/sync/wire_protocol,
   ../execution_chain/core/[tx_pool, chain, pow/difficulty],


### PR DESCRIPTION
.nimble file, nimbus-eth1 binaries, docker built release files, etc now get the 'NimbusVersion' string from one place: 'version.nim'.

This PR also fix nightly build failure due to recent changes that import nim vm unfriendly stuff into version.nim