### PR TITLE
clean up some disk space in the Linux CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,15 @@ jobs:
       - name: Checkout nimbus-eth1
         uses: actions/checkout@v4
 
+      - name: Clean up disk space
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/lib/jvm || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/share/swift || true
+
       - id: shared-action
         uses: ./.github/actions/shared
         with:


### PR DESCRIPTION
The Linux amd64 runner is on/over the edge of disk space: Sometimes it fails with no more disk space, sometimes it successfully runs, but just barely: with less than 1 GB of available space.

Some numbers, before:
The amd64 runner starts with 57 out of 73 GB space used. Before any tests are run, 69 GB are used. After the tests there is 72+ GB used.
This PR cleans up 24 GB of space.

On the arm64 runner, the initial situation is much better: only 33 out of 73 GB is used. After the tests, 48 GB are used. Not really needed, but this PR cleans up 9 GB of space there.