### PR TITLE
Improve header verification for stateless execution

### DIFF
--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -101,7 +101,7 @@ proc processBlock*(c: ForkedChainRef,
     if vmState.com.statelessWitnessValidation:
       doAssert witness.validateKeys(vmState.ledger.getWitnessKeys()).isOk()
       let executionWitness = ExecutionWitness.build(witness, vmState.ledger)
-      ?executionWitness.statelessProcessBlock(c.com, parentBlk.header, blk)
+      ?executionWitness.statelessProcessBlock(c.com, blk)
 
     ?vmState.ledger.txFrame.persistWitness(blkHash, witness)
 

--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -187,7 +187,7 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
     if vmState.com.statelessWitnessValidation:
       doAssert witness.validateKeys(vmState.ledger.getWitnessKeys()).isOk()
       let executionWitness = ExecutionWitness.build(witness, vmState.ledger)
-      ?executionWitness.statelessProcessBlock(com, p.parent, blk)
+      ?executionWitness.statelessProcessBlock(com, blk)
 
     ?vmState.ledger.txFrame.persistWitness(header.computeBlockHash(), witness)
 

--- a/tests/test_stateless_witness_verification.nim
+++ b/tests/test_stateless_witness_verification.nim
@@ -41,6 +41,7 @@ suite "Stateless: Witness Verification":
       header1 = Header(number: 1)
       header2 = Header(number: 2, parentHash: header1.computeRlpHash())
       header3 = Header(number: 3, parentHash: header2.computeRlpHash(), stateRoot: stateRoot)
+      header4 = Header(number: 4, parentHash: header3.computeRlpHash())
 
     ledger.txFrame.persistHeader(header1.computeRlpHash(), header1).expect("success")
     ledger.txFrame.persistHeader(header2.computeRlpHash(), header2).expect("success")
@@ -69,5 +70,12 @@ suite "Stateless: Witness Verification":
 
     let
       executionWitness = ExecutionWitness.build(witness, ledger)
-      verificationResult = executionWitness.verify(stateRoot)
-    check verificationResult.isOk()
+      headersRes = executionWitness.verifyHeaders(header4)
+
+    check:
+      headersRes.isOk()
+      headersRes[].len() == 3
+      headersRes[][0] == header1
+      headersRes[][1] == header2
+      headersRes[][2] == header3
+    check executionWitness.verifyState(stateRoot).isOk()


### PR DESCRIPTION
This is a small refactor/improvement to the stateless execution function:
- Created a separate `verifyHeaders` function which returns the decoded and sorted block headers after validation. 
- The headers are then used to populate the block hashes in the database. Removes the redundant rlp decoding of the headers.
- The parent header is no longer required to be passed in because this can be pulled out of the execution witness after validation.
