### PR TITLE
Run EL CI on Portal changes and run Portal CI on EL changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,9 @@ on:
   push:
     paths-ignore:
       - 'doc/**'
-      - 'docs/**'
+      - 'portal/docs/**'
       - '**/*.md'
-      - '**/*.yml'
       - 'hive_integration/**'
-      - 'portal/**'
-      - '.github/workflows/portal*.yml'
       - 'nimbus_verified_proxy/**'
       - '.github/workflows/nimbus_verified_proxy.yml'
       - '.github/workflows/build_base_image.yml'
@@ -27,12 +24,9 @@ on:
   pull_request:
     paths-ignore:
       - 'doc/**'
-      - 'docs/**'
+      - 'portal/docs/**'
       - '**/*.md'
-      - '**/*.yml'
       - 'hive_integration/**'
-      - 'portal/**'
-      - '.github/workflows/portal*.yml'
       - 'nimbus_verified_proxy/**'
       - '.github/workflows/nimbus_verified_proxy.yml'
       - '.github/workflows/build_base_image.yml'

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -16,11 +16,9 @@ on:
       - master
     paths-ignore:
       - 'doc/**'
-      - 'docs/**'
+      - 'portal/docs/**'
       - '**/*.md'
       - 'hive_integration/**'
-      - 'portal/**'
-      - '.github/workflows/portal*.yml'
       - 'nimbus_verified_proxy/**'
       - '.github/workflows/nimbus_verified_proxy.yml'
       - '.github/workflows/build_base_image.yml'
@@ -31,11 +29,9 @@ on:
       - master
     paths-ignore:
       - 'doc/**'
-      - 'docs/**'
+      - 'portal/docs/**'
       - '**/*.md'
       - 'hive_integration/**'
-      - 'portal/**'
-      - '.github/workflows/portal*.yml'
       - 'nimbus_verified_proxy/**'
       - '.github/workflows/nimbus_verified_proxy.yml'
       - '.github/workflows/build_base_image.yml'

--- a/.github/workflows/portal.yml
+++ b/.github/workflows/portal.yml
@@ -8,30 +8,24 @@
 name: Nimbus Portal CI
 on:
   push:
-    paths:
-      - '.github/workflows/portal.yml'
-      - 'portal/**'
-      - '!portal/**.md'
-      - '!portal/docs/**'
-      - 'execution_chain/rpc/hexstrings.nim'
-      - 'execution_chain/rpc/rpc_*.nim'
-      - 'execution_chain/db/**'
-      - 'vendor/**'
-      - 'Makefile'
-      - 'nimbus.nimble'
+    paths-ignore:
+      - 'doc/**'
+      - 'portal/docs/**'
+      - '**/*.md'
+      - 'nimbus_verified_proxy/**'
+      - '.github/workflows/nimbus_verified_proxy.yml'
+      - '.github/workflows/build_base_image.yml'
+      - 'docker/**'
 
   pull_request:
-    paths:
-      - '.github/workflows/portal.yml'
-      - 'portal/**'
-      - '!portal/**.md'
-      - '!portal/docs/**'
-      - 'execution_chain/rpc/hexstrings.nim'
-      - 'execution_chain/rpc/rpc_*.nim'
-      - 'execution_chain/db/**'
-      - 'vendor/**'
-      - 'Makefile'
-      - 'nimbus.nimble'
+    paths-ignore:
+      - 'doc/**'
+      - 'portal/docs/**'
+      - '**/*.md'
+      - 'nimbus_verified_proxy/**'
+      - '.github/workflows/nimbus_verified_proxy.yml'
+      - '.github/workflows/build_base_image.yml'
+      - 'docker/**'
 
   workflow_dispatch:
 


### PR DESCRIPTION
Reason here is twofold:
- Portal gets integrated with EL, testing needs to be covered on changes from both sides
- Practically, currently we need to overrule merging rules when EL CI did not get triggered as there are required jobs to be run before merge to master. This is not great.