### PR TITLE
fix release asset name following eth2 standard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,10 @@ jobs:
           make dist-${{ matrix.os }}-${{ matrix.cpu }}
           cd dist
           ARCHIVE=$(echo *.tar.gz)
+          ARCHIVE_DIR=$(basename -s .tar.gz -- *.tar.gz)
           tar -xzf ${ARCHIVE}
-          NEW_ARCHIVE_DIR="nimbus-eth1-${{ matrix.os }}-${{ matrix.cpu }}-${{ steps.extract_branch.outputs.tag_name }}-$(git rev-parse --short=8 HEAD)"
-          mv ${ARCHIVE%.tar.gz} ${NEW_ARCHIVE_DIR}
-          tar -czf ${NEW_ARCHIVE_DIR}.tar.gz ${NEW_ARCHIVE_DIR}
-          cp ${NEW_ARCHIVE_DIR}.tar.gz nimbus-eth1-${{ matrix.os }}-${{ matrix.cpu }}.tar.gz
-          echo "archive=${NEW_ARCHIVE_DIR}.tar.gz" >> $GITHUB_OUTPUT
-          echo "archive_dir=${NEW_ARCHIVE_DIR}" >> $GITHUB_OUTPUT
+          echo "archive=${ARCHIVE}" >> $GITHUB_OUTPUT
+          echo "archive_dir=${ARCHIVE_DIR}" >> $GITHUB_OUTPUT
 
       - name: Upload archive artefact
         uses: actions/upload-artifact@v4
@@ -74,7 +71,6 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.cpu }}-archive
           path: |
             ./dist/${{ steps.make_dist.outputs.archive }}
-            ./dist/nimbus-eth1-${{ matrix.os }}-${{ matrix.cpu }}.tar.gz
           retention-days: 2
 
       - name: Upload checksum artefact

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -110,6 +110,7 @@ const
     paP256VerifyAddress        # paP256Verify
   ]
 
+  # These names are in accordance to EIP mentioned ABIs
   precompileNames*: array[Precompiles, string] = [
     "ECREC",
     "SHA256",


### PR DESCRIPTION
We don't want unversioned release assets for e.g `nimbus-eth1-linux-amd64.tar.gz`
Also following `nimbus-eth2` release naming conventions