### PR TITLE
Portal bridge: Fix crash when JSON-RPC methods not available

### DIFF
--- a/execution_chain/portal/portal.nim
+++ b/execution_chain/portal/portal.nim
@@ -91,7 +91,7 @@ proc getBlockBodyByHeader*(historyExpiry: HistoryExpiryRef, header: Header): Res
     return err("Portal RPC is not available")
 
   (waitFor rpc.historyGetBlockBody(header)).mapErr(
-    proc(e: PortalRpcError): string =
-      debug "Portal request failed", error = $e
-      "Portal request failed: " & $e
+    proc(e: PortalErrorResponse): string =
+      debug "Portal request failed", error = $e.message
+      "Portal request failed: " & $e.message
   )

--- a/portal/bridge/history/portal_history_bridge.nim
+++ b/portal/bridge/history/portal_history_bridge.nim
@@ -181,13 +181,14 @@ proc runBackfillLoopSyncMode(
 
       block bodyBlock:
         let _ = (await historyGetBlockBody(bridge.portalClient, blockTuple.header)).valueOr:
-          info "Failed to find block body content, gossiping..", error = $error
+          debug "Failed to find block body content, gossiping..", error = $error.message
           await bridge.gossipBlockBody(blockNumber, blockTuple.body)
           break bodyBlock
 
       block receiptsBlock:
         let _ = (await historyGetReceipts(bridge.portalClient, blockTuple.header)).valueOr:
-          info "Failed to find block receipts content, gossiping..", error = $error
+          debug "Failed to find block receipts content, gossiping..",
+            error = $error.message
           await bridge.gossipReceipts(
             blockNumber, blockTuple.receipts.to(StoredReceipts)
           )

--- a/portal/rpc/portal_rpc_client.nim
+++ b/portal/rpc/portal_rpc_client.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import
   json_serialization,
   chronos,
@@ -14,41 +16,32 @@ import
   json_rpc/rpcclient,
   ../common/common_types,
   ../network/history/[history_content, history_validation],
-  ./rpc_calls/[rpc_discovery_calls, rpc_portal_calls, rpc_portal_debug_calls]
+  ./rpc_calls/[rpc_discovery_calls, rpc_portal_calls, rpc_portal_debug_calls],
+  ./rpc_types
 
-export rpcclient, rpc_discovery_calls, rpc_portal_calls, rpc_portal_debug_calls, results
+export
+  rpcclient, rpc_discovery_calls, rpc_portal_calls, rpc_portal_debug_calls, results,
+  rpc_types
 
 type
   PortalRpcClient* = distinct RpcClient
 
-  PortalRpcError* = enum
-    ContentNotFound
-    InvalidContentKey
-    InvalidContentValue
-    ContentValidationFailed
-
-  ErrorResponse = object
+  PortalErrorResponse* = object
     code*: int
     message*: string
+
+const
+  InvalidJsonRpcError* = -1
+  ReceivedInvalidDataError* = -2
 
 proc init*(T: type PortalRpcClient, rpcClient: RpcClient): T =
   T(rpcClient)
 
-func toPortalRpcError(e: ref CatchableError): PortalRpcError =
-  let error =
-    try:
-      Json.decode(e.msg, ErrorResponse)
-    except SerializationError as e:
-      raiseAssert(e.msg)
-
-  if error.code == -39001:
-    ContentNotFound
-  elif error.code == -32602:
-    InvalidContentKey
-  elif error.code == -32603:
-    ContentValidationFailed
-  else:
-    raiseAssert(e.msg)
+func toPortalRpcError*(error: string): PortalErrorResponse =
+  try:
+    Json.decode(error, PortalErrorResponse)
+  except SerializationError as e:
+    PortalErrorResponse(code: InvalidJsonRpcError, message: error)
 
 template toBytes(content: string): seq[byte] =
   try:
@@ -58,7 +51,7 @@ template toBytes(content: string): seq[byte] =
 
 proc historyGetBlockBody*(
     client: PortalRpcClient, header: Header
-): Future[Result[BlockBody, PortalRpcError]] {.async: (raises: []).} =
+): Future[Result[BlockBody, PortalErrorResponse]] {.async: (raises: []).} =
   ## Fetches the block body for the given block header from the Portal History
   ## Network. The data is first looked up in the node's local database before
   ## trying to fetch it from the network. The block header needs to be passed
@@ -69,15 +62,20 @@ proc historyGetBlockBody*(
       try:
         await RpcClient(client).portal_historyGetBlockBody(headerBytes)
       except CatchableError as e:
-        return err(e.toPortalRpcError())
+        return err(e.msg.toPortalRpcError())
     blockBody = decodeRlp(content.toBytes(), BlockBody).valueOr:
-      return err(InvalidContentValue)
+      return err(
+        PortalErrorResponse(
+          code: ReceivedInvalidDataError,
+          message: "Failed to decode received BlockBody: " & error,
+        )
+      )
 
   ok(blockBody)
 
 proc historyGetReceipts*(
     client: PortalRpcClient, header: Header
-): Future[Result[StoredReceipts, PortalRpcError]] {.async: (raises: []).} =
+): Future[Result[StoredReceipts, PortalErrorResponse]] {.async: (raises: []).} =
   ## Fetches the receipts for the given block header from the Portal History
   ## Network. The data is first looked up in the node's local database before
   ## trying to fetch it from the network. The block header needs to be passed
@@ -88,8 +86,13 @@ proc historyGetReceipts*(
       try:
         await RpcClient(client).portal_historyGetReceipts(headerBytes)
       except CatchableError as e:
-        return err(e.toPortalRpcError())
+        return err(e.msg.toPortalRpcError())
     receipts = decodeRlp(content.toBytes(), StoredReceipts).valueOr:
-      return err(InvalidContentValue)
+      return err(
+        PortalErrorResponse(
+          code: ReceivedInvalidDataError,
+          message: "Failed to decode received StoredReceipts: " & error,
+        )
+      )
 
   ok(receipts)

--- a/portal/tests/rpc_tests/test_portal_rpc_client.nim
+++ b/portal/tests/rpc_tests/test_portal_rpc_client.nim
@@ -127,7 +127,7 @@ procSuite "Portal RPC Client":
       let blockBodyRes = await tc.client.historyGetBlockBody(blockHeader)
       check:
         blockBodyRes.isErr()
-        blockBodyRes.error() == ContentNotFound
+        blockBodyRes.error().code == ContentNotFoundError.code
 
     # Test content validation failed
     block:
@@ -136,7 +136,7 @@ procSuite "Portal RPC Client":
       let blockBodyRes = await tc.client.historyGetBlockBody(blockHeader)
       check:
         blockBodyRes.isErr()
-        blockBodyRes.error() == ContentNotFound
+        blockBodyRes.error().code == ContentNotFoundError.code
 
     # When local node has the content the validation is skipped
     block:
@@ -160,7 +160,7 @@ procSuite "Portal RPC Client":
       let receiptsRes = await tc.client.historyGetReceipts(blockHeader)
       check:
         receiptsRes.isErr()
-        receiptsRes.error() == ContentNotFound
+        receiptsRes.error().code == ContentNotFoundError.code
 
     # Test content validation failed
     block:
@@ -169,7 +169,7 @@ procSuite "Portal RPC Client":
       let receiptsRes = await tc.client.historyGetReceipts(blockHeader)
       check:
         receiptsRes.isErr()
-        receiptsRes.error() == ContentNotFound
+        receiptsRes.error().code == ContentNotFoundError.code
 
     # When local node has the content the validation is skipped
     block:


### PR DESCRIPTION
Remove overly aggressive use of raiseAssert in error parsing and rework a bit.

Also move a spammy info log to debug.