### PR TITLE
Switch RocksDB block cache from LruCache to HyperClockCache

### DIFF
--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -317,6 +317,11 @@ type
       defaultValue: defaultBlockCacheSize
       name: "debug-rocksdb-block-cache-size".}: int
 
+    rocksdbBlockCacheType {.
+      hidden
+      defaultValue: defaultBlockCacheType
+      name: "debug-rocksdb-block-cache-type" .}: RocksDbBlockCacheType
+
     rdbVtxCacheSize {.
       hidden
       defaultValue: defaultRdbVtxCacheSize
@@ -811,7 +816,8 @@ func dbOptions*(config: ExecutionClientConf, noKeyCache = false): DbOptions =
       else: config.rdbBranchCacheSize,
     rdbPrintStats = config.rdbPrintStats,
     maxSnapshots = config.aristoDbMaxSnapshots,
-    parallelStateRootComputation = config.parallelStateRootComputation
+    parallelStateRootComputation = config.parallelStateRootComputation,
+    blockCacheType = config.rocksdbBlockCacheType,
   )
 
 func jwtSecretOpt*(config: ExecutionClientConf): Opt[InputFile] =

--- a/execution_chain/db/core_db/backend/aristo_rocksdb.nim
+++ b/execution_chain/db/core_db/backend/aristo_rocksdb.nim
@@ -179,7 +179,11 @@ proc newRocksDbCoreDbRef*(basePath: string, opts: DbOptions, wipe = false): Core
         # significant portion of the inner trie nodes!
         # This code sets up a single block cache to be shared, a strategy that
         # plausibly can be refined in the future.
-        cacheCreateLRU(opts.blockCacheSize, autoClose = true)
+        case opts.blockCacheType
+        of lruCache:
+          cacheCreateLRU(opts.blockCacheSize, autoClose = true)
+        of hyperClockCache:
+          cacheCreateHyperClock(opts.blockCacheSize, autoClose = true)
       else:
         nil
     dbOpts = opts.toDbOpts()

--- a/execution_chain/db/opts.nim
+++ b/execution_chain/db/opts.nim
@@ -45,7 +45,7 @@ const
     ## Cache of branches and leaves in the state MPTs (world and account)
   defaultMaxSnapshots* = 5
     ## The max number of snapshots to store in the aristo database.
-  defaultBlockCacheType* = lruCache
+  defaultBlockCacheType* = hyperClockCache
     ## The default RocksDb block cache.
 
 type DbOptions* = object # Options that are transported to the database layer

--- a/execution_chain/db/opts.nim
+++ b/execution_chain/db/opts.nim
@@ -14,6 +14,10 @@ import results
 
 export results
 
+type RocksDbBlockCacheType* = enum
+  lruCache = "lru"
+  hyperClockCache = "hyperclock"
+
 const
   # https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning
   defaultMaxOpenFiles* = 2048
@@ -41,6 +45,8 @@ const
     ## Cache of branches and leaves in the state MPTs (world and account)
   defaultMaxSnapshots* = 5
     ## The max number of snapshots to store in the aristo database.
+  defaultBlockCacheType* = lruCache
+    ## The default RocksDb block cache.
 
 type DbOptions* = object # Options that are transported to the database layer
   maxOpenFiles*: int
@@ -53,6 +59,7 @@ type DbOptions* = object # Options that are transported to the database layer
   rdbPrintStats*: bool
   maxSnapshots*: int
   parallelStateRootComputation*: bool
+  blockCacheType*: RocksDbBlockCacheType
 
 func init*(
     T: type DbOptions,
@@ -65,7 +72,8 @@ func init*(
     rdbBranchCacheSize = defaultRdbBranchCacheSize,
     rdbPrintStats = false,
     maxSnapshots = defaultMaxSnapshots,
-    parallelStateRootComputation = false
+    parallelStateRootComputation = false,
+    blockCacheType = defaultBlockCacheType,
 ): T =
   T(
     maxOpenFiles: maxOpenFiles,
@@ -77,5 +85,6 @@ func init*(
     rdbBranchCacheSize: rdbBranchCacheSize,
     rdbPrintStats: rdbPrintStats,
     maxSnapshots: maxSnapshots,
-    parallelStateRootComputation: parallelStateRootComputation
+    parallelStateRootComputation: parallelStateRootComputation,
+    blockCacheType: blockCacheType
   )


### PR DESCRIPTION
HyperClockCache is the newer high performance cache implementation which is now the new default and it is recommend to upgrade to it. It is also meant to perform better for multithreaded workloads. I did some short benchmarks and the results look good, some small improvements. 

See the release notes of the rocksdb 10.7.0 release https://github.com/facebook/rocksdb/releases:


Public API Changes
- HyperClockCache with no estimated_entry_charge is now production-ready and is the preferred block cache implementation vs. LRUCache. Please consider updating your code to minimize the risk of hitting performance bottlenecks or anomalies from LRUCache. See cache.h for more detail.

Behavior Changes
- The default provided block cache implementation is now HyperClockCache instead of LRUCache, when block_cache is nullptr (default) and no_block_cache==false (default). We recommend explicitly creating a HyperClockCache block cache based on memory budget and sharing it across all column families and even DB instances. This change could expose previously hidden memory or resource leaks.


This PR sets the HyperClockCache as the new default but also makes setting the cache choice configurable on the command line so we can easily switch back to the LruCache if desired.