### PR TITLE
Use block access list when replaying blocks on startup

### DIFF
--- a/execution_chain/core/chain/forked_chain/chain_serialize.nim
+++ b/execution_chain/core/chain/forked_chain/chain_serialize.nim
@@ -1,5 +1,5 @@
 # nimbus-execution-client
-# Copyright (c) 2025 Status Research & Development GmbH
+# Copyright (c) 2025-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2025 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
Serialize BAL into base on shutdown and use it when replaying blocks on startup in order to speed up block processing. This will be useful once parallel execution is supported.