### PR TITLE
Witness: Implement optimisation where touched code can be skipped

### DIFF
--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -155,6 +155,7 @@ proc processBlock*(
     # when building the witness.
     vmState.ledger.clearWitnessKeys()
     vmState.ledger.clearCollapsedSiblings()
+    vmState.ledger.clearDeployedCodeHashes()
     vmState.ledger.clearBlockHashesCache()
 
     processBlock()

--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -191,6 +191,7 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
     # when building the witness.
     vmState.ledger.clearWitnessKeys()
     vmState.ledger.clearCollapsedSiblings()
+    vmState.ledger.clearDeployedCodeHashes()
     vmState.ledger.clearBlockHashesCache()
 
     processBlock()

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -570,6 +570,9 @@ proc getNonce*(ledger: LedgerRef, address: Address): AccountNonce =
 
 func isDeployedCode(ledger: LedgerRef, codeHash: Hash32): bool =
   ## Check if codeHash was deployed in any currently active save point.
+  ## A deployment only counts while every save point it lives in is still
+  ## active: reverted deployments are rolled back and must not suppress
+  ## witness entries.
   var sp = ledger.savePoint
   while sp != nil:
     if codeHash in sp.deployedCodeHashes:
@@ -577,20 +580,22 @@ func isDeployedCode(ledger: LedgerRef, codeHash: Hash32): bool =
     sp = sp.parentSavePoint
   false
 
+proc recordCodeRead(ledger: LedgerRef, address: Address, acc: AccountRef) =
+  ## Mark the code as touched in the witness keys, unless the code was
+  ## deployed earlier in this block.
+  ## We overwrite any existing false entry so codeTouched is set to true
+  ## even if the account was previously accessed without touching the code.
+  if acc.isNil or acc.statement.codeHash == EMPTY_CODE_HASH or
+      not ledger.isDeployedCode(acc.statement.codeHash):
+    ledger.witnessKeys[(address, Opt.none(UInt256))] = true
+
 proc getCode*(ledger: LedgerRef,
               address: Address,
               returnHash: static[bool] = false): auto =
   let acc = ledger.getAccount(address, false)
 
   if ledger.collectWitness:
-    let lookupKey = (address, Opt.none(UInt256))
-    # Only mark codeTouched if the code isn't deployed in this block.
-    # Deployed code can be recovered from tx data directly.
-    # We overwrite any existing false entry so codeTouched is set to true
-    # even if the account was previously accessed without touching the code.
-    if acc.isNil or acc.statement.codeHash == EMPTY_CODE_HASH or
-        not ledger.isDeployedCode(acc.statement.codeHash):
-      ledger.witnessKeys[lookupKey] = true
+    ledger.recordCodeRead(address, acc)
 
   if acc.isNil:
     when returnHash:
@@ -651,10 +656,7 @@ proc getCodeSize*(ledger: LedgerRef, address: Address): int =
   let acc = ledger.getAccount(address, false)
 
   if ledger.collectWitness:
-    let lookupKey = (address, Opt.none(UInt256))
-    if acc.isNil or acc.statement.codeHash == EMPTY_CODE_HASH or
-        not ledger.isDeployedCode(acc.statement.codeHash):
-      ledger.witnessKeys[lookupKey] = true
+    ledger.recordCodeRead(address, acc)
 
   if acc.isNil:
     return 0

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -141,6 +141,8 @@ type
     dirty: Table[Address, AccountRef]
     selfDestruct: HashSet[Address]
     accessList: ac_access_list.AccessList
+    deployedCodeHashes: HashSet[Hash32]
+      ## Caches codeHashes deployed via CREATE in this savepoint.
 
 const
   resetFlags = {
@@ -520,6 +522,7 @@ proc commit*(ledger: LedgerRef, savePoint: LedgerSpRef) =
   ledger.savePoint.dirty.mergeAndReset(savePoint.dirty)
   ledger.savePoint.accessList.mergeAndReset(savePoint.accessList)
   ledger.savePoint.selfDestruct.mergeAndReset(savePoint.selfDestruct)
+  ledger.savePoint.deployedCodeHashes.mergeAndReset(savePoint.deployedCodeHashes)
 
   savePoint.parentSavePoint = nil # Release memory
 
@@ -565,16 +568,30 @@ proc getNonce*(ledger: LedgerRef, address: Address): AccountNonce =
   if acc.isNil: EMPTY_ACCOUNT.nonce
   else: acc.statement.nonce
 
+func isDeployedCode(ledger: LedgerRef, codeHash: Hash32): bool =
+  ## Check if codeHash was deployed in any currently active save point.
+  var sp = ledger.savePoint
+  while sp != nil:
+    if codeHash in sp.deployedCodeHashes:
+      return true
+    sp = sp.parentSavePoint
+  false
+
 proc getCode*(ledger: LedgerRef,
               address: Address,
               returnHash: static[bool] = false): auto =
+  let acc = ledger.getAccount(address, false)
+
   if ledger.collectWitness:
     let lookupKey = (address, Opt.none(UInt256))
-    # We overwrite any existing record here so that codeTouched is always set to
-    # true even if an account was previously accessed without touching the code
-    ledger.witnessKeys[lookupKey] = true
+    # Only mark codeTouched if the code isn't deployed in this block.
+    # Deployed code can be recovered from tx data directly.
+    # We overwrite any existing false entry so codeTouched is set to true
+    # even if the account was previously accessed without touching the code.
+    if acc.isNil or acc.statement.codeHash == EMPTY_CODE_HASH or
+        not ledger.isDeployedCode(acc.statement.codeHash):
+      ledger.witnessKeys[lookupKey] = true
 
-  let acc = ledger.getAccount(address, false)
   if acc.isNil:
     when returnHash:
       return (EMPTY_CODE_HASH, CodeBytesRef())
@@ -631,13 +648,14 @@ proc getOriginalCode*(ledger: LedgerRef, address: Address): CodeBytesRef =
   acc.original.code
 
 proc getCodeSize*(ledger: LedgerRef, address: Address): int =
+  let acc = ledger.getAccount(address, false)
+
   if ledger.collectWitness:
     let lookupKey = (address, Opt.none(UInt256))
-    # We overwrite any existing record here so that codeTouched is always set to
-    # true even if an account was previously accessed without touching the code
-    ledger.witnessKeys[lookupKey] = true
+    if acc.isNil or acc.statement.codeHash == EMPTY_CODE_HASH or
+        not ledger.isDeployedCode(acc.statement.codeHash):
+      ledger.witnessKeys[lookupKey] = true
 
-  let acc = ledger.getAccount(address, false)
   if acc.isNil:
     return 0
   getCodeSizeImpl(ledger, acc)
@@ -758,6 +776,8 @@ proc setCode*(ledger: LedgerRef, address: Address, code: seq[byte]) =
     # a given that it will be executed within LRU range
     acc.code = ledger.code.get(codeHash).valueOr(CodeBytesRef.init(code))
     acc.flags.incl CodeChanged
+    if ledger.collectWitness and code.len > 0:
+      ledger.savePoint.deployedCodeHashes.incl(codeHash)
 
 proc setStorage*(ledger: LedgerRef, address: Address, slot, value: UInt256) =
   let acc = ledger.getAccount(address)
@@ -888,6 +908,9 @@ template clearWitnessKeys*(ledger: LedgerRef) =
 template clearCollapsedSiblings*(ledger: LedgerRef) =
   ledger.txFrame.aTx.collapsedSiblings.setLen(0)
 
+template clearDeployedCodeHashes*(ledger: LedgerRef) =
+  ledger.savePoint.deployedCodeHashes.clear()
+
 proc getBlockHash*(ledger: LedgerRef, blockNumber: BlockNumber): Hash32 =
   # Range checks must be done earlier, any miss here treated as an error:
   # we record it as a fatalError.
@@ -979,6 +1002,7 @@ proc persist*(ledger: LedgerRef,
   if clearWitness:
     ledger.clearWitnessKeys()
     ledger.clearCollapsedSiblings()
+    ledger.clearDeployedCodeHashes()
     ledger.clearBlockHashesCache()
 
 iterator addresses*(ledger: LedgerRef): Address =

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -26,10 +26,6 @@ const skipFiles = [
   #
   # --- eest_zkevm files with failures ---
   #
-  # Witness codes mismatch -> codes optimisation: implemented in
-  # https://github.com/status-im/nimbus-eth1/pull/4099
-  "witness_codes_create_same_hash_then_read.json",
-
   # No fail yet as we don't check/use public keys. We could check them easily
   # but the better way is to use them as optimization and check automatically
   # that way.


### PR DESCRIPTION
Implementation of optimisation where touched code can be skipped from the witness if that same code was deployed in an earlier transaction in the same block.

In this scenario the witness can be smaller as that code is technically not required for the stateless execution, as it is already available via the transaction in the block, and thus in stateless execution will already be there after executing the earlier transaction.

Not fully sure however if this added complexity is worth the optimisation. As in, I have no view on how often a case like that occurs, and maybe more edge cases exist,  but it is however a scenario tested in EEST zkevm tests.

We could of course decide not to implement this, as the bigger witness will also work as input in practice.


**More details:**

The test that currently fails on this is `tests/fixtures/eest_zkevm/blockchain_tests/for_amsterdam/amsterdam/eip8025_optional_proofs/witness_bytecodes_contract_creation/witness_codes_create_same_hash_then_read.json`

```sh
Witness codes mismatch

got: ExecutionWitness:
State:
0xf869a0209d57be05dd69371c4dd2e871bce6e9f4124236825bb612ee18a45e5675be51b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a06e49e66782037c0555897870e29fa5e552daf4719552131a0abce779daec0a5d
0xf869a020b5222927ae1e67653ae291eff51f30e094e808b1ac5d2cff6b17af88d0fb02b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0bc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a
0xf869a037d65eaa92c6bc4c13a5ec45527f0c18ea8932588728769ec7aecfe6d9f32e42b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0f57acd40259872606d76197ef052f3d35588dadf919ee1f0e3cb9b62d3f4b02c
0xf869a03d6aea581b220579a2b99819299dd32c7c28a420018ecb0bde93af007ad89a31b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a078c6cb5202685228bbcbfb992b1c4e116c7ec5ef11e25b8e92716cfc628ddd60
0xf869a03f86c581c7d7b44eecbb92fd9e5867945ec1acdc0ea5bbabda21d17dddf06473b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a00345a365d2f4c5975b9f1599abe0a2ee76b7a3a731bc68781bd04c84e4858f50
0xf87180808080808080a0de12128dd97b161a53d43e7720c6b143083880bc6e51b61f4c5dac9c31e2554980808080a031357c4a138624e300159fc631211a29d8373db4bdf59b80dad6e816593d0bcb8080a0b5790ff14363bee5d40c4a9fd9d6a515fc44683cc4d46666b4d9c775dded101780
0xf872a0398c46c1cd401c84822dcbb14183ac2741d636ee3f98aff311669bf73e5fa0e2b84ff84d80893635c9adc5dea00000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
0xf872a039e34e8721da3b1f81c1f9a283ef9560ce1cce3f7883f67353b3ee188452884eb84ff84d80893635c9adc5dea00000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
0xf8d1a09e5ad71f774e0d0dd63f978cc6021e09acb8fbcecdbfff2975d362926c4f9ace80a0b5b019eac3ef7c2d4afafb62220bef8661aebbb166638c4e09a745c57168fa7aa066a64e47bae97c0fccdc260c76b1c987c89560cb40e86ea17a1d5fd49e35bebe8080a0bdb213f8b2bd52a0366a3e93592a7adfc40ae2181e5789771c8878a6ddc5f6e58080a022503b76949777417a4a627be5f1b4aa33cc4733eba69b4dfa6ff6e707b0f336808080a008be39f7c15cc06a7d863615397887281eadcbdb7907665d0683ca3c6383e6b0808080
Codes:
0x00
0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500
0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500
0x3373fffffffffffffffffffffffffffffffffffffffe1460cb5760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff146101f457600182026001905f5b5f82111560685781019083028483029004916001019190604d565b909390049250505036603814608857366101f457346101f4575f5260205ff35b34106101f457600154600101600155600354806003026004013381556001015f35815560010160203590553360601b5f5260385f601437604c5fa0600101600355005b6003546002548082038060101160df575060105b5f5b8181146101835782810160030260040181604c02815460601b8152601401816001015481526020019060020154807fffffffffffffffffffffffffffffffff00000000000000000000000000000000168252906010019060401c908160381c81600701538160301c81600601538160281c81600501538160201c81600401538160181c81600301538160101c81600201538160081c81600101535360010160e1565b910180921461019557906002556101a0565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff14156101cd57505f5b6001546002828201116101e25750505f6101e8565b01600290035b5f555f600155604c025ff35b5f5ffd
0x3373fffffffffffffffffffffffffffffffffffffffe1460d35760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1461019a57600182026001905f5b5f82111560685781019083028483029004916001019190604d565b9093900492505050366060146088573661019a573461019a575f5260205ff35b341061019a57600154600101600155600354806004026004013381556001015f358155600101602035815560010160403590553360601b5f5260605f60143760745fa0600101600355005b6003546002548082038060021160e7575060025b5f5b8181146101295782810160040260040181607402815460601b815260140181600101548152602001816002015481526020019060030154905260010160e9565b910180921461013b5790600255610146565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff141561017357505f5b6001546001828201116101885750505f61018e565b01600190035b5f555f6001556074025ff35b5f5ffd
Headers:
0xf90279a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a078b1f16cfcaebb599589d6aca588206634ef5e007f9d15ac553491be7ec0d4c8a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080808407270e00808000a0000000000000000000000000000000000000000000000000000000000000000088000000000000000007a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b4218080a00000000000000000000000000000000000000000000000000000000000000000a0e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d4934780

expected: ExecutionWitness:
State:
0xf869a0209d57be05dd69371c4dd2e871bce6e9f4124236825bb612ee18a45e5675be51b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a06e49e66782037c0555897870e29fa5e552daf4719552131a0abce779daec0a5d
0xf869a020b5222927ae1e67653ae291eff51f30e094e808b1ac5d2cff6b17af88d0fb02b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0bc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a
0xf869a037d65eaa92c6bc4c13a5ec45527f0c18ea8932588728769ec7aecfe6d9f32e42b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0f57acd40259872606d76197ef052f3d35588dadf919ee1f0e3cb9b62d3f4b02c
0xf869a03d6aea581b220579a2b99819299dd32c7c28a420018ecb0bde93af007ad89a31b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a078c6cb5202685228bbcbfb992b1c4e116c7ec5ef11e25b8e92716cfc628ddd60
0xf869a03f86c581c7d7b44eecbb92fd9e5867945ec1acdc0ea5bbabda21d17dddf06473b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a00345a365d2f4c5975b9f1599abe0a2ee76b7a3a731bc68781bd04c84e4858f50
0xf87180808080808080a0de12128dd97b161a53d43e7720c6b143083880bc6e51b61f4c5dac9c31e2554980808080a031357c4a138624e300159fc631211a29d8373db4bdf59b80dad6e816593d0bcb8080a0b5790ff14363bee5d40c4a9fd9d6a515fc44683cc4d46666b4d9c775dded101780
0xf872a0398c46c1cd401c84822dcbb14183ac2741d636ee3f98aff311669bf73e5fa0e2b84ff84d80893635c9adc5dea00000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
0xf872a039e34e8721da3b1f81c1f9a283ef9560ce1cce3f7883f67353b3ee188452884eb84ff84d80893635c9adc5dea00000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
0xf8d1a09e5ad71f774e0d0dd63f978cc6021e09acb8fbcecdbfff2975d362926c4f9ace80a0b5b019eac3ef7c2d4afafb62220bef8661aebbb166638c4e09a745c57168fa7aa066a64e47bae97c0fccdc260c76b1c987c89560cb40e86ea17a1d5fd49e35bebe8080a0bdb213f8b2bd52a0366a3e93592a7adfc40ae2181e5789771c8878a6ddc5f6e58080a022503b76949777417a4a627be5f1b4aa33cc4733eba69b4dfa6ff6e707b0f336808080a008be39f7c15cc06a7d863615397887281eadcbdb7907665d0683ca3c6383e6b0808080
Codes:
0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500
0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500
0x3373fffffffffffffffffffffffffffffffffffffffe1460cb5760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff146101f457600182026001905f5b5f82111560685781019083028483029004916001019190604d565b909390049250505036603814608857366101f457346101f4575f5260205ff35b34106101f457600154600101600155600354806003026004013381556001015f35815560010160203590553360601b5f5260385f601437604c5fa0600101600355005b6003546002548082038060101160df575060105b5f5b8181146101835782810160030260040181604c02815460601b8152601401816001015481526020019060020154807fffffffffffffffffffffffffffffffff00000000000000000000000000000000168252906010019060401c908160381c81600701538160301c81600601538160281c81600501538160201c81600401538160181c81600301538160101c81600201538160081c81600101535360010160e1565b910180921461019557906002556101a0565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff14156101cd57505f5b6001546002828201116101e25750505f6101e8565b01600290035b5f555f600155604c025ff35b5f5ffd
0x3373fffffffffffffffffffffffffffffffffffffffe1460d35760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1461019a57600182026001905f5b5f82111560685781019083028483029004916001019190604d565b9093900492505050366060146088573661019a573461019a575f5260205ff35b341061019a57600154600101600155600354806004026004013381556001015f358155600101602035815560010160403590553360601b5f5260605f60143760745fa0600101600355005b6003546002548082038060021160e7575060025b5f5b8181146101295782810160040260040181607402815460601b815260140181600101548152602001816002015481526020019060030154905260010160e9565b910180921461013b5790600255610146565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff141561017357505f5b6001546001828201116101885750505f61018e565b01600190035b5f555f6001556074025ff35b5f5ffd
Headers:
0xf90279a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a078b1f16cfcaebb599589d6aca588206634ef5e007f9d15ac553491be7ec0d4c8a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080808407270e00808000a0000000000000000000000000000000000000000000000000000000000000000088000000000000000007a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b4218080a00000000000000000000000000000000000000000000000000000000000000000a0e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d4934780
)

```

code `0x00` can be optimised away there.

As stated in description of the test case:

`"description": "Tx1 deploys a contract, tx2 calls a pre-state contract with same code.\n\nThe pre-state contract's bytecode must not appear in\nexecutionWitness.codes because the same code hash was already\nwritten by tx1's CREATE.  A stateless verifier observed\nthe bytecode from the CREATE transaction data, so including it\nin the witness is redundant.",`


The test vector contains this account pre-state

```json
            "0x37f536464af59c8d7358cae965f92cbeadd58dcb": {
                "nonce": "0x01",
                "balance": "0x00",
                "code": "0x00",
                "storage": {}
            },
```
With code "0x00"


And with these transactions:

```json
                "transactions": [
                    {
                        "type": "0x00",
                        "chainId": "0x01",
                        "nonce": "0x00",
                        "gasPrice": "0x0a",
                        "gasLimit": "0x07a120",
                        "value": "0x00",
                        "data": "0x610001600081600b8239f300",
                        "v": "0x26",
                        "r": "0x86aa3c082ab77fa3436485fdfe566c8da623e3dd411e08bc6307e2f4cb7dfd99",
                        "s": "0x58aacce317b2904591b9ad1f5a76ffdd4ffc22b8726dfc8b95cf6b707b8e77db",
                        "sender": "0x1ad9bc24818784172ff393bb6f89f094d4d2ca29",
                        "to": ""
                    },
                    {
                        "type": "0x00",
                        "chainId": "0x01",
                        "nonce": "0x00",
                        "gasPrice": "0x0a",
                        "gasLimit": "0x030d40",
                        "to": "0x37f536464af59c8d7358cae965f92cbeadd58dcb",
                        "value": "0x00",
                        "data": "0x",
                        "v": "0x25",
                        "r": "0x15d5b46d6b4ca7e1f28b7f5bf1816d5b4c9016d08555733d3406671bcb7acc72",
                        "s": "0x03002753cc37e17df4fd0d12490727aada3efc7f8dffd3816f80a52318613ed2",
                        "sender": "0xdd616a20f3b01fc95e6b1701d8a07331d06dd897"
                    }
                ]
```

So:
- Pre-state: 0x37f536464af59c8d7358cae965f92cbeadd58dcb already exists with code: 0x00
- tx1: deploys new contract at 0x36bdd8886852759e2046e3bf4c290d5c29c81d82 with code 0x00 (same hash)
- tx2: calls the pre-existing 0x37f536464af59c8d7358cae965f92cbeadd58dcb

You can see the same thing if you check BAL accesses in the test vector.

Now, regarding this solution in the PR:
- I did not just add the code in the Witness keys as is done now, and then additionally filter out on the witness build as it is order dependent. If tx1 and tx2 are inverted, the code MUST be included.
There is a test case for this:
`tests/fixtures/eest_zkevm/blockchain_tests/for_amsterdam/amsterdam/eip8025_optional_proofs/witness_bytecodes_contract_creation/witness_keeps_prestate_code_read_even_if_later_created_with_same_hash.json`

- I did not apply the hashset directly on ledger either because it can still rollback (contract call reverted)
There is a test case for this too:
`tests/fixtures/eest_zkevm/blockchain_tests/for_amsterdam/amsterdam/eip8025_optional_proofs/witness_bytecodes_contract_creation/witness_codes_reverted_create_same_hash_then_read.json`

Hence the current suggested solution. Although not sure if we MUST do this, considering the extra complexity it might not be worth optimising for this edge (?) case?