### PR TITLE
Portal: Allow for double amount of concurrent offers

### DIFF
--- a/portal/bridge/history/portal_history_bridge.nim
+++ b/portal/bridge/history/portal_history_bridge.nim
@@ -247,7 +247,7 @@ proc runHistory*(config: PortalBridgeConf) =
             if peers == genericDecline + rateLimited + transferInProgress:
               # No peers accepted or already stored the content.
               # Decline reasons are likely temporary, so retry.
-              warn "All peers declined, rate limited, or transfer in progress; retrying...",
+              debug "All peers declined, rate limited, or transfer in progress; retrying...",
                 contentKey = contentKeyHex
               # Sleep 5 seconds to back off a bit before retrying
               await sleepAsync(5.seconds)

--- a/portal/network/wire/portal_protocol_config.nim
+++ b/portal/network/wire/portal_protocol_config.nim
@@ -63,7 +63,7 @@ const
   defaultDisableContentCache* = false
   defaultOfferCacheSize* = 1024
   defaultDisableOfferCache* = false
-  defaultMaxConcurrentOffers* = 50
+  defaultMaxConcurrentOffers* = 100
   defaultAlpha* = 3
   revalidationTimeout* = chronos.seconds(30)
   defaultDisableBanNodes* = true


### PR DESCRIPTION
Current setting of 50x is a little conservative and 100x will allow for the fleet to propagate data gossiped from a bridge at a higher rate

Also update a portal bridge log statement that should be debug.