### PR TITLE
BAL-devnet-2: EIP-7778: Block Gas Accounting without Refunds

### DIFF
--- a/execution_chain/core/tx_pool/tx_packer.nim
+++ b/execution_chain/core/tx_pool/tx_packer.nim
@@ -124,7 +124,7 @@ proc runTxCommit(pst: var TxPacker; item: TxItemRef; callResult: LogResult, xp: 
 
   # Return remaining gas to the block gas counter so it is
   # available for the next transaction.
-  vmState.gasPool += item.tx.gasLimit - callResult.gasUsed
+  vmState.gasPool += item.tx.gasLimit - callResult.blockGasUsed
 
   # gasUsed accounting
   vmState.cumulativeGasUsed += callResult.gasUsed

--- a/execution_chain/transaction/call_types.nim
+++ b/execution_chain/transaction/call_types.nim
@@ -56,7 +56,8 @@ type
 
   LogResult* = object
     logEntries*: seq[Log]
-    gasUsed*:    GasInt
+    gasUsed*: GasInt
+    blockGasUsed*: GasInt
 
   OutputResult* = object
     error*:   string


### PR DESCRIPTION
fix #3905 

~~- [ ] It's still unclear how `gasSpent` of `Receipt` should be implemented, as an optional field or new type of receipt?~~
~~- [ ] Add `gasSpent` field to web3 and RPC `ReceiptObject`.~~
~~- [ ] Add `gasSpent` field to tests.~~