### PR TITLE
Portal: Adjust history JSON-RPC API + re-add web3_clientVersion

### DIFF
--- a/execution_chain/portal/portal.nim
+++ b/execution_chain/portal/portal.nim
@@ -90,7 +90,7 @@ proc getBlockBodyByHeader*(historyExpiry: HistoryExpiryRef, header: Header): Res
   let rpc = historyExpiry.rpcProvider.valueOr:
     return err("Portal RPC is not available")
 
-  (waitFor rpc.historyGetBlockBody(header.number, header)).mapErr(
+  (waitFor rpc.historyGetBlockBody(header)).mapErr(
     proc(e: PortalRpcError): string =
       "Portal request failed: " & $e
   )

--- a/portal/bridge/history/portal_history_bridge.nim
+++ b/portal/bridge/history/portal_history_bridge.nim
@@ -164,38 +164,32 @@ proc runBackfillLoopAuditMode(
 
     # body
     block bodyBlock:
-      let
-        contentKey = blockBodyContentKey(blockNumber)
-        _ =
-          try:
-            (
-              await bridge.portalClient.portal_historyGetContent(
-                contentKey.encode.asSeq().toHex(),
-                rlp.encode(blockTuple.header).to0xHex(),
-              )
-            ).content
-          except CatchableError as e:
-            error "Failed to find block body content", error = e.msg
-            break bodyBlock
+      let _ =
+        try:
+          (
+            await bridge.portalClient.portal_historyGetBlockBody(
+              rlp.encode(blockTuple.header).to0xHex()
+            )
+          )
+        except CatchableError as e:
+          error "Failed to find block body content", error = e.msg
+          break bodyBlock
 
       info "Retrieved block body from Portal network"
       bodySuccess = true
 
     # receipts
     block receiptsBlock:
-      let
-        contentKey = receiptsContentKey(blockNumber)
-        _ =
-          try:
-            (
-              await bridge.portalClient.portal_historyGetContent(
-                contentKey.encode.asSeq().toHex(),
-                rlp.encode(blockTuple.header).to0xHex(),
-              )
-            ).content
-          except CatchableError as e:
-            error "Failed to find block receipts content", error = e.msg
-            break receiptsBlock
+      let _ =
+        try:
+          (
+            await bridge.portalClient.portal_historyGetReceipts(
+              rlp.encode(blockTuple.header).to0xHex()
+            )
+          )
+        except CatchableError as e:
+          error "Failed to find block receipts content", error = e.msg
+          break receiptsBlock
 
       info "Retrieved block receipts from Portal network"
       receiptsSuccess = true

--- a/portal/network/history/history_endpoints.nim
+++ b/portal/network/history/history_endpoints.nim
@@ -13,10 +13,12 @@ export results, history_network
 
 proc getBlockBody*(
     n: HistoryNetwork, header: Header
-): Future[Opt[BlockBody]] {.async: (raises: [CancelledError], raw: true).} =
+): Future[Result[BlockBody, string]] {.async: (raises: [CancelledError], raw: true).} =
   n.getContent(blockBodyContentKey(header.number), BlockBody, header)
 
 proc getReceipts*(
     n: HistoryNetwork, header: Header
-): Future[Opt[StoredReceipts]] {.async: (raises: [CancelledError], raw: true).} =
+): Future[Result[StoredReceipts, string]] {.
+    async: (raises: [CancelledError], raw: true)
+.} =
   n.getContent(receiptsContentKey(header.number), StoredReceipts, header)

--- a/portal/rpc/rpc_calls/rpc_portal_calls.nim
+++ b/portal/rpc/rpc_calls/rpc_portal_calls.nim
@@ -27,10 +27,13 @@ createRpcSigsFromNim(RpcClient):
     enr: Record, contentKey: string, contentValue: string
   ): string
 
-  proc portal_historyGetContent(contentKey: string, headerBytes: string): ContentInfo
+  proc portal_historyGetContent(contentKey: string): ContentInfo
   proc portal_historyPutContent(
     contentKey: string, contentValue: string
   ): PutContentResult
+
+  proc portal_historyGetBlockBody(headerBytes: string): string
+  proc portal_historyGetReceipts(headerBytes: string): string
 
   ## Portal Beacon Light Client Network json-rpc calls
   proc portal_beaconNodeInfo(): NodeInfo

--- a/portal/rpc/rpc_web3_api.nim
+++ b/portal/rpc/rpc_web3_api.nim
@@ -1,0 +1,14 @@
+# Nimbus
+# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import json_rpc/rpcserver, ../version
+
+proc installWeb3ApiHandlers*(rpcServer: RpcServer) =
+  rpcServer.rpc("web3_clientVersion") do() -> string:
+    return clientVersion

--- a/portal/tests/rpc_tests/test_portal_rpc_client.nim
+++ b/portal/tests/rpc_tests/test_portal_rpc_client.nim
@@ -89,9 +89,7 @@ proc setupTest(rng: ref HmacDrbgContext): Future[TestCase] {.async.} =
 
   let rpcHttpServer = RpcHttpServer.new()
   rpcHttpServer.addHttpServer(ta, maxRequestBodySize = 16 * 1024 * 1024)
-  rpcHttpServer.installPortalHistoryApiHandlers(
-    historyNode1.historyNetwork.portalProtocol
-  )
+  rpcHttpServer.installPortalHistoryApiHandlers(historyNode1.historyNetwork)
   rpcHttpServer.start()
 
   await client.connect(localSrvAddress, rpcHttpServer.localAddress[0].port, false)
@@ -121,7 +119,7 @@ procSuite "Portal RPC Client":
 
     # Test content not found
     block:
-      let blockBodyRes = await tc.client.historyGetBlockBody(blockNumber, blockHeader)
+      let blockBodyRes = await tc.client.historyGetBlockBody(blockHeader)
       check:
         blockBodyRes.isErr()
         blockBodyRes.error() == ContentNotFound
@@ -130,16 +128,16 @@ procSuite "Portal RPC Client":
     block:
       tc.historyNode2.store(blockNumber, blockBody)
 
-      let blockBodyRes = await tc.client.historyGetBlockBody(blockNumber, blockHeader)
+      let blockBodyRes = await tc.client.historyGetBlockBody(blockHeader)
       check:
         blockBodyRes.isErr()
-        blockBodyRes.error() == ContentValidationFailed
+        blockBodyRes.error() == ContentNotFound
 
     # When local node has the content the validation is skipped
     block:
       tc.historyNode1.store(blockNumber, blockBody)
 
-      let blockBodyRes = await tc.client.historyGetBlockBody(blockNumber, blockHeader)
+      let blockBodyRes = await tc.client.historyGetBlockBody(blockHeader)
       check:
         blockBodyRes.isOk()
 
@@ -154,7 +152,7 @@ procSuite "Portal RPC Client":
 
     # Test content not found
     block:
-      let receiptsRes = await tc.client.historyGetReceipts(blockNumber, blockHeader)
+      let receiptsRes = await tc.client.historyGetReceipts(blockHeader)
       check:
         receiptsRes.isErr()
         receiptsRes.error() == ContentNotFound
@@ -163,16 +161,16 @@ procSuite "Portal RPC Client":
     block:
       tc.historyNode2.store(blockNumber, receipts)
 
-      let receiptsRes = await tc.client.historyGetReceipts(blockNumber, blockHeader)
+      let receiptsRes = await tc.client.historyGetReceipts(blockHeader)
       check:
         receiptsRes.isErr()
-        receiptsRes.error() == ContentValidationFailed
+        receiptsRes.error() == ContentNotFound
 
     # When local node has the content the validation is skipped
     block:
       tc.historyNode1.store(blockNumber, receipts)
 
-      let receiptsRes = await tc.client.historyGetReceipts(blockNumber, blockHeader)
+      let receiptsRes = await tc.client.historyGetReceipts(blockHeader)
       check:
         receiptsRes.isOk()
 


### PR DESCRIPTION
- Re-Add again web3_clientVersion
- Adjust back to the standardized portal_historyGetContent and portal_historyTraceGetContent, but without validation or storing
- Add instead portal_historyGetBlockBody and portal_historyGetReceipts with validation and storing

Point 1 and 2 are required for glados tooling.

The last can be used for EL integration (and is used and adjusted here for Nimbus EL integration)