### PR TITLE
devp2p eth/71 fixes and tests

### DIFF
--- a/execution_chain/sync/wire_protocol/eth/eth_handler.nim
+++ b/execution_chain/sync/wire_protocol/eth/eth_handler.nim
@@ -249,8 +249,6 @@ proc getBlockHeaders*(ctx: EthWireRef,
 
 proc getBlockAccessLists*(
     ctx: EthWireRef, req: BlockAccessListsRequest): BlockAccessListsPacket =
-  const emptyBal = default(BlockAccessList)
-
   var blockHashes = req.blockHashes
   blockHashes.setLen(min(req.blockHashes.len(), MAX_BALS_SERVE))
 
@@ -262,17 +260,18 @@ proc getBlockAccessLists*(
     totalBytes = 0
     i = 0
     res = BlockAccessListsPacket(
-      accessLists: newSeqOfCap[BlockAccessList](balValues.len())
+      accessLists: newSeqOfCap[RawBlockAccessList](balValues.len())
     )
 
   while totalBytes <= SOFT_RESPONSE_LIMIT and i <= balValues.high:
     if balValues[i].isSome():
-      res.accessLists.add BlockAccessList.decode(balValues[i].get())
-          .expect("BALs from the db should decode successfully")
-      totalBytes += balValues[i].get().len()
+      let bal = balValues[i].get()
+      res.accessLists.add RawBlockAccessList(bal)
+      assert bal.len() > 0 # The empty list is encoded as 0xC0 (a single byte)
+      totalBytes += bal.len()
     else:
-      res.accessLists.add(emptyBal)
-      inc totalBytes # the empty rlp list takes only a single byte
+      res.accessLists.add RawBlockAccessList(@[0x80'u8])
+      inc totalBytes # 0x80 is a single byte
 
     inc i
   

--- a/execution_chain/sync/wire_protocol/eth/eth_handler.nim
+++ b/execution_chain/sync/wire_protocol/eth/eth_handler.nim
@@ -20,14 +20,14 @@ logScope:
   topics = "eth-wire"
 
 const
-  MAX_RECEIPTS_SERVE*  = 1024
-  MAX_HEADERS_SERVE*   = 1024
-  MAX_BODIES_SERVE*    = 256
+  MAX_RECEIPTS_SERVE  = 1024
+  MAX_HEADERS_SERVE   = 1024
+  MAX_BODIES_SERVE    = 256
   # https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getpooledtransactions-0x09
-  MAX_TXS_SERVE*       = 256
-  MAX_BALS_SERVE*      = 256
-  MAX_ACTION_HANDLER*  = 512
-  NUM_ACTION_WORKERS*  = 4
+  MAX_TXS_SERVE       = 256
+  MAX_BALS_SERVE      = 256
+  MAX_ACTION_HANDLER  = 512
+  NUM_ACTION_WORKERS  = 4
 
 # ------------------------------------------------------------------------------
 # Public constructor/destructor

--- a/execution_chain/sync/wire_protocol/eth/eth_handler.nim
+++ b/execution_chain/sync/wire_protocol/eth/eth_handler.nim
@@ -20,14 +20,14 @@ logScope:
   topics = "eth-wire"
 
 const
-  MAX_RECEIPTS_SERVE  = 1024
-  MAX_HEADERS_SERVE   = 1024
-  MAX_BODIES_SERVE    = 256
+  MAX_RECEIPTS_SERVE*  = 1024
+  MAX_HEADERS_SERVE*   = 1024
+  MAX_BODIES_SERVE*    = 256
   # https://github.com/ethereum/devp2p/blob/master/caps/eth.md#getpooledtransactions-0x09
-  MAX_TXS_SERVE       = 256
-  MAX_BALS_SERVE      = 256
-  MAX_ACTION_HANDLER  = 512
-  NUM_ACTION_WORKERS  = 4
+  MAX_TXS_SERVE*       = 256
+  MAX_BALS_SERVE*      = 256
+  MAX_ACTION_HANDLER*  = 512
+  NUM_ACTION_WORKERS*  = 4
 
 # ------------------------------------------------------------------------------
 # Public constructor/destructor

--- a/execution_chain/sync/wire_protocol/eth/eth_requester.nim
+++ b/execution_chain/sync/wire_protocol/eth/eth_requester.nim
@@ -212,10 +212,14 @@ proc getReceipts*(peer: Peer; firstBlockReceiptIndex: uint64; packet: ReceiptsRe
                   timeout: Duration = milliseconds(10000'i64)): Future[
     Opt[StoredReceipts70Packet]] {.async: (raises: [CancelledError, EthP2PError],
                                    raw: true).} =
+  let req = StoredReceipts70Request(
+    firstBlockReceiptIndex: firstBlockReceiptIndex,
+    blockHashes: packet.blockHashes
+  )
   if peer.supports(eth71):
-    eth71.rlpxSendRequest(peer, timeout, GetReceiptsMsg, firstBlockReceiptIndex, packet.blockHashes)
+    eth71.rlpxSendRequest(peer, timeout, GetReceiptsMsg, req)
   else:
-    eth70.rlpxSendRequest(peer, timeout, GetReceiptsMsg, firstBlockReceiptIndex, packet.blockHashes)
+    eth70.rlpxSendRequest(peer, timeout, GetReceiptsMsg, req)
 
 proc receipts*(responder: Responder;
                receipts: openArray[seq[Receipt]]): Future[void] {.

--- a/execution_chain/sync/wire_protocol/eth/eth_responder.nim
+++ b/execution_chain/sync/wire_protocol/eth/eth_responder.nim
@@ -275,7 +275,7 @@ proc getReceipts70UserHandler[PROTO](response: Responder; req: StoredReceipts70R
 
 proc getReceiptsThunk[PROTO](peer: Peer; data: Rlp) {.
     async: (raises: [CancelledError, EthP2PError]).} =
-  when PROTO is eth70:
+  when PROTO is eth70 or PROTO is eth71:
     PROTO.rlpxWithPacketResponder(StoredReceipts70Request, peer, data):
       await getReceipts70UserHandler[PROTO](response, packet)
   else:
@@ -284,7 +284,7 @@ proc getReceiptsThunk[PROTO](peer: Peer; data: Rlp) {.
 
 proc receiptsThunk[PROTO](peer: Peer; data: Rlp) {.
     async: (raises: [CancelledError, EthP2PError]).} =
-  when PROTO is eth70:
+  when PROTO is eth70 or PROTO is eth71:
     PROTO.rlpxWithFutureHandler(StoredReceipts70Packet,
       ReceiptsMsg, peer, data, [lastBlockIncomplete, receipts])
   elif PROTO is eth69:
@@ -477,10 +477,6 @@ template registerCommonThunk(protocol: ProtocolInfo, PROTO: type) =
               pooledTransactionsThunk[PROTO], PooledTransactionsPacket)
   registerMsg(protocol, GetPooledTransactionsMsg, "getPooledTransactions",
               getPooledTransactionsThunk[PROTO], PooledTransactionsRequest)
-  registerMsg(protocol, ReceiptsMsg, "receipts",
-              receiptsThunk[PROTO], ReceiptsPacket)
-  registerMsg(protocol, GetReceiptsMsg, "getReceipts",
-              getReceiptsThunk[PROTO], ReceiptsRequest)
 
 proc eth68Registration() =
   let
@@ -490,6 +486,10 @@ proc eth68Registration() =
   registerMsg(protocol, StatusMsg, "status",
               status68Thunk, Status68Packet)
   registerCommonThunk(protocol, eth68)
+  registerMsg(protocol, ReceiptsMsg, "receipts",
+              receiptsThunk[eth68], ReceiptsPacket)
+  registerMsg(protocol, GetReceiptsMsg, "getReceipts",
+              getReceiptsThunk[eth68], ReceiptsRequest)
   registerProtocol(protocol)
 
 proc eth69Registration() =
@@ -500,6 +500,10 @@ proc eth69Registration() =
   registerMsg(protocol, StatusMsg, "status",
               status69OrLaterThunk[eth69], Status69Packet)
   registerCommonThunk(protocol, eth69)
+  registerMsg(protocol, ReceiptsMsg, "receipts",
+              receiptsThunk[eth69], ReceiptsPacket)
+  registerMsg(protocol, GetReceiptsMsg, "getReceipts",
+              getReceiptsThunk[eth69], ReceiptsRequest)
   registerMsg(protocol, BlockRangeUpdateMsg, "blockRangeUpdate",
               blockRangeUpdateThunk[eth69], BlockRangeUpdatePacket)
   registerProtocol(protocol)
@@ -512,6 +516,10 @@ proc eth70Registration() =
   registerMsg(protocol, StatusMsg, "status",
               status69OrLaterThunk[eth70], Status69Packet)
   registerCommonThunk(protocol, eth70)
+  registerMsg(protocol, ReceiptsMsg, "receipts",
+              receiptsThunk[eth70], StoredReceipts70Packet)
+  registerMsg(protocol, GetReceiptsMsg, "getReceipts",
+              getReceiptsThunk[eth70], StoredReceipts70Request)
   registerMsg(protocol, BlockRangeUpdateMsg, "blockRangeUpdate",
               blockRangeUpdateThunk[eth70], BlockRangeUpdatePacket)
   registerProtocol(protocol)
@@ -524,6 +532,10 @@ proc eth71Registration() =
   registerMsg(protocol, StatusMsg, "status",
               status69OrLaterThunk[eth71], Status69Packet)
   registerCommonThunk(protocol, eth71)
+  registerMsg(protocol, ReceiptsMsg, "receipts",
+              receiptsThunk[eth71], StoredReceipts70Packet)
+  registerMsg(protocol, GetReceiptsMsg, "getReceipts",
+              getReceiptsThunk[eth71], StoredReceipts70Request)
   registerMsg(protocol, BlockRangeUpdateMsg, "blockRangeUpdate",
               blockRangeUpdateThunk[eth71], BlockRangeUpdatePacket)
   registerMsg(protocol, GetBlockAccessListsMsg, "getBlockAccessLists",

--- a/execution_chain/sync/wire_protocol/eth/eth_responder.nim
+++ b/execution_chain/sync/wire_protocol/eth/eth_responder.nim
@@ -335,8 +335,9 @@ proc getBlockAccessListsUserHandler[PROTO](response: Responder; req: BlockAccess
   
 proc getBlockAccessListsThunk[PROTO](peer: Peer; data: Rlp) {.
     async: (raises: [CancelledError, EthP2PError]).} =
-  PROTO.rlpxWithPacketResponder(BlockAccessListsRequest, peer, data):
-    await getBlockAccessListsUserHandler[PROTO](response, packet)
+  PROTO.rlpxWithPacketResponder(seq[Hash32], peer, data):
+    await getBlockAccessListsUserHandler[PROTO](response,
+      BlockAccessListsRequest(blockHashes: packet))
 
 proc blockAccessListsThunk[PROTO](peer: Peer; data: Rlp) {.
     async: (raises: [CancelledError, EthP2PError]).} =

--- a/execution_chain/sync/wire_protocol/eth/eth_types.nim
+++ b/execution_chain/sync/wire_protocol/eth/eth_types.nim
@@ -123,8 +123,14 @@ type
   BlockAccessListsRequest* = object
     blockHashes*: seq[Hash32]
 
+  # A raw RLP-encoded block access list for a single block. Used instead of
+  # BlockAccessList to allow encoding unavailable entries as the RLP empty
+  # string (0x80) rather than the empty list (0xC0). Available entries are
+  # stored as their RLP-encoded bytes and unavailable entries are @[0x80'u8].
+  RawBlockAccessList* = distinct seq[byte]
+
   BlockAccessListsPacket* = object
-    accessLists*: seq[BlockAccessList]
+    accessLists*: seq[RawBlockAccessList]
 
   SeenObject* = ref object
     lastSeen*: Time
@@ -144,3 +150,11 @@ type
     gossipEnabled*: bool
     cleanupTimer*: Future[void].Raising([CancelledError])
     brUpdateTimer*: Future[void].Raising([CancelledError])
+
+proc append*(w: var RlpWriter, x: RawBlockAccessList) =
+  w.appendRawBytes(distinctBase(x))
+
+proc read*(rlp: var Rlp, T: type RawBlockAccessList): T {.raises: [RlpError].} =
+  let rawBytes = @(rlp.rawData)
+  rlp.skipElem()
+  RawBlockAccessList(rawBytes)

--- a/tests/networking/p2p_test_helper.nim
+++ b/tests/networking/p2p_test_helper.nim
@@ -25,7 +25,7 @@ type
     com    : CommonRef
     node*  : EthereumNode
     txPool : TxPoolRef
-    chain  : ForkedChainRef
+    chain* : ForkedChainRef
     wire   : EthWireRef
 
 const

--- a/tests/networking/test_devp2p_eth71.nim
+++ b/tests/networking/test_devp2p_eth71.nim
@@ -33,7 +33,7 @@ proc seedBal(env: TestEnv, hash: Hash32, bal: BlockAccessList) =
   let balToStore: BlockAccessListRef = new BlockAccessList
   balToStore[] = bal
 
-  env.chain.latestTxFrame.persistBlockAccessList(hash, balToStore) #.expect("persistBlockAccessList should succeed")
+  env.chain.latestTxFrame.persistBlockAccessList(hash, balToStore)
 
 func makeHash(i: int): Hash32 =
   keccak256(i.uint64.toBytesLE)
@@ -264,3 +264,135 @@ procSuite "devp2p eth/71 Tests":
     env2.close()
     env1.close()
 
+  asyncTest "getBlockHeaders":
+    var
+      env1 = newTestEnv()
+      env2 = newTestEnv()
+
+    env2.node.startListening()
+
+    let connRes = await env1.node.rlpxConnect(newNode(env2.node.toENode()))
+    check connRes.isOk()
+
+    let peer = connRes.get()
+    check peer.supports(eth71)
+
+    let
+      req = BlockHeadersRequest(
+        startBlock: BlockHashOrNumber(isHash: false, number: 0),
+        maxResults: 1,
+        skip: 0,
+        reverse: false)
+      respOpt = await peer.getBlockHeaders(req, timeout = chronos.seconds(3))
+    check respOpt.isSome()
+
+    let resp = respOpt.get()
+    check:
+      resp.headers.len() == 1
+      resp.headers[0].number == 0
+
+    env2.close()
+    env1.close()
+
+  asyncTest "getBlockBodies":
+    var
+      env1 = newTestEnv()
+      env2 = newTestEnv()
+
+    env2.node.startListening()
+
+    let connRes = await env1.node.rlpxConnect(newNode(env2.node.toENode()))
+    check connRes.isOk()
+
+    let peer = connRes.get()
+    check peer.supports(eth71)
+
+    let
+      req = BlockBodiesRequest(blockHashes: @[env2.chain.latestHash])
+      respOpt = await peer.getBlockBodies(req, timeout = chronos.seconds(3))
+    check respOpt.isSome()
+
+    let resp = respOpt.get()
+    check:
+      resp.bodies.len() == 1
+
+    env2.close()
+    env1.close()
+
+  asyncTest "getPooledTransactions":
+    var
+      env1 = newTestEnv()
+      env2 = newTestEnv()
+
+    env2.node.startListening()
+
+    let connRes = await env1.node.rlpxConnect(newNode(env2.node.toENode()))
+    check connRes.isOk()
+
+    let peer = connRes.get()
+    check peer.supports(eth71)
+
+    let
+      req = PooledTransactionsRequest(txHashes: @[makeHash(777)])
+      respOpt = await peer.getPooledTransactions(req, timeout = chronos.seconds(3))
+    check respOpt.isSome()
+
+    let resp = respOpt.get()
+    check resp.transactions.len() == 0
+
+    env2.close()
+    env1.close()
+
+  asyncTest "blockRangeUpdate":
+    var
+      env1 = newTestEnv()
+      env2 = newTestEnv()
+
+    env2.node.startListening()
+
+    let connRes = await env1.node.rlpxConnect(newNode(env2.node.toENode()))
+    check connRes.isOk()
+
+    let peer = connRes.get()
+    check peer.supports(eth71)
+
+    await peer.blockRangeUpdate(
+      BlockRangeUpdatePacket(
+        earliest: 0,
+        latest: 0,
+        latestHash: default(Hash32)))
+
+    # Verify the connection remains usable after sending BlockRangeUpdate.
+    let
+      req = BlockAccessListsRequest(blockHashes: @[default(Hash32)])
+      respOpt = await peer.getBlockAccessLists(req, timeout = chronos.seconds(3))
+    check respOpt.isSome()
+
+    env2.close()
+    env1.close()
+
+  asyncTest "getReceipts (eth70+ format)":
+    var
+      env1 = newTestEnv()
+      env2 = newTestEnv()
+
+    env2.node.startListening()
+
+    let connRes = await env1.node.rlpxConnect(newNode(env2.node.toENode()))
+    check connRes.isOk()
+
+    let peer = connRes.get()
+    check peer.supports(eth71)
+
+    let
+      req = ReceiptsRequest(blockHashes: @[makeHash(888)])
+      respOpt = await peer.getReceipts(0'u64, req, timeout = chronos.seconds(3))
+    check respOpt.isSome()
+
+    let resp = respOpt.get()
+    check:
+      resp.receipts.len() == 0
+      resp.lastBlockIncomplete
+
+    env2.close()
+    env1.close()

--- a/tests/networking/test_devp2p_eth71.nim
+++ b/tests/networking/test_devp2p_eth71.nim
@@ -14,12 +14,29 @@ import
   unittest2,
   testutils,
   chronos,
-  eth/rlp,
+  eth/[common, rlp],
+  stew/endians2,
   ../../execution_chain/networking/p2p,
   ../../execution_chain/sync/wire_protocol,
+  ../../execution_chain/sync/wire_protocol/eth/eth_handler,
+  ../../execution_chain/core/chain/forked_chain,
+  ../../execution_chain/db/core_db,
+  ../../execution_chain/db/core_db/core_apps,
   ./stubloglevel,
   ./p2p_test_helper
 
+const
+  UNAVAILABLE_BAL_BYTES = @[0x80.byte]
+  EMPTY_BAL_BYTES       = @[0xc0.byte]
+
+proc seedBal(env: TestEnv, hash: Hash32, bal: BlockAccessList) =
+  let balToStore: BlockAccessListRef = new BlockAccessList
+  balToStore[] = bal
+
+  env.chain.latestTxFrame.persistBlockAccessList(hash, balToStore) #.expect("persistBlockAccessList should succeed")
+
+func makeHash(i: int): Hash32 =
+  keccak256(i.uint64.toBytesLE)
 
 procSuite "devp2p eth/71 Tests":
 
@@ -36,18 +53,213 @@ procSuite "devp2p eth/71 Tests":
     let peer = connRes.get()
     check peer.supports(eth71)
 
-    let 
-      req = BlockAccessListsRequest(blockHashes: @[default(Hash32), default(Hash32)])
+    let
+      req = BlockAccessListsRequest(blockHashes: @[default(Hash32)])
+      respOpt = await peer.getBlockAccessLists(req, timeout = chronos.seconds(3))
+    check respOpt.isSome()
+
+    let resp = respOpt.get()
+    check resp.accessLists.len() == 1
+
+    let balBytes = resp.accessLists[0]
+    check:
+      distinctBase(balBytes) == UNAVAILABLE_BAL_BYTES
+      rlp.encode(balBytes) == UNAVAILABLE_BAL_BYTES
+
+    env2.close()
+    env1.close()
+
+  asyncTest "getBlockAccessLists - empty BAL available":
+    var
+      env1 = newTestEnv()
+      env2 = newTestEnv()
+
+    env2.node.startListening()
+
+    let connRes = await env1.node.rlpxConnect(newNode(env2.node.toENode()))
+    check connRes.isOk()
+
+    let peer = connRes.get()
+    check peer.supports(eth71)
+
+    let blockHash = makeHash(2)
+    seedBal(env2, blockHash, default(BlockAccessList))
+
+    let
+      req = BlockAccessListsRequest(blockHashes: @[blockHash])
+      respOpt = await peer.getBlockAccessLists(req, timeout = chronos.seconds(3))
+    check respOpt.isSome()
+
+    let resp = respOpt.get()
+    check resp.accessLists.len() == 1
+
+    let balBytes = resp.accessLists[0].distinctBase()
+    check:
+      balBytes == EMPTY_BAL_BYTES
+      BlockAccessList.decode(balBytes).expect("valid BAL") == default(BlockAccessList)
+
+    env2.close()
+    env1.close()
+
+  asyncTest "getBlockAccessLists - non empty BAL available":
+    var
+      env1 = newTestEnv()
+      env2 = newTestEnv()
+
+    env2.node.startListening()
+
+    let connRes = await env1.node.rlpxConnect(newNode(env2.node.toENode()))
+    check connRes.isOk()
+
+    let peer = connRes.get()
+    check peer.supports(eth71)
+
+    let blockHash = makeHash(1)
+
+    var bal: BlockAccessList = newSeq[AccountChanges](1)
+    bal[0].address = Address.fromHex("0x1234567890123456789012345678901234567890")
+    
+    seedBal(env2, blockHash, bal)
+
+    let
+      req = BlockAccessListsRequest(blockHashes: @[blockHash])
+      respOpt = await peer.getBlockAccessLists(req, timeout = chronos.seconds(3))
+    check respOpt.isSome()
+
+    let resp = respOpt.get()
+    check resp.accessLists.len() == 1
+
+    let balBytes = resp.accessLists[0].distinctBase()
+    check:
+      balBytes.len() > 0
+      BlockAccessList.decode(balBytes).expect("valid BAL") == bal
+
+    env2.close()
+    env1.close()
+
+  asyncTest "getBlockAccessLists - mixed unavailable, empty and non empty BALs":
+    var
+      env1 = newTestEnv()
+      env2 = newTestEnv()
+
+    env2.node.startListening()
+
+    let connRes = await env1.node.rlpxConnect(newNode(env2.node.toENode()))
+    check connRes.isOk()
+
+    let peer = connRes.get()
+    check peer.supports(eth71)
+
+    let
+      unavailableHash = makeHash(3)
+      emptyHash       = makeHash(4)
+      nonEmptyHash    = makeHash(5)
+
+    let emptyBal = default(BlockAccessList)
+
+    var nonEmptyBal: BlockAccessList = newSeq[AccountChanges](1)
+    nonEmptyBal[0].address = Address.fromHex("0x1111111111111111111111111111111111111111")
+
+    seedBal(env2, emptyHash, emptyBal)
+    seedBal(env2, nonEmptyHash, nonEmptyBal)
+
+    let
+      req = BlockAccessListsRequest(
+        blockHashes: @[unavailableHash, emptyHash, nonEmptyHash])
       respOpt = await peer.getBlockAccessLists(req, timeout = chronos.seconds(3))
     check respOpt.isSome()
 
     let resp = respOpt.get()
     check resp.accessLists.len() == req.blockHashes.len()
 
+    let
+      unavailableBytes = resp.accessLists[0].distinctBase()
+      emptyBytes = resp.accessLists[1].distinctBase()
+      nonEmptyBytes = resp.accessLists[2].distinctBase()
+
+    check:
+      unavailableBytes == UNAVAILABLE_BAL_BYTES
+      emptyBytes == EMPTY_BAL_BYTES
+      BlockAccessList.decode(emptyBytes).expect("valid BAL") == emptyBal
+      BlockAccessList.decode(nonEmptyBytes).expect("valid BAL") == nonEmptyBal
+
+    env2.close()
+    env1.close()
+
+  asyncTest "getBlockAccessLists - MAX_BALS_SERVE cap":
+    var
+      env1 = newTestEnv()
+      env2 = newTestEnv()
+
+    env2.node.startListening()
+
+    let connRes = await env1.node.rlpxConnect(newNode(env2.node.toENode()))
+    check connRes.isOk()
+
+    let peer = connRes.get()
+    check peer.supports(eth71)
+
+    let numExtra = 4
+    var hashes = newSeq[Hash32](MAX_BALS_SERVE + numExtra)
+    for i in 0 ..< hashes.len:
+      hashes[i] = makeHash(i)
+
+    let
+      req = BlockAccessListsRequest(blockHashes: hashes)
+      respOpt = await peer.getBlockAccessLists(req, timeout = chronos.seconds(3))
+    check respOpt.isSome()
+
+    let resp = respOpt.get()
+    check resp.accessLists.len() == MAX_BALS_SERVE
+
     for balBytes in resp.accessLists:
-      check:
-        distinctBase(balBytes) == @[0x80.byte]
-        rlp.encode(balBytes) == @[0x80.byte]
+      check distinctBase(balBytes) == UNAVAILABLE_BAL_BYTES
+
+    env2.close()
+    env1.close()
+
+  asyncTest "getBlockAccessLists - SOFT_RESPONSE_LIMIT respected":
+    var
+      env1 = newTestEnv()
+      env2 = newTestEnv()
+
+    env2.node.startListening()
+
+    let connRes = await env1.node.rlpxConnect(newNode(env2.node.toENode()))
+    check connRes.isOk()
+
+    let peer = connRes.get()
+    check peer.supports(eth71)
+
+    # Build several large BALs so the cumulative payload exceeds SOFT_RESPONSE_LIMIT.
+    const
+      numSeeded = 5
+      entriesPerBal = 30_000
+    var
+      hashes = newSeq[Hash32](numSeeded)
+      bals = newSeq[BlockAccessList](numSeeded)
+
+    let testAddress = Address.fromHex("0x1111111111111111111111111111111111111111")
+    for i in 0 ..< numSeeded:
+      hashes[i] = makeHash(100 + i)
+      var bal = newSeq[AccountChanges](entriesPerBal)
+      for j in 0 ..< entriesPerBal:
+        bal[j].address = testAddress
+      bals[i] = bal
+      seedBal(env2, hashes[i], bal)
+
+    let
+      req = BlockAccessListsRequest(blockHashes: hashes)
+      respOpt = await peer.getBlockAccessLists(req, timeout = chronos.seconds(10))
+    check respOpt.isSome()
+
+    let resp = respOpt.get()
+    check:
+      resp.accessLists.len() > 0
+      resp.accessLists.len() < numSeeded
+
+    for i, balBytes in resp.accessLists:
+      check BlockAccessList.decode(balBytes.distinctBase()).expect("valid BAL") == bals[i]
 
     env2.close()
     env1.close()

--- a/tests/networking/test_devp2p_eth71.nim
+++ b/tests/networking/test_devp2p_eth71.nim
@@ -18,7 +18,7 @@ import
   stew/endians2,
   ../../execution_chain/networking/p2p,
   ../../execution_chain/sync/wire_protocol,
-  ../../execution_chain/sync/wire_protocol/eth/eth_handler,
+  ../../execution_chain/sync/wire_protocol/eth/eth_handler {.all.},
   ../../execution_chain/core/chain/forked_chain,
   ../../execution_chain/db/core_db,
   ../../execution_chain/db/core_db/core_apps,

--- a/tests/networking/test_devp2p_eth71.nim
+++ b/tests/networking/test_devp2p_eth71.nim
@@ -1,0 +1,54 @@
+# nimbus-execution-client
+# Copyright (c) 2018-2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.used.}
+
+import
+  std/typetraits,
+  unittest2,
+  testutils,
+  chronos,
+  eth/rlp,
+  ../../execution_chain/networking/p2p,
+  ../../execution_chain/sync/wire_protocol,
+  ./stubloglevel,
+  ./p2p_test_helper
+
+
+procSuite "devp2p eth/71 Tests":
+
+  asyncTest "getBlockAccessLists - BAL unavailable":
+    var
+      env1 = newTestEnv()
+      env2 = newTestEnv()
+
+    env2.node.startListening()
+
+    let connRes = await env1.node.rlpxConnect(newNode(env2.node.toENode()))
+    check connRes.isOk()
+
+    let peer = connRes.get()
+    check peer.supports(eth71)
+
+    let 
+      req = BlockAccessListsRequest(blockHashes: @[default(Hash32), default(Hash32)])
+      respOpt = await peer.getBlockAccessLists(req, timeout = chronos.seconds(3))
+    check respOpt.isSome()
+
+    let resp = respOpt.get()
+    check resp.accessLists.len() == req.blockHashes.len()
+
+    for balBytes in resp.accessLists:
+      check:
+        distinctBase(balBytes) == @[0x80.byte]
+        rlp.encode(balBytes) == @[0x80.byte]
+
+    env2.close()
+    env1.close()
+

--- a/tests/test_networking.nim
+++ b/tests/test_networking.nim
@@ -1,5 +1,5 @@
 # nimbus-execution-client
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))

--- a/tests/test_networking.nim
+++ b/tests/test_networking.nim
@@ -14,4 +14,5 @@ import
   ./networking/test_ecies,
   ./networking/test_bootnodes,
   ./networking/test_rlpx_thunk,
-  ./networking/test_rlpxtransport
+  ./networking/test_rlpxtransport,
+  ./networking/test_devp2p_eth71,

--- a/tests/test_networking.nim
+++ b/tests/test_networking.nim
@@ -15,4 +15,4 @@ import
   ./networking/test_bootnodes,
   ./networking/test_rlpx_thunk,
   ./networking/test_rlpxtransport,
-  ./networking/test_devp2p_eth71,
+  ./networking/test_devp2p_eth71


### PR DESCRIPTION
Changes in this PR:
- Implement the change to return 0x80 (empty rlp string) when the BAL doesn't exist. See here: https://github.com/ethereum/EIPs/pull/11553
- Added unit tests to cover eth/71 message flows.
- Fixed issues with receipts message request and handling for the new eth/70 receipt message type.