### PR TITLE
Downgrade linux-arm64 compiler and link with glibc 2.35

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -29,7 +29,7 @@ jobs:
       run:
         shell: bash
 
-    name: '${{ matrix.os }}-${{ matrix.cpu }}'
+    name: 'build-${{ matrix.os }}-${{ matrix.cpu }}'
     runs-on: ubuntu-latest
 
     steps:
@@ -83,7 +83,7 @@ jobs:
       run:
         shell: bash
 
-    name: '${{ matrix.os }}-${{ matrix.cpu }}'
+    name: 'run-binary-${{ matrix.os }}-${{ matrix.cpu }}'
     runs-on: ${{ matrix.builder }}
 
     steps:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -72,6 +72,31 @@ jobs:
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_execution_client.sha512sum
           retention-days: 2
 
+  run-binary:
+    needs: [build, matrix_config]
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix_config.outputs.matrix) }}
+
+    defaults:
+      run:
+        shell: bash
+
+    name: '${{ matrix.os }}-${{ matrix.cpu }}'
+    runs-on: ${{ matrix.builder }}
+
+    steps:
+      - name: Download artefacts
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ matrix.os }}-${{ matrix.cpu }}-archive
+
+      - name: Run binary
+        run: |
+          tar -xvzf nimbus-eth1-${{ matrix.os }}-${{ matrix.cpu }}-nightly-latest.tar.gz --strip-components=1
+          build/nimbus_execution_client --help
+
   nightly-build-release:
     name: Nightly build release
     needs: build

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,9 @@ VERIF_PROXY_OUT_PATH ?= build/libverifproxy/
 	dist \
 	eest \
 	t8n \
-	t8n_test
+	t8n_test \
+	evmstate \
+	evmstate_test
 
 ifeq ($(NIM_PARAMS),)
 # "variables.mk" was not included, so we update the submodules.

--- a/docker/dist/Dockerfile.linux-amd64
+++ b/docker/dist/Dockerfile.linux-amd64
@@ -9,7 +9,7 @@
 # according to those terms.
 
 # The build is reproducible only if this base image stays the same.
-FROM statusim/nimbus-eth1:dist_base_eth1_v2_linux_amd64@sha256:4eb9d6800889ea4b8422aecd82c0d6af45d6d2318a0be3777e4643d812078ed1
+FROM statusim/nimbus-eth1:dist_base_eth1_v2_linux_amd64@sha256:efa42e9735d99e78807ebcceb85b123142e0f4971b087ce66e4e89534b8fb424
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/Dockerfile.linux-arm64
+++ b/docker/dist/Dockerfile.linux-arm64
@@ -9,7 +9,7 @@
 # according to those terms.
 
 # The build is reproducible only if this base image stays the same.
-FROM statusim/nimbus-eth1:dist_base_eth1_v2_linux_arm64@sha256:133c2acbd093df66661b45141a31926164d124a4be86df5ca4475fa55c79d496
+FROM statusim/nimbus-eth1:dist_base_eth1_v2_linux_arm64@sha256:05b3bb79fea8fa4d7c0e6c05d56b7f33e4f302ccadefe52d535f1c44b7adace2
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/Dockerfile.macos-arm64
+++ b/docker/dist/Dockerfile.macos-arm64
@@ -11,7 +11,7 @@
 # syntax=docker/dockerfile:1
 
 # The build is reproducible only if this base image stays the same.
-FROM statusim/nimbus-eth1:dist_base_eth1_v2_macos_arm64@sha256:1277b1967b5ef3b0001f9c1bfea551025662b9b70e64b1d45eda79551cc5a34f AS osx-cross
+FROM statusim/nimbus-eth1:dist_base_eth1_v2_macos_arm64@sha256:986267752d5c4def09a66f30a3e84549a9557bf8996cc1d2acf3b2e6e0710666 AS osx-cross
 
 FROM ubuntu:24.04
 

--- a/docker/dist/Dockerfile.windows-amd64
+++ b/docker/dist/Dockerfile.windows-amd64
@@ -11,7 +11,7 @@
 # syntax=docker/dockerfile:1
 
 # The build is reproducible only if this base image stays the same.
-FROM statusim/nimbus-eth1:dist_base_eth1_v2_windows_amd64@sha256:aece618bb06002bf28ccc5937c7472de0482e0f329bcac2775be3934d7cdc592
+FROM statusim/nimbus-eth1:dist_base_eth1_v2_windows_amd64@sha256:b34f3503c157c1a205228eabc24a1f77f9469f4069cbcda9698886013dfe723e
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/base_image/Dockerfile.linux-arm64
+++ b/docker/dist/base_image/Dockerfile.linux-arm64
@@ -18,7 +18,9 @@
 
 FROM ubuntu:22.04
 
-ARG AARCH64_VERSION="14.3"
+# Use version 11.3 so we can link against glibc 2.35 and run on oldest supported Ubuntu LTS.
+# When oldest supported Ubuntu upgraded e.g. to 24.04, we can use compiler version 13.3.
+ARG AARCH64_VERSION="11.3"
 ENV AARCH64_BASE="https://developer.arm.com/-/media/Files/downloads/gnu/${AARCH64_VERSION}.rel1/binrel/"
 ENV AARCH64_URL="${AARCH64_BASE}/arm-gnu-toolchain-${AARCH64_VERSION}.rel1-x86_64-aarch64-none-linux-gnu.tar.xz"
 ENV ARCHIVE=aarch64

--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -117,7 +117,7 @@ elif [[ "${PLATFORM}" == "linux_arm64" ]]; then
     LOG_LEVEL="TRACE" \
     CC="${CC}" \
     CXX="${CXX}" \
-    NIMFLAGS="${NIMFLAGS_COMMON} --cpu:arm64 --arm64.linux.gcc.exe=${CC} --arm64.linux.gcc.linkerexe=${CXX} --gcc.exe=${CC} --gcc.linkerexe=${CXX} --passL:'-static-libstdc++'" \
+    NIMFLAGS="${NIMFLAGS_COMMON} --cpu:arm64 --arm64.linux.gcc.exe=${CC} --arm64.linux.gcc.linkerexe=${CXX} --passL:'-static-libstdc++'" \
     PARTIAL_STATIC_LINKING=1 \
     USE_SYSTEM_ROCKSDB=0 \
     ${BINARIES}
@@ -126,7 +126,7 @@ elif [[ "${PLATFORM}" == "macos_arm64" ]]; then
   export PATH="/osxcross/bin:${PATH}"
   export LD_LIBRARY_PATH="/osxcross/lib:$LD_LIBRARY_PATH"
   export OSXCROSS_MP_INC=1 # sets up include and library paths
-  export ZERO_AR_DATE=1 # avoid timestamps in binaries
+  export ZERO_AR_DATE=1    # avoid timestamps in binaries
   DARWIN_VER="24.5"
   CC="aarch64-apple-darwin${DARWIN_VER}-clang"
   CXX="aarch64-apple-darwin${DARWIN_VER}-clang++"
@@ -216,19 +216,19 @@ for BINARY in ${BINARIES}; do
     #
     # First two also happen with a native "dsymutil", while the next two only
     # with the "llvm-dsymutil" we use when cross-compiling.
-    "${DSYMUTIL}" build/${BINARY} 2>&1 \
-      | grep -v "failed to insert symbol" \
-      | grep -v "could not find object file symbol for symbol" \
-      | grep -v "while processing" \
-      | grep -v "warning: line table parameters mismatch. Cannot emit." \
-      || true
+    "${DSYMUTIL}" build/${BINARY} 2>&1 |
+      grep -v "failed to insert symbol" |
+      grep -v "could not find object file symbol for symbol" |
+      grep -v "while processing" |
+      grep -v "warning: line table parameters mismatch. Cannot emit." ||
+      true
     cp -a "./build/${BINARY}.dSYM" "${DIST_PATH}/build/"
   fi
   cd "${DIST_PATH}/build"
-  sha512sum "${BINARY}${EXT}" > "${BINARY}.sha512sum"
+  sha512sum "${BINARY}${EXT}" >"${BINARY}.sha512sum"
   cd - >/dev/null
 done
-sed -e "s/GIT_COMMIT/${GIT_COMMIT}/" docker/dist/README.md.tpl > "${DIST_PATH}/README.md"
+sed -e "s/GIT_COMMIT/${GIT_COMMIT}/" docker/dist/README.md.tpl >"${DIST_PATH}/README.md"
 
 if [[ "${PLATFORM}" == "linux_amd64" ]]; then
   sed -i -e 's/^make dist$/make dist-linux-amd64/' "${DIST_PATH}/README.md"

--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -795,13 +795,11 @@ func dbOptions*(conf: NimbusConf, noKeyCache = false): DbOptions =
     rdbPrintStats = conf.rdbPrintStats,
   )
 
+{.pop.}
+
 #-------------------------------------------------------------------
 # Constructor
 #-------------------------------------------------------------------
-
-# KLUDGE: The `load()` template does currently not work within any exception
-#         annotated environment.
-{.pop.}
 
 proc makeConfig*(cmdLine = commandLineParams()): NimbusConf =
   ## Note: this function is not gc-safe


### PR DESCRIPTION
Using statically linked musl libc when doing cross compilation and using c++ linker(due to librocksdb) at the same time presents a real headache. So, for the time being downgrading the arm64 compiler to version 11.3 and link with glibc 2.35 seems like a simpler solution.

fix #3655