### PR TITLE
Feat:implement eth_feehistory and eth_maxPriorityFeePerGas 

### DIFF
--- a/execution_chain/rpc/oracle.nim
+++ b/execution_chain/rpc/oracle.nim
@@ -106,8 +106,8 @@ proc processBlock(oracle: Oracle, bc: BlockContent, percentiles: openArray[float
     nextBlobBaseFee: getBlobBaseFee(calcExcessBlobGas(com, bc.header, fork), com, fork),
     gasUsedRatio: float64(bc.header.gasUsed) / float64(bc.header.gasLimit),
     blobGasUsedRatio:
-      # for pre-Cancun blocks the division becomes 0/0,which leads the evalution to result in a Nan
-      # guard the divisor to divisor to make sure we dont hit that case
+      # for pre-Cancun blocks the division becomes 0/0, which leads the evaluation to result in NaN
+      # guard the divisor to make sure this case is avoided
       if maxBlobGasPerBlock == 0'u64:
         0.0
       else:

--- a/execution_chain/rpc/oracle.nim
+++ b/execution_chain/rpc/oracle.nim
@@ -105,7 +105,13 @@ proc processBlock(oracle: Oracle, bc: BlockContent, percentiles: openArray[float
     nextBaseFee: calcBaseFee(com, bc),
     nextBlobBaseFee: getBlobBaseFee(calcExcessBlobGas(com, bc.header, fork), com, fork),
     gasUsedRatio: float64(bc.header.gasUsed) / float64(bc.header.gasLimit),
-    blobGasUsedRatio: float64(bc.header.blobGasUsed.get(0'u64)) / float64(maxBlobGasPerBlock)
+    blobGasUsedRatio:
+      # for pre-Cancun blocks the division becomes 0/0,which leads the evalution to result in a Nan
+      # guard the divisor to divisor to make sure we dont hit that case
+      if maxBlobGasPerBlock == 0'u64:
+        0.0
+      else:
+        float64(bc.header.blobGasUsed.get(0'u64)) / float64(maxBlobGasPerBlock)
   )
 
   if percentiles.len == 0:

--- a/execution_chain/rpc/oracle.nim
+++ b/execution_chain/rpc/oracle.nim
@@ -8,7 +8,7 @@
 # those terms.
 
 import
-  std/[hashes, algorithm, strutils],
+  std/[hashes, algorithm],
   eth/eip1559,
   stew/keyed_queue,
   stew/endians2,
@@ -56,7 +56,6 @@ type
     reward : UInt256
 
   BlockRange = object
-    pendingBlock: Opt[uint64]
     lastBlock: uint64
     blocks: uint64
 
@@ -76,11 +75,8 @@ func new*(_: type Oracle, chain: ForkedChainRef): Oracle =
     historyCache: KeyedQueue[CacheKey, ProcessedFees].init(),
   )
 
-func hash*(x: CacheKey): Hash =
-  var h: Hash = 0
-  h = h !& hash(x.number)
-  h = h !& hash(x.percentiles)
-  result = !$h
+template com(oracle: Oracle): CommonRef =
+  oracle.chain.com
 
 func toBytes(list: openArray[float64]): seq[byte] =
   for x in list:
@@ -100,13 +96,14 @@ func calcBaseFee(com: CommonRef, bc: BlockContent): UInt256 =
 # fills in the rest of the fields.
 proc processBlock(oracle: Oracle, bc: BlockContent, percentiles: openArray[float64]): ProcessedFees =
   let
+    com = oracle.com
     fork = com.toEVMFork(bc.header)
-    maxBlobGasPerBlock = getMaxBlobGasPerBlock(electra)
+    maxBlobGasPerBlock = getMaxBlobGasPerBlock(com, fork)
   result = ProcessedFees(
     baseFee: bc.header.baseFeePerGas.get(0.u256),
     blobBaseFee: getBlobBaseFee(bc.header.excessBlobGas.get(0'u64), com, fork),
-    nextBaseFee: calcBaseFee(oracle.com, bc),
-    nextBlobBaseFee: getBlobBaseFee(calcExcessBlobGas(bc.header, com, fork), com, fork),
+    nextBaseFee: calcBaseFee(com, bc),
+    nextBlobBaseFee: getBlobBaseFee(calcExcessBlobGas(com, bc.header, fork), com, fork),
     gasUsedRatio: float64(bc.header.gasUsed) / float64(bc.header.gasLimit),
     blobGasUsedRatio: float64(bc.header.blobGasUsed.get(0'u64)) / float64(maxBlobGasPerBlock)
   )
@@ -157,8 +154,7 @@ proc processBlock(oracle: Oracle, bc: BlockContent, percentiles: openArray[float
     result.reward[i] = sorter[txIndex].reward
 
 # resolveBlockRange resolves the specified block range to absolute block numbers while also
-# enforcing backend specific limitations. The pending block and corresponding receipts are
-# also returned if requested and available.
+# enforcing backend specific limitations.
 # Note: an error is only returned if retrieving the head header has failed. If there are no
 # retrievable blocks in the specified range then zero block count is returned with no error.
 proc resolveBlockRange(oracle: Oracle, blockId: BlockTag, numBlocks: uint64): Result[BlockRange, string] =
@@ -170,7 +166,6 @@ proc resolveBlockRange(oracle: Oracle, blockId: BlockTag, numBlocks: uint64): Re
   var
     reqEnd: uint64
     blocks = numBlocks
-    pendingBlock: Opt[uint64]
 
   if blockId.kind == bidNumber:
     reqEnd = blockId.number.uint64
@@ -178,23 +173,8 @@ proc resolveBlockRange(oracle: Oracle, blockId: BlockTag, numBlocks: uint64): Re
     if head < reqEnd:
       return err("RequestBeyondHead: requested " & $reqEnd & ", head " & $head)
   else:
-    # Resolve block tag.
-    let tag = blockId.alias.toLowerAscii
-    var resolved: Header
-    if tag == "pending":
-      try:
-        resolved = headerFromTag(oracle.com.db, blockId)
-        pendingBlock = Opt.some(resolved.number)
-      except CatchableError:
-        # Pending block not supported by backend, process only until latest block.
-        resolved = headBlock
-        # Update total blocks to return to account for this.
-        dec blocks
-    else:
-      try:
-        resolved = headerFromTag(oracle.com.db, blockId)
-      except CatchableError as exc:
-        return err(exc.msg)
+    let resolved = oracle.chain.headerFromTag(blockId).valueOr:
+      return err(error)
 
     # Absolute number resolved.
     reqEnd = resolved.number
@@ -208,7 +188,6 @@ proc resolveBlockRange(oracle: Oracle, blockId: BlockTag, numBlocks: uint64): Re
     blocks = reqEnd + 1
 
   ok(BlockRange(
-    pendingBlock:pendingBlock,
     lastBlock: reqEnd,
     blocks: blocks,
   ))
@@ -221,18 +200,20 @@ proc getBlockContent(oracle: Oracle,
     blockNumber: blockNumber
   )
 
-  let db = oracle.com.db
-  try:
-    bc.header = db.getBlockHeader(blockNumber.BlockNumber)
-    for tx in db.getBlockTransactions(bc.header):
-      bc.txs.add tx
+  bc.header = oracle.chain.headerByNumber(blockNumber.BlockNumber).valueOr:
+    return err(error)
 
-    for rc in db.getReceipts(bc.header.receiptsRoot):
-      bc.receipts.add rc
-
+  if not fullBlock:
     return ok(bc)
-  except RlpError as exc:
-    return err(exc.msg)
+
+  let blk = oracle.chain.blockByNumber(blockNumber.BlockNumber).valueOr:
+    return err(error)
+
+  bc.txs = blk.transactions
+  bc.receipts = oracle.chain.receiptsByBlockHash(bc.header.computeBlockHash).valueOr:
+    return err(error)
+
+  ok(bc)
 
 type
   OracleResult = object
@@ -271,8 +252,8 @@ proc addToResult(res: var OracleResult, i: int, fees: ProcessedFees) =
 
 # FeeHistory returns data relevant for fee estimation based on the specified range of blocks.
 # The range can be specified either with absolute block numbers or ending with the latest
-# or pending block. Backends may or may not support gathering data from the pending block
-# or blocks older than a certain age (specified in maxHistory). The first block of the
+# block. Backends may or may not support blocks older than a certain age
+# (specified in maxHistory). The first block of the
 # actually processed range is returned to avoid ambiguity when parts of the requested range
 # are not available or when the head has changed during processing this request.
 # Three arrays are returned based on the processed blocks:
@@ -322,33 +303,26 @@ proc feeHistory*(oracle: Oracle,
     next = oldestBlock
     res = OracleResult.init(br.blocks.int)
 
-  for i in 0..<blocks:
+  for _ in 0..<blocks:
     # Retrieve the next block number to fetch
     let blockNumber = next
     inc next
     if blockNumber > br.lastBlock:
       break
 
-    if br.pendingBlock.isSome and blockNumber >= br.pendingBlock.get:
-      let
-        bc = oracle.getBlockContent(blockNumber, br.pendingBlock.get, fullBlock).valueOr:
-               return err(error)
-        fees = oracle.processBlock(bc, rewardPercentiles)
-      res.addToResult((blockNumber - oldestBlock).int, fees)
-    else:
-      let
-        cacheKey = CacheKey(number: blockNumber, percentiles: percentileKey)
-        fr = oracle.historyCache.lruFetch(cacheKey)
+    let
+      cacheKey = CacheKey(number: blockNumber, percentiles: percentileKey)
+      fr = oracle.historyCache.lruFetch(cacheKey)
 
-      if fr.isOk:
-        res.addToResult((blockNumber - oldestBlock).int, fr.get)
-      else:
-        let bc = oracle.getBlockContent(blockNumber, blockNumber, fullBlock).valueOr:
-          return err(error)
-        let fees = oracle.processBlock(bc, rewardPercentiles)
-        discard oracle.historyCache.lruAppend(cacheKey, fees, 2048)
-        # send to results even if empty to guarantee that blocks items are sent in total
-        res.addToResult((blockNumber - oldestBlock).int, fees)
+    if fr.isOk:
+      res.addToResult((blockNumber - oldestBlock).int, fr.get)
+    else:
+      let bc = oracle.getBlockContent(blockNumber, blockNumber, fullBlock).valueOr:
+        return err(error)
+      let fees = oracle.processBlock(bc, rewardPercentiles)
+      discard oracle.historyCache.lruAppend(cacheKey, fees, 2048)
+      # send to results even if empty to guarantee that blocks items are sent in total
+      res.addToResult((blockNumber - oldestBlock).int, fees)
 
   if res.firstMissing == 0:
     return ok(FeeHistoryResult())

--- a/execution_chain/rpc/rpc_utils.nim
+++ b/execution_chain/rpc/rpc_utils.nim
@@ -29,22 +29,23 @@ import
   eth/common/transaction_utils,
   web3/eth_api_types
 
+func median(prices: var openArray[GasInt]): GasInt =
+  if prices.len == 0:
+    return 0.GasInt
+
+  sort(prices)
+  let middle = prices.len div 2
+  if prices.len mod 2 == 0:
+    let
+      a = prices[middle].uint64
+      b = prices[middle - 1].uint64
+    return (a div 2 + b div 2 + ((a mod 2 + b mod 2) div 2)).GasInt
+
+  prices[middle]
+
 proc calculateMedianGasPrice*(chain: ForkedChainRef): GasInt =
   const minGasPrice = 30_000_000_000.GasInt
-  var prices  = newSeqOfCap[GasInt](64)
-  let blk = chain.latestBlock
-  for tx in blk.transactions:
-    prices.add(tx.gasPrice)
-
-  if prices.len > 0:
-    sort(prices)
-    let middle = prices.len div 2
-    if prices.len mod 2 == 0:
-      # prevent overflow
-      let price = prices[middle].uint64 + prices[middle - 1].uint64
-      result = (price div 2).GasInt
-    else:
-      result = prices[middle]
+  var prices = chain.latestBlock.transactions.mapIt(it.gasPrice)
 
   # TODO: This should properly incorporate the base fee in the block data,
   # and recommend a gas fee that likely gets the block to confirm.
@@ -53,7 +54,15 @@ proc calculateMedianGasPrice*(chain: ForkedChainRef): GasInt =
   # sane minimum for compatibility to unblock testing.
   # Note: When this is fixed, update `tests/graphql/queries.toml` and
   # re-enable the "query.gasPrice" test case (remove `skip = true`).
-  result = max(result, minGasPrice)
+  result = max(median(prices), minGasPrice)
+
+proc calculateMedianMaxPriorityFeePerGas*(chain: ForkedChainRef): GasInt =
+  let blk = chain.latestBlock
+  var prices = blk.transactions
+    .mapIt(it.effectiveGasTip(blk.header.baseFeePerGas))
+    .filterIt(it > 0.GasInt)
+
+  median(prices)
 
 proc unsignedTx*(tx: TransactionArgs,
                  chain: ForkedChainRef,

--- a/execution_chain/rpc/rpc_utils.nim
+++ b/execution_chain/rpc/rpc_utils.nim
@@ -417,6 +417,8 @@ proc headerFromTag*(chain: ForkedChainRef, blockTag: BlockTag): Result[Header, s
       ok(chain.finalizedHeader)
     of "safe":
       ok(chain.safeHeader)
+    of "earliest":
+      chain.headerByNumber(base.BlockNumber(0))
     else:
       err("Unsupported block tag " & tag)
   of bidNumber:

--- a/execution_chain/rpc/server_api.nim
+++ b/execution_chain/rpc/server_api.nim
@@ -27,6 +27,7 @@ import
   ../evm/evm_errors,
   ../core/eip4844,
   ../core/pooled_txs_rlp,
+  ./oracle,
   ./rpc_types,
   ./rpc_utils,
   ./filters
@@ -116,6 +117,8 @@ proc blockFromTag(api: ServerAPIRef, blockTag: BlockTag, noHash: bool = false): 
   api.chain.blockFromTag(blockTag, noHash)
 
 proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManager) =
+  let oracle = Oracle.new(api.chain)
+
   server.rpc("eth_getBalance") do(data: Address, blockTag: BlockTag) -> UInt256:
     ## Returns the balance of the account of given address.
     let
@@ -743,3 +746,11 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
         return Opt.none(BlockAccessList)
 
     Opt.some(bal)
+
+  server.rpc("eth_feeHistory") do( blockCount: Quantity,newestBlock: BlockTag,rewardPercentiles: Opt[seq[float64]] ) -> FeeHistoryResult:
+      oracle.feeHistory(
+        blockCount.uint64,
+        newestBlock,
+        rewardPercentiles.get(@[])
+      ).valueOr:
+        raise newException(ValueError, error)

--- a/execution_chain/rpc/server_api.nim
+++ b/execution_chain/rpc/server_api.nim
@@ -116,9 +116,7 @@ proc frameFromTag(api: ServerAPIRef, blockTag: BlockTag): Result[CoreDbTxRef, st
 proc blockFromTag(api: ServerAPIRef, blockTag: BlockTag, noHash: bool = false): Result[Block, string] =
   api.chain.blockFromTag(blockTag, noHash)
 
-proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManager) =
-  let oracle = Oracle.new(api.chain)
-
+proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManager, oracle:Oracle) =
   server.rpc("eth_getBalance") do(data: Address, blockTag: BlockTag) -> UInt256:
     ## Returns the balance of the account of given address.
     let

--- a/execution_chain/rpc/server_api.nim
+++ b/execution_chain/rpc/server_api.nim
@@ -747,9 +747,11 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
 
     Opt.some(bal)
 
-  server.rpc("eth_feeHistory") do( blockCount: Quantity,newestBlock: BlockTag,rewardPercentiles: Opt[seq[float64]] ) -> FeeHistoryResult:
-      oracle.feeHistory(blockCount.uint64,newestBlock,rewardPercentiles.get(@[])).valueOr:
-        raise newException(ValueError, error)
+  server.rpc("eth_feeHistory") do(
+    blockCount: Quantity, newestBlock: BlockTag, rewardPercentiles: Opt[seq[float64]]
+  ) -> FeeHistoryResult:
+    oracle.feeHistory(blockCount.uint64, newestBlock, rewardPercentiles.get(@[])).valueOr:
+      raise newException(ValueError, error)
 
   server.rpc("eth_maxPriorityFeePerGas") do() -> Quantity:
     w3Qty(calculateMedianMaxPriorityFeePerGas(api.chain).uint64)

--- a/execution_chain/rpc/server_api.nim
+++ b/execution_chain/rpc/server_api.nim
@@ -37,6 +37,7 @@ logScope:
 
 type ServerAPIRef* = ref object
   txPool: TxPoolRef
+  oracle: Oracle
 
 const defaultTag = blockId("latest")
 
@@ -47,7 +48,10 @@ template chain(api: ServerAPIRef): ForkedChainRef =
   api.txPool.chain
 
 func newServerAPI*(txPool: TxPoolRef): ServerAPIRef =
-  ServerAPIRef(txPool: txPool)
+  ServerAPIRef(
+    txPool: txPool,
+    oracle: Oracle.new(txPool.chain),
+  )
 
 proc getTotalDifficulty*(api: ServerAPIRef, blockHash: Hash32, header: Header): Opt[UInt256] =
   api.txPool.chain.getTotalDifficulty(blockHash, header)
@@ -116,7 +120,7 @@ proc frameFromTag(api: ServerAPIRef, blockTag: BlockTag): Result[CoreDbTxRef, st
 proc blockFromTag(api: ServerAPIRef, blockTag: BlockTag, noHash: bool = false): Result[Block, string] =
   api.chain.blockFromTag(blockTag, noHash)
 
-proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManager, oracle:Oracle) =
+proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManager) =
   server.rpc("eth_getBalance") do(data: Address, blockTag: BlockTag) -> UInt256:
     ## Returns the balance of the account of given address.
     let
@@ -748,7 +752,7 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
   server.rpc("eth_feeHistory") do(
     blockCount: Quantity, newestBlock: BlockTag, rewardPercentiles: Opt[seq[float64]]
   ) -> FeeHistoryResult:
-    oracle.feeHistory(blockCount.uint64, newestBlock, rewardPercentiles.get(@[])).valueOr:
+    api.oracle.feeHistory(blockCount.uint64, newestBlock, rewardPercentiles.get(@[])).valueOr:
       raise newException(ValueError, error)
 
   server.rpc("eth_maxPriorityFeePerGas") do() -> Quantity:

--- a/execution_chain/rpc/server_api.nim
+++ b/execution_chain/rpc/server_api.nim
@@ -748,9 +748,8 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
     Opt.some(bal)
 
   server.rpc("eth_feeHistory") do( blockCount: Quantity,newestBlock: BlockTag,rewardPercentiles: Opt[seq[float64]] ) -> FeeHistoryResult:
-      oracle.feeHistory(
-        blockCount.uint64,
-        newestBlock,
-        rewardPercentiles.get(@[])
-      ).valueOr:
+      oracle.feeHistory(blockCount.uint64,newestBlock,rewardPercentiles.get(@[])).valueOr:
         raise newException(ValueError, error)
+
+  server.rpc("eth_maxPriorityFeePerGas") do() -> Quantity:
+    w3Qty(calculateMedianMaxPriorityFeePerGas(api.chain).uint64)

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -24,7 +24,7 @@ import
   ../execution_chain/core/eip4844,
   ../execution_chain/utils/utils,
   ../execution_chain/[common, rpc],
-  ../execution_chain/rpc/[rpc_types, common as rpc_common],
+  ../execution_chain/rpc/[rpc_types, rpc_utils, common as rpc_common],
   ../execution_chain/beacon/web3_eth_conv,
   ../execution_chain/networking/p2p,
   ../execution_chain/nimbus_desc,
@@ -289,6 +289,7 @@ createRpcSigsFromNim(RpcClient):
   proc net_peerCount(): Quantity
   proc admin_nodeInfo(): NodeInfo
   proc admin_peers(): seq[PeerInfo]
+  proc eth_maxPriorityFeePerGas(): Quantity
 
 proc rpcMain*() =
   suite "Remote Procedure Calls":
@@ -380,6 +381,10 @@ proc rpcMain*() =
     test "eth_gasPrice":
       let res = await client.eth_gasPrice()
       check res == w3Qty(30_000_000_050)  # Avg of `unsignedTx1` / `unsignedTx2`
+
+    test "eth_maxPriorityFeePerGas":
+      let res = await client.eth_maxPriorityFeePerGas()
+      check res == w3Qty(calculateMedianMaxPriorityFeePerGas(env.chain).uint64)
 
     test "eth_accounts":
       let res = await client.eth_accounts()


### PR DESCRIPTION
This pr introduces the eth_feehistory and eth_maxPriorityFeePerGas rpc methods into Nimbus EL and closes the following issues
- https://github.com/status-im/nimbus-eth1/issues/3505
- https://github.com/status-im/nimbus-eth1/issues/3944

hive test results
```
Apr  9 21:31:17.020 INF API: test started suite=0 test=32 name="eth_feeHistory/fee-history (nimbus-el)"
Apr  9 21:31:17.022 INF API: test ended suite=0 test=32 pass=true
```
```
>>  {"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x1","0x1b",[95,99]]}
<<  {"jsonrpc":"2.0","result":{"oldestBlock":"0x1b","baseFeePerGas":["0x000000000000000000000000000000000000000000000000000000003b9aca00","0x00000000000000000000000000000000000000000000000000000000342dc057"],"baseFeePerBlobGas":["0x0000000000000000000000000000000000000000000000000000000000000000","0x0000000000000000000000000000000000000000000000000000000000000000"],"gasUsedRatio":[0.0016543629259729885],"blobGasUsedRatio":[0.0],"reward":[["0x0000000000000000000000000000000000000000000000000000000000000001","0x0000000000000000000000000000000000000000000000000000000000000001"]]},"id":1}
```
addresses parts of https://github.com/status-im/nimbus-eth1/issues/3942