### PR TITLE
Remove call to dispose when block validation fails

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -486,9 +486,7 @@ proc validateBlock(c: ForkedChainRef,
   # the stateroot computation.
   c.updateSnapshot(blk, txFrame)
 
-  var receipts = c.processBlock(parent, txFrame, blk, blkHash, finalized).valueOr:
-    txFrame.dispose()
-    return err(error)
+  var receipts = ?c.processBlock(parent, txFrame, blk, blkHash, finalized)
 
   c.writeBaggage(blk, blkHash, txFrame, receipts)
 

--- a/execution_chain/core/chain/forked_chain/chain_serialize.nim
+++ b/execution_chain/core/chain/forked_chain/chain_serialize.nim
@@ -134,9 +134,7 @@ proc replayBlock(fc: ForkedChainRef;
   # Set finalized to true in order to skip the stateroot check when replaying the
   # block because the blocks should have already been checked previously during
   # the initial block execution.
-  var receipts = fc.processBlock(parent, txFrame, blk.blk, blk.hash, finalized = true).valueOr:
-    txFrame.dispose()
-    return err(error)
+  var receipts = ?fc.processBlock(parent, txFrame, blk.blk, blk.hash, finalized = true)
 
   fc.writeBaggage(blk.blk, blk.hash, txFrame, receipts)
 


### PR DESCRIPTION
The call to dispose is causing a segfault during block import because it appears that the same block may get imported/processed multiple times if the validation fails the first time. On the second validation there is a crash when creating the snapshot because the txFrame has already been disposed.

