### PR TITLE
EIP-7928: Block level access lists (#3836)

### DIFF
--- a/execution_chain/beacon/api_handler.nim
+++ b/execution_chain/beacon/api_handler.nim
@@ -25,6 +25,7 @@ export
   getPayloadV3,
   getPayloadV4,
   getPayloadV5,
+  getPayloadV6,
   getPayloadBodiesByHash,
   getPayloadBodiesByRange,
   newPayload,

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -41,20 +41,41 @@ func validateVersionedHashed(payload: ExecutionPayload,
   true
 
 template validateVersion(com, timestamp, payloadVersion, apiVersion) =
-  if apiVersion == Version.V4:
+  if apiVersion == Version.V5:
+    if not com.isAmsterdamOrLater(timestamp):
+      raise unsupportedFork("newPayloadV5 expect payload timestamp fall within Amsterdam")
+    if payloadVersion != Version.V4:
+      raise invalidParams("newPayload" & $apiVersion &
+      " expect ExecutionPayloadV4" &
+      " but got ExecutionPayload" & $payloadVersion)
+
+  elif apiVersion == Version.V4:
     if not com.isPragueOrLater(timestamp):
       raise unsupportedFork("newPayloadV4 expect payload timestamp fall within Prague")
+    if payloadVersion != Version.V3:
+      raise invalidParams("newPayload" & $apiVersion &
+      " expect ExecutionPayloadV3" &
+      " but got ExecutionPayload" & $payloadVersion)
 
-  if com.isPragueOrLater(timestamp):
+  elif apiVersion == Version.V3:
+    if not com.isCancunOrLater(timestamp):
+      raise unsupportedFork("newPayloadV3 expect payload timestamp fall within Cancun")
+    if payloadVersion != Version.V3:
+      raise invalidParams("newPayload" & $apiVersion &
+      " expect ExecutionPayloadV3" &
+      " but got ExecutionPayload" & $payloadVersion)
+
+  if com.isAmsterdamOrLater(timestamp):
+    if payloadVersion != Version.V4:
+      raise invalidParams("if timestamp is Amsterdam or later, " &
+        "payload must be ExecutionPayloadV4, got ExecutionPayload" & $payloadVersion)
+
+  elif com.isPragueOrLater(timestamp):
     if payloadVersion != Version.V3:
       raise invalidParams("if timestamp is Prague or later, " &
         "payload must be ExecutionPayloadV3, got ExecutionPayload" & $payloadVersion)
 
-  if apiVersion == Version.V3:
-    if not com.isCancunOrLater(timestamp):
-      raise unsupportedFork("newPayloadV3 expect payload timestamp fall within Cancun")
-
-  if com.isCancunOrLater(timestamp):
+  elif com.isCancunOrLater(timestamp):
     if payloadVersion != Version.V3:
       raise invalidParams("if timestamp is Cancun or later, " &
         "payload must be ExecutionPayloadV3, got ExecutionPayload" & $payloadVersion)
@@ -67,13 +88,6 @@ template validateVersion(com, timestamp, payloadVersion, apiVersion) =
   elif payloadVersion != Version.V1:
     raise invalidParams("if timestamp is earlier than Shanghai, " &
       "payload must be ExecutionPayloadV1, got ExecutionPayload" & $payloadVersion)
-
-  if apiVersion == Version.V3 or apiVersion == Version.V4:
-    # both newPayloadV3 and newPayloadV4 expect ExecutionPayloadV3
-    if payloadVersion != Version.V3:
-      raise invalidParams("newPayload" & $apiVersion &
-      " expect ExecutionPayload3" &
-      " but got ExecutionPayload" & $payloadVersion)
 
 template validatePayload(apiVersion, payloadVersion, payload) =
   if payloadVersion >= Version.V2:
@@ -88,6 +102,11 @@ template validatePayload(apiVersion, payloadVersion, payload) =
     if payload.excessBlobGas.isNone:
       raise invalidParams("newPayload" & $apiVersion &
         "excessBlobGas is expected from execution payload")
+
+  if apiVersion >= Version.V5 or payloadVersion >= Version.V4:
+    if payload.blockAccessList.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        "blockAccessList is expected from execution payload")
 
 # https://github.com/ethereum/execution-apis/blob/40088597b8b4f48c45184da002e27ffc3c37641f/src/engine/prague.md#request
 func validateExecutionRequest(blockHash: Hash32,

--- a/execution_chain/beacon/web3_eth_conv.nim
+++ b/execution_chain/beacon/web3_eth_conv.nim
@@ -84,14 +84,25 @@ func ethWithdrawals*(x: Opt[seq[WithdrawalV1]]):
   if x.isNone: Opt.none(seq[Withdrawal])
   else: Opt.some(ethWithdrawals x.get)
 
-func ethTx*(x: Web3Tx): common.Transaction {.gcsafe, raises:[RlpError].} =
+func ethTx*(x: Web3Tx): common.Transaction {.gcsafe, raises: [RlpError].} =
   result = rlp.decode(distinctBase x, common.Transaction)
 
 func ethTxs*(list: openArray[Web3Tx]):
-               seq[common.Transaction] {.gcsafe, raises:[RlpError].} =
+               seq[common.Transaction] {.gcsafe, raises: [RlpError].} =
   result = newSeqOfCap[common.Transaction](list.len)
   for x in list:
     result.add ethTx(x)
+
+func ethBlockAccessList*(
+    bal: openArray[byte]): BlockAccessList {.gcsafe, raises: [RlpError].} =
+  rlp.decode(bal, BlockAccessList)
+
+func ethBlockAccessList*(
+    bal: Opt[seq[byte]]): Opt[BlockAccessList] {.gcsafe, raises: [RlpError].} =
+  if bal.isNone():
+    Opt.none(BlockAccessList)
+  else:
+    Opt.some(ethBlockAccessList(bal.get))
 
 # ------------------------------------------------------------------------------
 # Eth types to Web3 types
@@ -153,5 +164,14 @@ func w3Txs*(list: openArray[common.Transaction]): seq[Web3Tx] =
   result = newSeqOfCap[Web3Tx](list.len)
   for tx in list:
     result.add w3Tx(tx)
+
+func w3BlockAccessList*(bal: BlockAccessList): seq[byte] =
+  bal.encode()
+
+func w3BlockAccessList*(bal: Opt[BlockAccessList]): Opt[seq[byte]] =
+  if bal.isNone():
+    Opt.none(seq[byte])
+  else:
+    Opt.some(w3BlockAccessList(bal.get))
 
 chronicles.formatIt(Quantity): $(distinctBase it)

--- a/execution_chain/block_access_list/block_access_list_builder.nim
+++ b/execution_chain/block_access_list/block_access_list_builder.nim
@@ -43,6 +43,8 @@ type
     accounts*: Table[Address, AccountData]
       ## Maps address -> account data
 
+  BlockAccessListRef* = ref BlockAccessList
+
 template init*(T: type AccountData): T =
   AccountData()
 
@@ -119,11 +121,11 @@ func slotCmp(x, y: StorageKey | StorageValue): int =
 func slotChangesCmp(x, y: SlotChanges): int =
   cmp(x.slot.data.toHex(), y.slot.data.toHex())
 
-func addressCmp(x, y: AccountChanges): int =
+func accChangesCmp(x, y: AccountChanges): int =
   cmp(x.address.data.toHex(), y.address.data.toHex())
 
-func buildBlockAccessList*(builder: BlockAccessListBuilderRef): BlockAccessList =
-  var blockAccessList: BlockAccessList
+func buildBlockAccessList*(builder: BlockAccessListBuilderRef): BlockAccessListRef =
+  let blockAccessList: BlockAccessListRef = new BlockAccessList
 
   for address, accData in builder.accounts.mpairs():
     # Collect and sort storageChanges
@@ -163,7 +165,7 @@ func buildBlockAccessList*(builder: BlockAccessListBuilderRef): BlockAccessList 
       codeChanges.add((BlockAccessIndex(balIndex), Bytecode(code)))
     codeChanges.sort(balIndexCmp)
 
-    blockAccessList.add(AccountChanges(
+    blockAccessList[].add(AccountChanges(
       address: address,
       storageChanges: storageChanges,
       storageReads: storageReads,
@@ -172,6 +174,6 @@ func buildBlockAccessList*(builder: BlockAccessListBuilderRef): BlockAccessList 
       codeChanges: codeChanges
     ))
 
-  blockAccessList.sort(addressCmp)
+  blockAccessList[].sort(accChangesCmp)
 
   blockAccessList

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -515,8 +515,6 @@ proc validateBlock(c: ForkedChainRef,
     txFrame.dispose()
     return err(error)
 
-  c.writeBaggage(blk, blkHash, txFrame, receipts)
-
   # Checkpoint creates a snapshot of ancestor changes in txFrame - it is an
   # expensive operation, specially when creating a new branch (ie when blk
   # is being applied to a block that is currently not a head).

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -661,6 +661,7 @@ proc init*(
       fcuSafe:          fcuSafe,
       baseQueue:        initDeque[BlockRef](),
       lastBaseLogTime:  EthTime.now(),
+      badBlocks:        LruCache[Hash32, (Block, Opt[BlockAccessListRef])].init(100),
     )
 
   # updateFinalized will stop ancestor lineage
@@ -883,6 +884,12 @@ proc latestBlock*(c: ForkedChainRef): Block =
     # It's a base block
     return c.baseTxFrame.getEthBlock(c.latest.hash).expect("baseBlock exists")
   c.latest.blk
+
+proc getBadBlocks*(c: ForkedChainRef): seq[(Block, Opt[BlockAccessListRef])] =
+  var blks: seq[(Block, Opt[BlockAccessListRef])]
+  for badBlock in c.badBlocks.values():
+    blks.add(badBlock)
+  blks
 
 proc headerByNumber*(c: ForkedChainRef, number: BlockNumber): Result[Header, string] =
   if number > c.latest.number:

--- a/execution_chain/core/chain/forked_chain/chain_desc.nim
+++ b/execution_chain/core/chain/forked_chain/chain_desc.nim
@@ -13,13 +13,16 @@
 import
   std/[tables, deques],
   chronos,
+  minilru,
   ../../../common,
   ../../../db/[core_db, fcu_db],
   ../../../portal/portal,
   ./block_quarantine,
   ./chain_branch
 
-export tables
+from ../../../block_access_list/block_access_list_builder import BlockAccessListRef
+
+export tables, minilru
 
 type
   QueueItem* = object
@@ -98,6 +101,11 @@ type
     processingQueueLoop*: Future[void].Raising([CancelledError])
       # Prevent async re-entrancy messing up FC state
       # on both `importBlock` and `forkChoice`.
+
+    badBlocks*: LruCache[Hash32, (Block, Opt[BlockAccessListRef])]
+      # Recent blocks that failed validation for any reason,
+      # indexed by block hash and containing a tuple of the block
+      # and the generated block access list.
 
 # ------------------------------------------------------------------------------
 # These functions are private to ForkedChainRef

--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -43,12 +43,12 @@ proc writeBaggage*(
 
   if blk.blockAccessList.isSome:
     txFrame.persistBlockAccessList(
-      header.blockAccessListHash.expect("blockAccessListHash should be verified before"),
+      blkHash,
       blk.blockAccessList.get(),
     )
   elif generatedBal.isSome:
     txFrame.persistBlockAccessList(
-      header.blockAccessListHash.expect("blockAccessListHash should be verified before"),
+      blkHash,
       generatedBal.get()[],
     )
 
@@ -73,17 +73,19 @@ proc processBlock*(
         c.com.isAmsterdamOrLater(header.timestamp),
   )
 
-  ?c.com.validateHeaderAndKinship(blk, vmState.parent, txFrame)
+  c.com.validateHeaderAndKinship(blk, vmState.parent, txFrame).isOkOr:
+    c.badBlocks.put(blkHash, (blk, vmState.blockAccessList))
+    return err(error)
 
   template processBlock(): auto =
-    # When processing a finalized block, we optimistically assume that the state
-    # root will check out and delay such validation for when it's time to persist
-    # changes to disk
-    ?vmState.processBlock(
+    vmState.processBlock(
       blk,
       skipValidation = false,
       skipReceipts = false,
       skipUncles = true,
+      # When processing a finalized block, we optimistically assume that the state
+      # root will check out and delay such validation for when it's time to persist
+      # changes to disk
       skipStateRootCheck = finalized and not c.eagerStateRoot,
       # Depending on the BAL retention period of clients, finalized blocks might
       # be received without a BAL. In this case we skip checking the block BAL
@@ -96,7 +98,9 @@ proc processBlock*(
       # skipped.
       skipPostExecBalCheck = finalized and blk.blockAccessList.isSome(),
       taskpool = c.com.taskpool,
-    )
+    ).isOkOr:
+      c.badBlocks.put(blkHash, (blk, vmState.blockAccessList))
+      return err(error)
 
   if not vmState.com.statelessProviderEnabled:
     processBlock()

--- a/execution_chain/core/chain/forked_chain/chain_serialize.nim
+++ b/execution_chain/core/chain/forked_chain/chain_serialize.nim
@@ -133,8 +133,6 @@ proc replayBlock(fc: ForkedChainRef;
     txFrame.dispose()
     return err(error)
 
-  fc.writeBaggage(blk.blk, blk.hash, txFrame, receipts)
-
   # Checkpoint creates a snapshot of ancestor changes in txFrame - it is an
   # expensive operation, specially when creating a new branch (ie when blk
   # is being applied to a block that is currently not a head).

--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -71,7 +71,7 @@ proc getVmState(
     doAssert txFrame.getSavedStateBlockNumber() == parent.number
 
     vmState.init(parent, header, p.com, txFrame, storeSlotHash = storeSlotHash,
-      enableBalTracker = NoValidation notin p.flags and
+      enableBalTracker = FullValidation in p.flags and
           p.com.isAmsterdamOrLater(header.timestamp))
 
     p.vmState = vmState

--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -53,10 +53,15 @@ proc commitOrRollbackDependingOnGasUsed(
   # an early stop. It would rather detect differing values for the  block
   # header `gasUsed` and the `vmState.cumulativeGasUsed` at a later stage.
   if header.gasLimit < vmState.cumulativeGasUsed + gasUsed:
+    if vmState.balTrackerEnabled:
+      vmState.balTracker.rollbackCallFrame()
     vmState.ledger.rollback(accTx)
     err(&"invalid tx: block header gasLimit reached. gasLimit={header.gasLimit}, gasUsed={vmState.cumulativeGasUsed}, addition={gasUsed}")
   else:
     # Accept transaction and collect mining fee.
+    if vmState.balTrackerEnabled:
+      vmState.balTracker.trackAddBalanceChange(vmState.coinbase(), gasUsed.u256 * priorityFee.u256)
+      vmState.balTracker.commitCallFrame()
     vmState.ledger.commit(accTx)
     vmState.ledger.addBalance(vmState.coinbase(), gasUsed.u256 * priorityFee.u256)
     vmState.cumulativeGasUsed += gasUsed
@@ -108,13 +113,15 @@ proc processTransactionImpl(
   let
     com = vmState.com
     txRes = roDB.validateTransaction(tx, sender, header.gasLimit, baseFee256, excessBlobGas, com, fork)
-    res = if txRes.isOk:      
+    res = if txRes.isOk:
       # Execute the transaction.
       vmState.captureTxStart(tx.gasLimit)
-      let
-        accTx = vmState.ledger.beginSavepoint
-      var
-        callResult = tx.txCallEvm(sender, vmState, baseFee)
+
+      if vmState.balTrackerEnabled:
+        vmState.balTracker.beginCallFrame()
+      let accTx = vmState.ledger.beginSavepoint()
+
+      var callResult = tx.txCallEvm(sender, vmState, baseFee)
       vmState.captureTxEnd(tx.gasLimit - callResult.gasUsed)
 
       let tmp = commitOrRollbackDependingOnGasUsed(

--- a/execution_chain/core/tx_pool.nim
+++ b/execution_chain/core/tx_pool.nim
@@ -45,6 +45,7 @@ import
   ./chain/forked_chain,
   ./pooled_txs
 
+from ../evm/state import blockAccessList
 from eth/common/eth_types_rlp import rlpHash
 
 # ------------------------------------------------------------------------------
@@ -161,7 +162,7 @@ proc assembleBlock*(
       wrapperVersion: getWrapperVersion(com, blk.header.timestamp)
     )
     currentRlpSize = rlp.getEncodedLength(blk.header)
-  
+
   if blk.withdrawals.isSome:
     currentRlpSize = currentRlpSize + rlp.getEncodedLength(blk.withdrawals.get())
 
@@ -207,6 +208,10 @@ proc assembleBlock*(
       Opt.some(pst.executionRequests)
     else:
       Opt.none(seq[seq[byte]])
+
+  if com.isAmsterdamOrLater(blk.header.timestamp):
+    let bal = xp.vmState.blockAccessList.expect("block access list exists")
+    blk.blockAccessList = Opt.some(bal[])
 
   ok AssembledBlock(
     blk: blk,

--- a/execution_chain/core/tx_pool/tx_desc.nim
+++ b/execution_chain/core/tx_pool/tx_desc.nim
@@ -87,8 +87,7 @@ proc setupVMState(com: CommonRef;
                   parentHash: Hash32,
                   pos: PosPayloadAttr,
                   parentFrame: CoreDbTxRef): BaseVMState =
-  let
-    fork = com.toEVMFork(pos.timestamp)
+  let fork = com.toEVMFork(pos.timestamp)
 
   BaseVMState.new(
     parent   = parent,
@@ -103,7 +102,8 @@ proc setupVMState(com: CommonRef;
       parentHash   : parentHash,
     ),
     txFrame = parentFrame.txFrameBegin(),
-    com     = com)
+    com     = com,
+    enableBalTracker = com.isAmsterdamOrLater(pos.timestamp))
 
 template append(tab: var TxSenderTab, sn: TxSenderNonceRef) =
   tab[item.sender] = sn

--- a/execution_chain/core/tx_pool/tx_packer.nim
+++ b/execution_chain/core/tx_pool/tx_packer.nim
@@ -113,6 +113,8 @@ proc runTxCommit(pst: var TxPacker; item: TxItemRef; callResult: LogResult, xp: 
     gasTip  = item.tx.tip(pst.baseFee)
 
   let reward = callResult.gasUsed.u256 * gasTip.u256
+  if vmState.balTrackerEnabled:
+    vmState.balTracker.trackAddBalanceChange(xp.feeRecipient, reward)
   vmState.ledger.addBalance(xp.feeRecipient, reward)
   pst.blockValue += reward
 
@@ -141,6 +143,11 @@ proc vmExecInit(xp: TxPoolRef): Result[TxPacker, string] =
     stateRoot: xp.vmState.parent.stateRoot,
   )
 
+  # Setup block access list tracker for pre‑execution system calls
+  if xp.vmState.balTrackerEnabled:
+    xp.vmState.balTracker.setBlockAccessIndex(0)
+    xp.vmState.balTracker.beginCallFrame()
+
   # EIP-4788
   if xp.nextFork >= FkCancun:
     let beaconRoot = xp.parentBeaconBlockRoot
@@ -151,6 +158,10 @@ proc vmExecInit(xp: TxPoolRef): Result[TxPacker, string] =
   if xp.nextFork >= FkPrague:
     xp.vmState.processParentBlockHash(xp.vmState.blockCtx.parentHash).isOkOr:
       return err(error)
+
+  # Commit block access list tracker changes for pre‑execution system calls
+  if xp.vmState.balTrackerEnabled:
+    xp.vmState.balTracker.commitCallFrame()
 
   ok(packer)
 
@@ -187,6 +198,10 @@ proc vmExecGrabItem(pst: var TxPacker; item: TxItemRef, xp: TxPoolRef): bool =
   if not vmState.classifyValidatePacked(item):
     return ContinueWithNextAccount
 
+  if vmState.balTrackerEnabled:
+    vmState.balTracker.setBlockAccessIndex(pst.packedTxs.len() + 1)
+    vmState.balTracker.beginCallFrame()
+
   # Execute EVM for this transaction
   let
     accTx = vmState.ledger.beginSavepoint
@@ -196,6 +211,8 @@ proc vmExecGrabItem(pst: var TxPacker; item: TxItemRef, xp: TxPoolRef): bool =
 
   # Find out what to do next: accepting this tx or trying the next account
   if not vmState.classifyPacked(callResult.gasUsed):
+    if vmState.balTrackerEnabled:
+      vmState.balTracker.rollbackCallFrame(rollbackReads = true)
     vmState.ledger.rollback(accTx)
     if vmState.classifyPackedNext():
       return ContinueWithNextAccount
@@ -213,6 +230,9 @@ proc vmExecGrabItem(pst: var TxPacker; item: TxItemRef, xp: TxPoolRef): bool =
   vmState.blobGasUsed += blobGasUsed
   vmState.gasPool -= item.tx.gasLimit
 
+  if vmState.balTrackerEnabled:
+    vmState.balTracker.commitCallFrame()
+
   ContinueWithNextAccount
 
 proc vmExecCommit(pst: var TxPacker, xp: TxPoolRef): Result[void, string] =
@@ -220,10 +240,20 @@ proc vmExecCommit(pst: var TxPacker, xp: TxPoolRef): Result[void, string] =
     vmState = pst.vmState
     ledger = vmState.ledger
 
+  # Setup block access list tracker for post‑execution system calls
+  if vmState.balTrackerEnabled:
+    vmState.balTracker.setBlockAccessIndex(pst.packedTxs.len() + 1)
+    vmState.balTracker.beginCallFrame()
+
   # EIP-4895
   if vmState.fork >= FkShanghai:
-    for withdrawal in xp.withdrawals:
-      ledger.addBalance(withdrawal.address, withdrawal.weiAmount)
+    if vmState.balTrackerEnabled:
+      for withdrawal in xp.withdrawals:
+        vmState.balTracker.trackAddBalanceChange(withdrawal.address, withdrawal.weiAmount)
+        ledger.addBalance(withdrawal.address, withdrawal.weiAmount)
+    else:
+      for withdrawal in xp.withdrawals:
+        ledger.addBalance(withdrawal.address, withdrawal.weiAmount)
 
   # EIP-6110, EIP-7002, EIP-7251
   if vmState.fork >= FkPrague:
@@ -240,6 +270,11 @@ proc vmExecCommit(pst: var TxPacker, xp: TxPoolRef): Result[void, string] =
   pst.receiptsRoot = vmState.receipts.calcReceiptsRoot
   pst.logsBloom = vmState.receipts.createBloom
   pst.stateRoot = vmState.ledger.getStateRoot()
+
+  # Commit block access list tracker changes for post‑execution system calls
+  if vmState.balTrackerEnabled:
+    vmState.balTracker.commitCallFrame()
+
   ok()
 
 # ------------------------------------------------------------------------------
@@ -271,7 +306,7 @@ proc assembleHeader*(pst: TxPacker, xp: TxPoolRef): Header =
     vmState = pst.vmState
     com = vmState.com
 
-  result = Header(
+  var header = Header(
     parentHash:    vmState.blockCtx.parentHash,
     ommersHash:    EMPTY_UNCLE_HASH,
     coinbase:      xp.feeRecipient,
@@ -290,12 +325,12 @@ proc assembleHeader*(pst: TxPacker, xp: TxPoolRef): Header =
     )
 
   if com.isShanghaiOrLater(xp.timestamp):
-    result.withdrawalsRoot = Opt.some(calcWithdrawalsRoot(xp.withdrawals))
+    header.withdrawalsRoot = Opt.some(calcWithdrawalsRoot(xp.withdrawals))
 
   if com.isCancunOrLater(xp.timestamp):
-    result.parentBeaconBlockRoot = Opt.some(xp.parentBeaconBlockRoot)
-    result.blobGasUsed = Opt.some vmState.blobGasUsed
-    result.excessBlobGas = Opt.some vmState.blockCtx.excessBlobGas
+    header.parentBeaconBlockRoot = Opt.some(xp.parentBeaconBlockRoot)
+    header.blobGasUsed = Opt.some vmState.blobGasUsed
+    header.excessBlobGas = Opt.some vmState.blockCtx.excessBlobGas
 
   if com.isPragueOrLater(xp.timestamp):
     let requestsHash = calcRequestsHash([
@@ -303,7 +338,14 @@ proc assembleHeader*(pst: TxPacker, xp: TxPoolRef): Header =
       (WITHDRAWAL_REQUEST_TYPE, pst.withdrawalReqs),
       (CONSOLIDATION_REQUEST_TYPE, pst.consolidationReqs)
     ])
-    result.requestsHash = Opt.some(requestsHash)
+    header.requestsHash = Opt.some(requestsHash)
+
+  if com.isAmsterdamOrLater(xp.timestamp):
+    let bal = vmState.blockAccessList.expect("block access list exists")
+    header.blockAccessListHash = Opt.some(bal[].computeBlockAccessListHash())
+
+  header
+
 
 func blockValue*(pst: TxPacker): UInt256 =
   pst.blockValue

--- a/execution_chain/core/validate.nim
+++ b/execution_chain/core/validate.nim
@@ -47,15 +47,13 @@ func validateBlockAccessList*(
   if com.isAmsterdamOrLater(header.timestamp):
     if header.blockAccessListHash.isNone:
       return err("Post-Amsterdam block header must have blockAccessListHash")
-    elif blockAccessList.isNone:
-      return err("Post-Amsterdam block body must have blockAccessList")
-    else:
+    if blockAccessList.isSome:
       if blockAccessList.get.validate(header.blockAccessListHash.get).isErr():
         return err("Mismatched blockAccessListHash blockNumber = " & $header.number)
   else:
     if header.blockAccessListHash.isSome:
       return err("Pre-Amsterdam block header must not have blockAccessListHash")
-    elif blockAccessList.isSome:
+    if blockAccessList.isSome:
       return err("Pre-Amsterdam block body must not have blockAccessList")
 
   return ok()

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -410,18 +410,16 @@ proc getTransactions*(
     return ok(move(res))
 
 proc persistBlockAccessList*(
-    db: CoreDbTxRef, blockAccessListHash: Hash32, bal: BlockAccessList) =
-  db.put(blockAccessListHashKey(blockAccessListHash).toOpenArray, bal.encode())
+    db: CoreDbTxRef, blockHash: Hash32, bal: BlockAccessList) =
+  db.put(blockHashToBlockAccessListKey(blockHash).toOpenArray, bal.encode())
     .expect("persistBlockAccessList should succeed")
 
 proc getBlockAccessList*(
-    db: CoreDbTxRef,
-    blockAccessListHash: Hash32): Result[Opt[BlockAccessList], string] =
-  if blockAccessListHash == EMPTY_BLOCK_ACCESS_LIST_HASH:
-    return ok(Opt.some(default(BlockAccessList)))
-
-  let balBytes = db.getOrEmpty(blockAccessListHashKey(blockAccessListHash).toOpenArray).valueOr:
-    return err("getBlockAccessList: " & $$error)
+    db: CoreDbTxRef, blockHash: Hash32): Result[Opt[BlockAccessList], string] =
+  let balBytes = db.getOrEmpty(
+      blockHashToBlockAccessListKey(blockHash).toOpenArray
+    ).valueOr:
+      return err("getBlockAccessList: " & $$error)
 
   if balBytes == EmptyBlob:
     return ok(Opt.none(BlockAccessList))

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -672,13 +672,16 @@ proc selfDestruct*(ac: LedgerRef, address: Address) =
   ac.setBalance(address, 0.u256)
   ac.savePoint.selfDestruct.incl address
 
-proc selfDestruct6780*(ac: LedgerRef, address: Address) =
+proc selfDestruct6780*(ac: LedgerRef, address: Address): bool =
   let acc = ac.getAccount(address, false)
   if acc.isNil:
-    return
+    return false
 
   if NewlyCreated in acc.flags:
     ac.selfDestruct(address)
+    true
+  else:
+    false
 
 proc selfDestructLen*(ac: LedgerRef): int =
   ac.savePoint.selfDestruct.len

--- a/execution_chain/db/storage_types.nim
+++ b/execution_chain/db/storage_types.nim
@@ -111,7 +111,7 @@ func blockHashToWitnessKey*(h: Hash32): DbKey {.inline.} =
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32
 
-func blockAccessListHashKey*(h: Hash32): DbKey {.inline.} =
+func blockHashToBlockAccessListKey*(h: Hash32): DbKey {.inline.} =
   result.data[0] = byte ord(blockAccessList)
   result.data[1 .. 32] = h.data
   result.dataEndPos = uint8 32

--- a/execution_chain/evm/interpreter/op_handlers/oph_memory.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_memory.nim
@@ -43,6 +43,8 @@ proc sstoreImpl(c: Computation, slot, newValue: UInt256): EvmResultVoid =
   ? c.opcodeGasCost(Sstore, res.gasCost, "SSTORE")
   c.gasMeter.refundGas(res.gasRefund)
 
+  if c.vmState.balTrackerEnabled:
+    c.vmState.balTracker.trackStorageWrite(c.msg.contractAddress, slot, newValue)
   c.vmState.mutateLedger:
     db.setStorage(c.msg.contractAddress, slot, newValue)
   ok()
@@ -63,6 +65,8 @@ proc sstoreNetGasMeteringImpl(c: Computation; slot, newValue: UInt256, coldAcces
 
   c.gasMeter.refundGas(res.gasRefund)
 
+  if c.vmState.balTrackerEnabled:
+    c.vmState.balTracker.trackStorageWrite(c.msg.contractAddress, slot, newValue)
   c.vmState.mutateLedger:
     db.setStorage(c.msg.contractAddress, slot, newValue)
   ok()

--- a/execution_chain/evm/message.nim
+++ b/execution_chain/evm/message.nim
@@ -15,7 +15,8 @@ import
   ./precompiles,
   ../common/evmforks,
   ../utils/utils,
-  ../db/ledger
+  ../db/ledger,
+  ../core/eip7702
 
 proc isCreate*(message: Message): bool =
   message.kind in {CallKind.Create, CallKind.Create2}
@@ -26,6 +27,8 @@ proc generateContractAddress*(vmState: BaseVMState,
                               salt = ZERO_CONTRACTSALT,
                               code = CodeBytesRef(nil)): Address =
   if kind == CallKind.Create:
+    if vmState.balTrackerEnabled:
+      vmState.balTracker.trackAddressAccess(sender)
     let creationNonce = vmState.readOnlyLedger().getNonce(sender)
     generateAddress(sender, creationNonce)
   else:
@@ -37,6 +40,15 @@ proc getCallCode*(vmState: BaseVMState, codeAddress: Address): CodeBytesRef =
     return CodeBytesRef(nil)
 
   if vmState.fork >= FkPrague:
+    if vmState.balTrackerEnabled:
+      vmState.balTracker.trackAddressAccess(codeAddress)
+      let
+        code = vmState.readOnlyLedger.getCode(codeAddress)
+        delegateTo = parseDelegationAddress(code)
+      if delegateTo.isSome():
+        vmState.balTracker.trackAddressAccess(delegateTo.get())
     vmState.readOnlyLedger.resolveCode(codeAddress)
   else:
+    if vmState.balTrackerEnabled:
+      vmState.balTracker.trackAddressAccess(codeAddress)
     vmState.readOnlyLedger.getCode(codeAddress)

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -758,6 +758,8 @@ proc getPrecompile*(fork: EVMFork, codeAddress: Address): Opt[Precompiles] =
   Opt.none(Precompiles)
 
 proc execPrecompile*(c: Computation, precompile: Precompiles) =
+  if c.vmState.balTrackerEnabled:
+    c.vmState.balTracker.trackAddressAccess(precompileAddrs[precompile])
   let fork = c.fork
   let res = case precompile
     of paEcRecover: ecRecover(c)

--- a/execution_chain/evm/types.nim
+++ b/execution_chain/evm/types.nim
@@ -15,9 +15,10 @@ import
   ./interpreter/[gas_costs, op_codes],
   ./transient_storage,
   ../db/ledger,
-  ../common/[common, evmforks]
+  ../common/[common, evmforks],
+  ../block_access_list/block_access_list_tracker
 
-export stack, memory, transient_storage
+export stack, memory, transient_storage, block_access_list_tracker
 
 type
   VMFlag* = enum
@@ -55,6 +56,7 @@ type
     blobGasUsed*      : uint64
     allLogs*          : seq[Log] # EIP-6110
     gasRefunded*      : int64    # Global gasRefunded counter
+    balTracker*       : BlockAccessListTrackerRef
 
   Computation* = ref object
     # The execution computation

--- a/execution_chain/rpc/debug.nim
+++ b/execution_chain/rpc/debug.nim
@@ -13,6 +13,7 @@ import
   # std/json,
   stew/byteutils,
   json_rpc/rpcserver,
+  eth/common/block_access_lists,
   # ./rpc_utils,
   ./rpc_types,
   #../tracer,
@@ -33,7 +34,16 @@ import
 #     disableStateDiff: Opt[bool]
 
 # TraceOptions.useDefaultSerializationIn JrpcConv
+
 ExecutionWitness.useDefaultSerializationIn JrpcConv
+
+# Block access list json serialization
+AccountChanges.useDefaultSerializationIn JrpcConv
+SlotChanges.useDefaultSerializationIn JrpcConv
+StorageChange.useDefaultSerializationIn JrpcConv
+BalanceChange.useDefaultSerializationIn JrpcConv
+NonceChange.useDefaultSerializationIn JrpcConv
+CodeChange.useDefaultSerializationIn JrpcConv
 
 # proc isTrue(x: Opt[bool]): bool =
 #   result = x.isSome and x.get() == true
@@ -83,6 +93,19 @@ proc getExecutionWitness*(chain: ForkedChainRef, blockHash: Hash32): Result[Exec
     executionWitness.addHeader(rlp.encode(header))
 
   ok(executionWitness)
+
+proc getBlockAccessList*(
+    chain: ForkedChainRef,
+    blockHash: Hash32): Result[BlockAccessList, string] =
+
+  let txFrame = chain.txFrame(blockHash).txFrameBegin()
+  defer:
+    txFrame.dispose()
+
+  let bal = (?txFrame.getBlockAccessList(blockHash)).valueOr:
+    return err("Block access list not found")
+
+  ok(bal)
 
 proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
   let
@@ -232,3 +255,17 @@ proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
       raise newException(ValueError, error)
 
     rlp.encode(header).to0xHex()
+
+  server.rpc("debug_getBlockAccessList") do(quantityTag: BlockTag) -> BlockAccessList:
+    ## Returns a block access list for the given block number.
+    let header = chain.headerFromTag(quantityTag).valueOr:
+      raise newException(ValueError, "Header not found")
+
+    chain.getBlockAccessList(header.computeBlockHash()).valueOr:
+      raise newException(ValueError, error)
+
+  server.rpc("debug_getBlockAccessListByBlockHash") do(blockHash: Hash32) -> BlockAccessList:
+    ## Returns a block access list for the given block hash.
+
+    chain.getBlockAccessList(blockHash).valueOr:
+      raise newException(ValueError, error)

--- a/execution_chain/rpc/engine_api.nim
+++ b/execution_chain/rpc/engine_api.nim
@@ -25,11 +25,13 @@ const supportedMethods: HashSet[string] =
     "engine_newPayloadV2",
     "engine_newPayloadV3",
     "engine_newPayloadV4",
+    "engine_newPayloadV5",
     "engine_getPayloadV1",
     "engine_getPayloadV2",
     "engine_getPayloadV3",
     "engine_getPayloadV4",
     "engine_getPayloadV5",
+    "engine_getPayloadV6",
     "engine_forkchoiceUpdatedV1",
     "engine_forkchoiceUpdatedV2",
     "engine_forkchoiceUpdatedV3",
@@ -66,6 +68,13 @@ proc setupEngineAPI*(engine: BeaconEngineRef, server: RpcServer) =
     await engine.newPayload(Version.V4, payload,
       expectedBlobVersionedHashes, parentBeaconBlockRoot, executionRequests)
 
+  server.rpc("engine_newPayloadV5") do(payload: ExecutionPayload,
+                                       expectedBlobVersionedHashes: Opt[seq[Hash32]],
+                                       parentBeaconBlockRoot: Opt[Hash32],
+                                       executionRequests: Opt[seq[seq[byte]]]) -> PayloadStatusV1:
+    await engine.newPayload(Version.V5, payload,
+      expectedBlobVersionedHashes, parentBeaconBlockRoot, executionRequests)
+
   server.rpc("engine_getPayloadV1") do(payloadId: Bytes8) -> ExecutionPayloadV1:
     return engine.getPayload(Version.V1, payloadId).executionPayload.V1
 
@@ -80,6 +89,9 @@ proc setupEngineAPI*(engine: BeaconEngineRef, server: RpcServer) =
 
   server.rpc("engine_getPayloadV5") do(payloadId: Bytes8) -> GetPayloadV5Response:
     return engine.getPayloadV5(payloadId)
+
+  server.rpc("engine_getPayloadV6") do(payloadId: Bytes8) -> GetPayloadV6Response:
+    return engine.getPayloadV6(payloadId)
 
   server.rpc("engine_forkchoiceUpdatedV1") do(update: ForkchoiceStateV1,
                     attrs: Opt[PayloadAttributesV1]) -> ForkchoiceUpdatedResponse:

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -45,6 +45,8 @@ proc initialAccessListEIP2929(call: CallParams) =
     if not call.isCreate:
       db.accessList(call.to)
       # If the `call.to` has a delegation, also warm its target.
+      if vmState.balTrackerEnabled:
+        vmState.balTracker.trackAddressAccess(call.to)
       let target = parseDelegationAddress(db.getCode(call.to))
       if target.isSome:
         db.accessList(target[])
@@ -68,6 +70,8 @@ proc preExecComputation(vmState: BaseVMState, call: CallParams): int64 =
   let ledger = vmState.ledger
 
   if not call.isCreate:
+    if vmState.balTrackerEnabled:
+      vmState.balTracker.trackIncNonceChange(call.sender)
     ledger.incNonce(call.sender)
 
   # EIP-7702
@@ -88,6 +92,8 @@ proc preExecComputation(vmState: BaseVMState, call: CallParams): int64 =
     ledger.accessList(authority)
 
     # 5. Verify the code of authority is either empty or already delegated.
+    if vmState.balTrackerEnabled:
+      vmState.balTracker.trackAddressAccess(authority)
     let code = ledger.getCode(authority)
     if code.len > 0:
       if not parseDelegation(code):
@@ -102,12 +108,18 @@ proc preExecComputation(vmState: BaseVMState, call: CallParams): int64 =
       gasRefund += PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST
 
     # 8. Set the code of authority to be 0xef0100 || address. This is a delegation designation.
-    if auth.address == zeroAddress:
-      ledger.setCode(authority, @[])
-    else:
-      ledger.setCode(authority, @(addressToDelegation(auth.address)))
+    let authCode =
+      if auth.address == zeroAddress:
+        @[]
+      else:
+        @(addressToDelegation(auth.address))
+    if vmState.balTrackerEnabled:
+      vmState.balTracker.trackCodeChange(authority, authCode)
+    ledger.setCode(authority, authCode)
 
     # 9. Increase the nonce of authority by one.
+    if vmState.balTrackerEnabled:
+      vmState.balTracker.trackNonceChange(authority, auth.nonce + 1)
     ledger.setNonce(authority, auth.nonce + 1)
 
   gasRefund
@@ -187,12 +199,16 @@ proc prepareToRunComputation(host: TransactionHost, call: CallParams) =
       fork = vmState.fork
 
     vmState.mutateLedger:
+      if vmState.balTrackerEnabled:
+        vmState.balTracker.trackSubBalanceChange(call.sender, call.gasLimit.u256 * call.gasPrice.u256)
       db.subBalance(call.sender, call.gasLimit.u256 * call.gasPrice.u256)
 
       # EIP-4844
       if fork >= FkCancun:
         let blobFee = calcDataFee(call.versionedHashes.len,
           vmState.blockCtx.excessBlobGas, vmState.com, fork)
+        if vmState.balTrackerEnabled:
+          vmState.balTracker.trackSubBalanceChange(call.sender, blobFee)
         db.subBalance(call.sender, blobFee)
 
 proc calculateAndPossiblyRefundGas(host: TransactionHost, call: CallParams): GasInt =
@@ -227,6 +243,8 @@ proc calculateAndPossiblyRefundGas(host: TransactionHost, call: CallParams): Gas
 
   # Refund for unused gas.
   if gasRemaining > 0 and not call.noGasCharge:
+    if host.vmState.balTrackerEnabled:
+      host.vmState.balTracker.trackAddBalanceChange(call.sender, gasRemaining.u256 * call.gasPrice.u256)
     host.vmState.mutateLedger:
       db.addBalance(call.sender, gasRemaining.u256 * call.gasPrice.u256)
 

--- a/scripts/eest_ci_cache.sh
+++ b/scripts/eest_ci_cache.sh
@@ -29,7 +29,7 @@ EEST_DEVNET_URL="https://github.com/ethereum/execution-spec-tests/releases/downl
 
 # --- BAL Release ---
 EEST_BAL_NAME="bal"
-EEST_BAL_VERSION="v1.6.0"
+EEST_BAL_VERSION="v1.8.0"
 EEST_BAL_DIR="${FIXTURES_DIR}/eest_bal"
 EEST_BAL_ARCHIVE="fixtures_bal.tar.gz"
 EEST_BAL_URL="https://github.com/ethereum/execution-spec-tests/releases/download/${EEST_BAL_NAME}%40${EEST_BAL_VERSION}/${EEST_BAL_ARCHIVE}"

--- a/tests/eest/eest_blockchain_test.nim
+++ b/tests/eest/eest_blockchain_test.nim
@@ -23,11 +23,7 @@ const
   ]
 
 const skipFiles = [
-    "consolidation_requests.json",
-    "withdrawal_requests.json",
-    "bal_call_and_oog.json",
-    "bal_delegatecall_and_oog.json",
-    "value_transfer_gas_calculation.json"
+  ""
 ]
 
 runEESTSuite(

--- a/tests/eest/eest_blockchain_test.nim
+++ b/tests/eest/eest_blockchain_test.nim
@@ -18,11 +18,16 @@ const
   eestType = "blockchain_tests"
   eestReleases = [
     "eest_develop",
-    "eest_devnet"
+    "eest_devnet",
+    "eest_bal"
   ]
 
 const skipFiles = [
-    ""
+    "consolidation_requests.json",
+    "withdrawal_requests.json",
+    "bal_call_and_oog.json",
+    "bal_delegatecall_and_oog.json",
+    "value_transfer_gas_calculation.json"
 ]
 
 runEESTSuite(

--- a/tests/eest/eest_engine_test.nim
+++ b/tests/eest/eest_engine_test.nim
@@ -26,11 +26,6 @@ const
 
 const skipFiles = [
   "CALLBlake2f_MaxRounds.json", # Doesn't work in github CI
-  "consolidation_requests.json",
-  "withdrawal_requests.json",
-  "bal_call_and_oog.json",
-  "bal_delegatecall_and_oog.json",
-  "value_transfer_gas_calculation.json"
 ]
 
 runEESTSuite(

--- a/tests/eest/eest_engine_test.nim
+++ b/tests/eest/eest_engine_test.nim
@@ -20,11 +20,17 @@ const
   eestType = "blockchain_tests_engine"
   eestReleases = [
     "eest_develop",
-    "eest_devnet"
+    "eest_devnet",
+    "eest_bal"
   ]
 
 const skipFiles = [
   "CALLBlake2f_MaxRounds.json", # Doesn't work in github CI
+  "consolidation_requests.json",
+  "withdrawal_requests.json",
+  "bal_call_and_oog.json",
+  "bal_delegatecall_and_oog.json",
+  "value_transfer_gas_calculation.json"
 ]
 
 runEESTSuite(

--- a/tests/test_block_access_list_builder.nim
+++ b/tests/test_block_access_list_builder.nim
@@ -35,7 +35,7 @@ suite "Block access list builder":
     builder.addTouchedAccount(address1)
     builder.addTouchedAccount(address1) # duplicate
 
-    let bal = builder.buildBlockAccessList()
+    let bal = builder.buildBlockAccessList()[]
     check:
       bal.len() == 3
       bal[0].address == address1
@@ -58,7 +58,7 @@ suite "Block access list builder":
     builder.addStorageWrite(address1, slot3, 3, 4.u256)
     builder.addStorageWrite(address1, slot3, 3, 5.u256) # duplicate should overwrite
 
-    let bal = builder.buildBlockAccessList()
+    let bal = builder.buildBlockAccessList()[]
     check:
       bal.len() == 2
       bal[0].address == address1
@@ -77,7 +77,7 @@ suite "Block access list builder":
     builder.addStorageRead(address1, slot1)
     builder.addStorageRead(address1, slot1) # duplicate
 
-    let bal = builder.buildBlockAccessList()
+    let bal = builder.buildBlockAccessList()[]
     check:
       bal.len() == 3
       bal[0].address == address1
@@ -94,7 +94,7 @@ suite "Block access list builder":
     builder.addBalanceChange(address1, 2, 2.u256)
     builder.addBalanceChange(address1, 2, 10.u256) # duplicate should overwrite
 
-    let bal = builder.buildBlockAccessList()
+    let bal = builder.buildBlockAccessList()[]
     check:
       bal.len() == 3
       bal[0].address == address1
@@ -111,7 +111,7 @@ suite "Block access list builder":
     builder.addNonceChange(address3, 1, 1)
     builder.addNonceChange(address3, 1, 10) # duplicate should overwrite
 
-    let bal = builder.buildBlockAccessList()
+    let bal = builder.buildBlockAccessList()[]
     check:
       bal.len() == 3
       bal[0].address == address1
@@ -127,7 +127,7 @@ suite "Block access list builder":
     builder.addCodeChange(address1, 3, @[0x3.byte])
     builder.addCodeChange(address1, 3, @[0x4.byte]) # duplicate should overwrite
 
-    let bal = builder.buildBlockAccessList()
+    let bal = builder.buildBlockAccessList()[]
     check:
       bal.len() == 2
       bal[0].address == address1
@@ -171,7 +171,7 @@ suite "Block access list builder":
     builder.addCodeChange(address1, 3, @[0x3.byte])
     builder.addCodeChange(address1, 3, @[0x4.byte]) # duplicate should overwrite
 
-    let bal = builder.buildBlockAccessList()
+    let bal = builder.buildBlockAccessList()[]
     check:
       bal.len() == 3
 

--- a/tests/test_block_access_list_validation.nim
+++ b/tests/test_block_access_list_validation.nim
@@ -31,7 +31,7 @@ suite "Block access list validation":
     let builder = BlockAccessListBuilderRef.init()
 
   test "Empty BAL should equal the EMPTY_BLOCK_ACCESS_LIST_HASH":
-    let emptyBal = builder.buildBlockAccessList()
+    let emptyBal = builder.buildBlockAccessList()[]
     check:
       emptyBal.validate(EMPTY_BLOCK_ACCESS_LIST_HASH).isOk()
       emptyBal.validate(default(Hash32)).isErr()
@@ -72,7 +72,7 @@ suite "Block access list validation":
     builder.addCodeChange(address1, 3, @[0x3.byte])
     builder.addCodeChange(address1, 3, @[0x4.byte]) # duplicate should overwrite
 
-    let bal = builder.buildBlockAccessList()
+    let bal = builder.buildBlockAccessList()[]
     check bal.validate(bal.computeBlockAccessListHash()).isOk()
 
   test "Storage changes and reads don't overlap for the same slot":
@@ -80,7 +80,7 @@ suite "Block access list validation":
     builder.addStorageWrite(address1, slot2, 2, 2.u256)
     builder.addStorageWrite(address1, slot3, 3, 3.u256)
 
-    var bal = builder.buildBlockAccessList()
+    var bal = builder.buildBlockAccessList()[]
     bal[0].storageReads = @[slot1.toBytes32()]
     check bal.validate(bal.computeBlockAccessListHash()).isErr()
 
@@ -89,7 +89,7 @@ suite "Block access list validation":
     builder.addTouchedAccount(address2)
     builder.addTouchedAccount(address3)
 
-    var bal = builder.buildBlockAccessList()
+    var bal = builder.buildBlockAccessList()[]
     check bal.validate(bal.computeBlockAccessListHash()).isOk()
     bal[0] = bal[2]
     check bal.validate(bal.computeBlockAccessListHash()).isErr()
@@ -99,7 +99,7 @@ suite "Block access list validation":
     builder.addStorageWrite(address1, slot2, 2, 2.u256)
     builder.addStorageWrite(address1, slot3, 3, 3.u256)
 
-    var bal = builder.buildBlockAccessList()
+    var bal = builder.buildBlockAccessList()[]
     check bal.validate(bal.computeBlockAccessListHash()).isOk()
     bal[0].storageChanges[0] = bal[0].storageChanges[2]
     check bal.validate(bal.computeBlockAccessListHash()).isErr()
@@ -109,7 +109,7 @@ suite "Block access list validation":
     builder.addStorageWrite(address1, slot1, 1, 1.u256)
     builder.addStorageWrite(address1, slot1, 2, 2.u256)
 
-    var bal = builder.buildBlockAccessList()
+    var bal = builder.buildBlockAccessList()[]
     check bal.validate(bal.computeBlockAccessListHash()).isOk()
     bal[0].storageChanges[0].changes[0] = bal[0].storageChanges[0].changes[2]
     check bal.validate(bal.computeBlockAccessListHash()).isErr()
@@ -119,7 +119,7 @@ suite "Block access list validation":
     builder.addStorageRead(address1, slot2)
     builder.addStorageRead(address1, slot3)
 
-    var bal = builder.buildBlockAccessList()
+    var bal = builder.buildBlockAccessList()[]
     check bal.validate(bal.computeBlockAccessListHash()).isOk()
     bal[0].storageReads[0] = bal[0].storageReads[2]
     check bal.validate(bal.computeBlockAccessListHash()).isErr()
@@ -129,7 +129,7 @@ suite "Block access list validation":
     builder.addBalanceChange(address1, 2, 2.u256)
     builder.addBalanceChange(address1, 3, 3.u256)
 
-    var bal = builder.buildBlockAccessList()
+    var bal = builder.buildBlockAccessList()[]
     check bal.validate(bal.computeBlockAccessListHash()).isOk()
     bal[0].balanceChanges[0] = bal[0].balanceChanges[2]
     check bal.validate(bal.computeBlockAccessListHash()).isErr()
@@ -139,7 +139,7 @@ suite "Block access list validation":
     builder.addNonceChange(address1, 2, 2)
     builder.addNonceChange(address1, 3, 3)
 
-    var bal = builder.buildBlockAccessList()
+    var bal = builder.buildBlockAccessList()[]
     check bal.validate(bal.computeBlockAccessListHash()).isOk()
     bal[0].nonceChanges[0] = bal[0].nonceChanges[2]
     check bal.validate(bal.computeBlockAccessListHash()).isErr()
@@ -149,7 +149,7 @@ suite "Block access list validation":
     builder.addCodeChange(address1, 1, @[0x2.byte])
     builder.addCodeChange(address1, 2, @[0x3.byte])
 
-    var bal = builder.buildBlockAccessList()
+    var bal = builder.buildBlockAccessList()[]
     check bal.validate(bal.computeBlockAccessListHash()).isOk()
     bal[0].codeChanges[0] = bal[0].codeChanges[2]
     check bal.validate(bal.computeBlockAccessListHash()).isErr()


### PR DESCRIPTION
This PR contains all the changes required to implement EIP-7928 which includes:
- Added BAL tracking into the evm to collect the required data for BAL building.
- BAL pre and post execution validation.
- Engine API changes.
- Added two new RPC endpoints debug_getBlockAccessList and debug_getBadBlocks.

BALs are only enabled at Amsterdam and the tracking is disabled otherwise so this change should have minimal impact pre-Amsterdam. 

