### PR TITLE
Remove block header from processTransaction

### DIFF
--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -102,7 +102,7 @@ proc processTransactions*(
     if vmState.balTrackerEnabled:
       vmState.balTracker.setBlockAccessIndex(txIndex + 1)
 
-    let rc = vmState.processTransaction(tx, sender, header)
+    let rc = vmState.processTransaction(tx, sender)
     if rc.isErr:
       return err("Error processing tx with index " & $(txIndex) & ":" & rc.error)
     if skipReceipts:

--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -33,24 +33,22 @@ export results, call_common
 # Private functions
 # ------------------------------------------------------------------------------
 
-func eip1559BaseFee(header: Header; fork: EVMFork): UInt256 =
+func eip1559BaseFee(vmState: BaseVMState; fork: EVMFork): UInt256 =
   ## Actually, `baseFee` should be 0 for pre-London headers already. But this
-  ## function just plays safe. In particular, the `test_general_state_json.nim`
-  ## module modifies this block header `baseFee` field unconditionally :(.
+  ## function just plays safe.
   if FkLondon <= fork:
-    result = header.baseFeePerGas.get(0.u256)
+    result = vmState.blockCtx.baseFeePerGas.get(0.u256)
 
 proc commitOrRollbackDependingOnGasUsed(
     vmState: BaseVMState;
     savePoint: LedgerSpRef;
-    header: Header;
     tx: Transaction;
     callResult: var LogResult;
     priorityFee: GasInt;
     blobGasUsed: GasInt;
       ): Result[void, string] =
   # Make sure that the tx does not exceed the maximum cumulative limit as
-  # set in the block header. Again, the EIP-1559 reference does not mention
+  # set in the vmState.blockCtx. Again, the EIP-1559 reference does not mention
   # an early stop. It would rather detect differing values for the  block
   # header `gasUsed` and the `vmState.cumulativeGasUsed` at a later stage.
   let gasUsed = callResult.gasUsed
@@ -60,18 +58,18 @@ proc commitOrRollbackDependingOnGasUsed(
     let limit2d = max(
       vmState.blockRegularGasUsed + callResult.blockRegularGasUsed,
       vmState.blockStateGasUsed + callResult.blockStateGasUsed)
-    if header.gasLimit < limit2d:
+    if vmState.blockCtx.gasLimit < limit2d:
       if vmState.balTrackerEnabled:
         vmState.balTracker.rollbackCallFrame()
       vmState.ledger.rollback(savePoint)
-      return err(&"invalid tx: block gas limit reached (2D). gasLimit={header.gasLimit}, regularGas={vmState.blockRegularGasUsed}+{callResult.blockRegularGasUsed}, stateGas={vmState.blockStateGasUsed}+{callResult.blockStateGasUsed}")
+      return err(&"invalid tx: block gas limit reached (2D). gasLimit={vmState.blockCtx.gasLimit}, regularGas={vmState.blockRegularGasUsed}+{callResult.blockRegularGasUsed}, stateGas={vmState.blockStateGasUsed}+{callResult.blockStateGasUsed}")
   else:
     let limit = vmState.cumulativeGasUsed + gasUsed
-    if header.gasLimit < limit:
+    if vmState.blockCtx.gasLimit < limit:
       if vmState.balTrackerEnabled:
         vmState.balTracker.rollbackCallFrame()
       vmState.ledger.rollback(savePoint)
-      return err(&"invalid tx: block header gasLimit reached. gasLimit={header.gasLimit}, gasUsed={vmState.cumulativeGasUsed}, addition={gasUsed}")
+      return err(&"invalid tx: block gasLimit reached. gasLimit={vmState.blockCtx.gasLimit}, gasUsed={vmState.cumulativeGasUsed}, addition={gasUsed}")
 
   # Accept transaction and collect mining fee.
   let txFee = gasUsed.u256 * priorityFee.u256
@@ -94,7 +92,6 @@ proc processTransactionImpl(
     vmState: BaseVMState; ## Parent accounts environment for transaction
     tx:      Transaction; ## Transaction to validate
     sender:  Address;  ## tx.recoverSender
-    header:  Header; ## Header for the block containing the current tx
       ): Result[LogResult, string] =
   ## Modelled after `https://eips.ethereum.org/EIPS/eip-1559#specification`_
   ## which provides a backward compatible framwork for EIP1559.
@@ -102,11 +99,11 @@ proc processTransactionImpl(
   let
     fork = vmState.fork
     roDB = vmState.readOnlyLedger
-    baseFee256 = header.eip1559BaseFee(fork)
+    baseFee256 = vmState.eip1559BaseFee(fork)
     baseFee = baseFee256.truncate(GasInt)
     priorityFee = min(tx.maxPriorityFeePerGasNorm(), tx.maxFeePerGasNorm() - baseFee)
-    excessBlobGas = header.excessBlobGas.get(0'u64)
-    regularGasAvailable = header.gasLimit - vmState.blockRegularGasUsed
+    excessBlobGas = vmState.blockCtx.excessBlobGas
+    regularGasAvailable = vmState.blockCtx.gasLimit - vmState.blockRegularGasUsed
 
   # Regular gas is capped at TX_MAX_GAS_LIMIT per EIP-7825.
   # State gas is not checked per-tx; block-end validation enforces
@@ -131,7 +128,7 @@ proc processTransactionImpl(
   # statement, here.
   let
     com = vmState.com
-    txRes = roDB.validateTransaction(tx, sender, header.gasLimit, baseFee256, excessBlobGas, com, fork)
+    txRes = roDB.validateTransaction(tx, sender, vmState.blockCtx.gasLimit, baseFee256, excessBlobGas, com, fork)
     res = if txRes.isOk:
       # Execute the transaction.
       vmState.captureTxStart(tx.gasLimit)
@@ -144,7 +141,7 @@ proc processTransactionImpl(
       vmState.captureTxEnd(tx.gasLimit - callResult.gasUsed)
 
       let tmp = commitOrRollbackDependingOnGasUsed(
-        vmState, savePoint, header, tx, callResult, priorityFee, blobGasUsed)
+        vmState, savePoint, tx, callResult, priorityFee, blobGasUsed)
 
       if tmp.isErr():
         err(tmp.error)
@@ -258,9 +255,8 @@ proc processTransaction*(
     vmState: BaseVMState; ## Parent accounts environment for transaction
     tx:      Transaction; ## Transaction to validate
     sender:  Address;  ## tx.recoverSender
-    header:  Header; ## Header for the block containing the current tx
       ): Result[LogResult, string] =
-  vmState.processTransactionImpl(tx, sender, header)
+  vmState.processTransactionImpl(tx, sender)
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/tracer.nim
+++ b/execution_chain/tracer.nim
@@ -164,7 +164,7 @@ proc traceTransactionImpl(
       stateDiff["beforeRoot"] = %(ledger.getStateRoot().toHex)
       stateCtx = CaptCtxRef.init(com, ledger.getStateRoot())
 
-    let rc = vmState.processTransaction(tx, sender, header)
+    let rc = vmState.processTransaction(tx, sender)
     gasUsed = if rc.isOk: rc.value.gasUsed else: 0
 
     if idx.uint64 == txIndex:
@@ -279,7 +279,7 @@ proc traceBlockImpl(
   for tx in blk.transactions:
     let
       sender = tx.recoverSender().expect("valid signature")
-      rc = vmState.processTransaction(tx, sender, header)
+      rc = vmState.processTransaction(tx, sender)
     if rc.isOk:
       gasUsed = gasUsed + rc.value.gasUsed
 

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -120,8 +120,7 @@ proc testFixtureIndexes(ctx: var TestCtx, testStatusIMPL: var TestStatus) =
     ledger.persist()
 
   let
-    rc = vmState.processTransaction(
-                ctx.tx, sender, ctx.header)
+    rc = vmState.processTransaction(ctx.tx, sender)
     callResult = if rc.isOk:
                    rc.value
                  else:

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -145,8 +145,7 @@ proc runExecution(ctx: var StateContext, conf: StateConf, pre: JsonNode): StateR
       writeRootHashToStderr(stateRoot)
 
   try:
-    let res = vmState.processTransaction(
-                   ctx.tx, sender, ctx.header)
+    let res = vmState.processTransaction(ctx.tx, sender)
     if res.isOk:
       callResult = res.value
     coinbaseStateClearing(vmState, ctx.header.coinbase)

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -275,7 +275,7 @@ proc exec(ctx: TransContext,
     if conf.traceEnabled.isSome:
       closeStream = setupTrace(conf, txIndex, computeRlpHash(tx), vmState)
 
-    let rc = vmState.processTransaction(tx, sender, header)
+    let rc = vmState.processTransaction(tx, sender)
 
     if conf.traceEnabled.isSome:
       closeTrace(vmState, closeStream)


### PR DESCRIPTION
Explicitly passing block header to `processTransaction` is not needed for correct operation. All required information is routed through BaseVMState's `blockCtx`.
This is the first step into unification of txPool packer and `processTransaction`.