### PR TITLE
Update bal index type to uint64

### DIFF
--- a/execution_chain/block_access_list/block_access_list_tracker.nim
+++ b/execution_chain/block_access_list/block_access_list_tracker.nim
@@ -100,8 +100,6 @@ proc setBlockAccessIndex*(tracker: BlockAccessListTrackerRef, blockAccessIndex: 
   ##   - 0: Pre-execution (system contracts like beacon roots, block hashes)
   ##   - 1..n: Transactions (tx at index i gets block_access_index i+1)
   ##   - n+1: Post-execution (withdrawals, requests)
-  doAssert blockAccessIndex >= int(uint16.low) and blockAccessIndex <= int(uint16.high)
-
   tracker.preStorageCache.clear()
   tracker.preBalanceCache.clear()
   tracker.preNonceCache.clear()

--- a/tests/test_block_access_list_tracker.nim
+++ b/tests/test_block_access_list_tracker.nim
@@ -87,16 +87,6 @@ suite "Block access list tracker":
       do:
         raiseAssert("AccountData should exist")
 
-  test "Set invalid block access index":
-    let balIndexes = [
-      uint16.low.int - 1,
-      uint16.high.int + 1
-    ]
-
-    for balIndex in balIndexes:
-      expect AssertionDefect:
-        tracker.setBlockAccessIndex(balIndex)
-
   test "Capture pre balance - stores in preBalanceCache and returns":
     block:
       let cacheKey = address1


### PR DESCRIPTION
EIP-7928 has been updated increasing the size of the BlockAccessIndex from uint16 to uint64. See here: https://github.com/ethereum/EIPs/pull/11535

The discussion in discord suggested that both uint32 and uint64 would be large enough to account for future gas limit increases but uint64 was selected in the end. We use int internally which is either a 32 bits or 64 bits depending on the platform so in practice this should be fine. We just update the BAL serialization to treat the rlp integer as a uint64 for correctness.