### PR TITLE
Add the state/codes sort into Witness build phase

### DIFF
--- a/execution_chain/stateless/stateless_execution.nim
+++ b/execution_chain/stateless/stateless_execution.nim
@@ -24,7 +24,7 @@ import
 export witness_types, common, headers, blocks, results
 
 proc statelessProcessBlock*(
-    witness: ExecutionWitness, com: CommonRef, blk: Block
+    witness: ExecutionWitness, com: CommonRef, blk: Block, verifyState = false
 ): Result[void, string] =
   let
     verifiedHeaders = ?witness.verifyHeaders(blk.header)
@@ -32,9 +32,10 @@ proc statelessProcessBlock*(
     parent = verifiedHeaders[^1] # The last header is the parent
     preStateRoot = parent.stateRoot
 
-  # Verify the witness against the parent header stateroot.
-  # This validates the state against the keys, the code and headers in the witness.
-  ?witness.verifyState(preStateRoot)
+  if verifyState:
+    # Verify the witness against the parent header stateroot.
+    # This validates the state against the keys, the code and headers in the witness.
+    ?witness.verifyState(preStateRoot)
 
   # Convert the list of trie nodes into a table keyed by node hash.
   var nodes: Table[Hash32, seq[byte]]

--- a/execution_chain/stateless/witness_generation.nim
+++ b/execution_chain/stateless/witness_generation.nim
@@ -9,9 +9,15 @@
 
 {.push raises: [], gcsafe.}
 
-import std/[tables, sets], minilru, eth/common, ../db/[ledger, core_db], ./witness_types
+import
+  std/[tables, sets, algorithm],
+  stew/byteutils,
+  minilru,
+  eth/common,
+  ../db/[ledger, core_db],
+  ./witness_types
 
-export common, ledger, witness_types
+export common, ledger, witness_types, byteutils
 
 proc build*(T: type Witness, witnessKeys: WitnessTable, preStateLedger: LedgerRef): T =
   var
@@ -55,6 +61,10 @@ proc build*(T: type Witness, witnessKeys: WitnessTable, preStateLedger: LedgerRe
   var multiProof: seq[seq[byte]]
   preStateLedger.txFrame.multiProof(proofPaths, multiProof).isOkOr:
     raiseAssert "Failed to get multiproof: " & $$error
+
+  # Sort the proof nodes lexicographically as is done in execution-specs:
+  # https://github.com/ethereum/execution-specs/blob/33aa038697162a3ba0aedbadf177c4c59ee5b007/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L230
+  multiProof.sort()
   witness.state = move(multiProof)
 
   for accPath, stoPaths in proofPaths:
@@ -93,7 +103,7 @@ proc build*(
     earliestBlockNumber = getEarliestCachedBlockNumber(blockHashes)
 
   if earliestBlockNumber.isSome():
-    # Add headers in ascending block number order
+    # Add headers in ascending block number order:
     # https://github.com/ethereum/execution-specs/blob/33aa038697162a3ba0aedbadf177c4c59ee5b007/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L175-L176
     for n in earliestBlockNumber.get() ..< parent.number:
       let blockHash = ledger.getBlockHash(BlockNumber(n))
@@ -112,6 +122,10 @@ proc build*(
     let code = ledger.txFrame.getCodeByHash(codeHash).valueOr:
       raiseAssert "Code not found"
     codes.add(code)
+
+  # Sort codes lexicographically as is done in execution-specs:
+  # https://github.com/ethereum/execution-specs/blob/33aa038697162a3ba0aedbadf177c4c59ee5b007/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L268
+  codes.sort()
 
   var headers: seq[seq[byte]]
   for headerHash in witness.headerHashes:

--- a/tests/eest/eest_blockchain.nim
+++ b/tests/eest/eest_blockchain.nim
@@ -11,7 +11,7 @@
 {.define: unittest2DisableParamFiltering.}
 
 import
-  std/[json, os, algorithm],
+  std/[json, os],
   unittest2,
   chronos,
   stew/byteutils,
@@ -29,6 +29,7 @@ import
   ../../execution_chain/common/common,
   ../../execution_chain/stateless/witness_types,
   ../../execution_chain/stateless/stateless_types,
+  ../../execution_chain/stateless/stateless_execution,
   ../../hive_integration/engine_client,
   ./eest_helpers,
   ./bal_parser
@@ -125,6 +126,52 @@ proc shortLog(witness: ExecutionWitness): string =
     res.add headerNode.to0xHex() & "\n"
   res
 
+proc compare(
+    generated, expected: ExecutionWitness, strict = false
+): Result[void, string] =
+  ## Compare witness state, nodes and headers, not comparing keys as these
+  ## are not included in the test vectors.
+  ## When strict is false, allow generated witness state and codes to be a
+  ## subset of expected. This is because some test vectors include extra unused
+  ## state nodes and code in the witness to test that stateless execution still
+  ## works. Same counts for the lexicographical order.
+  # Always comparing headers to be identical, including order
+  if generated.headers != expected.headers:
+    return err(
+      "Witness headers mismatch, got: " & $generated.shortLog & " expected: " &
+        $expected.shortLog
+    )
+
+  if strict:
+    # when strict enabled, also compare state and codes to be identical
+    if generated.state != expected.state:
+      return err(
+        "Witness state mismatch, got: " & $generated.shortLog & " expected: " &
+          $expected.shortLog
+      )
+    if generated.codes != expected.codes:
+      return err(
+        "Witness codes mismatch, got: " & $generated.shortLog & " expected: " &
+          $expected.shortLog
+      )
+  else:
+    # else allow them just to be a subset of expected
+    for node in generated.state:
+      if node notin expected.state:
+        return err(
+          "Witness state node missing from expected, got: " & $generated.shortLog &
+            " expected: " & $expected.shortLog
+        )
+
+    for code in generated.codes:
+      if code notin expected.codes:
+        return err(
+          "Witness code missing from expected, got: " & $generated.shortLog &
+            " expected: " & $expected.shortLog
+        )
+
+  ok()
+
 proc runTest(env: TestEnv, unit: BlockchainUnitEnv, statelessEnabled = false): Future[Result[void, string]] {.async.} =
   let blocks = parseBlocks(unit.blocks)
   var latestStateRoot = unit.genesisBlockHeader.stateRoot
@@ -137,33 +184,28 @@ proc runTest(env: TestEnv, unit: BlockchainUnitEnv, statelessEnabled = false): F
       if blk.badBlock:
         return err("Bad block got imported succesfully")
       else:
-        let successful_validation =
-          if blk.statelessValidationResult.isSome():
-            blk.statelessValidationResult.get().successful_validation
-          else:
-            true
-
-        if statelessEnabled and blk.witness.isSome() and successful_validation:
+        if statelessEnabled:
           # Get witness that should have been generated when importing the block
           var witness = env.chain.getExecutionWitness(blk.blk.header.computeRlpHash).valueOr:
             return err("Execution witness was not found in the database")
 
-          # Compare witness with test vector witness
-          # Note: Sorting seq of state and codes as is done in execution-specs:
-          # - https://github.com/ethereum/execution-specs/blob/33aa038697162a3ba0aedbadf177c4c59ee5b007/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L230
-          # - https://github.com/ethereum/execution-specs/blob/33aa038697162a3ba0aedbadf177c4c59ee5b007/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L268
-          # TODO: At some point we should move this into the witness logic (or future wrappers)
-          witness.state.sort()
-          witness.codes.sort()
-          let expectedWitness = blk.witness.value()
-          # Not comparing keys as these are not included in the test vectors.
-          # TODO: Remove them from our ExecutionWitness type?
-          if witness.state != expectedWitness.state:
-            return err("Witness state mismatch, got: " & $witness.shortLog & " expected: " & $expectedWitness.shortLog)
-          if witness.codes != expectedWitness.codes:
-            return err("Witness codes mismatch, got: " & $witness.shortLog & " expected: " & $expectedWitness.shortLog)
-          if witness.headers != expectedWitness.headers:
-            return err("Witness headers mismatch, got: " & $witness.shortLog & " expected: " & $expectedWitness.shortLog)
+          # process block stateless with generated witness
+          ?witness.statelessProcessBlock(env.chain.com, blk.blk, verifyState = true)
+
+          let successful_validation =
+            if blk.statelessValidationResult.isSome():
+              blk.statelessValidationResult.get().successful_validation
+            else:
+              true
+
+          if blk.witness.isSome() and successful_validation:
+            # If block witness in test vector and validation is successful,
+            # process block stateless with test vector witness
+            let expectedWitness = blk.witness.value()
+            ?expectedWitness.statelessProcessBlock(env.chain.com, blk.blk)
+
+            # compare both witnesses
+            ?compare(witness, expectedWitness)
     else:
       if not blk.badBlock:
         return err("Good block was rejected at import: " & res.error)

--- a/tests/eest/eest_helpers.nim
+++ b/tests/eest/eest_helpers.nim
@@ -253,7 +253,7 @@ proc prepareEnv*(
     let
       com = CommonRef.new(memDB, config,
         statelessProviderEnabled = statelessEnabled,
-        statelessWitnessValidation = statelessEnabled)
+        statelessWitnessValidation = false) # Running stateless execution separately in test runner
       chain = ForkedChainRef.init(com, enableQueue = true, persistBatchSize = 1)
 
     testEnv.chain = chain

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -84,19 +84,7 @@ const skipFiles = [
   "wallet_change_requirement_remove_pending_transaction.json", # persistStorage assert
   "callcode_to_precompile_from_called_contract.json", # stateRoot mismatch
   "validation_codes_missing_delegated_code_on_insufficient_balance_call.json", # blockAccessListHash mismatch
-  # This test vector specifically puts codes in unsorted order to test that stateless
-  # execution still works. But of course the witness will not match exactly.
-  "validation_codes_unsorted_but_complete.json",
-  # This test vector specifically adds unused butecode preimage to test that stateless
-  # execution still works. But of course the witness will not match exactly.
-  "validation_codes_extra_unused_bytecode.json",
-  # This test vector specifically puts state nodes in unsorted order to test that stateless
-  # execution still works. But of course the witness will not match exactly.
-  "validation_state_unsorted_but_complete.json",
   "validation_state_missing_delete_auxiliary_node.json", # persistStorage assert
-  # This test vector specifically adds unused trie nodes to test that stateless
-  # execution still works. But of course the witness will not match exactly.
-  "validation_state_extra_unused_trie_node.json",
 ]
 
 runEESTSuite(


### PR DESCRIPTION
- Move the sorts
- Make the compare more lenient + remove failing tests that pass now because of this
- Add stateless execution with test vector witness (instead of only generated witness) + add a verifyState disabler for this