### PR TITLE
fix: gate EIP-8024 opcodes on Amsterdam fork only

### DIFF
--- a/execution_chain/evm/interpreter/op_handlers/oph_defs.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_defs.nim
@@ -89,7 +89,7 @@ const
     VmOpPragueAndLater - {FkPrague}
 
   VmOpAmsterdamAndLater* =
-    VmOpOsakaAndLater - {FkOsaka}
+    {FkAmsterdam..EVMFork.high}
 
 # ------------------------------------------------------------------------------
 # End


### PR DESCRIPTION
## Summary
- Fix `VmOpAmsterdamAndLater` fork set to only include Amsterdam and future named forks

## Problem
`VmOpAmsterdamAndLater` was defined as:
```nim
VmOpAmsterdamAndLater = VmOpOsakaAndLater - {FkOsaka}
```

This left BPO forks (FkBpo1-5) in the set. BPO forks only change blob parameters and have no effect on opcode activation - they shouldn't be included in opcode fork sets.

Since bal-devnet-2 genesis has `bpo1Time: 0`, EIP-8024 opcodes (DUPN, SWAPN, EXCHANGE) were incorrectly active at genesis instead of at Amsterdam fork (Gloas epoch 1).

## Fix
Define `VmOpAmsterdamAndLater` explicitly as Amsterdam and future named forks:
```nim
VmOpAmsterdamAndLater = {FkAmsterdam..EVMFork.high}
```

## Comparison with other clients
In geth, EIP-8024 is correctly gated on Amsterdam only via `newAmsterdamInstructionSet()` in `core/vm/jump_table.go`.

## Test plan
- [ ] Multi-client devnet with evm-fuzz spamoor - verify no gasUsed mismatches pre-Gloas
- [ ] Verify DUPN/SWAPN/EXCHANGE return invalid opcode error before Amsterdam fork
- [ ] Verify opcodes work correctly after Amsterdam fork activates

🤖 Generated with [Claude Code](https://claude.ai/code)