### PR TITLE
security: change default listen address from 0.0.0.0 to 127.0.0.1

### DIFF
--- a/nimbus_verified_proxy/libverifproxy/verifproxy.nim
+++ b/nimbus_verified_proxy/libverifproxy/verifproxy.nim
@@ -31,7 +31,7 @@ proc initLib() =
     nimGC_setStackBottom(locals)
 
 proc runContext(ctx: ptr Context) {.thread.} =
-  const defaultListenAddress = (static parseIpAddress("0.0.0.0"))
+  const defaultListenAddress = (static parseIpAddress("127.0.0.1"))
   let str = $ctx.configJson
   try:
     let jsonNode = parseJson(str)


### PR DESCRIPTION


**Problem:**
- Default binding to `0.0.0.0` exposes the verified proxy service to all network interfaces
- Increases attack surface and enables unintended network access

**Solution:**
- Changed default listen address to `127.0.0.1` (localhost only)
- Maintains functionality while improving security posture

