### PR TITLE
Add delete and delete range functions to kvt utils

### DIFF
--- a/execution_chain/db/kvt/kvt_desc.nim
+++ b/execution_chain/db/kvt/kvt_desc.nim
@@ -48,6 +48,10 @@ type
 
   # -------------
 
+  DelKvpFn* =
+    proc(key: openArray[byte]): Result[void, KvtError] {.gcsafe, raises: [].}
+      ## Generic backend database delete function.
+
   DelRangeKvpFn* =
     proc(startKey, endKey: openArray[byte], compactRange: bool): Result[void, KvtError] {.gcsafe, raises: [].}
       ## Generic backend database bulk delete function.
@@ -82,6 +86,7 @@ type
     putKvpFn*: PutKvpFn              ## Bulk store key-value pairs
     putEndFn*: PutEndFn              ## Commit bulk store session
 
+    delKvpFn*: DelKvpFn              ## Delete key-value pair
     delRangeKvpFn*: DelRangeKvpFn    ## Bulk delete key-value pairs
 
     closeFn*: CloseFn                ## Generic destructor

--- a/execution_chain/db/kvt/kvt_init/memory_db.nim
+++ b/execution_chain/db/kvt/kvt_init/memory_db.nim
@@ -116,6 +116,16 @@ proc putEndFn(db: MemBackendRef): PutEndFn =
 
 # -------------
 
+proc delKvpFn(db: MemBackendRef): DelKvpFn =
+  result =
+    proc(key: openArray[byte]): Result[void, KvtError] =
+      if key.len == 0:
+        return err(KeyInvalid)
+
+      db.tab.del(@key)
+
+      ok()
+
 proc delRangeKvpFn(db: MemBackendRef): DelRangeKvpFn =
   result =
     proc(startKey, endKey: openArray[byte], compactRange: bool): Result[void, KvtError] =
@@ -163,6 +173,7 @@ proc memoryBackend*: KvtDbRef =
   db.putKvpFn = putKvpFn be
   db.putEndFn = putEndFn be
 
+  db.delKvpFn = delKvpFn(be)
   db.delRangeKvpFn = delRangeKvpFn(be)
 
   db.closeFn = closeFn be

--- a/execution_chain/db/kvt/kvt_utils.nim
+++ b/execution_chain/db/kvt/kvt_utils.nim
@@ -43,6 +43,12 @@ proc getBeLen*(
 
 # ------------
 
+proc delBe*(
+    db: KvtDbRef,
+    key: openArray[byte]
+    ): Result[void, KvtError] =
+  db.delKvpFn(key)
+
 proc delRangeBe*(
     db: KvtDbRef,
     startKey, endKey: openArray[byte],

--- a/tests/test_kvt.nim
+++ b/tests/test_kvt.nim
@@ -37,13 +37,39 @@ suite "Kvt TxFrame":
     check:
       db.putEndFn(batch).isOk()
 
-    db.finish()
-
     block:
       # using the same backend but new txRef and cache
       let tx = db.baseTxFrame()
       check:
         tx.get([byte 0, 1, 2]).expect("entry") == @[byte 0, 1, 3]
+
+    db.finish()
+
+  test "Delete":
+    let
+      tx0 = db.txFrameBegin(db.baseTxFrame())
+
+    check:
+      tx0.put([byte 0, 1, 1], [byte 0, 1, 4]).isOk()
+      tx0.put([byte 0, 1, 2], [byte 0, 1, 5]).isOk()
+      tx0.put([byte 0, 1, 3], [byte 0, 1, 6]).isOk()
+
+    let batch = db.putBegFn().expect("working batch")
+    db.persist(batch, tx0)
+    check:
+      db.putEndFn(batch).isOk()
+
+    check db.delBe([byte 0, 1, 2]).isOk()
+
+    block:
+      # using the same backend but new txRef and cache
+      let tx = db.baseTxFrame()
+      check:
+        tx.get([byte 0, 1, 1]).expect("entry") == @[byte 0, 1, 4]
+        not tx.hasKey([byte 0, 1, 2])
+        tx.get([byte 0, 1, 3]).expect("entry") == @[byte 0, 1, 6]
+
+    db.finish()
 
   test "Delete range":
     let
@@ -59,14 +85,14 @@ suite "Kvt TxFrame":
     check:
       db.putEndFn(batch).isOk()
 
-
-    check db.delRangeBe([byte 0, 1, 2], [byte 0, 1, 3], compactRange = false).isOk()
+    check db.delRangeBe([byte 0, 1, 1], [byte 0, 1, 3], compactRange = false).isOk()
 
     block:
       # using the same backend but new txRef and cache
       let tx = db.baseTxFrame()
       check:
-        tx.get([byte 0, 1, 1]).expect("entry") == @[byte 0, 1, 4]
+        not tx.hasKey([byte 0, 1, 1])
+        not tx.hasKey([byte 0, 1, 2])
         tx.get([byte 0, 1, 3]).expect("entry") == @[byte 0, 1, 6]
 
     db.finish()


### PR DESCRIPTION
This PR adds a delete range function to the kvt backend to support bulk deletes. 

The idea here is we bypass the kvt txFrame layers and go directly to the backend since the purpose of the method is really to delete historical data on disk and a bulk delete going through each of the in memory txframe layers would be slow.

The history expiry pruner can use this by importing the kvt_utils module and calling `delRangeBe`. 

The `compactRange` parameter doesn't compact the key range immediately but rather suggests to the RocksDb background job that the key ranges should be compacted.

cc @advaita-saha 