### PR TITLE
update versions to v0.2.0 for alpha release

### DIFF
--- a/execution_chain/version.nim
+++ b/execution_chain/version.nim
@@ -20,7 +20,7 @@ const
   NimbusMajor* = 0
   ## is the major number of Nimbus' version.
 
-  NimbusMinor* = 1
+  NimbusMinor* = 2
   ## is the minor number of Nimbus' version.
 
   NimbusPatch* = 0

--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -8,7 +8,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "nimbus"
-version       = "0.1.0"
+version       = "0.2.0"
 author        = "Status Research & Development GmbH"
 description   = "An Ethereum 2.0 Sharding Client for Resource-Restricted Devices"
 license       = "Apache License 2.0"


### PR DESCRIPTION
As per discussion with @tersec 
For alpha release version format like `<year>.<month>.<>` seems weird
This `0.2.0` seems suitable enough