### PR TITLE
MPT rlp encoding helper templates

### DIFF
--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -28,11 +28,13 @@ type
     prefix*: uint64
     tasksCompleted*: int
     tasksTotal*: int
-  
+
   ConcurrentHashKeyQueue* = ConcurrentQueue[3, (RootedVertexID, HashKey, int)]
   ConcurrentVertexBufQueue* = ConcurrentQueue[3, (RootedVertexID, VertexBuf)]
 
-proc `=copy`(dest: var WriteBatch; src: WriteBatch) {.error: "Copying WriteBatch is forbidden".} =
+proc `=copy`(
+    dest: var WriteBatch, src: WriteBatch
+) {.error: "Copying WriteBatch is forbidden".} =
   discard
 
 # Keep write batch size _around_ 1mb, give or take some overhead - this is a
@@ -66,20 +68,26 @@ proc flush(batch: var WriteBatch, db: AristoDbRef): Result[void, AristoError] =
     batch.writer = nil
   ok()
 
-template flushCheck(batch: var WriteBatch, db: AristoDbRef, parallel: static bool): Result[void, AristoError] =
+template flushCheck(
+    batch: var WriteBatch, db: AristoDbRef, parallel: static bool
+): Result[void, AristoError] =
   if batch.count mod batchSize == 0:
     ?batch.flush(db)
-    
+
     when parallel:
       if batch.count mod (batchSize * 100) == 0:
-        info "Writing computeKey cache", keys = batch.count, tasksCompleted = batch.progress(parallel)
+        info "Writing computeKey cache",
+          keys = batch.count, tasksCompleted = batch.progress(parallel)
       else:
-        debug "Writing computeKey cache", keys = batch.count, tasksCompleted = batch.progress(parallel)
+        debug "Writing computeKey cache",
+          keys = batch.count, tasksCompleted = batch.progress(parallel)
     else:
       if batch.count mod (batchSize * 100) == 0:
-        info "Writing computeKey cache", keys = batch.count, accounts = batch.progress(parallel)
+        info "Writing computeKey cache",
+          keys = batch.count, accounts = batch.progress(parallel)
       else:
-        debug "Writing computeKey cache", keys = batch.count, accounts = batch.progress(parallel)
+        debug "Writing computeKey cache",
+          keys = batch.count, accounts = batch.progress(parallel)
   ok()
 
 proc putVtx(
@@ -104,7 +112,7 @@ proc putKeyAtLevel(
     vtx: BranchRef,
     key: HashKey,
     level: int,
-    batch: var WriteBatch
+    batch: var WriteBatch,
 ): Result[void, AristoError] =
   ## Store a hash key in the given layer or directly to the underlying database
   ## which helps ensure that memory usage is proportional to the pending change
@@ -114,23 +122,21 @@ proc putKeyAtLevel(
   if level >= txRef.db.baseTxFrame().level:
     let frame = txRef.deltaAtLevel(level)
     frame.layersMergeKey(rvid, key)
-  
   elif level == dbLevel:
     ?batch.putVtx(txRef.db, rvid, vtx, key)
-
   else: # level > dbLevel but less than baseTxFrame level
     # Throw defect here because we should not be writing vertexes to the database if
     # from a lower level than the baseTxFrame level.
-    raiseAssert("Cannot write keys at level < baseTxFrame level. Found level = " &
-        $level & ", baseTxFrame level = " & $txRef.db.baseTxFrame().level)
+    raiseAssert(
+      "Cannot write keys at level < baseTxFrame level. Found level = " & $level &
+        ", baseTxFrame level = " & $txRef.db.baseTxFrame().level
+    )
 
   ok()
 
 proc mergeKeyAtLevel(
-    txRef: AristoTxRef,
-    rvid: RootedVertexID,
-    key: HashKey,
-    level: int) =
+    txRef: AristoTxRef, rvid: RootedVertexID, key: HashKey, level: int
+) =
   doAssert level >= txRef.db.baseTxFrame().level
 
   let frame = txRef.deltaAtLevel(level)
@@ -138,10 +144,7 @@ proc mergeKeyAtLevel(
     frame.layersMergeKey(rvid, key)
 
 proc putVtxBlob(
-    batch: var WriteBatch,
-    db: AristoDbRef,
-    rvid: RootedVertexID,
-    vtx: openArray[byte],
+    batch: var WriteBatch, db: AristoDbRef, rvid: RootedVertexID, vtx: openArray[byte]
 ): Result[void, AristoError] =
   if batch.writer == nil:
     batch.writer = ?db.putBegFn()
@@ -153,10 +156,8 @@ proc putVtxBlob(
   ok()
 
 func layersGetKeyOrVtx*(
-    db: AristoTxRef,
-    rvid: RootedVertexID,
-    parallel: static bool): Opt[((HashKey, VertexRef), int)] =
-
+    db: AristoTxRef, rvid: RootedVertexID, parallel: static bool
+): Opt[((HashKey, VertexRef), int)] =
   for w in db.rstack(stopAtSnapshot = true):
     if w.snapshot.level.isSome():
       when parallel:
@@ -181,19 +182,22 @@ func layersGetKeyOrVtx*(
   Opt.none(((HashKey, VertexRef), int))
 
 proc getKey(
-    txRef: AristoTxRef, rvid: RootedVertexID, skipLayers: static bool, parallel: static bool
+    txRef: AristoTxRef,
+    rvid: RootedVertexID,
+    skipLayers: static bool,
+    parallel: static bool,
 ): Result[((HashKey, VertexRef), int), AristoError] =
-  const 
+  const
     emptyFlags: set[GetVtxFlag] = {}
-    flags = 
+    flags =
       when parallel:
-        {GetVtxFlag.PeekCache, GetVtxFlag.NoPutCache} 
+        {GetVtxFlag.PeekCache, GetVtxFlag.NoPutCache}
       else:
         when skipLayers:
-          {GetVtxFlag.PeekCache} 
-        else: 
-          emptyFlags  
-  
+          {GetVtxFlag.PeekCache}
+        else:
+          emptyFlags
+
   when not skipLayers:
     let keyVtxRes = txRef.layersGetKeyOrVtx(rvid, parallel)
     if keyVtxRes.isSome():
@@ -218,14 +222,14 @@ template childVid(vp: VertexRef): VertexID =
     default(VertexID)
 
 proc computeKeyImplTask(
-    txRef: ptr AristoTxRef,
-    rvid: RootedVertexID,
-    batch: ptr WriteBatch,
-    vtx: ptr VertexRef,
-    level: int,
-    skipLayers: bool,
-    keyQueue: ptr ConcurrentHashKeyQueue,
-    vtxBufQueue: ptr ConcurrentVertexBufQueue
+  txRef: ptr AristoTxRef,
+  rvid: RootedVertexID,
+  batch: ptr WriteBatch,
+  vtx: ptr VertexRef,
+  level: int,
+  skipLayers: bool,
+  keyQueue: ptr ConcurrentHashKeyQueue,
+  vtxBufQueue: ptr ConcurrentVertexBufQueue,
 ): Result[(HashKey, int), AristoError]
 
 proc computeKeyImpl(
@@ -238,7 +242,7 @@ proc computeKeyImpl(
     spawnTpTasks: static bool,
     parallel: static bool,
     keyQueue: ptr ConcurrentHashKeyQueue,
-    vtxBufQueue: ptr ConcurrentVertexBufQueue
+    vtxBufQueue: ptr ConcurrentVertexBufQueue,
 ): Result[(HashKey, int), AristoError] =
   # The bloom filter available used only when creating the key cache from an
   # empty state
@@ -253,7 +257,8 @@ proc computeKeyImpl(
       let skey =
         if vtx.stoID.isValid:
           let
-            keyvtxl = ?txRef.getKey((vtx.stoID.vid, vtx.stoID.vid), skipLayers, parallel)
+            keyvtxl =
+              ?txRef.getKey((vtx.stoID.vid, vtx.stoID.vid), skipLayers, parallel)
             (skey, sl) =
               if keyvtxl[0][0].isValid:
                 (keyvtxl[0][0], keyvtxl[1])
@@ -267,7 +272,7 @@ proc computeKeyImpl(
                   spawnTpTasks = false,
                   parallel,
                   keyQueue,
-                  vtxBufQueue
+                  vtxBufQueue,
                 )
           level = max(level, sl)
           skey
@@ -286,7 +291,7 @@ proc computeKeyImpl(
         keyvtxs[n] = ?txRef.getKey((rvid.root, subvid), skipLayers, parallel)
 
       when spawnTpTasks:
-        var 
+        var
           futs: array[16, Flowvar[Result[(HashKey, int), AristoError]]]
           keyQueues: array[16, ConcurrentHashKeyQueue]
           vtxBufQueues: array[16, ConcurrentVertexBufQueue]
@@ -317,18 +322,17 @@ proc computeKeyImpl(
             let childVid = keyvtx[0][1].childVid
             if not childVid.isValid:
               # leaf vertex without storage ID - we can compute the key trivially
-              (keyvtx[0][0], keyvtx[1]) =
-                ?txRef.computeKeyImpl(
-                  (rvid.root, subvid),
-                  batch,
-                  keyvtx[0][1],
-                  keyvtx[1],
-                  skipLayers = skipLayers,
-                  spawnTpTasks = false,
-                  parallel,
-                  keyQueue,
-                  vtxBufQueue
-                )
+              (keyvtx[0][0], keyvtx[1]) = ?txRef.computeKeyImpl(
+                (rvid.root, subvid),
+                batch,
+                keyvtx[0][1],
+                keyvtx[1],
+                skipLayers = skipLayers,
+                spawnTpTasks = false,
+                parallel,
+                keyQueue,
+                vtxBufQueue,
+              )
               n += 1
               continue
 
@@ -349,25 +353,30 @@ proc computeKeyImpl(
             keyQueues[minIdx].init()
             vtxBufQueues[minIdx].init()
             futs[minIdx] = txRef.db.taskpool.spawn computeKeyImplTask(
-              txRef.addr, vid, batchPtr, vtxPtr, level, skipLayers, 
-              keyQueues[minIdx].addr, vtxBufQueues[minIdx].addr)
+              txRef.addr,
+              vid,
+              batchPtr,
+              vtxPtr,
+              level,
+              skipLayers,
+              keyQueues[minIdx].addr,
+              vtxBufQueues[minIdx].addr,
+            )
             inc batch.tasksTotal
-
           else:
             when not parallel:
               batch.enter(n)
-            (keyvtxs[minIdx][0][0], keyvtxs[minIdx][1]) =
-              ?txRef.computeKeyImpl(
-                (rvid.root, vtx.bVid(uint8 minIdx)),
-                batch,
-                keyvtxs[minIdx][0][1],
-                keyvtxs[minIdx][1],
-                skipLayers,
-                spawnTpTasks = false,
-                parallel,
-                keyQueue,
-                vtxBufQueue
-              )
+            (keyvtxs[minIdx][0][0], keyvtxs[minIdx][1]) = ?txRef.computeKeyImpl(
+              (rvid.root, vtx.bVid(uint8 minIdx)),
+              batch,
+              keyvtxs[minIdx][0][1],
+              keyvtxs[minIdx][1],
+              skipLayers,
+              spawnTpTasks = false,
+              parallel,
+              keyQueue,
+              vtxBufQueue,
+            )
             when not parallel:
               batch.leave(n)
 
@@ -376,10 +385,10 @@ proc computeKeyImpl(
         for i, f in futs:
           if f.isSpawned() and not f.isReady():
             runningFutsIndexes.incl(i.uint8)
-        
+
         while runningFutsIndexes.len() > 0:
           var indexesToRemove: seq[uint8]
-          
+
           for i in runningFutsIndexes:
             if futs[i].isReady():
               indexesToRemove.add(i)
@@ -391,7 +400,7 @@ proc computeKeyImpl(
                 var k: (RootedVertexID, HashKey, int)
                 if keyQueues[i].tryPop(k):
                   txRef.mergeKeyAtLevel(k[0], k[1], k[2])
-                
+
             if not vtxBufQueues[i].isEmpty():
               var v: (RootedVertexID, VertexBuf)
               if vtxBufQueues[i].tryPop(v):
@@ -439,7 +448,7 @@ proc computeKeyImpl(
   # root key also changing while leaves that have never been hashed will see
   # their hash being saved directly to the backend.
 
-  if vtx.vType in Branches:      
+  if vtx.vType in Branches:
     when parallel and not spawnTpTasks:
       if level >= txRef.db.baseTxFrame().level:
         keyQueue[].push((rvid, key, level))
@@ -448,8 +457,10 @@ proc computeKeyImpl(
         vtx.blobifyTo(key, vtxBuf)
         vtxBufQueue[].push((rvid, vtxBuf))
       else:
-        raiseAssert("Cannot write keys at level < baseTxFrame level. Found level = " &
-          $level & ", baseTxFrame level = " & $txRef.db.baseTxFrame().level)
+        raiseAssert(
+          "Cannot write keys at level < baseTxFrame level. Found level = " & $level &
+            ", baseTxFrame level = " & $txRef.db.baseTxFrame().level
+        )
     else:
       ?txRef.putKeyAtLevel(rvid, BranchRef(vtx), key, level, batch)
 
@@ -463,21 +474,39 @@ proc computeKeyImplTask(
     level: int,
     skipLayers: bool,
     keyQueue: ptr ConcurrentHashKeyQueue,
-    vtxBufQueue: ptr ConcurrentVertexBufQueue
+    vtxBufQueue: ptr ConcurrentVertexBufQueue,
 ): Result[(HashKey, int), AristoError] =
   if skipLayers:
-    txRef[].computeKeyImpl(rvid, batch[], vtx[], level, skipLayers = true, 
-        spawnTpTasks = false, parallel = true, keyQueue, vtxBufQueue)
+    txRef[].computeKeyImpl(
+      rvid,
+      batch[],
+      vtx[],
+      level,
+      skipLayers = true,
+      spawnTpTasks = false,
+      parallel = true,
+      keyQueue,
+      vtxBufQueue,
+    )
   else:
-    txRef[].computeKeyImpl(rvid, batch[], vtx[], level, skipLayers = false, 
-        spawnTpTasks = false, parallel = true, keyQueue, vtxBufQueue)
+    txRef[].computeKeyImpl(
+      rvid,
+      batch[],
+      vtx[],
+      level,
+      skipLayers = false,
+      spawnTpTasks = false,
+      parallel = true,
+      keyQueue,
+      vtxBufQueue,
+    )
 
 proc computeKeyImpl(
-    txRef: AristoTxRef, 
-    rvid: RootedVertexID, 
-    skipLayers: static bool, 
-    spawnTpTasks: static bool, 
-    parallel: static bool
+    txRef: AristoTxRef,
+    rvid: RootedVertexID,
+    skipLayers: static bool,
+    spawnTpTasks: static bool,
+    parallel: static bool,
 ): Result[HashKey, AristoError] =
   let (keyvtx, level) =
     when skipLayers:
@@ -490,16 +519,7 @@ proc computeKeyImpl(
 
   var batch: WriteBatch
   let res = computeKeyImpl(
-    txRef,
-    rvid,
-    batch,
-    keyvtx[1],
-    level,
-    skipLayers,
-    spawnTpTasks,
-    parallel,
-    nil,
-    nil
+    txRef, rvid, batch, keyvtx[1], level, skipLayers, spawnTpTasks, parallel, nil, nil
   )
 
   if res.isOk:
@@ -508,9 +528,11 @@ proc computeKeyImpl(
     if batch.count > 0:
       when parallel:
         if batch.count >= batchSize * 100:
-          info "Wrote computeKey cache", keys = batch.count, tasksCompleted = batch.progress(parallel)
+          info "Wrote computeKey cache",
+            keys = batch.count, tasksCompleted = batch.progress(parallel)
         else:
-          debug "Wrote computeKey cache", keys = batch.count, tasksCompleted = batch.progress(parallel)
+          debug "Wrote computeKey cache",
+            keys = batch.count, tasksCompleted = batch.progress(parallel)
       else:
         if batch.count >= batchSize * 100:
           info "Wrote computeKey cache", keys = batch.count, accounts = "100.00%"
@@ -522,7 +544,7 @@ proc computeKeyImpl(
 proc computeKey*(
     txRef: AristoTxRef, # Database, top layer
     rvid: RootedVertexID, # Vertex to convert
-    skipLayers: static bool = false
+    skipLayers: static bool = false,
 ): Result[HashKey, AristoError] =
   ## Compute the key for an arbitrary vertex ID. If successful, the length of
   ## the resulting key might be smaller than 32. If it is used as a root vertex
@@ -532,24 +554,24 @@ proc computeKey*(
   txRef.computeKeyImpl(rvid, skipLayers, spawnTpTasks = false, parallel = false)
 
 proc computeStateRoot*(
-    txRef: AristoTxRef,
-    skipLayers: static bool = false
+    txRef: AristoTxRef, skipLayers: static bool = false
 ): Result[HashKey, AristoError] =
   ## Ensure that key cache is topped up with the latest state root
   ## and return the computed value.
-  if txRef.db.parallelStateRootComputation and txRef.db.taskpool != nil and txRef.db.taskpool.numThreads > 1:
+  if txRef.db.parallelStateRootComputation and txRef.db.taskpool != nil and
+      txRef.db.taskpool.numThreads > 1:
     txRef.computeKeyImpl(
       (STATE_ROOT_VID, STATE_ROOT_VID),
       skipLayers,
       spawnTpTasks = when compileOption("threads"): true else: false,
-      parallel = when compileOption("threads"): true else: false
+      parallel = when compileOption("threads"): true else: false,
     )
   else:
     txRef.computeKeyImpl(
       (STATE_ROOT_VID, STATE_ROOT_VID),
       skipLayers,
       spawnTpTasks = false,
-      parallel = false
+      parallel = false,
     )
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -13,21 +13,12 @@
 import
   std/strformat,
   chronicles,
-  eth/common/[accounts_rlp, base_rlp, hashes_rlp],
   results,
-  ./[aristo_desc, aristo_get, aristo_layers, aristo_blobify],
+  ./[aristo_desc, aristo_get, aristo_layers, aristo_blobify, aristo_serialise],
   ./aristo_desc/desc_backend,
   ../../concurrency/queue
 
 export aristo_desc, chronicles
-
-const
-  MAX_RLP_SIZE_ACCOUNT_LEAF = 111
-  MAX_RLP_SIZE_STORAGE_LEAF = 34
-  MAX_RLP_SIZE_ACCOUNT_LEAF_NODE = 149
-  MAX_RLP_SIZE_STORAGE_LEAF_NODE = 71
-  MAX_RLP_SIZE_BRANCH_NODE = 533
-  MAX_RLP_SIZE_EXTENSION_NODE = 69
 
 type
   WriteBatch* = object
@@ -161,25 +152,6 @@ proc putVtxBlob(
 
   ok()
 
-template encodeLeaf(w: var RlpWriter, pfx: NibblesBuf, leafData: untyped): HashKey =
-  w.startList(2)
-  w.append(pfx.toHexPrefix(isLeaf = true).data())
-  w.append(leafData)
-  w.finish(asOpenArray = true).digestTo(HashKey)
-
-template encodeBranch(w: var RlpWriter, vtx: VertexRef, subKeyForN: untyped): HashKey =
-  w.startList(17)
-  for (n {.inject.}, subvid {.inject.}) in vtx.allPairs():
-    w.append(subKeyForN)
-  w.append EmptyBlob
-  w.finish(asOpenArray = true).digestTo(HashKey)
-
-template encodeExt(w: var RlpWriter, pfx: NibblesBuf, branchKey: HashKey): HashKey =
-  w.startList(2)
-  w.append(pfx.toHexPrefix(isLeaf = false).data())
-  w.append(branchKey)
-  w.finish(asOpenArray = true).digestTo(HashKey)
-
 func layersGetKeyOrVtx*(
     db: AristoTxRef,
     rvid: RootedVertexID,
@@ -274,55 +246,37 @@ proc computeKeyImpl(
   # Top-most level of all the verticies this hash computation depends on
   var level = level
 
-  # TODO this is the same code as when serializing NodeRef, without the NodeRef
-  
   let key =
     case vtx.vType
     of AccLeaf:
       let vtx = AccLeafRef(vtx)
-      var writer = RlpArrayBufWriter[MAX_RLP_SIZE_ACCOUNT_LEAF_NODE, 1]()
-      writer.encodeLeaf(vtx.pfx):
-        let
-          stoID = vtx.stoID
-          skey =
-            if stoID.isValid:
-              let
-                keyvtxl = ?txRef.getKey((stoID.vid, stoID.vid), skipLayers, parallel)
-                (skey, sl) =
-                  if keyvtxl[0][0].isValid:
-                    (keyvtxl[0][0], keyvtxl[1])
-                  else:
-                    ?txRef.computeKeyImpl(
-                      (stoID.vid, stoID.vid),
-                      batch,
-                      keyvtxl[0][1],
-                      keyvtxl[1],
-                      skipLayers = skipLayers,
-                      spawnTpTasks = false,
-                      parallel,
-                      keyQueue,
-                      vtxBufQueue
-                    )
-              level = max(level, sl)
-              skey
-            else:
-              VOID_HASH_KEY
-
-        var w = RlpArrayBufWriter[MAX_RLP_SIZE_ACCOUNT_LEAF, 1]()
-        w.append(Account(
-          nonce: vtx.account.nonce,
-          balance: vtx.account.balance,
-          storageRoot: skey.to(Hash32),
-          codeHash: vtx.account.codeHash
-        ))
-        w.finish(asOpenArray = true)
+      let skey =
+        if vtx.stoID.isValid:
+          let
+            keyvtxl = ?txRef.getKey((vtx.stoID.vid, vtx.stoID.vid), skipLayers, parallel)
+            (skey, sl) =
+              if keyvtxl[0][0].isValid:
+                (keyvtxl[0][0], keyvtxl[1])
+              else:
+                ?txRef.computeKeyImpl(
+                  (vtx.stoID.vid, vtx.stoID.vid),
+                  batch,
+                  keyvtxl[0][1],
+                  keyvtxl[1],
+                  skipLayers = skipLayers,
+                  spawnTpTasks = false,
+                  parallel,
+                  keyQueue,
+                  vtxBufQueue
+                )
+          level = max(level, sl)
+          skey
+        else:
+          VOID_HASH_KEY
+      rlpEncodeAccLeaf(vtx.pfx, vtx.account, skey).digestTo(HashKey)
     of StoLeaf:
       let vtx = StoLeafRef(vtx)
-      var writer = RlpArrayBufWriter[MAX_RLP_SIZE_STORAGE_LEAF_NODE, 1]()
-      writer.encodeLeaf(vtx.pfx):
-        var w = RlpArrayBufWriter[MAX_RLP_SIZE_STORAGE_LEAF, 1]()
-        w.append(vtx.stoData)
-        w.finish(asOpenArray = true)
+      rlpEncodeStoLeaf(vtx.pfx, vtx.stoData).digestTo(HashKey)
     of Branches:
       # For branches, we need to load the vertices before recursing into them
       # to exploit their on-disk order
@@ -465,23 +419,18 @@ proc computeKeyImpl(
             keyQueues[i].dispose()
             vtxBufQueues[i].dispose()
 
-      template writeBranch(w: var RlpWriter, vtx: BranchRef): HashKey =
-        w.encodeBranch(vtx):
-          if subvid.isValid:
-            level = max(level, keyvtxs[n][1])
-            keyvtxs[n][0][0]
-          else:
-            VOID_HASH_KEY
+      template branchSubKey(): untyped =
+        if subvid.isValid:
+          level = max(level, keyvtxs[n][1])
+          keyvtxs[n][0][0]
+        else:
+          VOID_HASH_KEY
 
       if vtx.vType == ExtBranch:
-        let vtx = ExtBranchRef(vtx)
-        var writer = RlpArrayBufWriter[MAX_RLP_SIZE_EXTENSION_NODE, 1]()
-        writer.encodeExt(vtx.pfx):
-          var bwriter = RlpArrayBufWriter[MAX_RLP_SIZE_BRANCH_NODE, 1]()
-          bwriter.writeBranch(vtx)
+        let brKey = rlpEncodeBranch(vtx, branchSubKey()).digestTo(HashKey)
+        rlpEncodeExt(ExtBranchRef(vtx).pfx, brKey).digestTo(HashKey)
       else:
-        var writer = RlpArrayBufWriter[MAX_RLP_SIZE_BRANCH_NODE, 1]()
-        writer.writeBranch(vtx)
+        rlpEncodeBranch(vtx, branchSubKey()).digestTo(HashKey)
 
   # Cache the hash into the same storage layer as the the top-most value that it
   # depends on (recursively) - this could be an ephemeral in-memory layer or the

--- a/execution_chain/db/aristo/aristo_serialise.nim
+++ b/execution_chain/db/aristo/aristo_serialise.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023-2025 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -41,17 +41,18 @@ template rlpEncodeAccLeaf*(
   accLeafW.append(pfx.toHexPrefix(isLeaf = true).data())
   block:
     var accW = RlpArrayBufWriter[MAX_RLP_SIZE_ACCOUNT_LEAF, 1]()
-    accW.append(Account(
-      nonce: account.nonce,
-      balance: account.balance,
-      storageRoot: storageKey.to(Hash32),
-      codeHash: account.codeHash))
+    accW.append(
+      Account(
+        nonce: account.nonce,
+        balance: account.balance,
+        storageRoot: storageKey.to(Hash32),
+        codeHash: account.codeHash,
+      )
+    )
     accLeafW.append(accW.finish(asOpenArray = true))
   accLeafW.finish(asOpenArray = true)
 
-template rlpEncodeStoLeaf*(
-    pfx: NibblesBuf, stoData: UInt256
-): openArray[byte] =
+template rlpEncodeStoLeaf*(pfx: NibblesBuf, stoData: UInt256): openArray[byte] =
   var stoLeafW = RlpArrayBufWriter[MAX_RLP_SIZE_STORAGE_LEAF_NODE, 1]()
   stoLeafW.startList(2)
   stoLeafW.append(pfx.toHexPrefix(isLeaf = true).data())
@@ -69,9 +70,7 @@ template rlpEncodeBranch*(vtx: VertexRef, subKeyForN: untyped): openArray[byte] 
   branchW.append EmptyBlob
   branchW.finish(asOpenArray = true)
 
-template rlpEncodeExt*(
-    pfx: NibblesBuf, branchKey: HashKey
-): openArray[byte] =
+template rlpEncodeExt*(pfx: NibblesBuf, branchKey: HashKey): openArray[byte] =
   var extW = RlpArrayBufWriter[MAX_RLP_SIZE_EXTENSION_NODE, 1]()
   extW.startList(2)
   extW.append(pfx.toHexPrefix(isLeaf = false).data())
@@ -102,7 +101,7 @@ proc to*(node: NodeRef, T: type array[2, seq[byte]]): T =
     let vtx = StoLeafRef(node.vtx)
     [@(rlpEncodeStoLeaf(vtx.pfx, vtx.stoData)), @[]]
 
-proc digestTo*(node: NodeRef; T: type HashKey): T =
+proc digestTo*(node: NodeRef, T: type HashKey): T =
   ## Convert the argument `node` to the corresponding Merkle hash key. Note
   ## that a `Dummy` node is encoded as as a `Leaf`.
   ##

--- a/execution_chain/db/aristo/aristo_serialise.nim
+++ b/execution_chain/db/aristo/aristo_serialise.nim
@@ -33,36 +33,38 @@ const
 # RLP encoding templates for MPT nodes
 # ------------------------------------------------------------------------------
 
+template rlpEncodeAccLeafValue*(account: Account): openArray[byte] =
+  var accW = RlpArrayBufWriter[MAX_RLP_SIZE_ACCOUNT_LEAF, 1]()
+  accW.append(account)
+  accW.finish(asOpenArray = true)
+
 template rlpEncodeAccLeaf*(
     pfx: NibblesBuf, account: AristoAccount, storageKey: HashKey
 ): openArray[byte] =
   var accLeafW = RlpArrayBufWriter[MAX_RLP_SIZE_ACCOUNT_LEAF_NODE, 1]()
   accLeafW.startList(2)
   accLeafW.append(pfx.toHexPrefix(isLeaf = true).data())
-  block:
-    var accW = RlpArrayBufWriter[MAX_RLP_SIZE_ACCOUNT_LEAF, 1]()
-    accW.append(
-      Account(
-        nonce: account.nonce,
-        balance: account.balance,
-        storageRoot: storageKey.to(Hash32),
-        codeHash: account.codeHash,
-      )
-    )
-    accLeafW.append(accW.finish(asOpenArray = true))
+  accLeafW.append(rlpEncodeAccLeafValue(Account(
+      nonce: account.nonce,
+      balance: account.balance,
+      storageRoot: storageKey.to(Hash32),
+      codeHash: account.codeHash,
+  )))
   accLeafW.finish(asOpenArray = true)
+
+template rlpEncodeStoLeafValue*(stoData: UInt256): openArray[byte] =
+  var stoW = RlpArrayBufWriter[MAX_RLP_SIZE_STORAGE_LEAF, 1]()
+  stoW.append(stoData)
+  stoW.finish(asOpenArray = true)
 
 template rlpEncodeStoLeaf*(pfx: NibblesBuf, stoData: UInt256): openArray[byte] =
   var stoLeafW = RlpArrayBufWriter[MAX_RLP_SIZE_STORAGE_LEAF_NODE, 1]()
   stoLeafW.startList(2)
   stoLeafW.append(pfx.toHexPrefix(isLeaf = true).data())
-  block:
-    var stoW = RlpArrayBufWriter[MAX_RLP_SIZE_STORAGE_LEAF, 1]()
-    stoW.append(stoData)
-    stoLeafW.append(stoW.finish(asOpenArray = true))
+  stoLeafW.append(rlpEncodeStoLeafValue(stoData))
   stoLeafW.finish(asOpenArray = true)
 
-template rlpEncodeBranch*(vtx: VertexRef, subKeyForN: untyped): openArray[byte] =
+template rlpEncodeBranch*(vtx: BranchRef, subKeyForN: untyped): openArray[byte] =
   var branchW = RlpArrayBufWriter[MAX_RLP_SIZE_BRANCH_NODE, 1]()
   branchW.startList(17)
   for (n {.inject.}, subvid {.inject.}) in vtx.allPairs():
@@ -88,7 +90,7 @@ proc to*(node: NodeRef, T: type array[2, seq[byte]]): T =
   ##
   case node.vtx.vType
   of Branches:
-    let brData = @(rlpEncodeBranch(node.vtx, node.key[n]))
+    let brData = @(rlpEncodeBranch(BranchRef(node.vtx), node.key[n]))
     if node.vtx.vType == ExtBranch:
       let brHash = brData.digestTo(HashKey)
       [@(rlpEncodeExt(ExtBranchRef(node.vtx).pfx, brHash)), brData]
@@ -107,7 +109,7 @@ proc digestTo*(node: NodeRef, T: type HashKey): T =
   ##
   case node.vtx.vType
   of Branches:
-    let brKey = rlpEncodeBranch(node.vtx, node.key[n]).digestTo(HashKey)
+    let brKey = rlpEncodeBranch(BranchRef(node.vtx), node.key[n]).digestTo(HashKey)
     if node.vtx.vType == ExtBranch:
       rlpEncodeExt(ExtBranchRef(node.vtx).pfx, brKey).digestTo(HashKey)
     else:

--- a/execution_chain/db/aristo/aristo_serialise.nim
+++ b/execution_chain/db/aristo/aristo_serialise.nim
@@ -11,21 +11,76 @@
 {.push raises: [].}
 
 import
-  eth/[common, rlp],
+  eth/common/[accounts_rlp, base_rlp, hashes_rlp],
   results,
   ./[aristo_constants, aristo_desc]
+
+export aristo_constants, accounts_rlp
+
+# ------------------------------------------------------------------------------
+# RLP encoding constants
+# ------------------------------------------------------------------------------
+
+const
+  MAX_RLP_SIZE_ACCOUNT_LEAF* = 111
+  MAX_RLP_SIZE_STORAGE_LEAF* = 34
+  MAX_RLP_SIZE_ACCOUNT_LEAF_NODE* = 149
+  MAX_RLP_SIZE_STORAGE_LEAF_NODE* = 71
+  MAX_RLP_SIZE_BRANCH_NODE* = 533
+  MAX_RLP_SIZE_EXTENSION_NODE* = 69
+
+# ------------------------------------------------------------------------------
+# RLP encoding templates for MPT nodes
+# ------------------------------------------------------------------------------
+
+template rlpEncodeAccLeaf*(
+    pfx: NibblesBuf, account: AristoAccount, storageKey: HashKey
+): openArray[byte] =
+  var accLeafW = RlpArrayBufWriter[MAX_RLP_SIZE_ACCOUNT_LEAF_NODE, 1]()
+  accLeafW.startList(2)
+  accLeafW.append(pfx.toHexPrefix(isLeaf = true).data())
+  block:
+    var accW = RlpArrayBufWriter[MAX_RLP_SIZE_ACCOUNT_LEAF, 1]()
+    accW.append(Account(
+      nonce: account.nonce,
+      balance: account.balance,
+      storageRoot: storageKey.to(Hash32),
+      codeHash: account.codeHash))
+    accLeafW.append(accW.finish(asOpenArray = true))
+  accLeafW.finish(asOpenArray = true)
+
+template rlpEncodeStoLeaf*(
+    pfx: NibblesBuf, stoData: UInt256
+): openArray[byte] =
+  var stoLeafW = RlpArrayBufWriter[MAX_RLP_SIZE_STORAGE_LEAF_NODE, 1]()
+  stoLeafW.startList(2)
+  stoLeafW.append(pfx.toHexPrefix(isLeaf = true).data())
+  block:
+    var stoW = RlpArrayBufWriter[MAX_RLP_SIZE_STORAGE_LEAF, 1]()
+    stoW.append(stoData)
+    stoLeafW.append(stoW.finish(asOpenArray = true))
+  stoLeafW.finish(asOpenArray = true)
+
+template rlpEncodeBranch*(vtx: VertexRef, subKeyForN: untyped): openArray[byte] =
+  var branchW = RlpArrayBufWriter[MAX_RLP_SIZE_BRANCH_NODE, 1]()
+  branchW.startList(17)
+  for (n {.inject.}, subvid {.inject.}) in vtx.allPairs():
+    branchW.append(subKeyForN)
+  branchW.append EmptyBlob
+  branchW.finish(asOpenArray = true)
+
+template rlpEncodeExt*(
+    pfx: NibblesBuf, branchKey: HashKey
+): openArray[byte] =
+  var extW = RlpArrayBufWriter[MAX_RLP_SIZE_EXTENSION_NODE, 1]()
+  extW.startList(2)
+  extW.append(pfx.toHexPrefix(isLeaf = false).data())
+  extW.append(branchKey)
+  extW.finish(asOpenArray = true)
 
 # ------------------------------------------------------------------------------
 # Public RLP transcoder mixins
 # ------------------------------------------------------------------------------
-
-proc toRlpBytes*(acc: AristoAccount, key: HashKey): seq[byte] =
-  rlp.encode Account(
-    nonce: acc.nonce,
-    balance: acc.balance,
-    storageRoot: key.to(Hash32),
-    codeHash: acc.codeHash,
-  )
 
 proc to*(node: NodeRef, T: type array[2, seq[byte]]): T =
   ## Convert the argument pait `w` to a single or a double item list item of
@@ -34,78 +89,36 @@ proc to*(node: NodeRef, T: type array[2, seq[byte]]): T =
   ##
   case node.vtx.vType
   of Branches:
-    # Do branch node
-    var wr = initRlpWriter()
-    wr.startList(17)
-    for key in node.key:
-      wr.append key
-    wr.append EmptyBlob
-    let brData = wr.finish()
-
+    let brData = @(rlpEncodeBranch(node.vtx, node.key[n]))
     if node.vtx.vType == ExtBranch:
-      # Prefix branch by embedded extension node
       let brHash = brData.digestTo(HashKey)
-
-      var wrx = initRlpWriter()
-      wrx.startList(2)
-      wrx.append node.vtx.pfx.toHexPrefix(isleaf = false).data()
-      wrx.append brHash
-
-      [wrx.finish(), brData]
+      [@(rlpEncodeExt(ExtBranchRef(node.vtx).pfx, brHash)), brData]
     else:
-      # Do for pure branch node
       [brData, @[]]
   of AccLeaf:
     let vtx = AccLeafRef(node.vtx)
-    var wr = initRlpWriter()
-    wr.startList(2)
-    wr.append vtx.pfx.toHexPrefix(isleaf = true).data()
-    wr.append vtx.account.toRlpBytes(node.key[0])
-
-    [wr.finish(), @[]]
+    [@(rlpEncodeAccLeaf(vtx.pfx, vtx.account, node.key[0])), @[]]
   of StoLeaf:
     let vtx = StoLeafRef(node.vtx)
-    var wr = initRlpWriter()
-    wr.startList(2)
-    wr.append vtx.pfx.toHexPrefix(isleaf = true).data()
-    wr.append rlp.encode vtx.stoData
-
-    [wr.finish(), @[]]
+    [@(rlpEncodeStoLeaf(vtx.pfx, vtx.stoData)), @[]]
 
 proc digestTo*(node: NodeRef; T: type HashKey): T =
   ## Convert the argument `node` to the corresponding Merkle hash key. Note
   ## that a `Dummy` node is encoded as as a `Leaf`.
   ##
-  var wr = initRlpWriter()
   case node.vtx.vType
   of Branches:
-    # Do branch node
-    wr.startList(17)
-    for key in node.key:
-      wr.append key
-    wr.append EmptyBlob
-
-    # Do for embedded extension node
-    if 0 < node.vtx.pfx.len:
-      let brHash = wr.finish().digestTo(HashKey)
-      wr = initRlpWriter()
-      wr.startList(2)
-      wr.append node.vtx.pfx.toHexPrefix(isleaf = false).data()
-      wr.append brHash
+    let brKey = rlpEncodeBranch(node.vtx, node.key[n]).digestTo(HashKey)
+    if node.vtx.vType == ExtBranch:
+      rlpEncodeExt(ExtBranchRef(node.vtx).pfx, brKey).digestTo(HashKey)
+    else:
+      brKey
   of AccLeaf:
     let vtx = AccLeafRef(node.vtx)
-
-    wr.startList(2)
-    wr.append node.vtx.pfx.toHexPrefix(isleaf = true).data()
-    wr.append vtx.account.toRlpBytes(node.key[0])
+    rlpEncodeAccLeaf(vtx.pfx, vtx.account, node.key[0]).digestTo(HashKey)
   of StoLeaf:
     let vtx = StoLeafRef(node.vtx)
-    var wr = initRlpWriter()
-    wr.startList(2)
-    wr.append vtx.pfx.toHexPrefix(isleaf = true).data()
-    wr.append rlp.encode vtx.stoData
-
-  wr.finish().digestTo(HashKey)
+    rlpEncodeStoLeaf(vtx.pfx, vtx.stoData).digestTo(HashKey)
 
 # ------------------------------------------------------------------------------
 # End

--- a/tests/proof_helpers.nim
+++ b/tests/proof_helpers.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)

--- a/tests/proof_helpers.nim
+++ b/tests/proof_helpers.nim
@@ -8,7 +8,7 @@
 import
   stew/byteutils,
   eth/rlp,
-  eth/common/[keys, hashes_rlp],
+  eth/common/[accounts_rlp, base_rlp, hashes_rlp],
   web3/eth_api,
   ../execution_chain/db/aristo/aristo_proof
 

--- a/tests/proof_helpers.nim
+++ b/tests/proof_helpers.nim
@@ -8,7 +8,7 @@
 import
   stew/byteutils,
   eth/rlp,
-  eth/common/keys,
+  eth/common/[keys, hashes_rlp],
   web3/eth_api,
   ../execution_chain/db/aristo/aristo_proof
 


### PR DESCRIPTION
This updates the MPT node rlp encoding in aristo_serialise to use the RlpArrayBufWriter for improved performance and also refactors the code to unify and remove the code duplication across aristo_serialise and aristo_compute. Helper rlp encoding templates are added to aristo_serialise and re-used across both files.