### PR TITLE
Add EL debug_getBlockHeader and use for Portal block verification

### DIFF
--- a/execution_chain/rpc/debug.nim
+++ b/execution_chain/rpc/debug.nim
@@ -11,6 +11,7 @@
 
 import
   # std/json,
+  stew/byteutils,
   json_rpc/rpcserver,
   # ./rpc_utils,
   ./rpc_types,
@@ -222,3 +223,10 @@ proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
     ## Returns an execution witness for the given block hash.
     chain.getExecutionWitness(blockHash).valueOr:
       raise newException(ValueError, error)
+
+  server.rpc("debug_getBlockHeader") do(blockNumber: uint64) -> string:
+    ## Returns the rlp encoded block header in hex for the given block number.
+    let header = chain.baseTxFrame.getBlockHeader(blockNumber).valueOr:
+      raise newException(ValueError, error)
+
+    rlp.encode(header).to0xHex()

--- a/portal/bridge/nimbus_portal_bridge_conf.nim
+++ b/portal/bridge/nimbus_portal_bridge_conf.nim
@@ -8,15 +8,16 @@
 {.push raises: [].}
 
 import
-  std/[strutils, os, uri],
+  std/[strutils, os],
   confutils,
   confutils/std/net,
   nimcrypto/hash,
   ../network/network_metadata,
   ../eth_history/era1,
-  ../logging
+  ../logging,
+  ./common/rpc_helpers
 
-export net
+export net, rpc_helpers
 
 proc defaultEthDataDir*(): string =
   let dataDir =
@@ -36,14 +37,6 @@ const defaultEndEra* = uint64(era(network_metadata.mergeBlockNumber - 1))
 
 type
   TrustedDigest* = MDigest[32 * 8]
-
-  JsonRpcUrlKind* = enum
-    HttpUrl
-    WsUrl
-
-  JsonRpcUrl* = object
-    kind*: JsonRpcUrlKind
-    value*: string
 
   PortalBridgeCmd* = enum
     beacon = "Run a Portal bridge for the beacon network"
@@ -146,22 +139,4 @@ func parseCmdArg*(T: type TrustedDigest, input: string): T {.raises: [ValueError
   TrustedDigest.fromHex(input)
 
 func completeCmdArg*(T: type TrustedDigest, input: string): seq[string] =
-  return @[]
-
-proc parseCmdArg*(T: type JsonRpcUrl, p: string): T {.raises: [ValueError].} =
-  let
-    url = parseUri(p)
-    normalizedScheme = url.scheme.toLowerAscii()
-
-  if (normalizedScheme == "http" or normalizedScheme == "https"):
-    JsonRpcUrl(kind: HttpUrl, value: p)
-  elif (normalizedScheme == "ws" or normalizedScheme == "wss"):
-    JsonRpcUrl(kind: WsUrl, value: p)
-  else:
-    raise newException(
-      ValueError,
-      "The Web3 URL must specify one of following protocols: http/https/ws/wss",
-    )
-
-proc completeCmdArg*(T: type JsonRpcUrl, val: string): seq[string] =
   return @[]

--- a/portal/client/nimbus_portal_client_conf.nim
+++ b/portal/client/nimbus_portal_client_conf.nim
@@ -20,6 +20,7 @@ import
   stew/byteutils,
   stew/io2,
   beacon_chain/nimbus_binary_common,
+  ../bridge/common/rpc_helpers,
   ../logging,
   ../network/wire/portal_protocol_config
 
@@ -238,6 +239,12 @@ type
       defaultValue: false,
       name: "ws-compression"
     .}: bool
+
+    web3Url* {.
+      desc:
+        "Execution layer JSON-RPC API URL. Required for requesting block headers for content validation",
+      name: "web3-url"
+    .}: Option[JsonRpcUrl]
 
     tableIpLimit* {.
       hidden,

--- a/portal/network/portal_node.nim
+++ b/portal/network/portal_node.nim
@@ -72,6 +72,7 @@ proc new*(
     config: PortalNodeConfig,
     discovery: protocol.Protocol,
     subnetworks: set[PortalSubnetwork],
+    headerCallback: GetHeaderCallback = defaultNoGetHeader,
     bootstrapRecords: openArray[Record] = [],
     rng = newRng(),
 ): T =
@@ -98,6 +99,7 @@ proc new*(
             discovery,
             contentDB,
             streamManager,
+            headerCallback,
             bootstrapRecords = bootstrapRecords,
             portalConfig = config.portalConfig,
             contentRequestRetries = config.contentRequestRetries,


### PR DESCRIPTION
Portal no longer supports getting headers in its default history network. That's fine as the ELs will keep storing the header chain (for now) and thus does not need them. Portal however does need access to the headers in order to be able to verify bodies and receipts when those are being offered.

For this we had added a get header callback to the history network. In this PR we fill in the used get header callback to use the here newly added debug_getBlockHeader JSON-RPC method.

In case no web3 provider (EL) supporting this (only Nimbus) is provided, the node can still run but will not be able to accept & store any offered block bodies and receipts.