### PR TITLE
Rewire maxBlobs via CommonRef instead of ForkedChainRef

### DIFF
--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -89,6 +89,9 @@ type
     gasLimit: uint64
       ## Desired gas limit when building a block
 
+    maxBlobs: Opt[uint8]
+      ## For EIP-7872; allows constraining of max blobs packed into each payload
+
     when compileOption("threads"):
       taskpool*: Taskpool
         ## Shared task pool for offloading computation to other threads
@@ -475,6 +478,9 @@ func extraData*(com: CommonRef): string =
 func gasLimit*(com: CommonRef): uint64 =
   com.gasLimit
 
+func maxBlobs*(com: CommonRef): Opt[uint8] =
+  com.maxBlobs
+
 func maxBlobsPerBlock*(com: CommonRef, fork: HardFork): uint64 =
   doAssert(fork >= Cancun)
   com.config.blobSchedule[fork].expect("blobSchedule initialized").max
@@ -525,6 +531,13 @@ func `gasLimit=`*(com: CommonRef, val: uint64) =
     com.gasLimit = GAS_LIMIT_MAXIMUM
   else:
     com.gasLimit = val
+
+func `maxBlobs=`*(com: CommonRef, val: Opt[uint8]) =
+  com.maxBlobs = val
+
+func `maxBlobs=`*(com: CommonRef, val: Option[uint8]) =
+  if val.isSome:
+    com.maxBlobs = Opt.some(val.get)
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -126,6 +126,11 @@ type
       defaultValue: DEFAULT_GAS_LIMIT
       name: "gas-limit" .}: uint64
 
+    # https://eips.ethereum.org/EIPS/eip-7872
+    maxBlobs* {.
+      desc: "EIP-7872 maximum blobs used when building a local payload"
+      name: "max-blobs" .}: Option[uint8]
+
     # https://ethereum.org/developers/docs/networks/#ethereum-testnets
     network {.
       desc: "Name or id number of Ethereum network"
@@ -451,11 +456,6 @@ type
         desc: "Enable background pruning of expired block bodies and receipts"
         defaultValue: false
         name: "prune" .}: bool
-
-      # https://eips.ethereum.org/EIPS/eip-7872
-      maxBlobs* {.
-        desc: "EIP-7872 maximum blobs used when building a local payload"
-        name: "max-blobs" .}: Option[uint8]
 
       # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/authentication.md#key-distribution
       jwtSecret* {.

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -622,7 +622,6 @@ proc init*(
     persistBatchSize = PersistBatchSize;
     dynamicBatchSize = false;
     eagerStateRoot = false;
-    maxBlobs = none(uint8);
     enableQueue = false;
       ): T =
   ## Constructor that uses the current database ledger state for initialising.
@@ -664,7 +663,6 @@ proc init*(
       baseDistance:     baseDistance,
       persistBatchSize: persistBatchSize,
       dynamicBatchSize: dynamicBatchSize,
-      maxBlobs:         maxBlobs,
       quarantine:       Quarantine.init(),
       fcuHead:          fcuHead,
       fcuSafe:          fcuSafe,
@@ -1017,7 +1015,7 @@ proc payloadBodyV2ByHash*(c: ForkedChainRef, blockHash: Hash32): Result[Executio
       var blockBodyPortal = ?c.portal.getBlockBodyByHeader(header)
       # Same as above
       return ok(toPayloadBodyV2(
-        EthBlock.init(move(header), move(blockBodyPortal)), 
+        EthBlock.init(move(header), move(blockBodyPortal)),
           ?c.baseTxFrame.getBlockAccessList(header.computeRlpHash())))
 
   move(blk)
@@ -1060,7 +1058,7 @@ proc payloadBodyV2ByNumber*(c: ForkedChainRef, number: BlockNumber): Result[Exec
         var blockBodyPortal = ?c.portal.getBlockBodyByHeader(header)
         # same as above
         return ok(toPayloadBodyV2(
-          EthBlock.init(move(header), move(blockBodyPortal)), 
+          EthBlock.init(move(header), move(blockBodyPortal)),
             ?c.baseTxFrame.getBlockAccessList(header.computeRlpHash())))
 
     return blk

--- a/execution_chain/core/chain/forked_chain/chain_desc.nim
+++ b/execution_chain/core/chain/forked_chain/chain_desc.nim
@@ -90,9 +90,6 @@ type
       # Enable adjusting the persistBatchSize dynamically based on the
       # time it takes to update base.
 
-    maxBlobs*: Option[uint8]
-      # For EIP-7872; allows constraining of max blobs packed into each payload
-
     portal*: HistoryExpiryRef
       # History Expiry tracker and portal access entry point
 

--- a/execution_chain/core/tx_pool/tx_packer.nim
+++ b/execution_chain/core/tx_pool/tx_packer.nim
@@ -184,12 +184,13 @@ proc vmExecGrabItem(pst: var TxPacker; item: TxItemRef, xp: TxPoolRef): bool =
       return ContinueWithNextAccount
 
     let
+      maxBlobs = vmState.com.maxBlobs
       maxForkBlobsPerBlock = getMaxBlobsPerBlock(vmState.com, vmState.fork)
       maxBlobsPerBlock =
-        if xp.chain.maxBlobs.isSome:
+        if maxBlobs.isSome:
           # https://eips.ethereum.org/EIPS/eip-7872#specification
           # "If the minimum is zero, set the minimum to one."
-          min(max(xp.chain.maxBlobs.get, 1).uint64, maxForkBlobsPerBlock)
+          min(max(maxBlobs.get, 1).uint64, maxForkBlobsPerBlock)
         else:
           maxForkBlobsPerBlock
     if (pst.numBlobPerBlock + item.tx.versionedHashes.len).uint64 > maxBlobsPerBlock:

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -61,7 +61,6 @@ proc basicServices(nimbus: NimbusNode, config: ExecutionClientConf, com: CommonR
     eagerStateRoot = config.eagerStateRootCheck,
     persistBatchSize = config.persistBatchSize,
     dynamicBatchSize = config.dynamicBatchSize,
-    maxBlobs = config.maxBlobs,
     enableQueue = true)
   if config.deserializeFcState:
     fc.deserialize().isOkOr:
@@ -306,6 +305,7 @@ proc setupCommonRef*(config: ExecutionClientConf): CommonRef =
 
   com.extraData = config.extraData
   com.gasLimit = config.gasLimit
+  com.maxBlobs = config.maxBlobs
 
   com
 


### PR DESCRIPTION
Both `gasLimit` and `extraData` are wired through CommonRef and consumed by txPool. So when `maxBlobs` go through ForkedChainRef, it's an out of pattern route. Moreover, it has nothing todo with in memory chain. `maxBlobs` is used by the block builder.