### PR TITLE
fix: txpool should order by per-gas tip, not total gas expenditure

### DIFF
--- a/execution_chain/core/tx_pool.nim
+++ b/execution_chain/core/tx_pool.nim
@@ -61,10 +61,13 @@ export
 # ------------------------------------------------------------------------------
 
 export
-  tx,        # : Transaction
-  pooledTx,  # : PooledTransaction
-  id,        # : Hash32
-  sender     # : Address
+  tx,             # : Transaction
+  pooledTx,       # : PooledTransaction
+  id,             # : Hash32
+  sender,         # : Address
+  nonce,          # : AccountNonce
+  time,           # : Time
+  wrapperVersion  # : Opt[WrapperVersion]
 
 # ------------------------------------------------------------------------------
 # TxPoolRef constructor
@@ -82,7 +85,10 @@ proc new*(T: type TxPoolRef; chain: ForkedChainRef): T =
 export
   chain,
   com,
-  len
+  len,
+  baseFee,
+  senderCount,
+  allItems
 
 # chain(xp: TxPoolRef): ForkedChainRef
 # com(xp: TxPoolRef): CommonRef
@@ -95,6 +101,7 @@ export
 export
   addTx,
   getItem,
+  getNonce,
   contains,
   removeTx,
   removeExpiredTxs,

--- a/execution_chain/core/tx_pool/tx_desc.nim
+++ b/execution_chain/core/tx_pool/tx_desc.nim
@@ -160,7 +160,7 @@ proc insertToSenderTab(xp: TxPoolRef; item: TxItemRef): Result[void, TxError] =
   sn.insertOrReplace(item)
   ok()
 
-func baseFee(xp: TxPoolRef): GasInt =
+func baseFee*(xp: TxPoolRef): GasInt =
   ## Getter, baseFee for the next bock header. This value is auto-generated
   ## when a new insertion point is set via `head=`.
   if xp.vmState.blockCtx.baseFeePerGas.isSome:
@@ -177,7 +177,7 @@ func excessBlobGas(xp: TxPoolRef): GasInt =
 proc getBalance(xp: TxPoolRef; account: Address): UInt256 =
   xp.vmState.ledger.getBalance(account)
 
-proc getNonce(xp: TxPoolRef; account: Address): AccountNonce =
+proc getNonce*(xp: TxPoolRef; account: Address): AccountNonce =
   xp.vmState.ledger.getNonce(account)
 
 proc classifyValid(xp: TxPoolRef; tx: Transaction, sender: Address): bool =
@@ -439,6 +439,13 @@ iterator byPriceAndNonce*(xp: TxPoolRef): TxItemRef =
   for item in byPriceAndNonce(xp.senderTab, xp.idTab,
       xp.blobTab, xp.vmState.ledger, xp.baseFee, xp.nextFork):
     yield item
+
+iterator allItems*(xp: TxPoolRef): TxItemRef =
+  for _, item in xp.idTab:
+    yield item
+
+func senderCount*(xp: TxPoolRef): int =
+  xp.senderTab.len
 
 func getBlobAndProofV1*(xp: TxPoolRef, v: VersionedHash): Opt[BlobAndProofV1] =
   xp.blobTab.withValue(v, val):

--- a/execution_chain/core/tx_pool/tx_item.nim
+++ b/execution_chain/core/tx_pool/tx_item.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/execution_chain/core/tx_pool/tx_item.nim
+++ b/execution_chain/core/tx_pool/tx_item.nim
@@ -21,7 +21,6 @@ import
   ../../utils/utils,
   ../../transaction
 
-from ../eip4844 import getTotalBlobGas
 from eth/common/hashes import hash
 
 type
@@ -132,7 +131,7 @@ func wrapperVersion*(item: TxItemRef): Opt[WrapperVersion] =
 
 func calculatePrice*(item: TxItemRef; baseFee: GasInt) =
   ## Profit calculator
-  item.price = item.tx.gasLimit * item.tx.tip(baseFee) + item.tx.getTotalBlobGas
+  item.price = item.tx.tip(baseFee)
 
 func validateTxGasBump*(current: TxItemRef, added: TxItemRef): Result[void, TxError] =
   func txGasPrice(item: TxItemRef): TxGasPrice =

--- a/execution_chain/core/tx_pool/tx_tabs.nim
+++ b/execution_chain/core/tx_pool/tx_tabs.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/execution_chain/core/tx_pool/tx_tabs.nim
+++ b/execution_chain/core/tx_pool/tx_tabs.nim
@@ -11,7 +11,7 @@
 {.push raises: [].}
 
 import
-  std/[tables, heapqueue],
+  std/[tables, heapqueue, times],
   eth/common/base,
   eth/common/addresses,
   eth/common/hashes,
@@ -60,7 +60,11 @@ func removeLookup*(blobTab: var BlobLookupTab, item: TxItemRef) =
 # HeapQueue needs `<` to be overloaded for custom object
 # and in this case, we want to pop highest price first.
 # That's why we use '>' instead of '<' in the implementation.
-func `<`(a, b: TxItemRef): bool = a.price > b.price
+# Tiebreaker: earliest arrival first (FIFO), matching geth/reth.
+func `<`(a, b: TxItemRef): bool =
+  if a.price != b.price:
+    return a.price > b.price
+  a.time < b.time
 
 proc validBlobItem(item: TxItemRef;
                    fork: EVMFork;

--- a/execution_chain/core/tx_pool/tx_tabs.nim
+++ b/execution_chain/core/tx_pool/tx_tabs.nim
@@ -57,6 +57,11 @@ func removeLookup*(blobTab: var BlobLookupTab, item: TxItemRef) =
   for v in item.tx.versionedHashes:
     blobTab.del(v)
 
+# HeapQueue needs `<` to be overloaded for custom object
+# and in this case, we want to pop highest price first.
+# That's why we use '>' instead of '<' in the implementation.
+func `<`(a, b: TxItemRef): bool = a.price > b.price
+
 proc validBlobItem(item: TxItemRef;
                    fork: EVMFork;
                    sn: TxSenderNonceRef;
@@ -123,10 +128,6 @@ iterator byPriceAndNonce*(senderTab: TxSenderTab,
         item.calculatePrice(baseFee)
         byPrice.push(item)
 
-  # HeapQueue needs `<` to be overloaded for custom object
-  # and in this case, we want to pop highest price first.
-  # That's why we use '>' instead of '<' in the implementation.
-  func `<`(a, b: TxItemRef): bool {.used.} = a.price > b.price
   var byPrice = initHeapQueue[TxItemRef]()
 
   # Fill byPrice with `head item` from each account.

--- a/execution_chain/core/tx_pool/tx_tabs.nim
+++ b/execution_chain/core/tx_pool/tx_tabs.nim
@@ -11,7 +11,7 @@
 {.push raises: [].}
 
 import
-  std/[tables, heapqueue, times],
+  std/[tables, heapqueue],
   eth/common/base,
   eth/common/addresses,
   eth/common/hashes,
@@ -60,11 +60,7 @@ func removeLookup*(blobTab: var BlobLookupTab, item: TxItemRef) =
 # HeapQueue needs `<` to be overloaded for custom object
 # and in this case, we want to pop highest price first.
 # That's why we use '>' instead of '<' in the implementation.
-# Tiebreaker: earliest arrival first (FIFO), matching geth/reth.
-func `<`(a, b: TxItemRef): bool =
-  if a.price != b.price:
-    return a.price > b.price
-  a.time < b.time
+func `<`(a, b: TxItemRef): bool = a.price > b.price
 
 proc validBlobItem(item: TxItemRef;
                    fork: EVMFork;

--- a/execution_chain/rpc/debug.nim
+++ b/execution_chain/rpc/debug.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import
-  # std/json,
+  std/[json, times],
   json_rpc/rpcserver,
   web3/[eth_api_types, conversions],
   ./rpc_utils,
@@ -21,7 +21,8 @@ import
   ../beacon/web3_eth_conv,
   ../core/tx_pool,
   ../core/chain/forked_chain,
-  ../stateless/witness_types
+  ../stateless/witness_types,
+  ../transaction
 
 type
   BadBlock = object
@@ -244,3 +245,50 @@ proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
     ## Returns an execution witness for the given block hash.
     chain.getExecutionWitness(blockHash).valueOr:
       raise newException(ValueError, error)
+
+  ## Custom debug endpoints - not specified in the Execution API
+
+  server.rpc("debug_txPoolDump") do() -> JsonNode:
+    ## Returns a dump of the transaction pool state including per-sender
+    ## transaction details sorted by effective tip.
+    let
+      poolBaseFee = txPool.baseFee
+      now = getTime().utc.toTime
+
+    var senders = newJObject()
+
+    for item in txPool.allItems:
+      let
+        senderHex = $item.sender
+        tip = item.tx.effectiveGasTip(Opt.some(poolBaseFee.u256))
+        age = now - item.time
+        accountNonce = txPool.getNonce(item.sender)
+
+      var txNode = newJObject()
+      txNode["hash"] = newJString($item.id)
+      txNode["nonce"] = newJInt(item.nonce.int64)
+      txNode["accountNonce"] = newJInt(accountNonce.int64)
+      txNode["type"] = newJString($item.tx.txType)
+      txNode["gasLimit"] = newJInt(item.tx.gasLimit.int64)
+      txNode["maxFeePerGas"] = newJInt(item.tx.maxFeePerGasNorm.int64)
+      txNode["maxPriorityFeePerGas"] = newJInt(item.tx.maxPriorityFeePerGasNorm.int64)
+      txNode["effectiveTip"] = newJInt(tip.int64)
+      txNode["value"] = newJString($item.tx.value)
+      txNode["age"] = newJString($age)
+
+      let wv = item.wrapperVersion
+      if wv.isSome:
+        txNode["wrapperVersion"] = newJString($wv.get)
+        txNode["numBlobs"] = newJInt(item.tx.versionedHashes.len.int64)
+        txNode["maxFeePerBlobGas"] = newJString($item.tx.maxFeePerBlobGas)
+
+      if not senders.hasKey(senderHex):
+        senders[senderHex] = newJArray()
+      senders[senderHex].add(txNode)
+
+    var res = newJObject()
+    res["totalTxs"] = newJInt(txPool.len.int64)
+    res["senderCount"] = newJInt(txPool.senderCount.int64)
+    res["baseFee"] = newJInt(poolBaseFee.int64)
+    res["senders"] = senders
+    res

--- a/kurtosis-network-params.yml
+++ b/kurtosis-network-params.yml
@@ -18,6 +18,8 @@ participants:
     use_separate_vc: false
 additional_services:
   - assertoor
+  - spamoor
+  - dora
 mev_type: null
 assertoor_params:
   image: "ethpandaops/assertoor"

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -12,7 +12,7 @@
 
 import
   std/math,
-  eth/common/keys,
+  eth/common/[keys, transaction_utils],
   results,
   unittest2,
   chronos,
@@ -964,3 +964,45 @@ suite "TxPool test suite":
       tip0 = txs[0].effectiveGasTip(baseFee)
       tip1 = txs[1].effectiveGasTip(baseFee)
     check tip0 >= tip1
+
+  test "Tip ordering: equal tips use FIFO tiebreaker":
+    let
+      env = initEnv(Cancun)
+      xp = env.xp
+      mx = env.sender
+
+    xp.prevRandao = prevRandao
+    xp.feeRecipient = feeRecipient
+    xp.timestamp = EthTime.now()
+
+    let
+      accFirst = mx.getAccount(0)
+      accSecond = mx.getAccount(1)
+      # Identical tip and fee for both
+      tc = BaseTx(
+        txType: Opt.some(TxEip1559),
+        gasLimit: 75000,
+        gasTip: 5.gwei,
+        gasFee: 30.gwei,
+        recipient: Opt.some(recipient),
+        amount: 1.u256,
+      )
+      ptxFirst = mx.makeTx(tc, accFirst, 0)
+      ptxSecond = mx.makeTx(tc, accSecond, 0)
+
+    # Add first, then second — FIFO should preserve this order
+    xp.checkAddTx(ptxFirst)
+    xp.checkAddTx(ptxSecond)
+
+    let bundle = xp.checkAssembleBlock(2)
+    let txs = bundle.blk.transactions
+    let baseFee = bundle.blk.header.baseFeePerGas
+
+    # Both should have identical tips
+    let
+      tip0 = txs[0].effectiveGasTip(baseFee)
+      tip1 = txs[1].effectiveGasTip(baseFee)
+    check tip0 == tip1
+
+    # First-added tx should come first (FIFO)
+    check txs[0].recoverSender().expect("valid sig") == accFirst.address

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -12,7 +12,7 @@
 
 import
   std/math,
-  eth/common/[keys, transaction_utils],
+  eth/common/keys,
   results,
   unittest2,
   chronos,
@@ -964,45 +964,3 @@ suite "TxPool test suite":
       tip0 = txs[0].effectiveGasTip(baseFee)
       tip1 = txs[1].effectiveGasTip(baseFee)
     check tip0 >= tip1
-
-  test "Tip ordering: equal tips use FIFO tiebreaker":
-    let
-      env = initEnv(Cancun)
-      xp = env.xp
-      mx = env.sender
-
-    xp.prevRandao = prevRandao
-    xp.feeRecipient = feeRecipient
-    xp.timestamp = EthTime.now()
-
-    let
-      accFirst = mx.getAccount(0)
-      accSecond = mx.getAccount(1)
-      # Identical tip and fee for both
-      tc = BaseTx(
-        txType: Opt.some(TxEip1559),
-        gasLimit: 75000,
-        gasTip: 5.gwei,
-        gasFee: 30.gwei,
-        recipient: Opt.some(recipient),
-        amount: 1.u256,
-      )
-      ptxFirst = mx.makeTx(tc, accFirst, 0)
-      ptxSecond = mx.makeTx(tc, accSecond, 0)
-
-    # Add first, then second — FIFO should preserve this order
-    xp.checkAddTx(ptxFirst)
-    xp.checkAddTx(ptxSecond)
-
-    let bundle = xp.checkAssembleBlock(2)
-    let txs = bundle.blk.transactions
-    let baseFee = bundle.blk.header.baseFeePerGas
-
-    # Both should have identical tips
-    let
-      tip0 = txs[0].effectiveGasTip(baseFee)
-      tip1 = txs[1].effectiveGasTip(baseFee)
-    check tip0 == tip1
-
-    # First-added tx should come first (FIFO)
-    check txs[0].recoverSender().expect("valid sig") == accFirst.address

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -872,3 +872,95 @@ suite "TxPool test suite":
 
     # restore blobSchedule
     cc.blobSchedule[Prague] = bs
+
+  test "Tip ordering: higher per-gas tip is prioritized":
+    let
+      env = initEnv(Cancun)
+      xp = env.xp
+      mx = env.sender
+
+    xp.prevRandao = prevRandao
+    xp.feeRecipient = feeRecipient
+    xp.timestamp = EthTime.now()
+
+    let
+      accLow = mx.getAccount(0)
+      accHigh = mx.getAccount(1)
+      tcLow = BaseTx(
+        txType: Opt.some(TxEip1559),
+        gasLimit: 75000,
+        gasTip: 2.gwei,
+        gasFee: 30.gwei,
+        recipient: Opt.some(recipient),
+        amount: 1.u256,
+      )
+      tcHigh = BaseTx(
+        txType: Opt.some(TxEip1559),
+        gasLimit: 75000,
+        gasTip: 10.gwei,
+        gasFee: 30.gwei,
+        recipient: Opt.some(recipient),
+        amount: 1.u256,
+      )
+      ptxLow = mx.makeTx(tcLow, accLow, 0)
+      ptxHigh = mx.makeTx(tcHigh, accHigh, 0)
+
+    xp.checkAddTx(ptxLow)
+    xp.checkAddTx(ptxHigh)
+
+    let bundle = xp.checkAssembleBlock(2)
+    let txs = bundle.blk.transactions
+
+    # Higher tip tx should come first
+    let
+      baseFee = bundle.blk.header.baseFeePerGas
+      tip0 = txs[0].effectiveGasTip(baseFee)
+      tip1 = txs[1].effectiveGasTip(baseFee)
+    check tip0 >= tip1
+
+  test "Tip ordering: gasLimit does not affect priority":
+    let
+      env = initEnv(Cancun)
+      xp = env.xp
+      mx = env.sender
+
+    xp.prevRandao = prevRandao
+    xp.feeRecipient = feeRecipient
+    xp.timestamp = EthTime.now()
+
+    let
+      accHighGas = mx.getAccount(0)
+      accHighTip = mx.getAccount(1)
+      # High gasLimit, low tip
+      tcHighGas = BaseTx(
+        txType: Opt.some(TxEip1559),
+        gasLimit: 500000,
+        gasTip: 2.gwei,
+        gasFee: 30.gwei,
+        recipient: Opt.some(recipient),
+        amount: 1.u256,
+      )
+      # Low gasLimit, high tip
+      tcHighTip = BaseTx(
+        txType: Opt.some(TxEip1559),
+        gasLimit: 75000,
+        gasTip: 10.gwei,
+        gasFee: 30.gwei,
+        recipient: Opt.some(recipient),
+        amount: 1.u256,
+      )
+      ptxHighGas = mx.makeTx(tcHighGas, accHighGas, 0)
+      ptxHighTip = mx.makeTx(tcHighTip, accHighTip, 0)
+
+    xp.checkAddTx(ptxHighGas)
+    xp.checkAddTx(ptxHighTip)
+
+    let bundle = xp.checkAssembleBlock(2)
+    let txs = bundle.blk.transactions
+
+    # Higher per-gas tip tx should come first, regardless of gasLimit
+    let
+      baseFee = bundle.blk.header.baseFeePerGas
+      tip0 = txs[0].effectiveGasTip(baseFee)
+      tip1 = txs[1].effectiveGasTip(baseFee)
+    check tip0 >= tip1


### PR DESCRIPTION
The transaction pool's `calculatePrice` function in `tx_item.nim` computes a "price" used to order transactions for block building:
```nim
item.price = item.tx.gasLimit * item.tx.tip(baseFee) + item.tx.getTotalBlobGas
```
This orders by **total gas expenditure** instead of per-gas tip. A transaction with high `gasLimit` but low per-gas tip gets prioritized over one with lower `gasLimit` but much higher per-gas tip.

**Example with old logic**:
 - Tx A: gasLimit=500,000, tip=2 gwei → price = 500,000 × 2 gwei = 1×10^15
 - Tx B: gasLimit=75,000, tip=10 gwei → price = 75,000 × 10 gwei = 7.5×10^14
 - A is ordered first despite 5× lower per-gas tip

The standard approach (geth and other clients) orders by **effective gas tip per gas unit**.
The + getTotalBlobGas term is also maybe a dimensional error (adds gas units to wei), subsumed by this fix.


This PR also adds a debug rpc endpoint to check txpool behaviour 