### PR TITLE
Portal: Add the nimbus portal client as client_info for Ping msg

### DIFF
--- a/portal/network/history/history_network.nim
+++ b/portal/network/history/history_network.nim
@@ -25,7 +25,7 @@ from eth/common/accounts import EMPTY_ROOT_HASH
 export history_content, headers
 
 logScope:
-  topics = "portal_fin_hist"
+  topics = "portal_hist"
 
 const pingExtensionCapabilities = {CapabilitiesType, HistoryRadiusType}
 

--- a/portal/network/wire/ping_extensions.nim
+++ b/portal/network/wire/ping_extensions.nim
@@ -7,7 +7,7 @@
 
 {.push raises: [].}
 
-import ssz_serialization
+import ssz_serialization, stew/byteutils, ../../version
 
 const
   # Extension types
@@ -21,7 +21,9 @@ const
   MAX_CAPABILITIES_LENGTH* = 400
   MAX_ERROR_BYTE_LENGTH* = 300
 
-  NIMBUS_PORTAL_CLIENT_INFO* = ByteList[MAX_CLIENT_INFO_BYTE_LENGTH].init(@[])
+  NIMBUS_PORTAL_CLIENT_INFO* =
+    # Only provide client name, not version/OS-CPU/language
+    ByteList[MAX_CLIENT_INFO_BYTE_LENGTH].init((clientName & "///").toBytes())
 
 # Different ping extension payloads, TODO: could be moved to each their own file?
 type

--- a/portal/tools/portalcli.nim
+++ b/portal/tools/portalcli.nim
@@ -21,7 +21,8 @@ import
   eth/p2p/discoveryv5/protocol as discv5_protocol,
   ../common/common_utils,
   ../database/content_db,
-  ../network/wire/[portal_protocol, portal_stream, portal_protocol_config],
+  ../network/wire/
+    [portal_protocol, portal_stream, portal_protocol_config, portal_protocol_version],
   ../network/history/[history_content, history_network]
 
 const
@@ -232,6 +233,7 @@ proc run(config: PortalCliConf) =
     extIp,
     Opt.none(Port),
     extUdpPort,
+    localEnrFields = {portalEnrKey: rlp.encode(localPortalEnrField)},
     bootstrapRecords = bootstrapRecords,
     bindIp = bindIp,
     bindPort = udpPort,

--- a/portal/version.nim
+++ b/portal/version.nim
@@ -35,7 +35,9 @@ const
     "Copyright (c) 2021-" & compileYear & " Status Research & Development GmbH"
 
   # Short debugging identifier to be placed in the ENR
-  enrClientInfoShort* = toBytes("f")
+  # Note: This got replaced by the ping extension containing the client_info.
+  # Once no longer used it can be deprecated.
+  enrClientInfoShort* = toBytes("n")
 
 declareGauge versionGauge,
   "nimbus_portal_client version info (as metric labels)",


### PR DESCRIPTION
Only client name gets added, no other information such as version

Also change the ENR short name from f (=fluffy) to n (=nimbus). This field is likely to get deprecated/removed though.

And small logscope fix for history network