### PR TITLE
Add parameter to skip loading forked chain state on startup

### DIFF
--- a/execution_chain/config.nim
+++ b/execution_chain/config.nim
@@ -358,6 +358,11 @@ type
       desc: "Eagerly check state roots when syncing finalized blocks"
       name: "debug-eager-state-root".}: bool
 
+    deserializeFcState* {.
+      hidden
+      defaultValue: true
+      name: "debug-deserialize-fc-state" .}: bool
+
     statelessProviderEnabled* {.
       separator: "\pSTATELESS PROVIDER OPTIONS:"
       hidden

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -66,8 +66,11 @@ proc basicServices(nimbus: NimbusNode, conf: NimbusConf, com: CommonRef) =
     eagerStateRoot = conf.eagerStateRootCheck,
     persistBatchSize = conf.persistBatchSize,
     enableQueue = true)
-  fc.deserialize().isOkOr:
-    warn "Loading block DAG from database", msg=error
+  if conf.deserializeFcState:
+    fc.deserialize().isOkOr:
+      warn "Loading block DAG from database", msg=error
+  else:
+    warn "Skipped loading of block DAG from database", deserializeFcState = conf.deserializeFcState
 
   nimbus.fc = fc
   # Setup history expiry and portal


### PR DESCRIPTION
This is useful when debugging or when the forked chain state is corrupted due to a bug.