### PR TITLE
Fix invalid result error access + move empty txs check

### DIFF
--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -402,6 +402,11 @@ proc getTransactions*(
     var res: seq[Transaction]
     for encodedTx in db.getBlockTransactionData(txRoot):
       res.add(rlp.decode(encodedTx, Transaction))
+
+    # Txs not there in db - Happens during era1/era import, when we don't store txs and receipts
+    if (res.len == 0 and txRoot != zeroHash32):
+      return err("No transactions found in db for txRoot " & $txRoot)
+
     return ok(move(res))
 
 proc getBlockBody*(

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -404,7 +404,7 @@ proc getTransactions*(
       res.add(rlp.decode(encodedTx, Transaction))
 
     # Txs not there in db - Happens during era1/era import, when we don't store txs and receipts
-    if (res.len == 0 and txRoot != zeroHash32):
+    if (res.len == 0 and txRoot != emptyRoot):
       return err("No transactions found in db for txRoot " & $txRoot)
 
     return ok(move(res))

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -455,8 +455,10 @@ proc getUncleHashes*(
       ): Result[seq[Hash32], string] =
   var res: seq[Hash32]
   for blockHash in blockHashes:
-    let body = ?db.getBlockBody(blockHash)
-    res &= body.uncles.mapIt(it.computeRlpHash)
+    let header = ?db.getBlockHeader(blockHash)
+    let uncles = ?db.getUncles(header.ommersHash)
+
+    res &= uncles.mapIt(it.computeRlpHash)
   ok(res)
 
 proc getUncleHashes*(

--- a/execution_chain/db/payload_body_db.nim
+++ b/execution_chain/db/payload_body_db.nim
@@ -48,6 +48,10 @@ proc getExecutionPayloadBodyV1*(
   for encodedTx in db.getBlockTransactionData(header.txRoot):
     body.transactions.add TypedTransaction(encodedTx)
 
+  # Txs not there in db - Happens during era1/era import, when we don't store txs and receipts
+  if (body.transactions.len == 0 and header.txRoot != zeroHash32):
+    return err("No transactions found in db for txRoot " & $header.txRoot)
+
   if header.withdrawalsRoot.isSome:
     let withdrawalsRoot = header.withdrawalsRoot.value
     if withdrawalsRoot == emptyRoot:

--- a/execution_chain/db/payload_body_db.nim
+++ b/execution_chain/db/payload_body_db.nim
@@ -49,7 +49,7 @@ proc getExecutionPayloadBodyV1*(
     body.transactions.add TypedTransaction(encodedTx)
 
   # Txs not there in db - Happens during era1/era import, when we don't store txs and receipts
-  if (body.transactions.len == 0 and header.txRoot != zeroHash32):
+  if (body.transactions.len == 0 and header.txRoot != emptyRoot):
     return err("No transactions found in db for txRoot " & $header.txRoot)
 
   if header.withdrawalsRoot.isSome:


### PR DESCRIPTION
Check for empty txs in getBlockTransactionData and getExecutionPayloadBodyV1.

First step as more locations potentially require this on usage of also getBlockTransactions and getBlockTransactionHashes.

Can also add additionally check for rootHash calc.