### PR TITLE
Use raw async functions when creating handlers in ForkedChain

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -354,7 +354,7 @@ with --debug-eager-state-root."""
 
   count
 
-proc processUpdateBase(c: ForkedChainRef) {.async: (raises: [CancelledError]).} =
+proc processUpdateBase(c: ForkedChainRef): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
   if c.baseQueue.len > 0:
     let base = c.baseQueue.popFirst()
     c.persistedCount += c.updateBase(base)
@@ -387,16 +387,17 @@ proc processUpdateBase(c: ForkedChainRef) {.async: (raises: [CancelledError]).} 
           resolvedFin= c.latestFinalizedBlockNumber
       c.lastBaseLogTime = time
       c.persistedCount = 0
-    return
+    return ok()
 
   if c.queue.isNil:
     # This recursive mode only used in test env with small set of blocks
-    await c.processUpdateBase()
+    discard await c.processUpdateBase()
   else:
-    proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
-      await c.processUpdateBase()
-      ok()
+    proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError], raw: true).} =
+      c.processUpdateBase()
     await c.queue.addLast(QueueItem(handler: asyncHandler))
+
+  ok()
 
 proc queueUpdateBase(c: ForkedChainRef, base: BlockRef)
      {.async: (raises: [CancelledError]).} =
@@ -427,11 +428,10 @@ proc queueUpdateBase(c: ForkedChainRef, base: BlockRef)
 
   if c.queue.isNil:
     # This recursive mode only used in test env with small set of blocks
-    await c.processUpdateBase()
+    discard await c.processUpdateBase()
   else:
-    proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
-      await c.processUpdateBase()
-      ok()
+    proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError], raw: true).} =
+      c.processUpdateBase()
     await c.queue.addLast(QueueItem(handler: asyncHandler))
 
 proc validateBlock(c: ForkedChainRef,
@@ -517,32 +517,31 @@ proc validateBlock(c: ForkedChainRef,
 template queueOrphan(c: ForkedChainRef, parent: BlockRef, finalized = false): auto =
   if c.queue.isNil:
     # This recursive mode only used in test env with small set of blocks
-    c.processOrphan(parent, finalized)
+    discard await c.processOrphan(parent, finalized)
   else:
-    proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
-      await c.processOrphan(parent, finalized)
-      ok()
-    c.queue.addLast(QueueItem(handler: asyncHandler))
+    proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError], raw: true).} =
+      c.processOrphan(parent, finalized)
+    await c.queue.addLast(QueueItem(handler: asyncHandler))
 
-proc processOrphan(c: ForkedChainRef, parent: BlockRef, finalized = false)
+proc processOrphan(c: ForkedChainRef, parent: BlockRef, finalized = false): Future[Result[void, string]]
   {.async: (raises: [CancelledError]).} =
   if parent.txFrame.isNil:
     # This can happen if `processUpdateBase` put `updateBase`
     # before `processOrphan` and the `updateBase` remove orphan's parent.txFrame
     # But because of async nature, very hard to replicate or to make a test case.
     # https://github.com/status-im/nimbus-eth1/issues/3526
-    return
+    return ok()
 
   let
     orphan = c.quarantine.popOrphan(parent.hash).valueOr:
       # No more orphaned block
-      return
+      return ok()
     parent = (await c.validateBlock(parent, orphan, finalized)).valueOr:
       # Silent?
       # We don't return error here because the import is still ok()
       # but the quarantined blocks may not linked
-      return
-  await c.queueOrphan(parent, finalized)
+      return ok()
+  c.queueOrphan(parent, finalized)
 
 proc processQueue(c: ForkedChainRef) {.async: (raises: [CancelledError]).} =
   while true:
@@ -656,7 +655,7 @@ proc importBlock*(c: ForkedChainRef, blk: Block, finalized = false):
 
     let parent = ?(await c.validateBlock(parent, blk, finalized))
     if c.quarantine.hasOrphans():
-      await c.queueOrphan(parent, finalized)
+      c.queueOrphan(parent, finalized)
 
   else:
     # If its parent is an invalid block
@@ -730,8 +729,8 @@ proc stopProcessingQueue*(c: ForkedChainRef) {.async: (raises: []).} =
   await noCancel c.processingQueueLoop.cancelAndWait()
 
 template queueImportBlock*(c: ForkedChainRef, blk: Block, finalized = false): auto =
-  proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
-    await c.importBlock(blk, finalized)
+  proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError], raw: true).} =
+    c.importBlock(blk, finalized)
 
   let item = QueueItem(
     responseFut: Future[Result[void, string]].Raising([CancelledError]).init(),
@@ -744,8 +743,8 @@ template queueForkChoice*(c: ForkedChainRef,
                  headHash: Hash32,
                  finalizedHash: Hash32,
                  safeHash: Hash32 = zeroHash32): auto =
-  proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
-    await c.forkChoice(headHash, finalizedHash, safeHash)
+  proc asyncHandler(): Future[Result[void, string]] {.async: (raises: [CancelledError], raw: true).} =
+    c.forkChoice(headHash, finalizedHash, safeHash)
 
   let item = QueueItem(
     responseFut: Future[Result[void, string]].Raising([CancelledError]).init(),


### PR DESCRIPTION
In theory this should be more efficient because the handlers no longer introduce unnecessary await calls which create some small event queue related overhead.