### PR TITLE
fix consolidation request pre-deploy address

### DIFF
--- a/execution_chain/rpc/rpc_utils.nim
+++ b/execution_chain/rpc/rpc_utils.nim
@@ -320,7 +320,7 @@ proc populateConfigObject*(com: CommonRef, fork: HardFork): ConfigObject =
     ]
     pragueSystemContracts: seq[SystemContractPair] = @[
       SystemContractPair(
-        address: SYSTEM_ADDRESS,
+        address: CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS,
         name: "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS"
       ),
       SystemContractPair(


### PR DESCRIPTION
Wrong address was being used in `eth_config`