### PR TITLE
Adjust EL-Portal integration to use Portal json-rpc client

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -894,25 +894,31 @@ proc blockByHash*(c: ForkedChainRef, blockHash: Hash32): Result[Block, string] =
   # 4. Client software MAY NOT respond to requests for finalized blocks by hash.
   c.hashToBlock.withValue(blockHash, loc):
     return ok(loc[].blk)
-  let blk = c.baseTxFrame.getEthBlock(blockHash)
+  var header = ?c.baseTxFrame.getBlockHeader(blockHash)
+  var blockBody = c.baseTxFrame.getBlockBody(header)
   # Serves portal data if block not found in db
-  if blk.isErr or (blk.get.transactions.len == 0 and blk.get.header.transactionsRoot != zeroHash32):
+  if blockBody.isErr or (blockBody.get.transactions.len == 0 and header.transactionsRoot != zeroHash32):
     if c.isPortalActive:
-      return c.portal.getBlockByHash(blockHash)
-  blk
+      var blockBodyPortal = ?c.portal.getBlockBodyByHeader(header)
+      return ok(EthBlock.init(move(header), move(blockBodyPortal)))
+    else:
+      return err(blockBody.error)
+
+  ok(EthBlock.init(move(header), move(blockBody.get())))
 
 proc payloadBodyV1ByHash*(c: ForkedChainRef, blockHash: Hash32): Result[ExecutionPayloadBodyV1, string] =
   c.hashToBlock.withValue(blockHash, loc):
     return ok(toPayloadBody(loc[].blk))
 
-  let header = ?c.baseTxFrame.getBlockHeader(blockHash)
+  var header = ?c.baseTxFrame.getBlockHeader(blockHash)
   var blk = c.baseTxFrame.getExecutionPayloadBodyV1(header)
 
   # Serves portal data if block not found in db
   if blk.isErr or (blk.get.transactions.len == 0 and header.transactionsRoot != zeroHash32):
     if c.isPortalActive:
-      let blk = ?c.portal.getBlockByHash(blockHash)
-      return ok(toPayloadBody(blk))
+      var blockBodyPortal = ?c.portal.getBlockBodyByHeader(header)
+      # Same as above
+      return ok(toPayloadBody(EthBlock.init(move(header), move(blockBodyPortal))))
 
   move(blk)
 
@@ -921,16 +927,16 @@ proc payloadBodyV1ByNumber*(c: ForkedChainRef, number: BlockNumber): Result[Exec
     return err("Requested block number not exists: " & $number)
 
   if number <= c.base.number:
-    let
-      header = ?c.baseTxFrame.getBlockHeader(number)
-      blk = c.baseTxFrame.getExecutionPayloadBodyV1(header)
+    var header = ?c.baseTxFrame.getBlockHeader(number)
+    let blk = c.baseTxFrame.getExecutionPayloadBodyV1(header)
 
     # Txs not there in db - Happens during era1/era import, when we don't store txs and receipts
     if blk.isErr or (blk.get.transactions.len == 0 and header.transactionsRoot != emptyRoot):
       # Serves portal data if block not found in database
       if c.isPortalActive:
-        let blk = ?c.portal.getBlockByNumber(number)
-        return ok(toPayloadBody(blk))
+        var blockBodyPortal = ?c.portal.getBlockBodyByHeader(header)
+        # same as above
+        return ok(toPayloadBody(EthBlock.init(move(header), move(blockBodyPortal))))
 
     return blk
 
@@ -945,14 +951,18 @@ proc blockByNumber*(c: ForkedChainRef, number: BlockNumber): Result[Block, strin
     return err("Requested block number not exists: " & $number)
 
   if number <= c.base.number:
-    let blk = c.baseTxFrame.getEthBlock(number)
+    var header = ?c.baseTxFrame.getBlockHeader(number)
+    var blockBody = c.baseTxFrame.getBlockBody(header)
     # Txs not there in db - Happens during era1/era import, when we don't store txs and receipts
-    if blk.isErr or (blk.get.transactions.len == 0 and blk.get.header.transactionsRoot != emptyRoot):
+    if blockBody.isErr or (blockBody.get.transactions.len == 0 and header.transactionsRoot != emptyRoot):
       # Serves portal data if block not found in database
       if c.isPortalActive:
-        return c.portal.getBlockByNumber(number)
+        var blockBodyPortal = ?c.portal.getBlockBodyByHeader(header)
+        return ok(EthBlock.init(move(header), move(blockBodyPortal)))
+      else:
+        return err(blockBody.error)
     else:
-      return blk
+      return ok(EthBlock.init(move(header), move(blockBody.get())))
 
   loopIt(c.latest):
     if number >= it.number:

--- a/execution_chain/portal/portal.nim
+++ b/execution_chain/portal/portal.nim
@@ -13,10 +13,10 @@ import
   chronos,
   chronicles,
   results,
-  json_rpc/rpcclient,
   ../config,
   ../common,
-  eth/common/[base, eth_types, keys]
+  eth/common/[base, eth_types, keys],
+  ../../portal/rpc/portal_rpc_client
 
 logScope:
   topic = "portal"
@@ -24,18 +24,18 @@ logScope:
 type
   PortalRpc* = ref object
     url*: string
-    provider: RpcClient
+    provider: PortalRpcClient
 
   HistoryExpiryRef* = ref object
     portalEnabled*: bool
     rpc: Opt[PortalRpc]
-    limit*: base.BlockNumber # blockNumber limit till portal is activated, EIP specific
+    limit*: base.BlockNumber # blockNumber limit till portal is activated, EIP specific, TODO: not used atm?
 
 proc init*(T: type PortalRpc, url: string): T =
   let web3 = waitFor newWeb3(url)
   T(
     url: url,
-    provider: web3.provider
+    provider: PortalRpcClient.init(web3.provider)
   )
 
 func isPortalRpcEnabled(conf: NimbusConf): bool =
@@ -58,7 +58,7 @@ proc init*(T: type HistoryExpiryRef, conf: NimbusConf, com: CommonRef): T =
     networkId = com.networkId,
     portalLimit = conf.historyExpiryLimit
 
-  let 
+  let
     rpc = conf.getPortalRpc()
     portalEnabled =
       if com.networkId == MainNet and rpc.isSome:
@@ -67,7 +67,7 @@ proc init*(T: type HistoryExpiryRef, conf: NimbusConf, com: CommonRef): T =
       else:
         warn "Portal is only available for mainnet, skipping fetching data from Portal"
         false
-    limit = 
+    limit =
       if conf.historyExpiryLimit.isSome:
         conf.historyExpiryLimit.get()
       else:
@@ -79,165 +79,18 @@ proc init*(T: type HistoryExpiryRef, conf: NimbusConf, com: CommonRef): T =
     limit: limit
   )
 
-proc rpcProvider*(historyExpiry: HistoryExpiryRef): Result[RpcClient, string] =
+proc rpcProvider*(historyExpiry: HistoryExpiryRef): Result[PortalRpcClient, string] =
   if historyExpiry.portalEnabled and historyExpiry.rpc.isSome:
-    return ok(historyExpiry.rpc.get().provider)
+    ok(historyExpiry.rpc.get().provider)
   else:
-    return err("Portal RPC is not enabled or not available")
+    err("Portal RPC is not enabled or not available")
 
-proc toHeader(blkObj: BlockObject): Header =
-  Header(
-    parentHash: blkObj.parentHash,
-    ommersHash: blkObj.sha3Uncles,
-    coinbase: blkObj.miner,
-    stateRoot: blkObj.stateRoot,
-    transactionsRoot: blkObj.transactionsRoot,
-    receiptsRoot: blkObj.receiptsRoot,
-    logsBloom: blkObj.logsBloom,
-    difficulty: blkObj.difficulty,
-    number: uint64 blkObj.number,
-    gasLimit: uint64 blkObj.gasLimit,
-    gasUsed: uint64 blkObj.gasUsed,
-    timestamp: EthTime blkObj.timestamp,
-    extraData: seq[byte](blkObj.extraData),
-    mixHash: Bytes32(blkObj.mixHash),
-    nonce: blkObj.nonce.get(),
-    baseFeePerGas: blkObj.baseFeePerGas,
-    withdrawalsRoot: blkObj.withdrawalsRoot,
-    blobGasUsed: if blkObj.blobGasUsed.isNone: Opt.none(uint64) else: Opt.some(uint64 blkObj.blobGasUsed.get()),
-    excessBlobGas: if blkObj.excessBlobGas.isNone: Opt.none(uint64) else: Opt.some(uint64 blkObj.excessBlobGas.get()),
-    parentBeaconBlockRoot: blkObj.parentBeaconBlockRoot,
-    requestsHash: blkObj.requestsHash
+proc getBlockBodyByHeader*(historyExpiry: HistoryExpiryRef, header: Header): Result[BlockBody, string] =
+  debug "Fetching block body from Portal"
+  let rpc = historyExpiry.rpcProvider.valueOr:
+    return err("Portal RPC is not available")
+
+  (waitFor rpc.historyGetBlockBody(header.number, header)).mapErr(
+    proc(e: PortalRpcError): string =
+      "Portal request failed: " & $e
   )
-
-proc toTransactions(blkObj: BlockObject): seq[Transaction] =
-  var txs: seq[Transaction] = @[]
-  for txOrHash in blkObj.transactions:
-    case txOrHash.kind
-    of tohTx:
-      # Convert the TransactionObject to a Transaction.
-      let txType = TxType txOrHash.tx.`type`.get()
-      let accessList =
-        if txType >= TxEip2930:
-          AccessList txOrHash.tx.accessList.get()
-        else:
-          @[]
-      let (maxFeePerBlobGas, versionedHashes) =
-        if txType >= TxEip4844:
-          (txOrHash.tx.maxFeePerBlobGas.get(), txOrHash.tx.blobVersionedHashes.get())
-        else:
-          (0.u256, @[])
-      let authorizationList =
-        if txType >= TxEip7702:
-          txOrHash.tx.authorizationList.get()
-        else:
-          @[]
-
-      txs.add(
-        Transaction(
-          txType: txType,
-          chainId: MainNet, # Portal RPC doesn't support other networks
-          nonce: AccountNonce txOrHash.tx.nonce,
-          gasPrice: GasInt txOrHash.tx.gasPrice,
-          maxPriorityFeePerGas: GasInt txOrHash.tx.maxPriorityFeePerGas.get(),
-          maxFeePerGas: GasInt txOrHash.tx.maxFeePerGas.get(),
-          gasLimit: uint64 txOrHash.tx.gas,
-          to: txOrHash.tx.to,
-          value: txOrHash.tx.value,
-          payload: txOrHash.tx.input,
-          accessList: accessList,
-          maxFeePerBlobGas: maxFeePerBlobGas,
-          versionedHashes: versionedHashes,
-          authorizationList: authorizationList,
-          V: uint64 txOrHash.tx.v,
-          R: txOrHash.tx.r,
-          S: txOrHash.tx.s,
-        )
-      )
-    of tohHash:
-      continue
-  return txs
-
-proc toBlock(blkObj: BlockObject): Block =
-  Block(
-    header: toHeader(blkObj),
-    transactions: toTransactions(blkObj),
-    withdrawals: blkObj.withdrawals
-  )
-
-proc toBlockBody(blkObj: BlockObject): BlockBody =
-  BlockBody(
-    transactions: toTransactions(blkObj),
-    uncles: @[],
-    withdrawals: blkObj.withdrawals
-  )
-
-proc getBlockByNumber*(historyExpiry: HistoryExpiryRef, blockNumber: uint64, fullTxs: bool = true): Result[Block, string] =
-  debug "Fetching block from Portal"
-  try:
-    let 
-      rpc = historyExpiry.rpcProvider.valueOr:
-        return err("Portal RPC is not available")
-      res = waitFor rpc.eth_getBlockByNumber(blockId(blockNumber), fullTxs)
-    if res.isNil:
-      return err("Block not found in Portal")
-    return ok(res.toBlock())
-  except CatchableError as e:
-    debug "Failed to fetch block from Portal", err=e.msg
-    return err(e.msg)
-
-proc getBlockByHash*(historyExpiry: HistoryExpiryRef, blockHash: Hash32, fullTxs: bool = true): Result[Block, string] =
-  debug "Fetching block from Portal"
-  try:
-    let 
-      rpc = historyExpiry.rpcProvider.valueOr:
-        return err("Portal RPC is not available")
-      res = waitFor rpc.eth_getBlockByHash(blockHash, fullTxs)
-    if res.isNil:
-      return err("Block not found in Portal")
-    return ok(res.toBlock())
-  except CatchableError as e:
-    debug "Failed to fetch block from Portal", err=e.msg
-    return err(e.msg)
-
-proc getBlockBodyByHash*(historyExpiry: HistoryExpiryRef, blockHash: Hash32, fullTxs: bool = true): Result[BlockBody, string] =
-  debug "Fetching block from Portal"
-  try:
-    let 
-      rpc = historyExpiry.rpcProvider.valueOr:
-        return err("Portal RPC is not available")
-      res = waitFor rpc.eth_getBlockByHash(blockHash, fullTxs)
-    if res.isNil:
-      return err("Block not found in Portal")
-    return ok(res.toBlockBody())
-  except CatchableError as e:
-    debug "Failed to fetch block from Portal", err=e.msg
-    return err(e.msg)
-
-proc getHeaderByHash*(historyExpiry: HistoryExpiryRef, blockHash: Hash32): Result[Header, string] =
-  debug "Fetching header from Portal"
-  try:
-    let 
-      rpc = historyExpiry.rpcProvider.valueOr:
-        return err("Portal RPC is not available")
-      res = waitFor rpc.eth_getBlockByHash(blockHash, false)
-    if res.isNil:
-      return err("Header not found in Portal")
-    return ok(res.toHeader())
-  except CatchableError as e:
-    debug "Failed to fetch header from Portal", err=e.msg
-    return err(e.msg)
-
-proc getHeaderByNumber*(historyExpiry: HistoryExpiryRef, blockNumber: uint64): Result[Header, string] =
-  debug "Fetching header from Portal"
-  try:
-    let 
-      rpc = historyExpiry.rpcProvider.valueOr:
-        return err("Portal RPC is not available")
-      res = waitFor rpc.eth_getBlockByNumber(blockId(blockNumber), false)
-    if res.isNil:
-      return err("Header not found in Portal")
-    return ok(res.toHeader())
-  except CatchableError as e:
-    debug "Failed to fetch header from Portal", err=e.msg
-    return err(e.msg)


### PR DESCRIPTION
- Simplify by using the Portal json-rpc client API directly
- This is also required now as the nimbus_portal_client no longer support the EL (eth_) JSON-RPC API.
- Adjust the usage of it by taking into account that the header cannot be requested from Portal
