### PR TITLE
Set isFinalized flag inside ForkedChain importBlock call

### DIFF
--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -233,7 +233,7 @@ proc newPayload*(ben: BeaconEngineRef,
   trace "Importing block without sethead",
     hash = blockHash, number = header.number
 
-  let vres = await chain.queueImportBlock(blk, finalized = false)
+  let vres = await chain.queueImportBlock(blk)
   if vres.isErr:
     warn "Error importing block",
       number = header.number,

--- a/execution_chain/core/block_import.nim
+++ b/execution_chain/core/block_import.nim
@@ -58,7 +58,7 @@ proc importRlpBlocks*(blocksRlp:seq[byte],
         number=blk.header.number
       printBanner = true
 
-    let res = await chain.importBlock(blk, finalized = false)
+    let res = await chain.importBlock(blk)
     if res.isErr:
       error "Error occured when importing block",
         hash=blk.header.computeBlockHash.short,

--- a/execution_chain/sync/beacon/worker/blocks/blocks_import.nim
+++ b/execution_chain/sync/beacon/worker/blocks/blocks_import.nim
@@ -37,12 +37,7 @@ proc importBlock*(
       B=ctx.chain.baseNumber.bnStr, L=ctx.chain.latestNumber.bnStr
   else:
     try:
-      # At this point the header chain has already been verifed and so we know
-      # the block is finalized as long as the block number is less than or equal
-      # to the latest finalized block. Setting the finalized flag to true here
-      # has the effect of skipping the stateroot check for performance reasons.
-      let isFinalized = blk.header.number <= ctx.chain.latestFinalizedBlockNumber
-      (await ctx.chain.queueImportBlock(blk, isFinalized)).isOkOr:
+      (await ctx.chain.queueImportBlock(blk)).isOkOr:
         return err((ENoException, "", error, Moment.now() - start))
     except CancelledError as e:
       return err((ECancelledError,$e.name,e.msg,Moment.now()-start))

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -795,7 +795,7 @@ suite "ForkedChain mainnet replay":
     for i in 1..<fc.baseDistance * 2:
       era0.getEthBlock(i.BlockNumber, blk).expect("block in test database")
       check:
-        (waitFor fc.importBlock(blk, finalized = true)) == Result[void, string].ok()
+        (waitFor fc.importBlock(blk)) == Result[void, string].ok()
 
     check:
       (waitFor fc.forkChoice(blk.blockHash, blk.blockHash)) == Result[void, string].ok()
@@ -834,8 +834,8 @@ suite "ForkedChain mainnet replay":
     era0.getEthBlock(2.BlockNumber, blk2).expect("block in test database")
     era0.getEthBlock(3.BlockNumber, blk3).expect("block in test database")
 
-    check (waitFor fc.importBlock(blk1, finalized = false)).isOk()
+    check (waitFor fc.importBlock(blk1)).isOk()
     for i in 1..10:
-      check (waitFor fc.importBlock(invalidBlk, finalized = false)).isErr()
-    check (waitFor fc.importBlock(blk2, finalized = false)).isOk()
-    check (waitFor fc.importBlock(blk3, finalized = false)).isOk()
+      check (waitFor fc.importBlock(invalidBlk)).isErr()
+    check (waitFor fc.importBlock(blk2)).isOk()
+    check (waitFor fc.importBlock(blk3)).isOk()


### PR DESCRIPTION
This is a minor refactor which removes the `finalized` flag from the API of the `ForkedChain` `importBlock` call. The flag is now set internally based on the current value of `latestFinalizedBlockNumber`.