### PR TITLE
Portal: Remove client field from ENR

### DIFF
--- a/portal/client/nimbus_portal_client.nim
+++ b/portal/client/nimbus_portal_client.nim
@@ -150,12 +150,7 @@ proc run(portalClient: PortalClient, config: PortalConf) {.raises: [CatchableErr
       Opt.none(Port),
       extUdpPort,
       Opt.none(Port),
-      # Note: usage of the client field "c" is replaced with ping extensions client_info.
-      # This can be removed in the future when no more tooling relies on it.
-      localEnrFields = [
-        toFieldPair("c", enrClientInfoShort),
-        toFieldPair(portalEnrKey, getPortalEnrField(config.network)),
-      ],
+      localEnrFields = [toFieldPair(portalEnrKey, getPortalEnrField(config.network))],
       bootstrapRecords = bootstrapRecords,
       previousRecord = previousEnr,
       bindIp = Opt.some(bindIp),

--- a/portal/tools/portalcli.nim
+++ b/portal/tools/portalcli.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Copyright (c) 2021-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -239,13 +239,13 @@ proc run(config: PortalCliConf) =
     extIp,
     Opt.none(Port),
     extUdpPort,
+    Opt.none(Port),
     localEnrFields = {portalEnrKey: rlp.encode(localPortalEnrField)},
     bootstrapRecords = bootstrapRecords,
-    bindIp = bindIp,
+    bindIp = Opt.some(bindIp),
     bindPort = udpPort,
     enrAutoUpdate = config.enrAutoUpdate,
     rng = rng,
-    banNodes = true,
   )
 
   d.open()


### PR DESCRIPTION
This field is no longer needed/used to check which client runs. Instead the ping extensions are used to retrieve the client information.