### PR TITLE
Add blob schedule fallback test case and fix fallback logic

### DIFF
--- a/execution_chain/common/chain_config.nim
+++ b/execution_chain/common/chain_config.nim
@@ -395,22 +395,52 @@ proc validateChainConfig(conf: ChainConfig): bool =
     if cur.time.isSome:
       lastTimeBasedFork = cur
 
+func numBPOForks(): int {.compileTime.} =
+  for x in Prague..HardFork.high:
+    if toLowerAscii($x).startsWith("bpo"):
+      inc result
+
+func getBPOForks(N: static[int]): array[N, HardFork] {.compileTime.} =
+  var i = 0
+  for x in Prague..HardFork.high:
+    if toLowerAscii($x).startsWith("bpo"):
+      result[i] = x
+      inc i
+
+func getRegularForks(N: static[int]): array[N, HardFork] {.compileTime.} =
+  var i = 0
+  for x in Prague..HardFork.high:
+    if not toLowerAscii($x).startsWith("bpo"):
+      result[i] = x
+      inc i
+
+const
+  NumForksWithBlobSchedule = HardFork.high.int - Prague.int + 1 # minus Cancun, but cardinal + 1
+  NumBPOForks = numBPOForks()
+  NumRegularForks = NumForksWithBlobSchedule - NumBPOForks
+  BPOForks = getBPOForks(NumBPOForks)
+  RegularForks = getRegularForks(NumRegularForks)
+  
 proc configureBlobSchedule(conf: ChainConfig) =
-  var prevFork = Cancun
   if conf.blobSchedule[Cancun].isNone:
     conf.blobSchedule[Cancun] = Opt.some(BlobSchedule(target: 3'u64, max: 6'u64, baseFeeUpdateFraction: 3_338_477'u64))
   else:
     if conf.blobSchedule[Cancun].value.baseFeeUpdateFraction == 0:
       conf.blobSchedule[Cancun].value.baseFeeUpdateFraction = 3_338_477'u64
 
-  for fork in Prague..HardFork.high:
-    if conf.blobSchedule[fork].isNone:
-      conf.blobSchedule[fork] = conf.blobSchedule[prevFork]
-    if conf.blobSchedule[fork].value.baseFeeUpdateFraction == 0:
-      # Set fallback to Cancun's baseFeeUpdateFraction and prevent division by zero
-      warn "baseFeeUpdateFraction not set, fallback to Cancun's", fork=fork
-      conf.blobSchedule[fork].value.baseFeeUpdateFraction = 3_338_477'u64
-    prevFork = fork
+  template setBlobScheduleWithFallback(forks) =
+    var prevFork = Cancun
+    for fork in forks:
+      if conf.blobSchedule[fork].isNone:
+        conf.blobSchedule[fork] = conf.blobSchedule[prevFork]
+      if conf.blobSchedule[fork].value.baseFeeUpdateFraction == 0:
+        # Set fallback to Cancun's baseFeeUpdateFraction and prevent division by zero
+        warn "baseFeeUpdateFraction not set, fallback to Cancun's", fork=fork
+        conf.blobSchedule[fork].value.baseFeeUpdateFraction = 3_338_477'u64
+      prevFork = fork
+
+  setBlobScheduleWithFallback(RegularForks)
+  setBlobScheduleWithFallback(BPOForks)
 
 proc parseGenesis*(data: string): Genesis
      {.gcsafe.} =

--- a/tests/customgenesis/blobschedule_amsterdam_fallback.json
+++ b/tests/customgenesis/blobschedule_amsterdam_fallback.json
@@ -1,0 +1,45 @@
+{
+  "config": {
+    "chainId": 7042643276,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "mergeNetsplitBlock": 0,
+    "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
+    "shanghaiTime": 0,
+    "cancunTime": 0,
+    "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "prague": {
+        "target": 6,
+        "max": 9,
+        "baseFeeUpdateFraction": 5007716
+      },
+      "bpo1": {
+        "target": 9,
+        "max": 12,
+        "baseFeeUpdateFraction": 5008888
+      },      
+    },
+    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+    "pragueTime": 0,
+    "osakaTime": 1748362704,
+    "bpo1Time": 1748461008,
+    "bpo2Time": 1748559312,
+    "bpo3Time": 1748657616,
+    "bpo4Time": 1748755920,
+    "bpo5Time": 1748872656
+  }
+}

--- a/tests/test_genesis.nim
+++ b/tests/test_genesis.nim
@@ -196,6 +196,14 @@ proc customGenesisTest() =
       validateBlobSchedule(cg, Bpo4, 6, 9, 5007716)
       validateBlobSchedule(cg, Bpo5, 15, 20, 5007716)
 
+      check loadNetworkParams("blobschedule_amsterdam_fallback.json".findFilePath, cg)
+      validateBlobSchedule(cg, Cancun, 3, 6, 3338477)
+      validateBlobSchedule(cg, Prague, 6, 9, 5007716)
+      validateBlobSchedule(cg, Osaka, 6, 9, 5007716) # fallback to Prague
+      validateBlobSchedule(cg, Bpo1, 9, 12, 5008888)
+      validateBlobSchedule(cg, Amsterdam, 6, 9, 5007716) # fallback to Osaka, not Bpo1
+
+
 proc genesisMain() =
   genesisTest()
   customGenesisTest()


### PR DESCRIPTION
fix #3764

The fallback logic only applied to chain config parsed from json file. Built in blob schedule still need explicit value.