### PR TITLE
inlcude precompile name for precompile errors in debug logs

### DIFF
--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -865,4 +865,6 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
         c.setError(StatusCode.PrecompileFailure, $res.error.code, true)
       else:
         # swallow any other precompiles errors
-        debug "execPrecompiles validation error", errCode = $res.error.code
+        debug "execPrecompiles validation error", 
+          errCode = $res.error.code, 
+          precompile = precompile


### PR DESCRIPTION
Hoodi blocks are filled with precompile errors
Without this log, can't locate which is failing and why