### PR TITLE
Fix CI cache key issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure Github action's `hashFiles` produce consistent hash
+# of *.sh files used for cache key across OSes.
+*.sh text eol=lf

--- a/.github/actions/shared/action.yml
+++ b/.github/actions/shared/action.yml
@@ -125,10 +125,7 @@ runs:
       id: versions
       shell: bash
       run: |
-        getHash() {
-          git ls-remote "https://github.com/$1" "${2:-HEAD}" | cut -f 1
-        }
-        nbsHash=$(getHash status-im/nimbus-build-system)
+        nbsHash=$(git rev-parse HEAD:vendor/nimbus-build-system)
         echo "nimbus_build_system=$nbsHash" >> $GITHUB_OUTPUT
 
     - name: Restore prebuilt Nim from cache
@@ -150,10 +147,7 @@ runs:
       id: rocksdb-versions
       shell: bash
       run: |
-        getHash() {
-          git ls-remote "https://github.com/$1" "${2:-HEAD}" | cut -f 1
-        }
-        rocksHash=$(getHash status-im/nim-rocksdb)
+        rocksHash=$(git rev-parse HEAD:vendor/nim-rocksdb)
         echo "nim_rocksdb=$rocksHash" >> $GITHUB_OUTPUT
 
     - name: Restore prebuilt rocksdb from cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,31 +69,14 @@ jobs:
           rocksdb-cache: true
           eest-cache: true
 
-      - name: Run nimbus-eth1 tests (Windows)
-        if: runner.os == 'Windows'
+      - name: Run nimbus-eth1 tests
         run: |
           gcc --version
-          DEFAULT_MAKE_FLAGS="-j${ncpu} ENABLE_VMLOWMEM=${ENABLE_VMLOWMEM} ROCKSDB_CI_CACHE=RocksBinCache"
-          mingw32-make ${DEFAULT_MAKE_FLAGS} all test_import build_fuzzers check_revision
-          find . -type d -name "nimcache" -exec rm -rf {} +
-          mingw32-make ${DEFAULT_MAKE_FLAGS} test t8n_test eest_full_test
-
-      - name: Run nimbus-eth1 tests (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib"
-          DEFAULT_MAKE_FLAGS="-j${ncpu} ROCKSDB_CI_CACHE=RocksBinCache"
-          env CC=gcc make ${DEFAULT_MAKE_FLAGS} all test_import build_fuzzers check_revision
-          build/nimbus_execution_client --help
-          # CC, GOARCH, and CGO_ENABLED are needed to select correct compiler 32/64 bit
-          env CC=gcc GOARCH=${GOARCH} CXX=g++ CGO_ENABLED=1 make ${DEFAULT_MAKE_FLAGS} test t8n_test eest_full_test
-
-      - name: Run nimbus-eth1 tests (Macos)
-        if: runner.os == 'Macos'
-        run: |
-          export ZERO_AR_DATE=1 # avoid timestamps in binaries
+          #export ZERO_AR_DATE=1 # avoid timestamps in binaries
           DEFAULT_MAKE_FLAGS="-j${ncpu} ROCKSDB_CI_CACHE=RocksBinCache"
           make ${DEFAULT_MAKE_FLAGS} all test_import build_fuzzers check_revision
+          # clear some space
+          find . -type d -name "nimcache" -exec rm -rf {} +
           # "-static" option will not work for osx unless static system libraries are provided
           make ${DEFAULT_MAKE_FLAGS} test t8n_test eest_full_test
 

--- a/scripts/check_copyright_year.sh
+++ b/scripts/check_copyright_year.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2023-2024 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2023-2025 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-excluded_files="config.yaml|.gitmodules|.gitignore"
+excluded_files="config.yaml|.gitmodules|.gitignore|.gitattributes"
 excluded_extensions="json|md|png|txt|toml|gz|key|rlp|era1|cfg|py|sh|in|patch"
 
 current_year=$(date +"%Y")

--- a/scripts/rocksdb_ci_cache.sh
+++ b/scripts/rocksdb_ci_cache.sh
@@ -33,6 +33,13 @@ if [[ -n "$ROCKSDB_CI_CACHE" && -d "$ROCKSDB_CI_CACHE" ]]; then
   cp -a "$ROCKSDB_CI_CACHE"/* "$BUILD_DEST"/ || true # let this one fail with an empty cache dir
 fi
 
+if [ -f "${BUILD_DEST}/version.txt" ]; then
+  VERSION=$(cat "${BUILD_DEST}/version.txt")
+  echo "ROCKSDB CACHED VERSION: ${VERSION}"
+else
+  echo "ROCKSDB VERSION NOT FOUND"
+fi
+
 # This scripts has it's own logic to detect rebuilt or not
 if [[ "$ON_WINDOWS" == "0" ]]; then
   MAKE="${MAKE}" ${REPO_DIR}/vendor/nim-rocksdb/scripts/build_static_deps.sh


### PR DESCRIPTION
Case 1:
Using submodule repo HEAD hash for cache key will cause problem. e.g. cache generated with older content by some random PR because the PR with newest submodule hasn't been merged but the cache key already changed.

This problem happen with rocksdb. The cache key pointing to HEAD of the repo with version 10.4.2 but the content itself still version 10.2.1. This discrepancy causing the `rocksdb_ci_cache.sh` to rebuild the library for each commit rendering the cache useless.

This PR fix it using `git rev-parse HEAD:path/to/submodule` to replace `git ls-remote "https://github.com/$1" "${2:-HEAD}" | cut -f 1`. Random PR will not produce new cache with old content and only the PR responsible for bumping the submodule will generate the cache with correct content.

Case 2:
Builtin Github Action `hashFiles` use the OS copy of files can produce different hash. This can happen because of EOL difference on each OS.

So the CI generate different cache key for Windows vs the rest of OSes, while the content itself practically identical.

This PR fix it by forcing the hashed files checked out using one style of EOL in .gitattributes file.