### PR TITLE
Fix nim-bncurve branch tracking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -233,7 +233,7 @@
 	path = vendor/nim-bncurve
 	url = https://github.com/status-im/nim-bncurve.git
 	ignore = dirty
-	branch = untracked
+	branch = master
 [submodule "vendor/nim-rocksdb"]
 	path = vendor/nim-rocksdb
 	url = https://github.com/status-im/nim-rocksdb.git


### PR DESCRIPTION
#4055 changed the branch name of nim-bncurve to some weird value as part of an unrelated refactoring. Fix it to point to `master` again.