### PR TITLE
Portal: Adjust Portal ENR field as per portal specs update

### DIFF
--- a/portal/client/nimbus_portal_client.nim
+++ b/portal/client/nimbus_portal_client.nim
@@ -155,7 +155,7 @@ proc run(portalClient: PortalClient, config: PortalConf) {.raises: [CatchableErr
       # measure to easily identify & debug the clients used in the testnet.
       # Might make this into a, default off, cli option.
       localEnrFields =
-        {"c": enrClientInfoShort, portalVersionKey: SSZ.encode(localSupportedVersions)},
+        {"c": enrClientInfoShort, portalEnrKey: rlp.encode(localPortalEnrField)},
       bootstrapRecords = bootstrapRecords,
       previousRecord = previousEnr,
       bindIp = bindIp,

--- a/portal/tests/test_helpers.nim
+++ b/portal/tests/test_helpers.nim
@@ -32,7 +32,7 @@ proc initDiscoveryNode*(
   enrFields.add(localEnrFields)
   # Always inject the portal wire version field into the ENR
   # When no field, it would mean v0 only support
-  enrFields.add((portalVersionKey, SSZ.encode(localSupportedVersions)))
+  enrFields.add((portalEnrKey, rlp.encode(localPortalEnrField)))
 
   result = newProtocol(
     privKey,


### PR DESCRIPTION
This adjusts the Portal ENR field to:
- be RLP encoded
- must have a min and max version range
- also adds the chain ID

basically the implementation of https://github.com/ethereum/portal-network-specs/pull/408

I still don't find it that great to put version and chain info together (I as mentioned in the PR), but ok, I go with it.