### PR TITLE
Portal: rework db paths and general architecture

### DIFF
--- a/portal/client/nimbus_portal_client.nim
+++ b/portal/client/nimbus_portal_client.nim
@@ -165,13 +165,14 @@ proc run(portalClient: PortalClient, config: PortalConf) {.raises: [CatchableErr
   d.open()
 
   ## Force pruning - optional
+  ## Forced on history network database only currently
   if config.forcePrune:
     let db = ContentDB.new(
-      dataDir / config.network.getDbDirectory() / "contentdb_" &
-        d.localNode.id.toBytesBE().toOpenArray(0, 8).toHex(),
+      dataDir / dbDir,
       storageCapacity = config.storageCapacityMB * 1_000_000,
       radiusConfig = config.radiusConfig,
       localId = d.localNode.id,
+      subnetwork = PortalSubnetwork.history,
       manualCheckpoint = true,
     )
 

--- a/portal/network/beacon/beacon_network.nim
+++ b/portal/network/beacon/beacon_network.nim
@@ -481,6 +481,7 @@ proc statusLogLoop(n: BeaconNetwork) {.async: (raises: []).} =
       await sleepAsync(60.seconds)
 
       info "Beacon network status",
+        dbSize = $(n.beaconDb.size() div 1_000_000) & "mb",
         routingTableNodes = n.portalProtocol.routingTable.len()
   except CancelledError:
     trace "statusLogLoop canceled"

--- a/portal/network/history/history_network.nim
+++ b/portal/network/history/history_network.nim
@@ -237,6 +237,7 @@ proc statusLogLoop(n: HistoryNetwork) {.async: (raises: []).} =
       await sleepAsync(60.seconds)
 
       info "History network status",
+        dbSize = $(n.contentDB.size() div 1_000_000) & "mb",
         routingTableNodes = n.portalProtocol.routingTable.len()
   except CancelledError:
     trace "statusLogLoop canceled"
@@ -262,6 +263,8 @@ proc stop*(n: HistoryNetwork) {.async: (raises: []).} =
   if not n.statusLogLoop.isNil:
     futures.add(n.statusLogLoop.cancelAndWait())
   await noCancel(allFutures(futures))
+
+  n.contentDB.close()
 
   n.processContentLoops.setLen(0)
   n.statusLogLoop = nil

--- a/portal/network/portal_node.nim
+++ b/portal/network/portal_node.nim
@@ -12,7 +12,6 @@ import
   chronos,
   eth/p2p/discoveryv5/protocol,
   beacon_chain/spec/forks,
-  stew/byteutils,
   ../eth_history/history_data_ssz_e2s,
   ../database/content_db,
   ./wire/[portal_stream, portal_protocol_config],
@@ -35,7 +34,6 @@ type
 
   PortalNode* = ref object
     discovery: protocol.Protocol
-    contentDB: ContentDB
     streamManager: StreamManager
     historyNetwork*: Opt[HistoryNetwork]
     beaconNetwork*: Opt[BeaconNetwork]
@@ -58,13 +56,7 @@ proc onOptimisticHeader(
     when lcDataFork > LightClientDataFork.None:
       info "New LC optimistic header", optimistic_header = shortLog(forkyHeader)
 
-proc getDbDirectory*(network: PortalNetwork): string =
-  if network == PortalNetwork.mainnet:
-    "db"
-  else:
-    "db_" & network.symbolName()
-
-const dbDir = "portaldb"
+const dbDir* = "portaldb"
 
 proc new*(
     T: type PortalNode,
@@ -77,17 +69,6 @@ proc new*(
     rng = newRng(),
 ): T =
   let
-    # Store the database at contentdb prefixed with the first 8 chars of node id.
-    # This is done because the content in the db is dependant on the `NodeId` and
-    # the selected `Radius`.
-    contentDB = ContentDB.new(
-      config.dataDir / dbDir / "contentdb_" &
-        discovery.localNode.id.toBytesBE().toOpenArray(0, 8).toHex(),
-      storageCapacity = config.storageCapacity,
-      radiusConfig = config.portalConfig.radiusConfig,
-      localId = discovery.localNode.id,
-    )
-
     networkData =
       case network
       of PortalNetwork.mainnet:
@@ -99,6 +80,16 @@ proc new*(
 
     historyNetwork =
       if PortalSubnetwork.history in subnetworks:
+        # Store the database at contentdb prefixed with the first 8 chars of node id.
+        # This is done because the content in the db is dependant on the `NodeId` and
+        # the selected `Radius`.
+        let contentDB = ContentDB.new(
+          config.dataDir / dbDir,
+          storageCapacity = config.storageCapacity,
+          radiusConfig = config.portalConfig.radiusConfig,
+          localId = discovery.localNode.id,
+          subnetwork = PortalSubnetwork.history,
+        )
         Opt.some(
           HistoryNetwork.new(
             network,
@@ -119,7 +110,7 @@ proc new*(
     beaconNetwork =
       if PortalSubnetwork.beacon in subnetworks:
         let
-          beaconDb = BeaconDb.new(networkData, config.dataDir / dbDir / "beacondb")
+          beaconDb = BeaconDb.new(networkData, config.dataDir / dbDir)
           beaconNetwork = BeaconNetwork.new(
             network,
             discovery,
@@ -158,7 +149,6 @@ proc new*(
 
   PortalNode(
     discovery: discovery,
-    contentDB: contentDB,
     streamManager: streamManager,
     historyNetwork: historyNetwork,
     beaconNetwork: beaconNetwork,
@@ -172,16 +162,16 @@ proc statusLogLoop(n: PortalNode) {.async: (raises: []).} =
       # drop a lot when using the logbase2 scale, namely `/ 2` per 1 logaritmic
       # radius drop.
       # TODO: Get some float precision calculus?
-      let
-        radius = n.contentDB.dataRadius
-        radiusPercentage = radius div (UInt256.high() div u256(100))
-        logRadius = logDistance(radius, u256(0))
+      if n.historyNetwork.isSome():
+        let
+          radius = n.historyNetwork.value.contentDB.dataRadius
+          radiusPercentage = radius div (UInt256.high() div u256(100))
+          logRadius = logDistance(radius, u256(0))
 
-      info "Portal node status",
-        dbSize = $(n.contentDB.size() div 1_000_000) & "mb",
-        radiusPercentage = radiusPercentage.toString(10) & "%",
-        radius = radius.toHex(),
-        logRadius
+        info "Portal node status",
+          radiusPercentage = radiusPercentage.toString(10) & "%",
+          radius = radius.toHex(),
+          logRadius
 
       await sleepAsync(60.seconds)
   except CancelledError:
@@ -206,17 +196,16 @@ proc stop*(n: PortalNode) {.async: (raises: []).} =
 
   var futures: seq[Future[void]]
 
+  if not n.statusLogLoop.isNil():
+    futures.add(n.statusLogLoop.cancelAndWait())
   if n.historyNetwork.isSome():
     futures.add(n.historyNetwork.value.stop())
   if n.beaconNetwork.isSome():
     futures.add(n.beaconNetwork.value.stop())
   if n.beaconLightClient.isSome():
     futures.add(n.beaconLightClient.value.stop())
-  if not n.statusLogLoop.isNil():
-    futures.add(n.statusLogLoop.cancelAndWait())
 
   await noCancel(allFutures(futures))
 
   await n.discovery.closeWait()
-  n.contentDB.close()
   n.statusLogLoop = nil

--- a/portal/tests/history_network_tests/history_test_helpers.nim
+++ b/portal/tests/history_network_tests/history_test_helpers.nim
@@ -36,6 +36,7 @@ proc newHistoryNetwork*(
       uint32.high,
       RadiusConfig(kind: Static, logRadius: 256),
       node.localNode.id,
+      PortalSubnetwork.history,
       inMemory = true,
     )
     streamManager = StreamManager.new(node)

--- a/portal/tests/rpc_tests/test_portal_rpc_client.nim
+++ b/portal/tests/rpc_tests/test_portal_rpc_client.nim
@@ -31,7 +31,12 @@ proc newHistoryNode(rng: ref HmacDrbgContext, port: int): HistoryNode =
   let
     node = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(port))
     db = ContentDB.new(
-      "", uint32.high, RadiusConfig(kind: Dynamic), node.localNode.id, inMemory = true
+      "",
+      uint32.high,
+      RadiusConfig(kind: Dynamic),
+      node.localNode.id,
+      PortalSubnetwork.history,
+      inMemory = true,
     )
     streamManager = StreamManager.new(node)
     historyNetwork = HistoryNetwork.new(PortalNetwork.mainnet, node, db, streamManager)

--- a/portal/tests/test_content_db.nim
+++ b/portal/tests/test_content_db.nim
@@ -10,18 +10,22 @@
 import
   unittest2,
   stint,
+  ../network/wire/portal_protocol_config,
   ../network/beacon/beacon_content,
   ../database/content_db,
   ./test_helpers
 
 suite "Content Database":
   const testId = u256(0)
-  # Note: We are currently not really testing something new here just basic
-  # underlying kvstore.
   test "ContentDB basic API":
     let
       db = ContentDB.new(
-        "", uint32.high, RadiusConfig(kind: Dynamic), testId, inMemory = true
+        "",
+        uint32.high,
+        RadiusConfig(kind: Dynamic),
+        testId,
+        PortalSubnetwork.history,
+        inMemory = true,
       )
       key = ContentId(UInt256.high()) # Some key
 
@@ -62,7 +66,12 @@ suite "Content Database":
 
   test "ContentDB size":
     let db = ContentDB.new(
-      "", uint32.high, RadiusConfig(kind: Dynamic), testId, inMemory = true
+      "",
+      uint32.high,
+      RadiusConfig(kind: Dynamic),
+      testId,
+      PortalSubnetwork.history,
+      inMemory = true,
     )
 
     let numBytes = 10000
@@ -107,7 +116,12 @@ suite "Content Database":
     let
       storageCapacity = 1_000_000'u64 # 1MB
       db = ContentDB.new(
-        "", storageCapacity, RadiusConfig(kind: Dynamic), testId, inMemory = true
+        "",
+        storageCapacity,
+        RadiusConfig(kind: Dynamic),
+        testId,
+        PortalSubnetwork.history,
+        inMemory = true,
       )
       numBytes = 1_000
       bytes = genByteSeq(numBytes)
@@ -129,7 +143,12 @@ suite "Content Database":
 
     let
       db = ContentDB.new(
-        "", startCapacity, RadiusConfig(kind: Dynamic), testId, inMemory = true
+        "",
+        startCapacity,
+        RadiusConfig(kind: Dynamic),
+        testId,
+        PortalSubnetwork.history,
+        inMemory = true,
       )
       localId = UInt256.fromHex(
         "30994892f3e4889d99deb5340050510d1842778acc7a7948adffa475fed51d6e"
@@ -162,7 +181,12 @@ suite "Content Database":
     let
       storageCapacity = 100_000'u64
       db = ContentDB.new(
-        "", storageCapacity, RadiusConfig(kind: Dynamic), testId, inMemory = true
+        "",
+        storageCapacity,
+        RadiusConfig(kind: Dynamic),
+        testId,
+        PortalSubnetwork.history,
+        inMemory = true,
       )
       radiusHandler = createRadiusHandler(db)
 
@@ -170,7 +194,14 @@ suite "Content Database":
 
   test "ContentDB radius - 0 capacity":
     let
-      db = ContentDB.new("", 0, RadiusConfig(kind: Dynamic), testId, inMemory = true)
+      db = ContentDB.new(
+        "",
+        0,
+        RadiusConfig(kind: Dynamic),
+        testId,
+        PortalSubnetwork.history,
+        inMemory = true,
+      )
       radiusHandler = createRadiusHandler(db)
 
     check radiusHandler() == UInt256.low()

--- a/portal/tests/wire_protocol_tests/test_portal_wire_protocol.nim
+++ b/portal/tests/wire_protocol_tests/test_portal_wire_protocol.nim
@@ -44,7 +44,12 @@ proc initPortalProtocol(
   let
     d = initDiscoveryNode(rng, privKey, address, bootstrapRecords)
     db = ContentDB.new(
-      "", uint32.high, RadiusConfig(kind: Dynamic), d.localNode.id, inMemory = true
+      "",
+      uint32.high,
+      RadiusConfig(kind: Dynamic),
+      d.localNode.id,
+      PortalSubnetwork.history,
+      inMemory = true,
     )
     manager = StreamManager.new(d)
     q = newAsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])](50)
@@ -503,7 +508,12 @@ procSuite "Portal Wire Protocol Tests":
 
       dbLimit = 400_000'u32
       db = ContentDB.new(
-        "", dbLimit, RadiusConfig(kind: Dynamic), node1.localNode.id, inMemory = true
+        "",
+        dbLimit,
+        RadiusConfig(kind: Dynamic),
+        node1.localNode.id,
+        PortalSubnetwork.history,
+        inMemory = true,
       )
       m = StreamManager.new(node1)
       q = newAsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])](50)

--- a/portal/tools/fcli_db.nim
+++ b/portal/tools/fcli_db.nim
@@ -6,7 +6,13 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  chronicles, confutils, stint, eth/common/keys, ../database/content_db, ./benchmark
+  chronicles,
+  confutils,
+  stint,
+  eth/common/keys,
+  ../database/content_db,
+  ../network/wire/portal_protocol_config,
+  ./benchmark
 
 when defined(posix):
   import system/ansi_c
@@ -75,6 +81,7 @@ proc cmdGenerate(conf: DbConf) =
       maxDbSize,
       RadiusConfig(kind: Dynamic),
       u256(0),
+      subnetwork = PortalSubnetwork.history,
       inMemory = false,
     )
     bytes = newSeq[byte](conf.contentSize)
@@ -93,6 +100,7 @@ proc cmdBench(conf: DbConf) =
       4_000_000_000'u64,
       RadiusConfig(kind: Dynamic),
       u256(0),
+      subnetwork = PortalSubnetwork.history,
       inMemory = false,
     )
     bytes = newSeq[byte](conf.contentSize)
@@ -149,6 +157,7 @@ proc cmdPrune(conf: DbConf) =
       storageCapacity = 1_000_000, # Doesn't matter if only space reclaiming is done
       RadiusConfig(kind: Dynamic),
       u256(0),
+      subnetwork = PortalSubnetwork.history,
       manualCheckpoint = true,
     )
 

--- a/portal/tools/portalcli.nim
+++ b/portal/tools/portalcli.nim
@@ -248,7 +248,12 @@ proc run(config: PortalCliConf) =
 
   let
     db = ContentDB.new(
-      "", config.storageSize, defaultRadiusConfig, d.localNode.id, inMemory = true
+      "",
+      config.storageSize,
+      defaultRadiusConfig,
+      d.localNode.id,
+      PortalSubnetwork.history,
+      inMemory = true,
     )
     sm = StreamManager.new(d)
     cq = newAsyncQueue[(Opt[NodeId], ContentKeysList, seq[seq[byte]])](50)


### PR DESCRIPTION
- Rework db names and paths: 
├── portaldb
│   ├── beacondb
│   │   └── beacondb.sqlite3
│   └── contentdb-history
│        └── contentdb_history.sqlite3
- Make contentdb subnetwork specific
- Add db.size for BeaconDB
- Remove contentid prefix from ContentDB path. With the newer,
better pruning system it becomes feasible to change contentid and
let the contentdb prune as new data comes in
- Fix force pruning db path (this was broken since dbPath changes)