### PR TITLE
Fix EthTime only forkId func to fix eth_config JSON-RPC method

### DIFF
--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -357,7 +357,11 @@ func forkId*(com: CommonRef, head, time: uint64): ForkId {.gcsafe.} =
 func forkId*(com: CommonRef, forkActivationTime: EthTime): ForkId {.gcsafe.} =
   ## Get ForkId for given timestamp (EIP-2124/2364/6122)
   ## Only works for timestamp based forks
-  com.forkIdCalculator.calculateForkId(0'u64, forkActivationTime.uint64)
+  # For `calculateForkId` with timestamp the block number needs to be set sufficiently
+  # high to include all block number based forks.
+  # It could be set to `blockNumberThresholds[GrayGlacier]` but then the code needs to
+  # deal with possible Opt.none(), so instead set to uint64.high()
+  com.forkIdCalculator.calculateForkId(uint64.high(), forkActivationTime.uint64)
 
 func forkId*(com: CommonRef, head: BlockNumber, time: EthTime): ForkId {.gcsafe.} =
   ## Get ForkId for given block number / timestamp (EIP-2124/2364/6122)

--- a/tests/test_forkid.nim
+++ b/tests/test_forkid.nim
@@ -108,6 +108,11 @@ template runComputeForkIdTest(network: untyped, name: string) =
         # And also when set to current fork timestamp
         com.compatibleForkId(computedId, BlockNumber(0'u64), EthTime(1761921403'u64)) == true
 
+      if x.time != 0'u64:
+        # Only for time-based forks check also the time-only function
+        let computedIdTimeOnly = com.forkId(EthTime(x.time))
+        check computedIdTimeOnly == expectedId
+
 const
   ValidationTests = [
 


### PR DESCRIPTION
Without this fix, the returned ForkId value would always be the fork hash from genesis.