### PR TITLE
Fix JSON error object for eth_estimateGas

### DIFF
--- a/execution_chain/evm/async_evm.nim
+++ b/execution_chain/evm/async_evm.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2025 Status Research & Development GmbH
+# Copyright (c) 2025-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -410,7 +410,7 @@ proc estimateGas*(
     evmResult = rpcEstimateGas(tx, header, vmState, EVM_CALL_GAS_CAP)
     gasEstimate =
       ?evmResult.mapErr(
-        proc(e: EvmErrorObj): string =
-          "EVM execution failed: " & $e.code
+        proc(e: (EvmErrorObj, OutputResult)): string =
+          "EVM execution failed: " & $e[0].code
       )
   ok(gasEstimate)

--- a/execution_chain/rpc/server_api.nim
+++ b/execution_chain/rpc/server_api.nim
@@ -354,9 +354,14 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
         raise newException(ValueError, "Block not found")
       headerHash = header.computeBlockHash
       txFrame = api.chain.txFrame(headerHash)
-      #TODO: change 0 to configureable gas cap
+      # TODO: change 0 to configureable gas cap
       gasUsed = rpcEstimateGas(args, header, headerHash, api.com, txFrame, DEFAULT_RPC_GAS_CAP).valueOr:
-        raise newException(ValueError, "rpcEstimateGas error: " & $error.code)
+        let data = Opt.some(JrpcConv.encode(error[1].output.to0xHex()).JsonString)
+        raise (ref ApplicationError)(
+          code: 3,
+          msg: $error[1].error,
+          data: data,
+        )
     Quantity(gasUsed)
 
   server.rpc("eth_gasPrice") do() -> Quantity:


### PR DESCRIPTION
The error object should contain the EVM revert output in case of execution reverted.

estimateGas API wise is still rather ugly but a  minimal changes solution. The implementation can be improved anyhow with some quick sanity tries before the bin search. Further clean-up can be done at that improvement.