### PR TITLE
hive: fix discord notification url of jenkins jobs and don't notify GHCMGR

### DIFF
--- a/ci/hive.groovy
+++ b/ci/hive.groovy
@@ -146,7 +146,7 @@ pipeline {
       }
     }
     always {
-      archiveArtifacts artifacts: 'simulation-results/**', allowEmptyArchive: true
+      archiveArtifacts artifacts: 'hive/workspace/logs/**', allowEmptyArchive: true
       sshagent(credentials: ['jenkins-ssh']) {
         sh './scripts/hive-upload-logs.sh'
       }

--- a/ci/hive.groovy
+++ b/ci/hive.groovy
@@ -132,10 +132,8 @@ pipeline {
   }
 
   post {
-    success { script { github.notifyPR(true) } }
     failure {
       script {
-        github.notifyPR(true)
         if (!env.CHANGE_ID) { return }
         withCredentials([string(credentialsId: 'discord-hive-webhook', variable: 'DISCORD_WEBHOOK_URL')]) {
           withEnv([

--- a/scripts/hive-notify-discord.sh
+++ b/scripts/hive-notify-discord.sh
@@ -7,7 +7,7 @@ curl -s -H "Content-Type: application/json" -X POST "${DISCORD_WEBHOOK_URL}" -d 
     "color": 15158332,
     "fields": [
       {"name": "Branch", "value": "['"${CHANGE_BRANCH}"'](https://github.com/status-im/nimbus-eth1/tree/'"${CHANGE_BRANCH}"')", "inline": true},
-      {"name": "Build", "value": "[#'"${BUILD_NUMBER}"'](https://ci.status.im/blue/organizations/jenkins/nimbus-eth1%2Fplatforms%2Flinux%2Fx86_64%2Fhive/detail/PR-'"${CHANGE_ID}"'/'"${BUILD_NUMBER}"'/pipeline/)", "inline": true},
+      {"name": "Build", "value": "[#'"${BUILD_NUMBER}"'](https://ci.status.im/blue/organizations/jenkins/nimbus-eth1%2Fprs%2Flinux%2Fx86_64%2Fhive/detail/PR-'"${CHANGE_ID}"'/'"${BUILD_NUMBER}"'/pipeline/)", "inline": true},
       {"name": "Simulation", "value": "'"${SIMULATION_NAME}"'", "inline": true},
       {"name": "Failed Stages", "value": "['"${FAILED_STAGES}"'](https://hive.nimbus.team/#summary-sort=name&suite=sync)", "inline": false}
     ]


### PR DESCRIPTION
## Summary

- fix discord notification url to correct the path to jenkins job
- remove calls to notify github-comment-manager
- fixes archive path of hive logs in jenkins stage