### PR TITLE
unhide deprecation warnings

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -165,9 +165,6 @@ switch("hintAsError", "DuplicateModuleImport:on")
 # `switch("warning[CaseTransition]", "off")` fails with "Error: invalid command line option: '--warning[CaseTransition]'"
 switch("warning", "CaseTransition:off")
 
-# Transitional for Nim v2.2, due to newSeqUninit replacing newSeqUninitialized.
-switch("warning", "Deprecated:off")
-
 # nim-kzg shipping their own blst, nimbus-eth1 too.
 # disable nim-kzg's blst
 switch("define", "kzgExternalBlst")

--- a/execution_chain/core/block_import.nim
+++ b/execution_chain/core/block_import.nim
@@ -7,7 +7,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   chronicles,
@@ -54,14 +54,14 @@ proc importRlpBlocks*(blocksRlp:seq[byte],
 
     if not printBanner:
       info "Start importing block",
-        hash=blk.header.blockHash.short,
+        hash=blk.header.computeBlockHash.short,
         number=blk.header.number
       printBanner = true
 
     let res = await chain.importBlock(blk, finalized = false)
     if res.isErr:
       error "Error occured when importing block",
-        hash=blk.header.blockHash.short,
+        hash=blk.header.computeBlockHash.short,
         number=blk.header.number,
         msg=res.error
       if finalize:

--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -8,7 +8,7 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   stew/assign2,
@@ -79,11 +79,11 @@ proc getVmState(
 
   ok(p.vmState)
 
-proc dispose*(p: var Persister) =
+func dispose*(p: var Persister) =
   p.vmState.ledger.txFrame.dispose()
   p.vmState = nil
 
-proc init*(T: type Persister, com: CommonRef, flags: PersistBlockFlags): T =
+func init*(T: type Persister, com: CommonRef, flags: PersistBlockFlags): T =
   T(com: com, flags: flags)
 
 proc checkpoint*(p: var Persister): Result[void, string] =
@@ -95,7 +95,7 @@ proc checkpoint*(p: var Persister): Result[void, string] =
       # TODO replace logging with better error
       debug "wrong state root in block",
         blockNumber = p.parent.number,
-        blockHash = p.parent.blockHash,
+        blockHash = p.parent.computeBlockHash,
         parentHash = p.parent.parentHash,
         expected = p.parent.stateRoot,
         actual = stateRoot

--- a/execution_chain/core/eip4844.nim
+++ b/execution_chain/core/eip4844.nim
@@ -8,6 +8,8 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   stew/arrayops,
   nimcrypto/sha2,
@@ -23,8 +25,6 @@ from std/sequtils import mapIt
 
 export
   kzg
-
-{.push raises: [].}
 
 type
   Bytes64 = array[64, byte]
@@ -204,7 +204,7 @@ proc validateBlobTransactionWrapper4844*(tx: PooledTransaction):
 
   # Verify that commitments match the blobs by checking the KZG proof
   let res = kzg.verifyBlobKzgProofBatch(
-              tx.blobsBundle.blobs.mapIt(kzg.KzgBlob(bytes: it.bytes)),
+              tx.blobsBundle.blobs.mapIt(kzg.KzgBlob(bytes: it.data)),
               commitments,
               tx.blobsBundle.proofs.mapIt(kzg.KzgProof(bytes: it.data)))
 

--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -220,7 +220,7 @@ proc procBlkEpilogue(
       # TODO replace logging with better error
       debug "wrong state root in block",
         blockNumber = header.number,
-        blockHash = header.blockHash,
+        blockHash = header.computeBlockHash,
         parentHash = header.parentHash,
         expected = header.stateRoot,
         actual = stateRoot,
@@ -242,7 +242,7 @@ proc procBlkEpilogue(
         debug "wrong receiptRoot in block",
           blockNumber = header.number,
           parentHash = header.parentHash.short,
-          blockHash = header.blockHash.short,
+          blockHash = header.computeBlockHash.short,
           actual = receiptsRoot,
           expected = header.receiptsRoot
         return err("receiptRoot mismatch")
@@ -263,7 +263,7 @@ proc procBlkEpilogue(
         debug "wrong requestsHash in block",
           blockNumber = header.number,
           parentHash = header.parentHash.short,
-          blockHash = header.blockHash.short,
+          blockHash = header.computeBlockHash.short,
           actual = requestsHash,
           expected = header.requestsHash.get
         return err("requestsHash mismatch")

--- a/execution_chain/core/pooled_txs_rlp.nim
+++ b/execution_chain/core/pooled_txs_rlp.nim
@@ -7,7 +7,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   eth/common/transactions_rlp {.all.},
@@ -42,7 +42,7 @@ proc append*(w: var RlpWriter, tx: PooledTransaction) =
     w.append(tx.blobsBundle)
 
 proc read(rlp: var Rlp, T: type Blob): T {.raises: [RlpError].} =
-  rlp.read(result.bytes)
+  rlp.read(result.data)
 
 proc readTxTyped(rlp: var Rlp, tx: var PooledTransaction) {.raises: [RlpError].} =
   let

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -8,6 +8,8 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
+{.push raises: [].}
+
 import
   std/math,
   eth/common/keys,
@@ -253,7 +255,7 @@ suite "TxPool test suite":
       blobID: 0.BlobID
     )
     var ptx = mx.makeTx(tc, 0)
-    var z = ptx.blobsBundle.blobs[0].bytes
+    var z = ptx.blobsBundle.blobs[0].data
     z[0] = not z[0]
     ptx.blobsBundle.blobs[0] = pooled_txs.KzgBlob z
     xp.checkAddTx(ptx, txErrorInvalidBlob)


### PR DESCRIPTION
This PR leaves two deprecation warnings in place:
```
nimbus-eth1/execution_chain/networking/discoveryv5.nim(21, 1) Warning: Please use closeWait() instead; close is deprecated [Deprecated]
nimbus-eth1/execution_chain/networking/eth1_enr.nim(17, 1) Warning: Use the Result[Record] version instead; fromURI is deprecated [Deprecated]
```

The first proposes to `asyncSpawn closeWait()`, which, in general sometimes `asyncSpawn` might prove necessary or useful, but in general it can also lose track of `Future`s and become the root cause of hard-to-trace crashes, so it seems useful to keep this as a compilation warning, pending more specific action.

The second is effectively a false positive due to
https://github.com/status-im/nimbus-eth1/blob/1ec00066d7f8d7025d362590c463f2d21e6e9eef/execution_chain/networking/eth1_enr.nim#L17-L18
which matches all of the `fromURI` definitions, including the deprecated ones, even though `nimbus-eth1` doesn't actually use the deprecated ones. I'm not sure I'd defend calling that a Nim bug; it seems to be a correct warning.

To resolve that:
- https://github.com/status-im/nim-eth/pull/817