### PR TITLE
Automatically update gitsubmodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+version: 2
+updates:
+  - package-ecosystem: gitsubmodule
+    directory: /
+    ignore:
+      - dependency-name: vendor/nim-libp2p
+        versions: ["<= 0.0.0"]
+      - dependency-name: vendor/nimbus-eth2
+        versions: ["<= 0.0.0"]
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,6 @@ updates:
         versions: ["<= 0.0.0"]
       - dependency-name: vendor/nimbus-eth2
         versions: ["<= 0.0.0"]
+      - dependency-name: vendor/nim-rocksdb
     schedule:
       interval: daily

--- a/.gitmodules
+++ b/.gitmodules
@@ -209,7 +209,7 @@
 [submodule "vendor/nim-mcl"]
 	path = vendor/nim-mcl
 	url = https://github.com/status-im/nim-mcl
-  branch = main
+	branch = main
 [submodule "vendor/nimbus-eth2"]
 	path = vendor/nimbus-eth2
 	url = https://github.com/status-im/nimbus-eth2.git


### PR DESCRIPTION
Configure dependabot to propose updates to latest release of submodules, or to latest HEAD if we are past the latest release, except nimbus-eth2 and nim-libp2p.