### PR TITLE
Portal: share versioning with Nimbus

### DIFF
--- a/portal/version.nim
+++ b/portal/version.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2025 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -7,21 +7,20 @@
 
 {.push raises: [].}
 
-import std/[os, strutils], stew/byteutils, metrics, beacon_chain/buildinfo
+import
+  std/[os, strutils],
+  stew/byteutils,
+  metrics,
+  beacon_chain/buildinfo,
+  ../execution_chain/version
 
 export buildinfo
 
 const
-  versionMajor* = 0
-  versionMinor* = 1
-  versionBuild* = 0
-
-  versionAsStr* = $versionMajor & "." & $versionMinor & "." & $versionBuild
-
   sourcePath = currentSourcePath.rsplit({DirSep, AltSep}, 1)[0]
   GitRevision = generateGitRevision(sourcePath)
 
-  fullVersionStr* = "v" & versionAsStr & "-" & GitRevision
+  fullVersionStr* = "v" & NimbusVersion & "-" & GitRevision
 
   clientName* = "nimbus_portal_client"
 


### PR DESCRIPTION
Much less as a step than https://github.com/status-im/nimbus-eth1/pull/3923, but at least Portal will follow the same release versions.