### PR TITLE
Portal: Fix debug_getBlockHeader number decode + rename method

### DIFF
--- a/execution_chain/portal/portal.nim
+++ b/execution_chain/portal/portal.nim
@@ -92,5 +92,6 @@ proc getBlockBodyByHeader*(historyExpiry: HistoryExpiryRef, header: Header): Res
 
   (waitFor rpc.historyGetBlockBody(header)).mapErr(
     proc(e: PortalRpcError): string =
+      debug "Portal request failed", error = $e
       "Portal request failed: " & $e
   )

--- a/execution_chain/rpc/debug.nim
+++ b/execution_chain/rpc/debug.nim
@@ -224,9 +224,11 @@ proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
     chain.getExecutionWitness(blockHash).valueOr:
       raise newException(ValueError, error)
 
-  server.rpc("debug_getBlockHeader") do(blockNumber: uint64) -> string:
-    ## Returns the rlp encoded block header in hex for the given block number.
-    let header = chain.baseTxFrame.getBlockHeader(blockNumber).valueOr:
+  server.rpc("debug_getHeaderByNumber") do(blockTag: BlockTag) -> string:
+    ## Returns the rlp encoded block header in hex for the given block number / tag.
+    # Note: When proposing this method for inclusion in the JSON-RPC spec,
+    # consider returning a header JSON object instead of RLP. Likely to be more accepted.
+    let header = chain.headerFromTag(blockTag).valueOr:
       raise newException(ValueError, error)
 
     rlp.encode(header).to0xHex()

--- a/portal/client/nimbus_portal_client.nim
+++ b/portal/client/nimbus_portal_client.nim
@@ -22,6 +22,7 @@ import
   eth/common/keys,
   eth/net/nat,
   eth/p2p/discoveryv5/protocol as discv5_protocol,
+  web3/[eth_api_types, conversions],
   ../common/common_utils,
   ../rpc/[
     rpc_discovery_api, rpc_portal_common_api, rpc_portal_history_api,
@@ -45,7 +46,7 @@ chronicles.formatIt(IoErrorCode):
 
 createRpcSigsFromNim(RpcClient):
   # EL debug call to get header for validation
-  proc debug_getBlockHeader(blockNumber: uint64): string
+  proc debug_getHeaderByNumber(blockNumber: BlockIdentifier): string
 
 func optionToOpt[T](o: Option[T]): Opt[T] =
   if o.isSome():
@@ -202,7 +203,7 @@ proc run(portalClient: PortalClient, config: PortalConf) {.raises: [CatchableErr
           blockNumber: uint64
       ): Future[Result[Header, string]] {.async: (raises: [CancelledError]), gcsafe.} =
         try:
-          let header = await rpcClient.debug_getBlockHeader(blockNumber)
+          let header = await rpcClient.debug_getHeaderByNumber(blockId(blockNumber))
           decodeRlp(header.hexToSeqByte(), Header)
         except CatchableError as e:
           err(e.msg)


### PR DESCRIPTION
Fix debug_getBlockHeader number decoding (use block tag instead) + rename the method to debug_getHeaderByNumber()