### PR TITLE
Disable loading of FC state on startup

### DIFF
--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -370,7 +370,7 @@ type
 
     deserializeFcState* {.
       hidden
-      defaultValue: true
+      defaultValue: false
       name: "debug-deserialize-fc-state" .}: bool
 
     statelessProviderEnabled* {.


### PR DESCRIPTION
On startup Nimbus will load the FC state and then reply every block loaded. This can sometimes be several thousand blocks (perhaps in the case of non-finalization) and it takes a very long time to complete and this makes the node to appear to stall.

If we disable this process then the node starts up without issue, and simply needs to resync up to head which isn't a big deal. 

If there was a reorg it is possible that the FC state blocks are no longer needed anyway so perhaps it is better to just start fresh from the latest finalized block on startup.