### PR TITLE
Update Portal bootstrap nodes

### DIFF
--- a/portal/network/network_metadata.nim
+++ b/portal/network/network_metadata.nim
@@ -44,8 +44,6 @@ const
   # rlp.rawData() in the enr code.
   mainnetBootstrapNodes* =
     loadCompileTimeBootstrapNodes(portalConfigDir / "bootstrap_nodes.txt")
-  angelfoodBootstrapNodes* =
-    loadCompileTimeBootstrapNodes(portalConfigDir / "bootstrap_nodes_angelfood.txt")
 
   historicalHashesAccumulatorSSZ* =
     slurp(portalConfigDir / "historical_hashes_accumulator.ssz")


### PR DESCRIPTION
Nodes have been reset, this means also new network keys and node ids.

I took the opportunity to initialize the 64 large nodes with node ids evenly spread over the id range.