### PR TITLE
Fix OverflowDefect crash in block validation

### DIFF
--- a/execution_chain/core/block_import.nim
+++ b/execution_chain/core/block_import.nim
@@ -83,7 +83,7 @@ proc importRlpBlocks*(importFile: string,
 proc importRlpBlocks*(conf: NimbusConf, com: CommonRef): Future[void] {.async: (raises: [CancelledError]).} =
   # Both baseDistance and persistBatchSize are 0,
   # we want changes persisted immediately
-  let chain = ForkedChainRef.init(com, baseDistance = 0, persistBatchSize = 0)
+  let chain = ForkedChainRef.init(com, baseDistance = 0, persistBatchSize = 1)
 
   # success or not, we quit after importing blocks
   for i, blocksFile in conf.blocksFile:

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -407,12 +407,12 @@ proc queueUpdateBase(c: ForkedChainRef, base: BlockRef)
                      else:
                        c.base
 
-  if prevQueuedBase.number == base.number:
+  if prevQueuedBase.number >= base.number:
     return
 
   var
-    number = base.number - min(base.number, PersistBatchSize)
-    steps  = newSeqOfCap[BlockRef]((base.number-prevQueuedBase.number) div PersistBatchSize + 1)
+    number = base.number - min(base.number, c.persistBatchSize)
+    steps  = newSeqOfCap[BlockRef]((base.number - prevQueuedBase.number) div c.persistBatchSize + 1)
     it = base
 
   steps.add base
@@ -420,7 +420,7 @@ proc queueUpdateBase(c: ForkedChainRef, base: BlockRef)
   while it.number > prevQueuedBase.number:
     if it.number == number:
       steps.add it
-      number -= min(number, PersistBatchSize)
+      number -= min(number, c.persistBatchSize)
     it = it.parent
 
   for i in countdown(steps.len-1, 0):
@@ -601,6 +601,8 @@ proc init*(
   ## This constructor also works well when resuming import after running
   ## `persistentBlocks()` used for `Era1` or `Era` import.
   ##
+  doAssert(persistBatchSize > 0)
+
   let
     baseTxFrame = com.db.baseTxFrame()
     base = baseTxFrame.getSavedStateBlockNumber
@@ -617,19 +619,19 @@ proc init*(
     fcuSafe = baseTxFrame.fcuSafe().valueOr:
       FcuHashAndNumber(hash: baseHash, number: base)
     fc = T(
-      com:             com,
-      base:            baseBlock,
-      latest:          baseBlock,
-      heads:           @[baseBlock],
-      hashToBlock:     {baseHash: baseBlock}.toTable,
-      baseTxFrame:     baseTxFrame,
-      baseDistance:    baseDistance,
-      persistBatchSize:persistBatchSize,
-      quarantine:      Quarantine.init(),
-      fcuHead:         fcuHead,
-      fcuSafe:         fcuSafe,
-      baseQueue:       initDeque[BlockRef](),
-      lastBaseLogTime: EthTime.now(),
+      com:              com,
+      base:             baseBlock,
+      latest:           baseBlock,
+      heads:            @[baseBlock],
+      hashToBlock:      {baseHash: baseBlock}.toTable,
+      baseTxFrame:      baseTxFrame,
+      baseDistance:     baseDistance,
+      persistBatchSize: persistBatchSize,
+      quarantine:       Quarantine.init(),
+      fcuHead:          fcuHead,
+      fcuSafe:          fcuSafe,
+      baseQueue:        initDeque[BlockRef](),
+      lastBaseLogTime:  EthTime.now(),
     )
 
   # updateFinalized will stop ancestor lineage
@@ -719,10 +721,8 @@ proc forkChoice*(c: ForkedChainRef,
   c.updateHead(head)
   c.updateFinalized(finalized, head)
 
-  let
-    base = c.calculateNewBase(finalized.number, head)
-
-  if base.number == c.base.number:
+  let base = c.calculateNewBase(finalized.number, head)
+  if base.number <= c.base.number:
     # The base is not updated, return.
     return ok()
 

--- a/tests/eest/eest_helpers.nim
+++ b/tests/eest/eest_helpers.nim
@@ -241,7 +241,7 @@ proc prepareEnv*(
       com = CommonRef.new(memDB, nil, config,
         statelessProviderEnabled = statelessEnabled,
         statelessWitnessValidation = statelessEnabled)
-      chain = ForkedChainRef.init(com, enableQueue = true, persistBatchSize = 0)
+      chain = ForkedChainRef.init(com, enableQueue = true, persistBatchSize = 1)
 
     testEnv.chain = chain
     testEnv.client = Opt.none(RpcHttpClient)

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -248,7 +248,7 @@ suite "ForkedChainRef tests":
   test "newBase on activeBranch":
     const info = "newBase on activeBranch"
     let com = env.newCom()
-    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 0)
+    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 1)
     checkImportBlock(chain, blk1)
     checkImportBlock(chain, blk2)
     checkImportBlock(chain, blk3)
@@ -281,7 +281,7 @@ suite "ForkedChainRef tests":
   test "newBase between oldBase and head":
     const info = "newBase between oldBase and head"
     let com = env.newCom()
-    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 0)
+    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 1)
     checkImportBlock(chain, blk1)
     checkImportBlock(chain, blk2)
     checkImportBlock(chain, blk3)
@@ -330,7 +330,7 @@ suite "ForkedChainRef tests":
   test "newBase move forward, fork and stay on that fork":
     const info = "newBase move forward, fork .."
     let com = env.newCom()
-    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 0)
+    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 1)
     checkImportBlock(chain, blk1)
     checkImportBlock(chain, blk2)
     checkImportBlock(chain, blk3)
@@ -355,7 +355,7 @@ suite "ForkedChainRef tests":
   test "newBase on shorter canonical arc, remove oldBase branches":
     const info = "newBase on shorter canonical, remove oldBase branches"
     let com = env.newCom()
-    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 0)
+    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 1)
     checkImportBlock(chain, blk1)
     checkImportBlock(chain, blk2)
     checkImportBlock(chain, blk3)
@@ -379,7 +379,7 @@ suite "ForkedChainRef tests":
   test "newBase on curbed non-canonical arc":
     const info = "newBase on curbed non-canonical .."
     let com = env.newCom()
-    var chain = ForkedChainRef.init(com, baseDistance = 5, persistBatchSize = 0)
+    var chain = ForkedChainRef.init(com, baseDistance = 5, persistBatchSize = 1)
     checkImportBlock(chain, blk1)
     checkImportBlock(chain, blk2)
     checkImportBlock(chain, blk3)
@@ -454,7 +454,7 @@ suite "ForkedChainRef tests":
        " (ign dup block)":
     const info = "newBase on shorter canonical .."
     let com = env.newCom()
-    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 0)
+    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 1)
     checkImportBlock(chain, blk1)
     checkImportBlock(chain, blk2)
     checkImportBlock(chain, blk3)
@@ -479,7 +479,7 @@ suite "ForkedChainRef tests":
   test "newBase on longer canonical arc, discard new branch":
     const info = "newBase on longer canonical .."
     let com = env.newCom()
-    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 0)
+    var chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 1)
     checkImportBlock(chain, blk1)
     checkImportBlock(chain, blk2)
     checkImportBlock(chain, blk3)
@@ -566,14 +566,14 @@ suite "ForkedChainRef tests":
   test "importing blocks with new CommonRef and FC instance, 3 blocks":
     const info = "importing blocks with new CommonRef and FC instance, 3 blocks"
     let com = env.newCom()
-    let chain = ForkedChainRef.init(com, baseDistance = 0, persistBatchSize = 0)
+    let chain = ForkedChainRef.init(com, baseDistance = 0, persistBatchSize = 1)
     checkImportBlock(chain, blk1)
     checkImportBlock(chain, blk2)
     checkImportBlock(chain, blk3)
     checkForkChoice(chain, blk3, blk3)
     check chain.validate info & " (1)"
     let cc = env.newCom(com.db)
-    let fc = ForkedChainRef.init(cc, baseDistance = 0, persistBatchSize = 0)
+    let fc = ForkedChainRef.init(cc, baseDistance = 0, persistBatchSize = 1)
     checkHeadHash fc, blk3.blockHash
     checkImportBlock(fc, blk4)
     checkForkChoice(fc, blk4, blk4)
@@ -582,12 +582,12 @@ suite "ForkedChainRef tests":
   test "importing blocks with new CommonRef and FC instance, 1 block":
     const info = "importing blocks with new CommonRef and FC instance, 1 block"
     let com = env.newCom()
-    let chain = ForkedChainRef.init(com, baseDistance = 0, persistBatchSize = 0)
+    let chain = ForkedChainRef.init(com, baseDistance = 0, persistBatchSize = 1)
     checkImportBlock(chain, blk1)
     checkForkChoice(chain, blk1, blk1)
     check chain.validate info & " (1)"
     let cc = env.newCom(com.db)
-    let fc = ForkedChainRef.init(cc, baseDistance = 0, persistBatchSize = 0)
+    let fc = ForkedChainRef.init(cc, baseDistance = 0, persistBatchSize = 1)
     checkHeadHash fc, blk1.blockHash
     checkImportBlock(fc, blk2)
     checkForkChoice(fc, blk2, blk2)


### PR DESCRIPTION
This fixes an underflow defect crash which was triggered when `c.baseDistance + c.persistBatchSize` is less than `latestFinalizedBlockNumber`. 

I also found that the `queueUpdateBase` function had the const `PersistBatchSize` value hard coded so updates were still applied every 4 blocks even when setting a custom `persistBatchSize`.

Resolves https://github.com/status-im/nimbus-eth1/issues/3507