### PR TITLE
Skip the state root checks when de-serializing the forked chain state on startup

### DIFF
--- a/execution_chain/core/chain/forked_chain/chain_serialize.nim
+++ b/execution_chain/core/chain/forked_chain/chain_serialize.nim
@@ -131,7 +131,10 @@ proc replayBlock(fc: ForkedChainRef;
   # the stateroot computation.
   fc.updateSnapshot(blk.blk, txFrame)
 
-  var receipts = fc.processBlock(parent, txFrame, blk.blk, blk.hash, false).valueOr:
+  # Set finalized to true in order to skip the stateroot check when replaying the
+  # block because the blocks should have already been checked previously during
+  # the initial block execution.
+  var receipts = fc.processBlock(parent, txFrame, blk.blk, blk.hash, finalized = true).valueOr:
     txFrame.dispose()
     return err(error)
 


### PR DESCRIPTION
On startup we deserialize the forked chain state which is loaded from the database. Considering that the state came from the database and the blocks should have already been executed previously in order to get into the forked chain state, we should be able to skip the state root checks here as a performance optimization.