### PR TITLE
Portal: Add portal_historyStore and portal_historyLocalContent

### DIFF
--- a/portal/rpc/rpc_calls/rpc_portal_calls.nim
+++ b/portal/rpc/rpc_calls/rpc_portal_calls.nim
@@ -32,6 +32,9 @@ createRpcSigsFromNim(RpcClient):
     contentKey: string, contentValue: string
   ): PutContentResult
 
+  proc portal_historyStore(contentKey: string, contentValue: string): bool
+  proc portal_historyLocalContent(contentKey: string): string
+
   proc portal_historyGetBlockBody(headerBytes: string): string
   proc portal_historyGetReceipts(headerBytes: string): string
 


### PR DESCRIPTION
These were part of Portal legacy history network. I've been needing them when testing integration with EL and thus added them. (They are still part of portal json-rpc spec)