### PR TITLE
CI: extract tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,9 @@ jobs:
 
       - name: Extract branch name
         id: extract_branch
-        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        run: | 
+          ref_name=$(echo "$GITHUB_REF" | sed -e 's#^refs/heads/##' -e 's#^refs/tags/##')
+          echo "branch_name=$ref_name" >> $GITHUB_OUTPUT
 
       - name: Build project
         id: make_dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,7 @@ jobs:
 
       - name: Extract branch name
         id: extract_branch
-        run: | 
-          ref_name=$(echo "$GITHUB_REF" | sed -e 's#^refs/heads/##' -e 's#^refs/tags/##')
-          echo "branch_name=$ref_name" >> $GITHUB_OUTPUT
+        run: echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Build project
         id: make_dist
@@ -63,7 +61,7 @@ jobs:
           cd dist
           ARCHIVE=$(echo *.tar.gz)
           tar -xzf ${ARCHIVE}
-          NEW_ARCHIVE_DIR="nimbus-eth1-${{ matrix.os }}-${{ matrix.cpu }}-${{ steps.extract_branch.outputs.branch_name }}-$(git rev-parse --short=8 HEAD)"
+          NEW_ARCHIVE_DIR="nimbus-eth1-${{ matrix.os }}-${{ matrix.cpu }}-${{ steps.extract_branch.outputs.tag_name }}-$(git rev-parse --short=8 HEAD)"
           mv ${ARCHIVE%.tar.gz} ${NEW_ARCHIVE_DIR}
           tar -czf ${NEW_ARCHIVE_DIR}.tar.gz ${NEW_ARCHIVE_DIR}
           cp ${NEW_ARCHIVE_DIR}.tar.gz nimbus-eth1-${{ matrix.os }}-${{ matrix.cpu }}.tar.gz
@@ -118,7 +116,7 @@ jobs:
 
       - name: Extract branch name
         id: extract_branch
-        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        run: echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Create release notes
         run: |
@@ -147,7 +145,7 @@ jobs:
         with:
           draft: true
           prerelease: false
-          name: 'Release build ("${{ steps.extract_branch.outputs.branch_name }}" branch)'
+          name: 'Release build ("${{ steps.extract_branch.outputs.tag_name }}")'
           body_path: release_notes.md
           files: |
             linux-amd64-archive/*


### PR DESCRIPTION
The release script for github actions had a `Extract branch name` step that expected branch names in the format `refs/heads/<branch_name>` but when used on tags the prefix is `refs/tags/<tag_name>`. This causes an invalid directory error.