### PR TITLE
Fix out of memory crash when building rocksdb on arm64 linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           #export ZERO_AR_DATE=1 # avoid timestamps in binaries
           DEFAULT_MAKE_FLAGS="-j${ncpu} ROCKSDB_CI_CACHE=RocksBinCache"
           if [ '${{ matrix.os }}' == 'linux' ] && [ '${{ matrix.cpu }}' == 'arm64' ]; then
+            # To reduce memory usage on arm linux we build rocksdb separately
             make ${DEFAULT_MAKE_FLAGS} rocksdb
           fi
           make ${DEFAULT_MAKE_FLAGS} all test_import build_fuzzers check_revision


### PR DESCRIPTION
Building rocksdb separately appears to reduce the memory usage. Only doing this for arm64 linux. 

-j is still set to ${ncpu} as before so the slow down in CI run time is minimal. 

RocksDb is also cached so this only impacts the run time when rebuilding rocksdb (when the library is updated).