### PR TITLE
Halve FC memory usage

### DIFF
--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -35,8 +35,8 @@ proc writeBaggage*(c: ForkedChainRef,
       header.withdrawalsRoot.expect("WithdrawalsRoot should be verified before"),
       blk.withdrawals.get)
 
-template updateSnapshot*(c: ForkedChainRef,
-            blk: Block,
+proc updateSnapshot*(c: ForkedChainRef,
+            number: BlockNumber,
             txFrame: CoreDbTxRef) =
   let pos = c.lastSnapshotPos
   c.lastSnapshotPos = (c.lastSnapshotPos + 1) mod c.lastSnapshots.len
@@ -51,7 +51,7 @@ template updateSnapshot*(c: ForkedChainRef,
   # Checkpoint creates a snapshot of ancestor changes in txFrame - it is an
   # expensive operation, specially when creating a new branch (ie when blk
   # is being applied to a block that is currently not a head)
-  txFrame.checkpoint(blk.header.number)
+  txFrame.checkpoint(number)
 
   c.lastSnapshots[pos] = txFrame
 

--- a/execution_chain/core/chain/forked_chain/chain_serialize.nim
+++ b/execution_chain/core/chain/forked_chain/chain_serialize.nim
@@ -129,7 +129,7 @@ proc replayBlock(fc: ForkedChainRef;
   # Update the snapshot before processing the block so that any vertexes in snapshots
   # from lower levels than the baseTxFrame are removed from the snapshot before running
   # the stateroot computation.
-  fc.updateSnapshot(parent.blk, parentFrame)
+  fc.updateSnapshot(parent.blk.header.number, parentFrame)
 
   # Set finalized to true in order to skip the stateroot check when replaying the
   # block because the blocks should have already been checked previously during


### PR DESCRIPTION
Blocks are getting stored both in BlockRef and in TxFrame - this is the less invasive change that delays storing block contents in TxFrame until it's time to update the base - the better option for the future is likely to not store the full block in BlockRef (and instead load it from TxFrame on demand)