### PR TITLE
Fix crash due to missing checkpoint on shutdown during sync

### DIFF
--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -329,6 +329,7 @@ proc runExeClient*(nimbus: NimbusNode, conf: NimbusConf) {.gcsafe.} =
         txFrame = fc.baseTxFrame
       fc.serialize(txFrame).isOkOr:
         error "FC.serialize error: ", msg=error
+      txFrame.checkpoint(fc.base.blk.header.number)
       com.db.persist(txFrame)
     com.db.finish()
 

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -327,10 +327,12 @@ proc runExeClient*(nimbus: NimbusNode, conf: NimbusConf) {.gcsafe.} =
       let
         fc = nimbus.fc
         txFrame = fc.baseTxFrame
+
       fc.serialize(txFrame).isOkOr:
         error "FC.serialize error: ", msg=error
-      txFrame.checkpoint(fc.base.blk.header.number)
+      txFrame.checkpoint(fc.base.blk.header.number, skipSnapshot = true)
       com.db.persist(txFrame)
+
     com.db.finish()
 
   case conf.cmd


### PR DESCRIPTION
I would sometimes get this error when stopping Nimbus with Ctrl-C while syncing:
```
../csu/libc-start.c(392) 
../sysdeps/nptl/libc_start_call_main.h(58) 
/home/user/development/status-im/nimbus-eth1/vendor/nim-json-rpc/json_rpc/client.nim(875) main
/home/user/development/status-im/nimbus-eth1/vendor/nim-json-rpc/json_rpc/client.nim(863) NimMain
/home/user/development/status-im/nimbus-eth1/execution_chain/nimbus_execution_client.nim(332) _ZN23nimbus_execution_client12runExeClientE3refIN11nimbus_desc26NimbusNodecolonObjectType_EEN6config10NimbusConfE
/home/user/development/status-im/nimbus-eth1/execution_chain/db/core_db/base.nim(102) _ZN4base7persistE3refIN9base_desc25CoreDbRefcolonObjectType_EE3refIN9base_desc27CoreDbTxRefcolonObjectType_EE
/home/user/development/status-im/nimbus-eth1/execution_chain/db/aristo/aristo_tx_frame.nim(119) _ZN15aristo_tx_frame7persistE3refIN11aristo_desc27AristoDbRefcolonObjectType_EE3refIN12desc_backend25PutHdlRefcolonObjectType_EE3refIN11aristo_desc27AristoTxRefcolonObjectType_EE
/home/user/development/status-im/nimbus-eth1/execution_chain/db/aristo/aristo_tx_frame.nim(127) _ZN15aristo_tx_frame7persistE3refIN11aristo_desc27AristoDbRefcolonObjectType_EE3refIN12desc_backend25PutHdlRefcolonObjectType_EE3refIN11aristo_desc27AristoTxRefcolonObjectType_EE
/home/user/development/status-im/nimbus-eth1/vendor/nim-results/results.nim(979) _ZN7results6expectE3varI6ResultIN9hardforks12BlobScheduleE4voidEE6string
/home/user/development/status-im/nimbus-eth1/vendor/nim-results/results.nim(438) _ZN7results17raiseResultDefectE6string
/home/user/development/status-im/nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/system/excpt.nim(349) _ZN6system18rawWriteStackTraceE3varI3seqIN6system15StackTraceEntryEEE
/home/user/development/status-im/nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/system/stacktraces.nim(62) _ZN11stacktraces30auxWriteStackTraceWithOverrideE3varI3seqIN6system15StackTraceEntryEEE
Error: unhandled exception: `checkpoint` before persisting frame [ResultDefect]
```

This fixes the problem by making sure there is a checkpoint completed before persist.