### PR TITLE
`NimbusConf` -> `ExecutionClientConf`

### DIFF
--- a/execution_chain/core/block_import.nim
+++ b/execution_chain/core/block_import.nim
@@ -15,7 +15,7 @@ import
   stew/io2,
   chronos,
   ./chain,
-  ../config,
+  ../conf,
   ../utils/utils,
   beacon_chain/process_state
 
@@ -80,14 +80,14 @@ proc importRlpBlocks*(importFile: string,
     return err($error)
   await importRlpBlocks(bytes, chain, finalize)
 
-proc importRlpBlocks*(conf: NimbusConf, com: CommonRef): Future[void] {.async: (raises: [CancelledError]).} =
+proc importRlpBlocks*(config: ExecutionClientConf, com: CommonRef): Future[void] {.async: (raises: [CancelledError]).} =
   # Both baseDistance and persistBatchSize are 0,
   # we want changes persisted immediately
   let chain = ForkedChainRef.init(com, baseDistance = 0, persistBatchSize = 1)
 
   # success or not, we quit after importing blocks
-  for i, blocksFile in conf.blocksFile:
-    (await importRlpBlocks(string blocksFile, chain, i == conf.blocksFile.len-1)).isOkOr:
+  for i, blocksFile in config.blocksFile:
+    (await importRlpBlocks(string blocksFile, chain, i == config.blocksFile.len-1)).isOkOr:
       warn "Error when importing blocks", msg=error
       # Finalize the existing chain in case of rlp read error
       (await chain.forkChoice(chain.latestHash, chain.latestHash)).isOkOr:

--- a/execution_chain/nimbus_desc.nim
+++ b/execution_chain/nimbus_desc.nim
@@ -21,8 +21,7 @@ import
   ./sync/beacon as beacon_sync,
   ./sync/wire_protocol,
   ./beacon/beacon_engine,
-  ./common,
-  ./config
+  ./common
 
 when enabledLogLevel == TRACE:
   import std/sequtils
@@ -37,8 +36,7 @@ export
   peers,
   beacon_sync,
   beacon_engine,
-  common,
-  config
+  common
 
 type
   NimbusNode* = ref object

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -13,17 +13,12 @@ import
   ../execution_chain/compile_info
 
 import
-  std/[net, options],
   chronicles,
   eth/net/nat,
   metrics,
   stew/byteutils,
   kzg4844/kzg,
-  ./rpc,
-  ./version_info,
-  ./constants,
-  ./nimbus_desc,
-  ./nimbus_import,
+  ./[conf, constants, nimbus_desc, nimbus_import, rpc, version_info],
   ./core/block_import,
   ./core/chain/forked_chain/chain_serialize,
   ./db/core_db/persistent,
@@ -60,24 +55,24 @@ template onException(
 # Private functions
 # ------------------------------------------------------------------------------
 
-proc basicServices(nimbus: NimbusNode, conf: NimbusConf, com: CommonRef) =
+proc basicServices(nimbus: NimbusNode, config: ExecutionClientConf, com: CommonRef) =
   # Setup the chain
   let fc = ForkedChainRef.init(com,
-    eagerStateRoot = conf.eagerStateRootCheck,
-    persistBatchSize = conf.persistBatchSize,
-    dynamicBatchSize = conf.dynamicBatchSize,
+    eagerStateRoot = config.eagerStateRootCheck,
+    persistBatchSize = config.persistBatchSize,
+    dynamicBatchSize = config.dynamicBatchSize,
     enableQueue = true)
-  if conf.deserializeFcState:
+  if config.deserializeFcState:
     fc.deserialize().isOkOr:
       warn "Loading block DAG from database", msg=error
   else:
-    warn "Skipped loading of block DAG from database", deserializeFcState = conf.deserializeFcState
+    warn "Skipped loading of block DAG from database", deserializeFcState = config.deserializeFcState
 
   nimbus.fc = fc
   # Setup history expiry and portal
 
   QuitFailure.onException("Cannot initialise RPC client history"):
-    nimbus.fc.portal = HistoryExpiryRef.init(conf, com)
+    nimbus.fc.portal = HistoryExpiryRef.init(config, com)
 
   # txPool must be informed of active head
   # so it can know the latest account state
@@ -85,28 +80,28 @@ proc basicServices(nimbus: NimbusNode, conf: NimbusConf, com: CommonRef) =
   nimbus.txPool = TxPoolRef.new(nimbus.fc)
   nimbus.beaconEngine = BeaconEngineRef.new(nimbus.txPool)
 
-proc manageAccounts(nimbus: NimbusNode, conf: NimbusConf) =
-  if conf.keyStoreDir.len > 0:
-    nimbus.accountsManager[].loadKeystores(conf.keyStoreDir).isOkOr:
+proc manageAccounts(nimbus: NimbusNode, config: ExecutionClientConf) =
+  if config.keyStoreDir.len > 0:
+    nimbus.accountsManager[].loadKeystores(config.keyStoreDir).isOkOr:
       fatal "Load keystore error", msg = error
       quit(QuitFailure)
 
-  if string(conf.importKey).len > 0:
-    nimbus.accountsManager[].importPrivateKey(string conf.importKey).isOkOr:
+  if string(config.importKey).len > 0:
+    nimbus.accountsManager[].importPrivateKey(string config.importKey).isOkOr:
       fatal "Import private key error", msg = error
       quit(QuitFailure)
 
-proc setupP2P(nimbus: NimbusNode, conf: NimbusConf, com: CommonRef) =
+proc setupP2P(nimbus: NimbusNode, config: ExecutionClientConf, com: CommonRef) =
   ## Creating P2P Server
   let
-    keypair = nimbus.rng[].getNetKeys(conf.netKey).valueOr:
+    keypair = nimbus.rng[].getNetKeys(config.netKey).valueOr:
       fatal "Get network keys error", msg = error
       quit(QuitFailure)
     natId = NimbusName & " " & NimbusVersion
     (extIp, extTcpPort, extUdpPort) =
-      setupAddress(conf.nat, conf.listenAddress, conf.tcpPort, conf.udpPort, natId)
+      setupAddress(config.nat, config.listenAddress, config.tcpPort, config.udpPort, natId)
 
-    bootstrapNodes = conf.getBootstrapNodes()
+    bootstrapNodes = config.getBootstrapNodes()
     fc = nimbus.fc
 
   func forkIdProc(): ForkID =
@@ -122,11 +117,11 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf, com: CommonRef) =
   )
 
   nimbus.ethNode = newEthereumNode(
-    keypair, extIp, extTcpPort, extUdpPort, conf.networkId, conf.agentString,
-    minPeers = conf.maxPeers,
+    keypair, extIp, extTcpPort, extUdpPort, config.networkId, config.agentString,
+    minPeers = config.maxPeers,
     bootstrapNodes = bootstrapNodes,
-    bindUdpPort = conf.udpPort, bindTcpPort = conf.tcpPort,
-    bindIp = conf.listenAddress,
+    bindUdpPort = config.udpPort, bindTcpPort = config.tcpPort,
+    bindIp = config.listenAddress,
     rng = nimbus.rng,
     forkIdProcs = forkIdProcs)
 
@@ -134,27 +129,27 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf, com: CommonRef) =
   nimbus.wire = nimbus.ethNode.addEthHandlerCapability(nimbus.txPool)
 
   # Connect directly to the static nodes
-  let staticPeers = conf.getStaticPeers()
+  let staticPeers = config.getStaticPeers()
   if staticPeers.len > 0:
     nimbus.peerManager = PeerManagerRef.new(
       nimbus.ethNode.peerPool,
-      conf.reconnectInterval,
-      conf.reconnectMaxRetry,
+      config.reconnectInterval,
+      config.reconnectMaxRetry,
       staticPeers
     )
     nimbus.peerManager.start()
 
   # Start Eth node
-  if conf.maxPeers > 0:
-    let discovery = conf.getDiscoveryFlags()
+  if config.maxPeers > 0:
+    let discovery = config.getDiscoveryFlags()
     nimbus.ethNode.connectToNetwork(
       enableDiscV4 = DiscoveryType.V4 in discovery,
       enableDiscV5 = DiscoveryType.V5 in discovery,
     )
 
   # Initalise beacon sync descriptor.
-  var syncerShouldRun = (conf.maxPeers > 0 or staticPeers.len > 0) and
-                        conf.engineApiServerEnabled()
+  var syncerShouldRun = (config.maxPeers > 0 or staticPeers.len > 0) and
+                        config.engineApiServerEnabled()
 
   # The beacon sync descriptor might have been pre-allocated with additional
   # features. So do not override.
@@ -164,13 +159,13 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf, com: CommonRef) =
     syncerShouldRun = true
 
   # Configure beacon syncer.
-  nimbus.beaconSyncRef.config(nimbus.ethNode, nimbus.fc, conf.maxPeers)
+  nimbus.beaconSyncRef.config(nimbus.ethNode, nimbus.fc, config.maxPeers)
 
   # Optional for pre-setting the sync target (e.g. for debugging)
-  if conf.beaconSyncTarget.isSome():
+  if config.beaconSyncTarget.isSome():
     syncerShouldRun = true
-    let hex = conf.beaconSyncTarget.unsafeGet
-    if not nimbus.beaconSyncRef.configTarget(hex, conf.beaconSyncTargetIsFinal):
+    let hex = config.beaconSyncTarget.unsafeGet
+    if not nimbus.beaconSyncRef.configTarget(hex, config.beaconSyncTargetIsFinal):
       fatal "Error parsing hash32 argument for --debug-beacon-sync-target",
         hash32=hex
       quit QuitFailure
@@ -180,14 +175,14 @@ proc setupP2P(nimbus: NimbusNode, conf: NimbusConf, com: CommonRef) =
   if not syncerShouldRun:
     nimbus.beaconSyncRef = BeaconSyncRef(nil)
 
-proc init*(nimbus: NimbusNode, conf: NimbusConf, com: CommonRef) =
+proc init*(nimbus: NimbusNode, config: ExecutionClientConf, com: CommonRef) =
   nimbus.accountsManager = new AccountsManager
   nimbus.rng = newRng()
 
-  basicServices(nimbus, conf, com)
-  manageAccounts(nimbus, conf)
-  setupP2P(nimbus, conf, com)
-  setupRpc(nimbus, conf, com)
+  basicServices(nimbus, config, com)
+  manageAccounts(nimbus, config)
+  setupP2P(nimbus, config, com)
+  setupRpc(nimbus, config, com)
 
   # Not starting syncer if there is definitely no way to run it. This
   # avoids polling (i.e. waiting for instructions) and some logging.
@@ -195,12 +190,12 @@ proc init*(nimbus: NimbusNode, conf: NimbusConf, com: CommonRef) =
       not nimbus.beaconSyncRef.start():
     nimbus.beaconSyncRef = BeaconSyncRef(nil)
 
-proc init*(T: type NimbusNode, conf: NimbusConf, com: CommonRef): T =
+proc init*(T: type NimbusNode, config: ExecutionClientConf, com: CommonRef): T =
   let nimbus = T()
-  nimbus.init(conf, com)
+  nimbus.init(config, com)
   nimbus
 
-proc preventLoadingDataDirForTheWrongNetwork(db: CoreDbRef; conf: NimbusConf) =
+proc preventLoadingDataDirForTheWrongNetwork(db: CoreDbRef; config: ExecutionClientConf) =
   proc writeDataDirId(kvt: CoreDbTxRef, calculatedId: Hash32) =
     info "Writing data dir ID", ID=calculatedId
     kvt.put(dataDirIdKey().toOpenArray, calculatedId.data).isOkOr:
@@ -210,13 +205,13 @@ proc preventLoadingDataDirForTheWrongNetwork(db: CoreDbRef; conf: NimbusConf) =
 
   let
     kvt = db.baseTxFrame()
-    calculatedId = calcHash(conf.networkId, conf.networkParams)
+    calculatedId = calcHash(config.networkId, config.networkParams)
     dataDirIdBytes = kvt.get(dataDirIdKey().toOpenArray).valueOr:
       # an empty database
       writeDataDirId(kvt, calculatedId)
       return
 
-  if conf.rewriteDatadirId:
+  if config.rewriteDatadirId:
     writeDataDirId(kvt, calculatedId)
     return
 
@@ -226,50 +221,50 @@ proc preventLoadingDataDirForTheWrongNetwork(db: CoreDbRef; conf: NimbusConf) =
       expected=calculatedId
     quit(QuitFailure)
 
-proc setupCommonRef*(conf: NimbusConf, taskpool: Taskpool): CommonRef =
+proc setupCommonRef*(config: ExecutionClientConf, taskpool: Taskpool): CommonRef =
   # Trusted setup is needed for processing Cancun+ blocks
   # If user not specify the trusted setup, baked in
   # trusted setup will be loaded, lazily.
-  if conf.trustedSetupFile.isSome:
-    let fileName = conf.trustedSetupFile.get()
+  if config.trustedSetupFile.isSome:
+    let fileName = config.trustedSetupFile.get()
     let res = kzg.loadTrustedSetup(fileName, 0)
     if res.isErr:
       fatal "Cannot load Kzg trusted setup from file", msg=res.error
       quit(QuitFailure)
 
   let coreDB = AristoDbRocks.newCoreDbRef(
-      conf.dataDir,
-      conf.dbOptions(noKeyCache = conf.cmd == NimbusCmd.`import`))
+      config.dataDir,
+      config.dbOptions(noKeyCache = config.cmd == NimbusCmd.`import`))
 
-  preventLoadingDataDirForTheWrongNetwork(coreDB, conf)
+  preventLoadingDataDirForTheWrongNetwork(coreDB, config)
 
   let com = CommonRef.new(
     db = coreDB,
     taskpool = taskpool,
-    networkId = conf.networkId,
-    params = conf.networkParams,
-    statelessProviderEnabled = conf.statelessProviderEnabled,
-    statelessWitnessValidation = conf.statelessWitnessValidation)
+    networkId = config.networkId,
+    params = config.networkParams,
+    statelessProviderEnabled = config.statelessProviderEnabled,
+    statelessWitnessValidation = config.statelessWitnessValidation)
 
-  if conf.extraData.len > 32:
+  if config.extraData.len > 32:
     warn "ExtraData exceeds 32 bytes limit, truncate",
-      extraData=conf.extraData,
-      len=conf.extraData.len
+      extraData=config.extraData,
+      len=config.extraData.len
 
-  if conf.gasLimit > GAS_LIMIT_MAXIMUM or
-     conf.gasLimit < GAS_LIMIT_MINIMUM:
+  if config.gasLimit > GAS_LIMIT_MAXIMUM or
+     config.gasLimit < GAS_LIMIT_MINIMUM:
     warn "GasLimit not in expected range, truncate",
       min=GAS_LIMIT_MINIMUM,
       max=GAS_LIMIT_MAXIMUM,
-      get=conf.gasLimit
+      get=config.gasLimit
 
-  com.extraData = conf.extraData
-  com.gasLimit = conf.gasLimit
+  com.extraData = config.extraData
+  com.gasLimit = config.gasLimit
 
   com
 
-template displayLaunchingInfo(conf: NimbusConf) =
-  info "Launching execution client", version = FullVersionStr, conf
+template displayLaunchingInfo(config: ExecutionClientConf) =
+  info "Launching execution client", version = FullVersionStr, config
 
 # ------------------------------------------------------------------------------
 # Public functions, `main()` API
@@ -277,18 +272,24 @@ template displayLaunchingInfo(conf: NimbusConf) =
 
 type StopFuture = Future[void].Raising([CancelledError])
 
-proc runExeClient*(conf: NimbusConf, com: CommonRef, stopper: StopFuture, displayLaunchingInfo: static[bool] = false, nimbus = NimbusNode(nil)) =
+proc runExeClient*(
+    config: ExecutionClientConf,
+    com: CommonRef,
+    stopper: StopFuture,
+    displayLaunchingInfo: static[bool] = false,
+    nimbus = NimbusNode(nil),
+) =
   ## Launches and runs the execution client for pre-configured `nimbus` and
   ## `conf` argument descriptors.
   ##
   when displayLaunchingInfo:
-    displayLaunchingInfo(conf)
+    displayLaunchingInfo(config)
 
   var nimbus = nimbus
   if nimbus.isNil:
-    nimbus = NimbusNode.init(conf, com)
+    nimbus = NimbusNode.init(config, com)
   else:
-    nimbus.init(conf, com)
+    nimbus.init(config, com)
 
   defer:
     let

--- a/execution_chain/nimbus_import.nim
+++ b/execution_chain/nimbus_import.nim
@@ -17,7 +17,7 @@ import
   stew/io2,
   beacon_chain/[era_db, process_state],
   beacon_chain/networking/network_metadata,
-  ./config,
+  ./conf,
   ./common/common,
   ./core/chain,
   ./db/era1_db,
@@ -96,11 +96,11 @@ template boolFlag(flags, b): PersistBlockFlags =
 proc running(): bool =
   not ProcessState.stopIt(notice("Shutting down", reason = it))
 
-proc importBlocks*(conf: NimbusConf, com: CommonRef) =
+proc importBlocks*(config: ExecutionClientConf, com: CommonRef) =
   let
     start = com.db.baseTxFrame().getSavedStateBlockNumber() + 1
     (cfg, genesis_validators_root, lastEra1Block, firstSlotAfterMerge) =
-      getMetadata(conf.networkId)
+      getMetadata(config.networkId)
     time0 = Moment.now()
 
   # These variables are used from closures on purpose, so as to place them on
@@ -109,16 +109,16 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
     slot = 1'u64
     time1 = Moment.now() # time at start of chunk
     csv =
-      if conf.csvStats.isSome:
-        openCsv(conf.csvStats.get())
+      if config.csvStats.isSome:
+        openCsv(config.csvStats.get())
       else:
         File(nil)
     flags =
-      boolFlag({PersistBlockFlag.NoValidation}, conf.noValidation) +
-      boolFlag({PersistBlockFlag.NoFullValidation}, not conf.fullValidation) +
-      boolFlag(NoPersistBodies, not conf.storeBodies) +
-      boolFlag({PersistBlockFlag.NoPersistReceipts}, not conf.storeReceipts) +
-      boolFlag({PersistBlockFlag.NoPersistSlotHashes}, not conf.storeSlotHashes)
+      boolFlag({PersistBlockFlag.NoValidation}, config.noValidation) +
+      boolFlag({PersistBlockFlag.NoFullValidation}, not config.fullValidation) +
+      boolFlag(NoPersistBodies, not config.storeBodies) +
+      boolFlag({PersistBlockFlag.NoPersistReceipts}, not config.storeReceipts) +
+      boolFlag({PersistBlockFlag.NoPersistSlotHashes}, not config.storeSlotHashes)
     blk: Block
     persister = Persister.init(com, flags)
     cstats: PersistStats # stats at start of chunk
@@ -150,7 +150,7 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
   proc checkpoint(force: bool = false) =
     let (blocks, txs, gas) = persister.stats
 
-    if not force and blocks.uint64 mod conf.chunkSize != 0:
+    if not force and blocks.uint64 mod config.chunkSize != 0:
       return
 
     persister.checkpoint().isOkOr:
@@ -269,19 +269,19 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
   if lastEra1Block > 0 and start <= lastEra1Block:
     let
       era1Name =
-        if conf.networkId == MainNet:
+        if config.networkId == MainNet:
           "mainnet"
-        elif conf.networkId == SepoliaNet:
+        elif config.networkId == SepoliaNet:
           "sepolia"
         else:
           raiseAssert "Other networks are unsupported or do not have an era1"
-      db = Era1DbRef.init(conf.era1Dir, era1Name, lastEra1Block + 1).valueOr:
+      db = Era1DbRef.init(config.era1Dir, era1Name, lastEra1Block + 1).valueOr:
         fatal "Could not open era1 database",
-          era1Dir = conf.era1Dir, era1Name = era1Name, error = error
+          era1Dir = config.era1Dir, era1Name = era1Name, error = error
         quit(QuitFailure)
 
     notice "Importing era1 archive",
-      start, dataDir = conf.dataDir, era1Dir = conf.era1Dir
+      start, dataDir = config.dataDir, era1Dir = config.era1Dir
 
     defer:
       db.dispose()
@@ -292,7 +292,7 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
         return false
       true
 
-    while running() and persister.stats.blocks.uint64 < conf.maxBlocks and
+    while running() and persister.stats.blocks.uint64 < config.maxBlocks and
         blockNumber <= lastEra1Block:
       if not loadEraBlock(blockNumber):
         notice "No more `era1` blocks to import", blockNumber, slot
@@ -302,26 +302,26 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
 
   block era1Import:
     if blockNumber > lastEra1Block:
-      if not isDir(conf.eraDir):
+      if not isDir(config.eraDir):
         if blockNumber == 0:
           fatal "`era` directory not found, cannot start import",
-            blockNumber, eraDir = conf.eraDir
+            blockNumber, eraDir = config.eraDir
           quit(QuitFailure)
         else:
           notice "`era` directory not found, stopping import at merge boundary",
-            blockNumber, eraDir = conf.eraDir
+            blockNumber, eraDir = config.eraDir
           break era1Import
 
       notice "Importing era archive",
-        blockNumber, dataDir = conf.dataDir, eraDir = conf.eraDir
+        blockNumber, dataDir = config.dataDir, eraDir = config.eraDir
 
       let
-        eraDB = EraDB.new(cfg, conf.eraDir, genesis_validators_root)
+        eraDB = EraDB.new(cfg, config.eraDir, genesis_validators_root)
         (historical_roots, historical_summaries, endSlot) = loadHistoricalRootsFromEra(
-          conf.eraDir, cfg
+          config.eraDir, cfg
         ).valueOr:
           fatal "Could not load historical summaries",
-            eraDir = conf.eraDir, error
+            eraDir = config.eraDir, error
           quit(QuitFailure)
 
       # Load the last slot number
@@ -350,7 +350,7 @@ proc importBlocks*(conf: NimbusConf, com: CommonRef) =
         true
 
       while running() and moreEraAvailable and
-          persister.stats.blocks.uint64 < conf.maxBlocks and slot < endSlot:
+          persister.stats.blocks.uint64 < config.maxBlocks and slot < endSlot:
         if not loadEra1Block():
           slot += 1
           continue

--- a/execution_chain/portal/portal.nim
+++ b/execution_chain/portal/portal.nim
@@ -13,8 +13,7 @@ import
   chronos,
   chronicles,
   results,
-  ../config,
-  ../common,
+  ../[common, conf],
   eth/common/[base, eth_types, keys],
   ../../portal/rpc/portal_rpc_client
 
@@ -38,28 +37,28 @@ proc init*(T: type PortalRpc, url: string): T =
     provider: PortalRpcClient.init(web3.provider)
   )
 
-func isPortalRpcEnabled(conf: NimbusConf): bool =
-  conf.portalUrl.len > 0
+func isPortalRpcEnabled(config: ExecutionClientConf): bool =
+  config.portalUrl.len > 0
 
-proc getPortalRpc(conf: NimbusConf): Opt[PortalRpc] =
-  if isPortalRpcEnabled(conf):
-    Opt.some(PortalRpc.init(conf.portalUrl))
+proc getPortalRpc(config: ExecutionClientConf): Opt[PortalRpc] =
+  if isPortalRpcEnabled(config):
+    Opt.some(PortalRpc.init(config.portalUrl))
   else:
     Opt.none(PortalRpc)
 
-proc init*(T: type HistoryExpiryRef, conf: NimbusConf, com: CommonRef): T =
-  if not conf.historyExpiry:
+proc init*(T: type HistoryExpiryRef, config: ExecutionClientConf, com: CommonRef): T =
+  if not config.historyExpiry:
     # history expiry haven't been activated yet
     return nil
 
   info "Initiating Portal with the following config",
-    portalUrl = conf.portalUrl,
-    historyExpiry = conf.historyExpiry,
+    portalUrl = config.portalUrl,
+    historyExpiry = config.historyExpiry,
     networkId = com.networkId,
-    portalLimit = conf.historyExpiryLimit
+    portalLimit = config.historyExpiryLimit
 
   let
-    rpc = conf.getPortalRpc()
+    rpc = config.getPortalRpc()
     portalEnabled =
       if com.networkId == MainNet and rpc.isSome:
         # Portal is only available for mainnet
@@ -68,8 +67,8 @@ proc init*(T: type HistoryExpiryRef, conf: NimbusConf, com: CommonRef): T =
         warn "Portal is only available for mainnet, skipping fetching data from Portal"
         false
     limit =
-      if conf.historyExpiryLimit.isSome:
-        conf.historyExpiryLimit.get()
+      if config.historyExpiryLimit.isSome:
+        config.historyExpiryLimit.get()
       else:
         com.posBlock().get()
 
@@ -90,6 +89,7 @@ proc getBlockBodyByHeader*(historyExpiry: HistoryExpiryRef, header: Header): Res
   let rpc = historyExpiry.rpcProvider.valueOr:
     return err("Portal RPC is not available")
 
+  # TODO nested waitFor
   (waitFor rpc.historyGetBlockBody(header)).mapErr(
     proc(e: PortalErrorResponse): string =
       debug "Portal request failed", error = $e.message

--- a/execution_chain/rpc.nim
+++ b/execution_chain/rpc.nim
@@ -7,18 +7,14 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   chronicles,
   websock/websock,
   json_rpc/rpcserver,
-  ./rpc/common,
-  ./rpc/debug,
-  ./rpc/engine_api,
-  ./rpc/jwt_auth,
-  ./rpc/cors,
-  ./rpc/rpc_server,
-  ./rpc/server_api,
-  ./nimbus_desc
+  ./rpc/[common, cors, debug, engine_api, jwt_auth, rpc_server, server_api],
+  ./[conf, nimbus_desc]
 
 export
   common,
@@ -29,32 +25,30 @@ export
   rpc_server,
   server_api
 
-{.push gcsafe, raises: [].}
-
 const DefaultChunkSize = 1024*1024
 
-func serverEnabled(conf: NimbusConf): bool =
-  conf.httpServerEnabled or
-    conf.engineApiServerEnabled
+func serverEnabled(config: ExecutionClientConf): bool =
+  config.httpServerEnabled or
+    config.engineApiServerEnabled
 
-func combinedServer(conf: NimbusConf): bool =
-  conf.httpServerEnabled and
-    conf.shareServerWithEngineApi
+func combinedServer(config: ExecutionClientConf): bool =
+  config.httpServerEnabled and
+    config.shareServerWithEngineApi
 
 func installRPC(server: RpcServer,
                 nimbus: NimbusNode,
-                conf: NimbusConf,
+                config: ExecutionClientConf,
                 com: CommonRef,
                 serverApi: ServerAPIRef,
                 flags: set[RpcFlag]) =
 
-  setupCommonRpc(nimbus.ethNode, conf, server)
+  setupCommonRpc(nimbus.ethNode, config, server)
 
   if RpcFlag.Eth in flags:
     setupServerAPI(serverApi, server, nimbus.accountsManager)
 
   if RpcFlag.Admin in flags:
-    setupAdminRpc(nimbus, conf, server)
+    setupAdminRpc(nimbus, config, server)
 
   if RpcFlag.Debug in flags:
     setupDebugRpc(com, nimbus.txPool, server)
@@ -118,7 +112,7 @@ func addHandler(handlers: var seq[RpcHandlerProc],
   handlers.add handlerProc
 
 proc addHttpServices(handlers: var seq[RpcHandlerProc],
-                     nimbus: NimbusNode, conf: NimbusConf,
+                     nimbus: NimbusNode, config: ExecutionClientConf,
                      com: CommonRef, serverApi: ServerAPIRef,
                      address: TransportAddress) =
 
@@ -127,94 +121,94 @@ proc addHttpServices(handlers: var seq[RpcHandlerProc],
   # ws depends on Sec-WebSocket-Version header
   # json-rpc have no reliable identification
 
-  if conf.wsEnabled:
+  if config.wsEnabled:
     let server = newRpcWebsocketHandler()
-    let rpcFlags = conf.getWsFlags() + {RpcFlag.Eth}
-    installRPC(server, nimbus, conf, com, serverApi, rpcFlags)
+    let rpcFlags = config.getWsFlags() + {RpcFlag.Eth}
+    installRPC(server, nimbus, config, com, serverApi, rpcFlags)
     handlers.addHandler(server)
     info "JSON-RPC WebSocket API enabled", url = "ws://" & $address
 
-  if conf.rpcEnabled:
+  if config.rpcEnabled:
     let server = newRpcHttpHandler()
-    let rpcFlags = conf.getRpcFlags() + {RpcFlag.Eth}
-    installRPC(server, nimbus, conf, com, serverApi, rpcFlags)
+    let rpcFlags = config.getRpcFlags() + {RpcFlag.Eth}
+    installRPC(server, nimbus, config, com, serverApi, rpcFlags)
     handlers.addHandler(server)
     info "JSON-RPC API enabled", url = "http://" & $address
 
 proc addEngineApiServices(handlers: var seq[RpcHandlerProc],
-                          nimbus: NimbusNode, conf: NimbusConf,
+                          nimbus: NimbusNode, config: ExecutionClientConf,
                           com: CommonRef, serverApi: ServerAPIRef,
                           address: TransportAddress) =
 
   # The order is important: ws, rpc
 
-  if conf.engineApiWsEnabled:
+  if config.engineApiWsEnabled:
     let server = newRpcWebsocketHandler()
     setupEngineAPI(nimbus.beaconEngine, server)
-    installRPC(server, nimbus, conf, com, serverApi, {RpcFlag.Eth})
+    installRPC(server, nimbus, config, com, serverApi, {RpcFlag.Eth})
     handlers.addHandler(server)
     info "Engine WebSocket API enabled", url = "ws://" & $address
 
-  if conf.engineApiEnabled:
+  if config.engineApiEnabled:
     let server = newRpcHttpHandler()
     setupEngineAPI(nimbus.beaconEngine, server)
-    installRPC(server, nimbus, conf, com, serverApi, {RpcFlag.Eth})
+    installRPC(server, nimbus, config, com, serverApi, {RpcFlag.Eth})
     handlers.addHandler(server)
     info "Engine API enabled", url = "http://" & $address
 
 proc addServices(handlers: var seq[RpcHandlerProc],
-                 nimbus: NimbusNode, conf: NimbusConf,
+                 nimbus: NimbusNode, config: ExecutionClientConf,
                  com: CommonRef, serverApi: ServerAPIRef,
                  address: TransportAddress) =
 
   # The order is important: ws, rpc
 
-  if conf.wsEnabled or conf.engineApiWsEnabled:
+  if config.wsEnabled or config.engineApiWsEnabled:
     let server = newRpcWebsocketHandler()
-    if conf.engineApiWsEnabled:
+    if config.engineApiWsEnabled:
       setupEngineAPI(nimbus.beaconEngine, server)
 
-      if not conf.wsEnabled:
-        installRPC(server, nimbus, conf, com, serverApi, {RpcFlag.Eth})
+      if not config.wsEnabled:
+        installRPC(server, nimbus, config, com, serverApi, {RpcFlag.Eth})
 
       info "Engine WebSocket API enabled", url = "ws://" & $address
 
-    if conf.wsEnabled:
-      let rpcFlags = conf.getWsFlags() + {RpcFlag.Eth}
-      installRPC(server, nimbus, conf, com, serverApi, rpcFlags)
+    if config.wsEnabled:
+      let rpcFlags = config.getWsFlags() + {RpcFlag.Eth}
+      installRPC(server, nimbus, config, com, serverApi, rpcFlags)
       info "JSON-RPC WebSocket API enabled", url = "ws://" & $address
 
     handlers.addHandler(server)
 
-  if conf.rpcEnabled or conf.engineApiEnabled:
+  if config.rpcEnabled or config.engineApiEnabled:
     let server = newRpcHttpHandler()
-    if conf.engineApiEnabled:
+    if config.engineApiEnabled:
       setupEngineAPI(nimbus.beaconEngine, server)
-      if not conf.rpcEnabled:
-        installRPC(server, nimbus, conf, com, serverApi, {RpcFlag.Eth})
+      if not config.rpcEnabled:
+        installRPC(server, nimbus, config, com, serverApi, {RpcFlag.Eth})
 
       info "Engine API enabled", url = "http://" & $address
 
-    if conf.rpcEnabled:
-      let rpcFlags = conf.getRpcFlags() + {RpcFlag.Eth}
-      installRPC(server, nimbus, conf, com, serverApi, rpcFlags)
+    if config.rpcEnabled:
+      let rpcFlags = config.getRpcFlags() + {RpcFlag.Eth}
+      installRPC(server, nimbus, config, com, serverApi, rpcFlags)
 
       info "JSON-RPC API enabled", url = "http://" & $address
 
     handlers.addHandler(server)
 
-proc setupRpc*(nimbus: NimbusNode, conf: NimbusConf,
+proc setupRpc*(nimbus: NimbusNode, config: ExecutionClientConf,
                com: CommonRef) =
-  if not conf.engineApiEnabled:
+  if not config.engineApiEnabled:
     warn "Engine API disabled, the node will not respond to consensus client updates (enable with `--engine-api`)"
 
-  if not conf.serverEnabled:
+  if not config.serverEnabled:
     return
 
   # Provide JWT authentication handler for rpcHttpServer
   let jwtKey = block:
     # Create or load shared secret
-    let rc = nimbus.rng.jwtSharedSecret(conf)
+    let rc = nimbus.rng.jwtSharedSecret(config)
     if rc.isErr:
       fatal "Failed create or load shared secret",
         msg = $(rc.unsafeError) # avoid side effects
@@ -222,16 +216,16 @@ proc setupRpc*(nimbus: NimbusNode, conf: NimbusConf,
     rc.value
 
   let
-    allowedOrigins = conf.getAllowedOrigins()
+    allowedOrigins = config.getAllowedOrigins()
     jwtAuthHook = httpJwtAuth(jwtKey)
     corsHook = httpCors(allowedOrigins)
     serverApi = newServerAPI(nimbus.txPool)
 
-  if conf.combinedServer:
+  if config.combinedServer:
     let hooks: seq[RpcAuthHook] = @[jwtAuthHook, corsHook]
     var handlers: seq[RpcHandlerProc]
-    let address = initTAddress(conf.httpAddress, conf.httpPort)
-    handlers.addServices(nimbus, conf, com, serverApi, address)
+    let address = initTAddress(config.httpAddress, config.httpPort)
+    handlers.addServices(nimbus, config, com, serverApi, address)
     let res = newHttpServerWithParams(address, hooks, handlers)
     if res.isErr:
       fatal "Cannot create RPC server", msg=res.error
@@ -240,11 +234,11 @@ proc setupRpc*(nimbus: NimbusNode, conf: NimbusConf,
     nimbus.httpServer.start()
     return
 
-  if conf.httpServerEnabled:
+  if config.httpServerEnabled:
     let hooks = @[corsHook]
     var handlers: seq[RpcHandlerProc]
-    let address = initTAddress(conf.httpAddress, conf.httpPort)
-    handlers.addHttpServices(nimbus, conf, com, serverApi, address)
+    let address = initTAddress(config.httpAddress, config.httpPort)
+    handlers.addHttpServices(nimbus, config, com, serverApi, address)
     let res = newHttpServerWithParams(address, hooks, handlers)
     if res.isErr:
       fatal "Cannot create RPC server", msg=res.error
@@ -252,11 +246,11 @@ proc setupRpc*(nimbus: NimbusNode, conf: NimbusConf,
     nimbus.httpServer = res.get
     nimbus.httpServer.start()
 
-  if conf.engineApiServerEnabled:
+  if config.engineApiServerEnabled:
     let hooks = @[jwtAuthHook, corsHook]
     var handlers: seq[RpcHandlerProc]
-    let address = initTAddress(conf.engineApiAddress, conf.engineApiPort)
-    handlers.addEngineApiServices(nimbus, conf, com, serverApi, address)
+    let address = initTAddress(config.engineApiAddress, config.engineApiPort)
+    handlers.addEngineApiServices(nimbus, config, com, serverApi, address)
     let res = newHttpServerWithParams(address, hooks, handlers)
     if res.isErr:
       fatal "Cannot create RPC server", msg=res.error

--- a/execution_chain/rpc/common.nim
+++ b/execution_chain/rpc/common.nim
@@ -14,7 +14,7 @@ import
   chronos,
   eth/enode/enode,
   ../networking/[p2p, peer_pool, p2p_types],
-  ../config,
+  ../conf,
   ../beacon/web3_eth_conv,
   ../nimbus_desc,
   web3/conversions,
@@ -58,25 +58,25 @@ PeerInfo.useDefaultSerializationIn JrpcConv
 
 JrpcConv.automaticSerialization(int, true)
 
-proc setupCommonRpc*(node: EthereumNode, conf: NimbusConf, server: RpcServer) =
+proc setupCommonRpc*(node: EthereumNode, config: ExecutionClientConf, server: RpcServer) =
   server.rpc("web3_clientVersion") do() -> string:
-    result = conf.agentString
+    result = config.agentString
 
   server.rpc("web3_sha3") do(data: seq[byte]) -> Hash32:
     result = keccak256(data)
 
   server.rpc("net_version") do() -> string:
-    result = $conf.networkId
+    result = $config.networkId
 
   server.rpc("net_listening") do() -> bool:
     let numPeers = node.numPeers
-    result = numPeers < conf.maxPeers
+    result = numPeers < config.maxPeers
 
   server.rpc("net_peerCount") do() -> Quantity:
     let peerCount = uint node.numPeers
     result = w3Qty(peerCount)
 
-proc setupAdminRpc*(nimbus: NimbusNode, conf: NimbusConf, server: RpcServer) =
+proc setupAdminRpc*(nimbus: NimbusNode, config: ExecutionClientConf, server: RpcServer) =
   let node = nimbus.ethNode
 
   server.rpc("admin_nodeInfo") do() -> NodeInfo:
@@ -85,7 +85,7 @@ proc setupAdminRpc*(nimbus: NimbusNode, conf: NimbusConf, server: RpcServer) =
       nodeId = toNodeId(node.keys.pubkey)
       nodeInfo = NodeInfo(
         id: nodeId.toHex,
-        name: conf.agentString,
+        name: config.agentString,
         enode: $enode,
         ip: $enode.address.ip,
         ports: NodePorts(

--- a/execution_chain/rpc/jwt_auth.nim
+++ b/execution_chain/rpc/jwt_auth.nim
@@ -25,7 +25,7 @@ import
   nimcrypto/[hmac, sha2, utils],
   stew/[byteutils, objects],
   results,
-  ../config,
+  ../conf,
   ./jwt_auth_helper,
   ./rpc_server
 
@@ -187,7 +187,7 @@ proc jwtGenSecret*(rng: ref rand.HmacDrbgContext): JwtGenSecret =
 
 proc jwtSharedSecret*(
     rndSecret: JwtGenSecret;
-    config: NimbusConf;
+    config: ExecutionClientConf;
       ): Result[JwtSharedKey, JwtError] =
   ## Return a key for jwt authentication preferable from the argument file
   ## `config.jwtSecret` (which contains at least 32 bytes hex encoded random
@@ -251,7 +251,7 @@ proc jwtSharedSecret*(
   except ValueError:
     return err(jwtKeyInvalidHexString)
 
-proc jwtSharedSecret*(rng: ref rand.HmacDrbgContext; config: NimbusConf):
+proc jwtSharedSecret*(rng: ref rand.HmacDrbgContext; config: ExecutionClientConf):
                     Result[JwtSharedKey, JwtError] =
   ## Variant of `jwtSharedSecret()` with explicit random generator argument.
   try:

--- a/execution_chain/utils/era_helpers.nim
+++ b/execution_chain/utils/era_helpers.nim
@@ -15,7 +15,6 @@ import
   metrics,
   std/[os, strutils],
   stew/io2,
-  ../config,
   utils,
   eth/common/[hashes, headers, blocks, transactions_rlp],
   eth/common/transactions as tx_types,

--- a/tests/networking/p2p_test_helper.nim
+++ b/tests/networking/p2p_test_helper.nim
@@ -12,15 +12,15 @@ import
   chronos,
   stint,
   eth/common/keys,
-  ../../execution_chain/networking/[p2p, discoveryv4],
+  ../../execution_chain/networking/p2p,
   ../../execution_chain/core/chain/forked_chain,
   ../../execution_chain/core/tx_pool,
   ../../execution_chain/sync/wire_protocol,
-  ../../execution_chain/config
+  ../../execution_chain/conf
 
 type
   TestEnv* = ref object
-    conf   : NimbusConf
+    config : ExecutionClientConf
     com    : CommonRef
     node*  : EthereumNode
     txPool : TxPoolRef
@@ -30,15 +30,15 @@ type
 const
   genesisFile = "tests/customgenesis/cancun123.json"
 
-proc makeCom(conf: NimbusConf): CommonRef =
+proc makeCom(config: ExecutionClientConf): CommonRef =
   CommonRef.new(
     newCoreDbRef DefaultDbMemory,
     Taskpool.new(),
-    conf.networkId,
-    conf.networkParams
+    config.networkId,
+    config.networkParams
   )
 
-proc envConfig(): NimbusConf =
+proc envConfig(): ExecutionClientConf =
   makeConfig(@[
     "--network:" & genesisFile,
     "--listen-address: 127.0.0.1",
@@ -69,14 +69,14 @@ proc newTestEnv*(): TestEnv =
   let
     rng    = newRng()
     node   = setupTestNode(rng)
-    conf   = envConfig()
-    com    = makeCom(conf)
+    config = envConfig()
+    com    = makeCom(config)
     chain  = ForkedChainRef.init(com, enableQueue = true)
     txPool = TxPoolRef.new(chain)
     wire   = node.addEthHandlerCapability(txPool)
 
   TestEnv(
-    conf   : conf,
+    config : config,
     com    : com,
     node   : node,
     txPool : txPool,

--- a/tests/test_configuration.nim
+++ b/tests/test_configuration.nim
@@ -15,7 +15,7 @@ import
   eth/net/nat,
   eth/enr/enr,
   stew/byteutils,
-  ../execution_chain/[common, config],
+  ../execution_chain/[common, conf],
   ../execution_chain/networking/netkeys,
   ./test_helpers
 
@@ -32,9 +32,9 @@ proc configurationMain*() =
       bootNode = "enode://a24ac7c5484ef4ed0c5eb2d36620ba4e4aa13b8c84684e1b4aab0cebea2ae45cb4d375b77eab56516d34bfbd3c1a833fc51296ff084b770b94fb9028c4d25ccf@52.169.42.101:30303"
 
     test "data-dir and key-store":
-      let conf = makeTestConfig()
-      check conf.dataDir() == defaultDataDir("", "mainnet")
-      check conf.keyStoreDir == defaultDataDir("", "mainnet") / "keystore"
+      let config = makeTestConfig()
+      check config.dataDir() == defaultDataDir("", "mainnet")
+      check config.keyStoreDir == defaultDataDir("", "mainnet") / "keystore"
 
       let cc = makeConfig(@["-d:apple\\bin", "-k:banana/bin"])
       check cc.dataDir() == "apple\\bin"
@@ -54,47 +54,47 @@ proc configurationMain*() =
 
     test "network loading config file with no genesis data":
       # no genesis will fallback to geth compatibility mode
-      let conf = makeConfig(@["--network:" & noGenesis])
-      check conf.networkParams.genesis.isNil.not
+      let config = makeConfig(@["--network:" & noGenesis])
+      check config.networkParams.genesis.isNil.not
 
     test "network loading config file with no 'config'":
       # no config will result in empty config, CommonRef keep working
-      let conf = makeConfig(@["--network:" & noConfig])
-      check conf.networkParams.config.isNil == false
+      let config = makeConfig(@["--network:" & noConfig])
+      check config.networkParams.config.isNil == false
 
     test "network-id":
       let aa = makeTestConfig()
       check aa.networkId == MainNet
       check aa.networkParams != NetworkParams()
 
-      let conf = makeConfig(@["--network:" & genesisFile, "--network:345"])
-      check conf.networkId == 345.u256
+      let config = makeConfig(@["--network:" & genesisFile, "--network:345"])
+      check config.networkId == 345.u256
 
     test "network-id first, network next":
-      let conf = makeConfig(@["--network:678", "--network:" & genesisFile])
-      check conf.networkId == 678.u256
+      let config = makeConfig(@["--network:678", "--network:" & genesisFile])
+      check config.networkId == 678.u256
 
     test "network-id set, no network":
-      let conf = makeConfig(@["--network:678"])
-      check conf.networkId == 678.u256
-      check conf.networkParams.genesis == Genesis()
-      check conf.networkParams.config == ChainConfig()
+      let config = makeConfig(@["--network:678"])
+      check config.networkId == 678.u256
+      check config.networkParams.genesis == Genesis()
+      check config.networkParams.config == ChainConfig()
 
     test "network-id not set, copy from chainId of custom network":
-      let conf = makeConfig(@["--network:" & genesisFile])
-      check conf.networkId == 123.u256
+      let config = makeConfig(@["--network:" & genesisFile])
+      check config.networkId == 123.u256
 
     test "network-id not set, sepolia set":
-      let conf = makeConfig(@["--network:sepolia"])
-      check conf.networkId == SepoliaNet
+      let config = makeConfig(@["--network:sepolia"])
+      check config.networkId == SepoliaNet
 
     test "network-id set, sepolia set":
-      let conf = makeConfig(@["--network:sepolia", "--network:123"])
-      check conf.networkId == 123.u256
+      let config = makeConfig(@["--network:sepolia", "--network:123"])
+      check config.networkId == 123.u256
 
     test "rpc-api":
-      let conf = makeTestConfig()
-      let flags = conf.getRpcFlags()
+      let config = makeTestConfig()
+      let flags = config.getRpcFlags()
       check { RpcFlag.Eth } == flags
 
       let aa = makeConfig(@["--rpc-api:eth"])
@@ -118,8 +118,8 @@ proc configurationMain*() =
       check { RpcFlag.Eth, RpcFlag.Admin } == ex
 
     test "ws-api":
-      let conf = makeTestConfig()
-      let flags = conf.getWsFlags()
+      let config = makeTestConfig()
+      let flags = config.getWsFlags()
       check { RpcFlag.Eth } == flags
 
       let aa = makeConfig(@["--ws-api:eth"])
@@ -135,8 +135,8 @@ proc configurationMain*() =
       check { RpcFlag.Eth, RpcFlag.Debug } == cx
 
     test "--bootstrap-node and --bootstrap-file":
-      let conf = makeTestConfig()
-      let bootnodes = conf.getBootstrapNodes()
+      let config = makeTestConfig()
+      let bootnodes = config.getBootstrapNodes()
       let bootNodeLen = bootnodes.enodes.len
       check bootNodeLen > 0 # mainnet bootnodes
 
@@ -159,8 +159,8 @@ proc configurationMain*() =
       check dx.enodes.len == bootNodeLen + 3
 
     test "static-peers":
-      let conf = makeTestConfig()
-      check conf.getStaticPeers().enodes.len == 0
+      let config = makeTestConfig()
+      check config.getStaticPeers().enodes.len == 0
 
       let aa = makeConfig(@["--static-peers:" & bootNode])
       check aa.getStaticPeers().enodes.len == 1
@@ -175,118 +175,118 @@ proc configurationMain*() =
       const
         chainid1 = "tests" / "customgenesis" / "chainid1.json"
 
-      let conf = makeConfig(@["--network:" & chainid1])
-      check conf.networkId == 1.u256
-      check conf.networkParams.config.londonBlock.get() == 1337
-      check conf.getBootstrapNodes().enodes.len == 0
+      let config = makeConfig(@["--network:" & chainid1])
+      check config.networkId == 1.u256
+      check config.networkParams.config.londonBlock.get() == 1337
+      check config.getBootstrapNodes().enodes.len == 0
 
     test "json-rpc enabled when json-engine api enabled and share same port":
-      let conf = makeConfig(@["--engine-api", "--engine-api-port:8545", "--http-port:8545"])
+      let config = makeConfig(@["--engine-api", "--engine-api-port:8545", "--http-port:8545"])
       check:
-        conf.engineApiEnabled == true
-        conf.rpcEnabled == false
-        conf.wsEnabled == false
-        conf.engineApiWsEnabled == false
-        conf.engineApiServerEnabled
-        conf.httpServerEnabled == false
-        conf.shareServerWithEngineApi
+        config.engineApiEnabled == true
+        config.rpcEnabled == false
+        config.wsEnabled == false
+        config.engineApiWsEnabled == false
+        config.engineApiServerEnabled
+        config.httpServerEnabled == false
+        config.shareServerWithEngineApi
 
     test "ws-rpc enabled when ws-engine api enabled and share same port":
-      let conf = makeConfig(@["--ws", "--engine-api-ws", "--engine-api-port:8546", "--http-port:8546"])
+      let config = makeConfig(@["--ws", "--engine-api-ws", "--engine-api-port:8546", "--http-port:8546"])
       check:
-        conf.engineApiWsEnabled
-        conf.wsEnabled
-        conf.engineApiEnabled == false
-        conf.rpcEnabled == false
-        conf.engineApiServerEnabled
-        conf.httpServerEnabled
-        conf.shareServerWithEngineApi
+        config.engineApiWsEnabled
+        config.wsEnabled
+        config.engineApiEnabled == false
+        config.rpcEnabled == false
+        config.engineApiServerEnabled
+        config.httpServerEnabled
+        config.shareServerWithEngineApi
 
     test "json-rpc stay enabled when json-engine api enabled and using different port":
-      let conf = makeConfig(@["--rpc", "--engine-api", "--engine-api-port:8550", "--http-port:8545"])
+      let config = makeConfig(@["--rpc", "--engine-api", "--engine-api-port:8550", "--http-port:8545"])
       check:
-        conf.engineApiEnabled
-        conf.rpcEnabled
-        conf.engineApiWsEnabled == false
-        conf.wsEnabled == false
-        conf.httpServerEnabled
-        conf.engineApiServerEnabled
-        conf.shareServerWithEngineApi == false
+        config.engineApiEnabled
+        config.rpcEnabled
+        config.engineApiWsEnabled == false
+        config.wsEnabled == false
+        config.httpServerEnabled
+        config.engineApiServerEnabled
+        config.shareServerWithEngineApi == false
 
     test "ws-rpc stay enabled when ws-engine api enabled and using different port":
-      let conf = makeConfig(@["--ws", "--engine-api-ws", "--engine-api-port:8551", "--http-port:8546"])
+      let config = makeConfig(@["--ws", "--engine-api-ws", "--engine-api-port:8551", "--http-port:8546"])
       check:
-        conf.engineApiWsEnabled
-        conf.wsEnabled
-        conf.engineApiEnabled == false
-        conf.rpcEnabled == false
-        conf.httpServerEnabled
-        conf.engineApiServerEnabled
-        conf.shareServerWithEngineApi == false
+        config.engineApiWsEnabled
+        config.wsEnabled
+        config.engineApiEnabled == false
+        config.rpcEnabled == false
+        config.httpServerEnabled
+        config.engineApiServerEnabled
+        config.shareServerWithEngineApi == false
 
     test "ws, rpc, and engine api not enabled":
-      let conf = makeConfig(@[])
+      let config = makeConfig(@[])
       check:
-        conf.engineApiWsEnabled == false
-        conf.wsEnabled == false
-        conf.engineApiEnabled == false
-        conf.rpcEnabled == false
-        conf.httpServerEnabled == false
-        conf.engineApiServerEnabled == false
-        conf.shareServerWithEngineApi == false
+        config.engineApiWsEnabled == false
+        config.wsEnabled == false
+        config.engineApiEnabled == false
+        config.rpcEnabled == false
+        config.httpServerEnabled == false
+        config.engineApiServerEnabled == false
+        config.shareServerWithEngineApi == false
 
     let rng = newRng()
     test "net-key random":
-      let conf = makeConfig(@["--net-key:random"])
-      check conf.netKey == "random"
-      let rc = rng[].getNetKeys(conf.netKey)
+      let config = makeConfig(@["--net-key:random"])
+      check config.netKey == "random"
+      let rc = rng[].getNetKeys(config.netKey)
       check rc.isOk
 
     test "net-key hex without 0x prefix":
-      let conf = makeConfig(@["--net-key:9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"])
-      check conf.netKey == "9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
-      let rc = rng[].getNetKeys(conf.netKey)
+      let config = makeConfig(@["--net-key:9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"])
+      check config.netKey == "9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
+      let rc = rng[].getNetKeys(config.netKey)
       check rc.isOk
       let pkhex = rc.get.seckey.toRaw.to0xHex
       check pkhex == "0x9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
 
     test "net-key hex with 0x prefix":
-      let conf = makeConfig(@["--net-key:0x9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"])
-      check conf.netKey == "0x9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
-      let rc = rng[].getNetKeys(conf.netKey)
+      let config = makeConfig(@["--net-key:0x9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"])
+      check config.netKey == "0x9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
+      let rc = rng[].getNetKeys(config.netKey)
       check rc.isOk
       let pkhex = rc.get.seckey.toRaw.to0xHex
       check pkhex == "0x9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
 
     test "net-key path":
-      let conf = makeConfig(@["--net-key:nimcache/key.txt"])
-      check conf.netKey == "nimcache/key.txt"
-      let rc1 = rng[].getNetKeys(conf.netKey)
+      let config = makeConfig(@["--net-key:nimcache/key.txt"])
+      check config.netKey == "nimcache/key.txt"
+      let rc1 = rng[].getNetKeys(config.netKey)
       check rc1.isOk
       let pkhex1 = rc1.get.seckey.toRaw.to0xHex
-      let rc2 = rng[].getNetKeys(conf.netKey)
+      let rc2 = rng[].getNetKeys(config.netKey)
       check rc2.isOk
       let pkhex2 = rc2.get.seckey.toRaw.to0xHex
       check pkhex1 == pkhex2
 
     test "default key-store and default data-dir":
-      let conf = makeTestConfig()
-      check conf.keyStoreDir() == conf.dataDir() / "keystore"
+      let config = makeTestConfig()
+      check config.keyStoreDir() == config.dataDir() / "keystore"
 
     test "custom key-store and custom data-dir":
-      let conf = makeConfig(@["--key-store:banana", "--data-dir:apple"])
-      check conf.keyStoreDir() == "banana"
-      check conf.dataDir() == "apple"
+      let config = makeConfig(@["--key-store:banana", "--data-dir:apple"])
+      check config.keyStoreDir() == "banana"
+      check config.dataDir() == "apple"
 
     test "default key-store and custom data-dir":
-      let conf = makeConfig(@["--data-dir:apple"])
-      check conf.dataDir() == "apple"
-      check conf.keyStoreDir() == "apple" / "keystore"
+      let config = makeConfig(@["--data-dir:apple"])
+      check config.dataDir() == "apple"
+      check config.keyStoreDir() == "apple" / "keystore"
 
     test "custom key-store and default data-dir":
-      let conf = makeConfig(@["--key-store:banana"])
-      check conf.dataDir() == defaultDataDir("", "mainnet")
-      check conf.keyStoreDir() == "banana"
+      let config = makeConfig(@["--key-store:banana"])
+      check config.dataDir() == defaultDataDir("", "mainnet")
+      check config.keyStoreDir() == "banana"
 
     test "loadKeystores missing address":
       var am = AccountsManager()
@@ -301,79 +301,79 @@ proc configurationMain*() =
       check res.error.find("expect json object of keystore data:") == 0
 
     test "TOML config file":
-      let conf = makeConfig(@["--config-file:tests/config_file/basic.toml"])
-      check conf.dataDir == "basic/data/dir"
-      check conf.era1DirFlag == some OutDir "basic/era1/dir"
-      check conf.eraDirFlag == some OutDir "basic/era/dir"
-      check conf.keyStoreDir == "basic/keystore"
-      check conf.importKey.string == "basic_import_key"
-      check conf.trustedSetupFile == some "basic_trusted_setup_file"
-      check conf.extraData == "basic_extra_data"
-      check conf.gasLimit == 5678
-      check conf.networkId == 777.u256
-      check conf.networkParams.config.isNil.not
+      let config = makeConfig(@["--config-file:tests/config_file/basic.toml"])
+      check config.dataDir == "basic/data/dir"
+      check config.era1DirFlag == some OutDir "basic/era1/dir"
+      check config.eraDirFlag == some OutDir "basic/era/dir"
+      check config.keyStoreDir == "basic/keystore"
+      check config.importKey.string == "basic_import_key"
+      check config.trustedSetupFile == some "basic_trusted_setup_file"
+      check config.extraData == "basic_extra_data"
+      check config.gasLimit == 5678
+      check config.networkId == 777.u256
+      check config.networkParams.config.isNil.not
 
-      check conf.logLevel == "DEBUG"
-      check conf.logStdout == StdoutLogKind.Json
+      check config.logLevel == "DEBUG"
+      check config.logStdout == StdoutLogKind.Json
 
-      check conf.metricsEnabled == true
-      check conf.metricsPort == 127.Port
-      check conf.metricsAddress == parseIpAddress("111.222.33.203")
+      check config.metricsEnabled == true
+      check config.metricsPort == 127.Port
+      check config.metricsAddress == parseIpAddress("111.222.33.203")
 
-      privateAccess(NimbusConf)
-      check conf.bootstrapNodes.len == 3
-      check conf.bootstrapNodes[0] == "enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666@18.138.108.67:30303"
-      check conf.bootstrapNodes[1] == "basic_bootstrap_file"
-      check conf.bootstrapNodes[2] == "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"
+      privateAccess(ExecutionClientConf)
+      check config.bootstrapNodes.len == 3
+      check config.bootstrapNodes[0] == "enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666@18.138.108.67:30303"
+      check config.bootstrapNodes[1] == "basic_bootstrap_file"
+      check config.bootstrapNodes[2] == "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"
 
-      check conf.staticPeers.len == 3
-      check conf.staticPeers[0] == "enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666@18.138.108.67:30303"
-      check conf.staticPeers[1] == "basic_static_peers_file"
-      check conf.staticPeers[2] == "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"
+      check config.staticPeers.len == 3
+      check config.staticPeers[0] == "enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666@18.138.108.67:30303"
+      check config.staticPeers[1] == "basic_static_peers_file"
+      check config.staticPeers[2] == "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"
 
-      check conf.reconnectMaxRetry == 10
-      check conf.reconnectInterval == 11
+      check config.reconnectMaxRetry == 10
+      check config.reconnectInterval == 11
 
-      check conf.listenAddress == parseIpAddress("123.124.125.34")
-      check conf.tcpPort == 5567.Port
-      check conf.udpPort == 8899.Port
-      check conf.maxPeers == 45
-      check conf.nat == NatConfig(hasExtIp: false, nat: NatAny)
-      check conf.discovery == ["V5"]
-      check conf.netKey == "random"
-      check conf.agentString == "basic_agent_string"
+      check config.listenAddress == parseIpAddress("123.124.125.34")
+      check config.tcpPort == 5567.Port
+      check config.udpPort == 8899.Port
+      check config.maxPeers == 45
+      check config.nat == NatConfig(hasExtIp: false, nat: NatAny)
+      check config.discovery == ["V5"]
+      check config.netKey == "random"
+      check config.agentString == "basic_agent_string"
 
-      check conf.numThreads == 12
-      check conf.persistBatchSize == 32
-      check conf.rocksdbMaxOpenFiles == 33
-      check conf.rocksdbWriteBufferSize == 34
-      check conf.rocksdbRowCacheSize == 35
-      check conf.rocksdbBlockCacheSize == 36
-      check conf.rdbVtxCacheSize == 37
-      check conf.rdbKeyCacheSize == 38
-      check conf.rdbBranchCacheSize == 39
-      check conf.rdbPrintStats == true
-      check conf.rewriteDatadirId == true
-      check conf.eagerStateRootCheck ==  false
+      check config.numThreads == 12
+      check config.persistBatchSize == 32
+      check config.rocksdbMaxOpenFiles == 33
+      check config.rocksdbWriteBufferSize == 34
+      check config.rocksdbRowCacheSize == 35
+      check config.rocksdbBlockCacheSize == 36
+      check config.rdbVtxCacheSize == 37
+      check config.rdbKeyCacheSize == 38
+      check config.rdbBranchCacheSize == 39
+      check config.rdbPrintStats == true
+      check config.rewriteDatadirId == true
+      check config.eagerStateRootCheck ==  false
 
-      check conf.statelessProviderEnabled == true
-      check conf.statelessWitnessValidation == true
+      check config.statelessProviderEnabled == true
+      check config.statelessWitnessValidation == true
 
-      check conf.httpPort == 12788.Port
-      check conf.httpAddress == parseIpAddress("123.124.125.36")
-      check conf.rpcEnabled == true
-      check conf.rpcApi == ["eth", "admin"]
-      check conf.wsEnabled == true
-      check conf.wsApi  == ["eth", "admin"]
-      check conf.historyExpiry == false
-      check conf.historyExpiryLimit == some 1111'u64
-      check conf.portalUrl == "uri://what.org"
+      check config.httpPort == 12788.Port
+      check config.httpAddress == parseIpAddress("123.124.125.36")
+      check config.rpcEnabled == true
+      check config.rpcApi == ["eth", "admin"]
+      check config.wsEnabled == true
+      check config.wsApi  == ["eth", "admin"]
+      check config.historyExpiry == false
+      check config.historyExpiryLimit == some 1111'u64
+      check config.portalUrl == "uri://what.org"
 
-      check conf.engineApiEnabled == true
-      check conf.engineApiPort == 12799.Port
-      check conf.engineApiAddress == parseIpAddress("123.124.125.37")
-      check conf.engineApiWsEnabled == true
-      check conf.allowedOrigins == ["*"]
-      check conf.jwtSecret.get.string == "basic_jwt_secret_file"
+      check config.engineApiEnabled == true
+      check config.engineApiPort == 12799.Port
+      check config.engineApiAddress == parseIpAddress("123.124.125.37")
+      check config.engineApiWsEnabled == true
+      check config.allowedOrigins == ["*"]
+      check config.jwtSecret.get.string == "basic_jwt_secret_file"
 
 configurationMain()

--- a/tests/test_engine_api.nim
+++ b/tests/test_engine_api.nim
@@ -20,7 +20,7 @@ import
 
 import
   ../execution_chain/rpc,
-  ../execution_chain/config,
+  ../execution_chain/conf,
   ../execution_chain/core/chain,
   ../execution_chain/core/tx_pool,
   ../execution_chain/beacon/beacon_engine,
@@ -52,18 +52,18 @@ const
   defaultGenesisFile = "tests/customgenesis/engine_api_genesis.json"
   mekongGenesisFile = "tests/customgenesis/mekong.json"
 
-proc setupConfig(genesisFile: string): NimbusConf =
+proc setupConfig(genesisFile: string): ExecutionClientConf =
   makeConfig(@[
     "--network:" & genesisFile,
     "--listen-address: 127.0.0.1",
   ])
 
-proc setupCom(conf: NimbusConf): CommonRef =
+proc setupCom(config: ExecutionClientConf): CommonRef =
   CommonRef.new(
     newCoreDbRef DefaultDbMemory,
     nil,
-    conf.networkId,
-    conf.networkParams
+    config.networkId,
+    config.networkParams
   )
 
 proc setupClient(port: Port): RpcHttpClient =
@@ -76,19 +76,19 @@ proc setupEnv(envFork: HardFork = MergeFork,
   doAssert(envFork >= MergeFork)
 
   let
-    conf  = setupConfig(genesisFile)
+    config  = setupConfig(genesisFile)
 
   if envFork >= Shanghai:
-    conf.networkParams.config.shanghaiTime = Opt.some(0.EthTime)
+    config.networkParams.config.shanghaiTime = Opt.some(0.EthTime)
 
   if envFork >= Cancun:
-    conf.networkParams.config.cancunTime = Opt.some(0.EthTime)
+    config.networkParams.config.cancunTime = Opt.some(0.EthTime)
 
   if envFork >= Prague:
-    conf.networkParams.config.pragueTime = Opt.some(0.EthTime)
+    config.networkParams.config.pragueTime = Opt.some(0.EthTime)
 
   let
-    com   = setupCom(conf)
+    com   = setupCom(config)
     chain = ForkedChainRef.init(com, enableQueue = true)
     txPool = TxPoolRef.new(chain)
 

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -15,7 +15,7 @@ import
   testutils,
   std/[os, strutils],
   ../execution_chain/common,
-  ../execution_chain/config,
+  ../execution_chain/conf,
   ../execution_chain/utils/utils,
   ../execution_chain/core/chain/forked_chain,
   ../execution_chain/core/chain/forked_chain/chain_desc,
@@ -33,30 +33,30 @@ const
 
 type
   TestEnv = object
-    conf: NimbusConf
+    config: ExecutionClientConf
 
 proc setupEnv(): TestEnv =
   let
-    conf = makeConfig(@[
+    config = makeConfig(@[
       "--network:" & genesisFile
     ])
 
-  TestEnv(conf: conf)
+  TestEnv(config: config)
 
 proc newCom(env: TestEnv): CommonRef =
   CommonRef.new(
       newCoreDbRef DefaultDbMemory,
       nil,
-      env.conf.networkId,
-      env.conf.networkParams
+      env.config.networkId,
+      env.config.networkParams
     )
 
 proc newCom(env: TestEnv, db: CoreDbRef): CommonRef =
   CommonRef.new(
       db,
       nil,
-      env.conf.networkId,
-      env.conf.networkParams
+      env.config.networkId,
+      env.config.networkParams
     )
 
 proc makeBlk(txFrame: CoreDbTxRef, number: BlockNumber, parentBlk: Block): Block =

--- a/tests/test_genesis.nim
+++ b/tests/test_genesis.nim
@@ -11,7 +11,6 @@
 import
   std/[os],
   unittest2,
-  ../execution_chain/config,
   ../execution_chain/utils/utils,
   ../execution_chain/common/common
 

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -9,7 +9,7 @@ import
   std/[os, macros, json, strformat, strutils, tables],
   stew/byteutils, net, eth/common/keys, unittest2,
   testutils/markdown_reports,
-  ../execution_chain/[constants, config, transaction, errors],
+  ../execution_chain/[constants, conf, transaction, errors],
   ../execution_chain/db/ledger,
   ../execution_chain/common,
   ../execution_chain/networking/[netkeys, p2p]
@@ -147,27 +147,27 @@ proc verifyLedger*(wantedState: JsonNode, ledger: ReadOnlyLedger) =
       raise newException(ValidationError, &"{ac} nonceDiff {wantedNonce.toHex} != {actualNonce.toHex}")
 
 proc setupEthNode*(
-    conf: NimbusConf, rng: var HmacDrbgContext,
+    config: ExecutionClientConf, rng: var HmacDrbgContext,
     capabilities: varargs[ProtocolInfo, `protocolInfo`]): EthereumNode =
-  let keypair = getNetKeys(rng, conf.netKey).tryGet()
+  let keypair = getNetKeys(rng, config.netKey).tryGet()
   let srvAddress = enode.Address(
-    ip: conf.listenAddress, tcpPort: conf.tcpPort, udpPort: conf.udpPort)
+    ip: config.listenAddress, tcpPort: config.tcpPort, udpPort: config.udpPort)
 
   var node = newEthereumNode(
     keypair,
-    Opt.some(conf.listenAddress),
-    Opt.some(conf.tcpPort),
-    Opt.some(conf.udpPort),
-    conf.networkId,
-    conf.agentString,
-    bindUdpPort = conf.udpPort,
-    bindTcpPort = conf.tcpPort)
+    Opt.some(config.listenAddress),
+    Opt.some(config.tcpPort),
+    Opt.some(config.udpPort),
+    config.networkId,
+    config.agentString,
+    bindUdpPort = config.udpPort,
+    bindTcpPort = config.tcpPort)
 
   for capability in capabilities:
     node.addCapability capability
 
   node
 
-proc makeTestConfig*(): NimbusConf =
+proc makeTestConfig*(): ExecutionClientConf =
   # commandLineParams() will not works inside all_tests
   makeConfig(@[])

--- a/tests/test_jwt_auth.nim
+++ b/tests/test_jwt_auth.nim
@@ -12,10 +12,10 @@
 ## ====================================
 
 import
-  ../execution_chain/config,
+  std/[sequtils, strformat],
+  ../execution_chain/conf,
   ../execution_chain/rpc/jwt_auth,
   ../execution_chain/rpc {.all.},
-  ./replay/pp,
   chronicles,
   chronos/apps/http/httpclient as chronoshttpclient,
   nimcrypto/[hmac, sha2, utils],

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -15,7 +15,7 @@ import
   minilru,
   results,
   chronos,
-  ../execution_chain/config,
+  ../execution_chain/conf,
   ../execution_chain/db/storage_types,
   ../execution_chain/common/common,
   ../execution_chain/core/chain,

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -15,7 +15,7 @@ import
   eth/rlp,
   eth/common/[transaction_utils, addresses],
   ../hive_integration/engine_client,
-  ../execution_chain/[constants, transaction, config, version_info],
+  ../execution_chain/[constants, transaction, conf, version_info],
   ../execution_chain/db/[ledger, storage_types],
   ../execution_chain/sync/wire_protocol,
   ../execution_chain/core/[tx_pool, chain, pow/difficulty],
@@ -34,7 +34,7 @@ import
 
 type
   TestEnv = object
-    conf     : NimbusConf
+    conf     : ExecutionClientConf
     com      : CommonRef
     txPool   : TxPoolRef
     server   : RpcHttpServer
@@ -78,17 +78,17 @@ proc persistFixtureBlock(chainDB: CoreDbTxRef) =
   chainDB.persistTransactions(header.number, header.txRoot, getBlockBody4514995().transactions)
   chainDB.persistReceipts(header.receiptsRoot, getReceipts4514995())
 
-proc setupConfig(): NimbusConf =
+proc setupConfig(): ExecutionClientConf =
   makeConfig(@[
     "--network:" & genesisFile
   ])
 
-proc setupCom(conf: NimbusConf): CommonRef =
+proc setupCom(config: ExecutionClientConf): CommonRef =
   CommonRef.new(
     newCoreDbRef DefaultDbMemory,
     nil,
-    conf.networkId,
-    conf.networkParams
+    config.networkId,
+    config.networkParams
   )
 
 proc setupClient(port: Port): RpcHttpClient =

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -21,7 +21,7 @@ import
   ../execution_chain/db/ledger,
   ../execution_chain/core/chain,
   ../execution_chain/core/eip4844,
-  ../execution_chain/[config, transaction, constants],
+  ../execution_chain/[conf, transaction, constants],
   ../execution_chain/core/tx_pool,
   ../execution_chain/core/tx_pool/tx_desc,
   ../execution_chain/core/pooled_txs,
@@ -50,7 +50,7 @@ const
 
 type
   TestEnv = object
-    conf  : NimbusConf
+    config: ExecutionClientConf
     com   : CommonRef
     chain : ForkedChainRef
     xp    : TxPoolRef
@@ -58,14 +58,14 @@ type
 
   CustomTx = CustomTransactionData
 
-proc initConf(envFork: HardFork): NimbusConf =
-  var conf = makeConfig(
+proc initConf(envFork: HardFork): ExecutionClientConf =
+  var config = makeConfig(
     @["--network:" & genesisFile]
   )
 
   doAssert envFork >= MergeFork
 
-  let cc = conf.networkParams.config
+  let cc = config.networkParams.config
   if envFork >= MergeFork:
     cc.mergeNetsplitBlock = Opt.some(0'u64)
 
@@ -77,11 +77,11 @@ proc initConf(envFork: HardFork): NimbusConf =
 
   if envFork >= Prague:
     cc.pragueTime = Opt.some(0.EthTime)
-    conf.networkParams.genesis.alloc[withdrawalTriggerContract] = GenesisAccount(
+    config.networkParams.genesis.alloc[withdrawalTriggerContract] = GenesisAccount(
       balance: 0.u256,
       code: triggerCode
     )
-    conf.networkParams.genesis.alloc[consolidationWithdrawalTrigger] = GenesisAccount(
+    config.networkParams.genesis.alloc[consolidationWithdrawalTrigger] = GenesisAccount(
       balance: 0.u256,
       code: triggerCode
     )
@@ -89,19 +89,19 @@ proc initConf(envFork: HardFork): NimbusConf =
   if envFork >= Osaka:
     cc.osakaTime = Opt.some(0.EthTime)
 
-  conf.networkParams.genesis.alloc[recipient] = GenesisAccount(code: contractCode)
-  conf
+  config.networkParams.genesis.alloc[recipient] = GenesisAccount(code: contractCode)
+  config
 
-proc initEnv(conf: NimbusConf): TestEnv =
+proc initEnv(config: ExecutionClientConf): TestEnv =
   let
     # create the sender first, because it will modify networkParams
-    sender = TxSender.new(conf.networkParams, 30)
+    sender = TxSender.new(config.networkParams, 30)
     com    = CommonRef.new(newCoreDbRef DefaultDbMemory,
-               nil, conf.networkId, conf.networkParams)
+               nil, config.networkId, config.networkParams)
     chain  = ForkedChainRef.init(com)
 
   TestEnv(
-    conf  : conf,
+    config: config,
     com   : com,
     chain : chain,
     xp    : TxPoolRef.new(chain),
@@ -109,8 +109,8 @@ proc initEnv(conf: NimbusConf): TestEnv =
   )
 
 proc initEnv(envFork: HardFork): TestEnv =
-  let conf = initConf(envFork)
-  initEnv(conf)
+  let config = initConf(envFork)
+  initEnv(config)
 
 template checkAddTx(xp, tx, errorCode) =
   let prevCount = xp.len
@@ -673,7 +673,7 @@ suite "TxPool test suite":
 
   test "Blobschedule":
     let
-      cc = env.conf.networkParams.config
+      cc = env.config.networkParams.config
       acc = mx.getAccount(26)
       tc = BlobTx(
         txType: Opt.some(TxEip4844),
@@ -830,15 +830,15 @@ suite "TxPool test suite":
 
   test "EIP-7594 BlobsBundle transition from Prague to Osaka":
     let
-      conf = initConf(Prague)
-      cc = conf.networkParams.config
+      config = initConf(Prague)
+      cc = config.networkParams.config
       timestamp = EthTime.now()
 
     # set osaka transition time
     cc.osakaTime = Opt.some(timestamp + 2)
 
     let
-      env = initEnv(conf)
+      env = initEnv(config)
       xp = env.xp
       mx = env.sender
       acc = mx.getAccount(0)


### PR DESCRIPTION
Following the pattern of the other configs, name execution client config after the service it configures - also, move naming scheme to match eth2 and other configs (`config` for variable and `conf` for the module) - this helps maintain parity between the various configs since large portions of them share UX, if not implementation (yet: https://github.com/status-im/nim-confutils/issues/114).

All in all, this frees up the `NimbusConf` name for the unified Nimbus node.