### PR TITLE
Add NimMain export to verifproxy library

### DIFF
--- a/nimbus_verified_proxy/libverifproxy/verifproxy.h
+++ b/nimbus_verified_proxy/libverifproxy/verifproxy.h
@@ -1,6 +1,6 @@
 /**
  * nimbus_verified_proxy
- * Copyright (c) 2024 Status Research & Development GmbH
+ * Copyright (c) 2024-2025 Status Research & Development GmbH
  * Licensed and distributed under either of
  *   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
  *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,6 +9,8 @@
 
 #ifndef __verifproxy__
 #define __verifproxy__
+
+void NimMain(void);
 
 typedef struct VerifProxyContext VerifProxyContext;
 typedef void (*onHeaderCallback)(const char* s, int t);


### PR DESCRIPTION
It seems NimMain was not provided in the header file for verifproxy.h, add corresponding definition so that C programs using the library can properly initialize Nim.