### PR TITLE
Exclude librocksdb.dll from  getting added in release tar for NVP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
           # Pack only the relevant binaries (and their checksums) from build/
           # Add additional files (LICENSE, README, configs) if desired with extra -C args.
           tar -czf "${NEC_TAR}" --exclude="build/nimbus_verified_proxy*" -C "${ARCHIVE_DIR}" .
-          tar -czf "${NVP_TAR}" --exclude="build/nimbus_execution_client*" -C "${ARCHIVE_DIR}" .
+          tar -czf "${NVP_TAR}" --exclude="build/nimbus_execution_client*" --exclude="build/librocksdb.dll" -C "${ARCHIVE_DIR}" .
 
           # Generate sha512 for the tarballs themselves
           sha512sum "${NEC_TAR}" > "${NEC_TAR}.sha512sum"


### PR DESCRIPTION
Current release tar for Windows includes librocksdb.dll which is not needed for NVP.