### PR TITLE
Portal: Fixes for historyTraceGetContent for glados compatibility

### DIFF
--- a/portal/rpc/rpc_portal_history_api.nim
+++ b/portal/rpc/rpc_portal_history_api.nim
@@ -33,6 +33,7 @@ export tables
 ContentInfo.useDefaultSerializationIn JrpcConv
 TraceContentLookupResult.useDefaultSerializationIn JrpcConv
 TraceObject.useDefaultSerializationIn JrpcConv
+FailureInfo.useDefaultSerializationIn JrpcConv
 NodeMetadata.useDefaultSerializationIn JrpcConv
 TraceResponse.useDefaultSerializationIn JrpcConv
 

--- a/portal/rpc/rpc_types.nim
+++ b/portal/rpc/rpc_types.nim
@@ -127,6 +127,7 @@ JrpcConv.automaticSerialization(uint16, true)
 JrpcConv.automaticSerialization(seq, true)
 JrpcConv.automaticSerialization(string, true)
 JrpcConv.automaticSerialization(bool, true)
+JrpcConv.automaticSerialization(JsonString, true)
 
 func getNodeInfo*(r: RoutingTable): NodeInfo =
   NodeInfo(enr: r.localNode.record, nodeId: r.localNode.id)
@@ -169,7 +170,7 @@ proc writeValue*(
   if v.isSome():
     w.writeValue(v.get())
   else:
-    w.writeValue("0x")
+    w.writeValue(JsonString("null"))
 
 proc readValue*(
     r: var JsonReader[JrpcConv], val: var NodeId


### PR DESCRIPTION
- Add failures (although we don't fill them in yet). This is not yet in spec but expected to exist for glados
- NodeId key in Table (json map) to have 0x and leading zeroes
- Write null for Optional None field instead of 0x. Could also omit the field but that would require nim-json-rpc server to set a custom JSON flavor. See also
https://github.com/status-im/nim-json-rpc/issues/239