### PR TITLE
Setup BAL EEST tests

### DIFF
--- a/.github/actions/shared/action.yml
+++ b/.github/actions/shared/action.yml
@@ -167,6 +167,7 @@ runs:
           tests/fixtures/eest_stable
           tests/fixtures/eest_develop
           tests/fixtures/eest_devnet
+          tests/fixtures/eest_bal
         # EEST release version contained in eest_ci_cache.sh.
         # Each time we bump EEST version, it should invalidate the cache too.
         key: eest-${{ hashFiles('scripts/eest_ci_cache.sh') }}

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,6 @@ tests/fixtures/eest_static
 tests/fixtures/eest_stable
 tests/fixtures/eest_develop
 tests/fixtures/eest_devnet
+tests/fixtures/eest_bal
 
 execution_chain/nimbus

--- a/scripts/eest_ci_cache.sh
+++ b/scripts/eest_ci_cache.sh
@@ -27,6 +27,14 @@ EEST_DEVNET_DIR="${FIXTURES_DIR}/eest_devnet"
 EEST_DEVNET_ARCHIVE="fixtures_fusaka-devnet-5.tar.gz"
 EEST_DEVNET_URL="https://github.com/ethereum/execution-spec-tests/releases/download/${EEST_DEVNET_NAME}%40${EEST_DEVNET_VERSION}/${EEST_DEVNET_ARCHIVE}"
 
+# --- BAL Release ---
+EEST_BAL_NAME="bal"
+EEST_BAL_VERSION="v1.6.0"
+EEST_BAL_DIR="${FIXTURES_DIR}/eest_bal"
+EEST_BAL_ARCHIVE="fixtures_bal.tar.gz"
+EEST_BAL_URL="https://github.com/ethereum/execution-spec-tests/releases/download/${EEST_BAL_NAME}%40${EEST_BAL_VERSION}/${EEST_BAL_ARCHIVE}"
+
+
 download_and_extract() {
   local url="$1"
   local dest_dir="$2"
@@ -75,3 +83,4 @@ download_and_extract() {
 # Download stable and develop versions
 download_and_extract "${EEST_DEVELOP_URL}" "${EEST_DEVELOP_DIR}" "${EEST_DEVELOP_NAME}" "${EEST_DEVELOP_VERSION}" "${EEST_DEVELOP_ARCHIVE}"
 download_and_extract "${EEST_DEVNET_URL}" "${EEST_DEVNET_DIR}" "${EEST_DEVNET_NAME}" "${EEST_DEVNET_VERSION}" "${EEST_DEVNET_ARCHIVE}"
+download_and_extract "${EEST_BAL_URL}" "${EEST_BAL_DIR}" "${EEST_BAL_NAME}" "${EEST_BAL_VERSION}" "${EEST_BAL_ARCHIVE}"

--- a/tests/eest/eest_helpers.nim
+++ b/tests/eest/eest_helpers.nim
@@ -56,6 +56,7 @@ type
     excessBlobGas: Opt[Quantity]
     parentBeaconBlockRoot: Opt[Hash32]
     requestsHash: Opt[Hash32]
+    blockAccessListHash: Opt[Hash32]
     hash*: Hash32
 
   BlockDesc* = object
@@ -202,6 +203,7 @@ func to*(g: GenesisHeader, _: type Header): Header =
     excessBlobGas: g.excessBlobGas.to(Opt[uint64]),
     parentBeaconBlockRoot: g.parentBeaconBlockRoot,
     requestsHash: g.requestsHash,
+    blockAccessListHash: g.blockAccessListHash,
   )
 
 proc setupClient*(port: Port): RpcHttpClient =


### PR DESCRIPTION
This just adds the test fixtures for the BAL EEST release (see [here](https://github.com/ethereum/execution-spec-tests/releases/tag/bal%40v1.6.0)) to our codebase but doesn't yet run the new tests.