### PR TITLE
Portal: Change JSON-RPC port defaults client/bridge

### DIFF
--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -450,7 +450,7 @@ type
         name: "debug-history-expiry-limit" }: Option[BlockNumber]
 
       portalUrl* {.
-        desc: "URL of the Portal Network"
+        desc: "URL of the Portal JSON-RPC API"
         defaultValue: ""
         name: "portal-url" }: string
 

--- a/portal/bridge/nimbus_portal_bridge_conf.nim
+++ b/portal/bridge/nimbus_portal_bridge_conf.nim
@@ -57,7 +57,7 @@ type
 
     portalRpcUrl* {.
       desc: "Portal node JSON-RPC API URL",
-      defaultValue: JsonRpcUrl(kind: HttpUrl, value: "http://127.0.0.1:8545"),
+      defaultValue: JsonRpcUrl(kind: HttpUrl, value: "http://127.0.0.1:8565"),
       name: "portal-rpc-url"
     .}: JsonRpcUrl
 
@@ -84,8 +84,11 @@ type
         name: "trusted-block-root"
       .}: Option[TrustedDigest]
     of PortalBridgeCmd.history:
-      web3Url* {.desc: "Execution layer JSON-RPC API URL", name: "web3-url".}:
-        JsonRpcUrl
+      web3Url* {.
+        desc: "Execution layer JSON-RPC API URL",
+        defaultValue: JsonRpcUrl(kind: HttpUrl, value: "http://127.0.0.1:8545"),
+        name: "web3-url"
+      .}: JsonRpcUrl
 
       blockVerify* {.
         desc: "Verify the block header, body and receipts",

--- a/portal/client/nimbus_portal_client_conf.nim
+++ b/portal/client/nimbus_portal_client_conf.nim
@@ -198,7 +198,7 @@ type
     .}: IpAddress
 
     rpcPort* {.
-      desc: "Port for the HTTP JSON-RPC server", defaultValue: 8545, name: "rpc-port"
+      desc: "Port for the HTTP JSON-RPC server", defaultValue: 8565, name: "rpc-port"
     .}: Port
 
     rpcApi* {.
@@ -222,7 +222,7 @@ type
 
     wsPort* {.
       desc: "Port for the WebSocket JSON-RPC server",
-      defaultValue: 8546,
+      defaultValue: 8566,
       name: "ws-port"
     .}: Port
 


### PR DESCRIPTION
Use to have port 8545/8546 for http/ws to be consistent with ELs as Portal client was considered light client alternative for ELs and this way devs don't have to adjust ports.

However, now the only use case is integration with an EL so it becomes annoying to have colliding ports when you actually have to run both together.