### PR TITLE
Add assertions to txFrame to prevent use after dispose

### DIFF
--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -135,7 +135,9 @@ type
     legs*: ArrayBuf[NibblesBuf.high + 1, Leg] ## Chain of vertices and IDs
     tail*: NibblesBuf              ## Portion of non completed path
 
-const dbLevel* = -1
+const
+  dbLevel* = -1
+  disposedLevel* = int.low
 
 # ------------------------------------------------------------------------------
 # Public helpers

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -16,10 +16,10 @@
 import results, ./[aristo_desc, aristo_layers]
 
 # ------------------------------------------------------------------------------
-# Public functions
+# Private functions
 # ------------------------------------------------------------------------------
 
-template isDisposed*(txFrame: AristoTxRef): bool =
+template isDisposed(txFrame: AristoTxRef): bool =
   txFrame.level == disposedLevel
 
 proc isKeyframe(txFrame: AristoTxRef): bool =
@@ -95,6 +95,10 @@ proc buildSnapshot(txFrame: AristoTxRef, minLevel: int) =
     txFrame.snapshot.copyFrom(frame)
 
   txFrame.snapshot.level = Opt.some(minLevel)
+
+# ------------------------------------------------------------------------------
+# Public functions
+# ------------------------------------------------------------------------------
 
 proc txFrameBegin*(
     db: AristoDbRef,

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -19,6 +19,9 @@ import results, ./[aristo_desc, aristo_layers]
 # Public functions
 # ------------------------------------------------------------------------------
 
+template isDisposed*(txFrame: AristoTxRef): bool =
+  txFrame.level == disposedLevel
+
 proc isKeyframe(txFrame: AristoTxRef): bool =
   txFrame == txFrame.db.txRef
 
@@ -27,6 +30,8 @@ proc buildSnapshot(txFrame: AristoTxRef, minLevel: int) =
   # ancestor changes as well as the changes in txFrame itself
   for frame in txFrame.stack(stopAtSnapshot = true):
     if frame != txFrame:
+      assert not frame.isDisposed()
+
       # Keyframes keep their snapshot insted of it being transferred to the new
       # frame - right now, only the base frame is a keyframe but this support
       # could be extended for example to epoch boundary frames which are likely
@@ -91,8 +96,12 @@ proc buildSnapshot(txFrame: AristoTxRef, minLevel: int) =
 
   txFrame.snapshot.level = Opt.some(minLevel)
 
-proc txFrameBegin*(db: AristoDbRef, parent: AristoTxRef, moveParentHashKeys = false): AristoTxRef =
-  let parent = if parent == nil: db.txRef else: parent
+proc txFrameBegin*(
+    db: AristoDbRef,
+    parentFrame: AristoTxRef,
+    moveParentHashKeys = false): AristoTxRef =
+  let parent = if parentFrame == nil: db.txRef else: parentFrame
+  doAssert not parent.isDisposed()
 
   AristoTxRef(
     db: db,
@@ -101,23 +110,28 @@ proc txFrameBegin*(db: AristoDbRef, parent: AristoTxRef, moveParentHashKeys = fa
     vTop: parent.vTop,
     level: parent.level + 1)
 
-proc dispose*(tx: AristoTxRef) =
-  tx[].reset()
+proc dispose*(txFrame: AristoTxRef) =
+  txFrame[].reset()
+  txFrame.level = disposedLevel
 
-proc checkpoint*(tx: AristoTxRef, blockNumber: uint64, skipSnapshot: bool) =
-  tx.blockNumber = Opt.some(blockNumber)
+proc checkpoint*(txFrame: AristoTxRef, blockNumber: uint64, skipSnapshot: bool) =
+  doAssert not txFrame.isDisposed()
 
+  txFrame.blockNumber = Opt.some(blockNumber)
   if not skipSnapshot:
     # Snapshots are expensive, therefore we only do it at checkpoints (which
     # presumably have gone through enough validation)
-    tx.buildSnapshot(tx.db.txRef.level)
+    txFrame.buildSnapshot(txFrame.db.txRef.level)
 
 proc clearSnapshot*(txFrame: AristoTxRef) =
+  doAssert not txFrame.isDisposed()
+
   if not txFrame.isKeyframe():
     txFrame.snapshot.reset()
 
-proc persist*(
-    db: AristoDbRef, batch: PutHdlRef, txFrame: AristoTxRef) =
+proc persist*(db: AristoDbRef, batch: PutHdlRef, txFrame: AristoTxRef) =
+  doAssert not txFrame.isDisposed()
+
   if txFrame == db.txRef and txFrame.isEmpty():
     # No changes in frame - no `checkpoint` requirement - nothing to do here
     return
@@ -137,6 +151,8 @@ proc persist*(
     var bottom: AristoTxRef
 
     for frame in txFrame.stack(stopAtSnapshot = true):
+      assert not frame.isDisposed()
+
       if bottom == nil:
         # db.txRef always is a snapshot, therefore we're guaranteed to end up
         # here


### PR DESCRIPTION
This PR implements a safeguard against use after dispose bugs when using the database txFrame API.

It adds a new const `disposedLevel = int.low` and sets the level of the txFrame to this value during the call to dispose. When used the txFrame assertions check that the frame has not yet been disposed.

