### PR TITLE
portal: remove dead Nothing type and unreachable request branch

### DIFF
--- a/portal/network/beacon/beacon_light_client_manager.nim
+++ b/portal/network/beacon/beacon_light_client_manager.nim
@@ -26,7 +26,6 @@ logScope:
   topics = "beacon_lc_man"
 
 type
-  Nothing = object
   ResponseError = object of CatchableError
 
   NetRes*[T] = Result[T, void]
@@ -173,11 +172,7 @@ proc workerTask[E](
 ): Future[bool] {.async: (raises: [CancelledError]).} =
   var didProgress = false
   try:
-    let value =
-      when E.K is Nothing:
-        await E.doRequest(self.network)
-      else:
-        await E.doRequest(self.network, key)
+    let value = await E.doRequest(self.network, key)
     if value.isOk:
       for val in value.get().values:
         let res = await self.valueVerifier(E)(val)


### PR DESCRIPTION
Remove the unused Nothing type and the unreachable when E.K is Nothing branch from workerTask in beacon_light_client_manager.nim. All endpoints in the current design require a key, so the generic no-key path was never exercised. This simplifies control flow without changing behavior.