### PR TITLE
Add to witness trie node for collapsed branch surviving sibling

### DIFF
--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -118,6 +118,7 @@ proc processBlock*(
     # witness keys and block hashes when processing the block as these will be used
     # when building the witness.
     vmState.ledger.clearWitnessKeys()
+    vmState.ledger.clearCollapsedSiblings()
     vmState.ledger.clearBlockHashesCache()
 
     processBlock()

--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -188,6 +188,7 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
     # witness keys and block hashes when processing the block as these will be used
     # when building the witness.
     vmState.ledger.clearWitnessKeys()
+    vmState.ledger.clearCollapsedSiblings()
     vmState.ledger.clearBlockHashesCache()
 
     processBlock()

--- a/execution_chain/db/aristo/aristo_delete.nim
+++ b/execution_chain/db/aristo/aristo_delete.nim
@@ -151,10 +151,11 @@ proc deleteAccount*(
   db.layersPutAccLeaf(accPath, nil)
 
   if otherLeaf.isValid:
-    db.layersPutAccLeaf(
-      Hash32(getBytes(NibblesBuf.fromBytes(accPath.data).replaceSuffix(otherLeaf.pfx))),
-      AccLeafRef(otherLeaf),
-    )
+    let sibAccPath =
+      Hash32(getBytes(NibblesBuf.fromBytes(accPath.data).replaceSuffix(otherLeaf.pfx)))
+    db.layersPutAccLeaf(sibAccPath, AccLeafRef(otherLeaf))
+    if db.collectWitness:
+      db.collapsedSiblings.add((sibAccPath, Opt.none(Hash32)))
 
   ok()
 
@@ -206,9 +207,12 @@ proc deleteSlot*(
   db.layersPutStoLeaf(mixPath, nil)
 
   if otherLeaf.isValid:
-    let leafMixPath =
-      mixUp(accPath, Hash32(getBytes(stoNibbles.replaceSuffix(otherLeaf.pfx))))
+    let
+      sibStoPath = Hash32(getBytes(stoNibbles.replaceSuffix(otherLeaf.pfx)))
+      leafMixPath = mixUp(accPath, sibStoPath)
     db.layersPutStoLeaf(leafMixPath, StoLeafRef(otherLeaf))
+    if db.collectWitness:
+      db.collapsedSiblings.add((accPath, Opt.some(sibStoPath)))
 
   # If there was only one item (that got deleted), update the account as well
   if stoHike.legs.len == 1:

--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -76,6 +76,18 @@ type
 
     blockNumber*: Opt[uint64]               ## Block number set when checkpointing the frame
 
+    collectWitness*: bool
+      ## When true, records collapsed siblings during deletion for witness
+      ## generation.
+
+    collapsedSiblings*: seq[tuple[sibAccPath: Hash32, sibStoPath: Opt[Hash32]]]
+      ## Records path pairs for each surviving sibling when a branch collapses
+      ## during deletion. `sibAccPath` is the account path (used to look up the
+      ## storage trie root); `sibStoPath` is the sibling's own path hash. For
+      ## account-trie collapses, sibStoPath is none. Used by witness
+      ## generation to include the sibling node in the witness for stateless
+      ## execution. Only populated when collectWitness is true.
+
     snapshot*: Snapshot
       ## Optional snapshot containing the cumulative changes from ancestors and
       ## the current frame
@@ -86,9 +98,9 @@ type
       ## -1 = stored in database, where relevant though typically should be
       ## compared with the base layer level instead.
 
-    when compileOption("threads"):      
+    when compileOption("threads"):
       lock*: ReadWriteLock
-        ## A read-write lock used to support thread safe reads and writes to the 
+        ## A read-write lock used to support thread safe reads and writes to the
         ## database from multiple threads.
 
   Snapshot* = object

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -390,6 +390,7 @@ proc init*(x: typedesc[LedgerRef], db: CoreDbTxRef, storeSlotHash: bool, collect
   result.code = typeof(result.code).init(codeLruSize)
   result.slots = typeof(result.slots).init(slotsLruSize)
   result.collectWitness = collectWitness
+  result.txFrame.aTx.collectWitness = collectWitness
   result.blockHashes = typeof(result.blockHashes).init(MAX_PREV_HEADER_DEPTH.int)
   discard result.beginSavePoint
 
@@ -660,8 +661,16 @@ proc clearEmptyAccounts(ledger: LedgerRef) =
 template getWitnessKeys*(ledger: LedgerRef): WitnessTable =
   ledger.witnessKeys
 
+template getCollapsedSiblings*(
+    ledger: LedgerRef
+): seq[tuple[sibAccPath: Hash32, sibStoPath: Opt[Hash32]]] =
+  ledger.txFrame.aTx.collapsedSiblings
+
 template clearWitnessKeys*(ledger: LedgerRef) =
   ledger.witnessKeys.clear()
+
+template clearCollapsedSiblings*(ledger: LedgerRef) =
+  ledger.txFrame.aTx.collapsedSiblings.setLen(0)
 
 proc getBlockHash*(ledger: LedgerRef, blockNumber: BlockNumber): Hash32 =
   ledger.blockHashes.get(blockNumber).valueOr:
@@ -742,6 +751,7 @@ proc persist*(ledger: LedgerRef,
 
   if clearWitness:
     ledger.clearWitnessKeys()
+    ledger.clearCollapsedSiblings()
     ledger.clearBlockHashesCache()
 
 iterator addresses*(ledger: LedgerRef): Address =

--- a/execution_chain/stateless/witness_generation.nim
+++ b/execution_chain/stateless/witness_generation.nim
@@ -19,7 +19,12 @@ import
 
 export common, ledger, witness_types, byteutils
 
-proc build*(T: type Witness, witnessKeys: WitnessTable, preStateLedger: LedgerRef): T =
+proc build*(
+    T: type Witness,
+    witnessKeys: WitnessTable,
+    collapsedSiblings: seq[tuple[sibAccPath: Hash32, sibStoPath: Opt[Hash32]]],
+    preStateLedger: LedgerRef,
+): T =
   var
     proofPaths: Table[Hash32, seq[Hash32]]
     addedCodeHashes: HashSet[Hash32]
@@ -58,6 +63,26 @@ proc build*(T: type Witness, witnessKeys: WitnessTable, preStateLedger: LedgerRe
         paths.add(slotPath)
         proofPaths[accPath] = paths
 
+  for accPath, stoPaths in proofPaths:
+    witness.addKey(accPreimages.getOrDefault(accPath))
+    for stoPath in stoPaths:
+      witness.addKey(stoPreimages.getOrDefault(stoPath))
+
+  # Merge collapsed sibling paths from branch collapses during deletion.
+  # For account-trie collapses sibStoPath is none. For storage-trie collapses
+  # sibAccPath is the account and sibStoPath is the storage path to prove.
+  for (sibAccPath, sibStoPath) in collapsedSiblings:
+    if sibStoPath.isNone():
+      # Account-trie collapse: ensure the account path has a proof entry
+      if sibAccPath notin proofPaths:
+        proofPaths[sibAccPath] = @[]
+    else:
+      # Storage-trie collapse: add storage path under its account
+      proofPaths.withValue(sibAccPath, v):
+        v[].add(sibStoPath.get())
+      do:
+        proofPaths[sibAccPath] = @[sibStoPath.get()]
+
   var multiProof: seq[seq[byte]]
   preStateLedger.txFrame.multiProof(proofPaths, multiProof).isOkOr:
     raiseAssert "Failed to get multiproof: " & $$error
@@ -66,11 +91,6 @@ proc build*(T: type Witness, witnessKeys: WitnessTable, preStateLedger: LedgerRe
   # https://github.com/ethereum/execution-specs/blob/33aa038697162a3ba0aedbadf177c4c59ee5b007/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L230
   multiProof.sort()
   witness.state = move(multiProof)
-
-  for accPath, stoPaths in proofPaths:
-    witness.addKey(accPreimages.getOrDefault(accPath))
-    for stoPath in stoPaths:
-      witness.addKey(stoPreimages.getOrDefault(stoPath))
 
   witness
 
@@ -96,7 +116,9 @@ proc build*(
   if validateStateRoot and parent.number > 0:
     doAssert preStateLedger.getStateRoot() == parent.stateRoot
 
-  var witness = Witness.build(ledger.getWitnessKeys(), preStateLedger)
+  var witness = Witness.build(
+    ledger.getWitnessKeys(), ledger.getCollapsedSiblings(), preStateLedger
+  )
 
   let
     blockHashes = ledger.getBlockHashesCache()

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -28,13 +28,9 @@ const skipFiles = [
   #
   # --- eest_develop files with failures ---
   #
-  "invalidAddr.json", # SIGSEGV
   "underflowTest.json", # stateRoot mismatch
   "CREATE2_HighNonceDelegatecall.json", # stateRoot mismatch
   "test_precompile_warming.json", # stateRoot mismatch
-  "StoreClearsAndInternalCallStoreClearsOOG.json", # persistStorage assert
-  "test_consolidation_requests.json", # persistStorage assert
-  "test_withdrawal_requests.json", # persistStorage assert
   "gasPriceDiffPlaces.json", # stateRoot mismatch
   "baseFeeDiffPlaces.json", # stateRoot mismatch
   "test_genesis_hash_available.json", # witness.validateKeys assert
@@ -47,23 +43,15 @@ const skipFiles = [
   "DelegatecallToPrecompileFromCalledContract.json", # stateRoot mismatch
   "CallWithNOTZeroValueToPrecompileFromCalledContract.json", # stateRoot mismatch
   "CallWithZeroValueToPrecompileFromCalledContract.json", # stateRoot mismatch
-  "walletAddOwnerRemovePendingTransaction.json", # persistStorage assert
-  "walletRemoveOwnerRemovePendingTransaction.json", # persistStorage assert
-  "walletChangeOwnerRemovePendingTransaction.json", # persistStorage assert
-  "walletConfirm.json", # persistStorage assert
-  "walletChangeRequirementRemovePendingTransaction.json", # persistStorage assert
   #
   # --- eest_zkevm files with failures ---
   #
   "varying_calldata_costs.json", # Witness state mismatch
-  "bal_7002_partial_sweep.json", # persistStorage assert
   "witness_codes_delegated_eoa_insufficient_balance.json", # blockAccessListHash mismatch
   "witness_codes_create_same_hash_then_read.json", # Witness codes mismatch
   "witness_headers_blockhash_boundary.json", # Witness state mismatch
   "witness_headers_extra_unused_older_ancestor.json", # Witness headers mismatch
-  "witness_state_sstore_delete_branch_collapse_adds_auxiliary_node.json", # persistStorage assert
   "witness_state_block_diff_delete_insert_before_delete_order.json", # persistStorage assert
-  "create_and_destroy_multiple_contracts_same_tx.json", # persist assert
   "genesis_hash_available.json", # Witness state mismatch
   "scenarios.json", # Witness state mismatch + stateRoot mismatch
   "withdrawal_requests.json", # persistStorage assert + Witness state mismatch
@@ -73,18 +61,11 @@ const skipFiles = [
   "return_bounds.json", # Witness state mismatch
   "underflow_test.json", # stateRoot mismatch
   "create2_high_nonce_delegatecall.json", # stateRoot mismatch
-  "store_clears_and_internal_call_store_clears_oog.json", # persistStorage assert
   "gas_price_diff_places.json", # stateRoot mismatch
   "base_fee_diff_places.json", # stateRoot mismatch
   "delegatecall_to_precompile_from_called_contract.json", # stateRoot mismatch
-  "wallet_add_owner_remove_pending_transaction.json", # persistStorage assert
-  "wallet_confirm.json", # persistStorage assert
-  "wallet_remove_owner_remove_pending_transaction.json", # persistStorage assert
-  "wallet_change_owner_remove_pending_transaction.json", # persistStorage assert
-  "wallet_change_requirement_remove_pending_transaction.json", # persistStorage assert
   "callcode_to_precompile_from_called_contract.json", # stateRoot mismatch
   "validation_codes_missing_delegated_code_on_insufficient_balance_call.json", # blockAccessListHash mismatch
-  "validation_state_missing_delete_auxiliary_node.json", # persistStorage assert
 ]
 
 runEESTSuite(

--- a/tests/test_stateless_witness_generation.nim
+++ b/tests/test_stateless_witness_generation.nim
@@ -44,7 +44,7 @@ suite "Stateless: Witness Generation":
     let witnessKeys = ledger.getWitnessKeys()
     check witnessKeys.len() == 1
 
-    let witness = Witness.build(witnessKeys, ledger)
+    let witness = Witness.build(witnessKeys, @[], ledger)
 
     check:
       witness.state.len() > 0
@@ -59,7 +59,7 @@ suite "Stateless: Witness Generation":
     let witnessKeys = ledger.getWitnessKeys()
     check witnessKeys.len() == 1
 
-    let witness = Witness.build(witnessKeys, ledger)
+    let witness = Witness.build(witnessKeys, @[], ledger)
 
     check:
       witness.state.len() > 0
@@ -75,7 +75,7 @@ suite "Stateless: Witness Generation":
     let witnessKeys = ledger.getWitnessKeys()
     check witnessKeys.len() == 2
 
-    let witness = Witness.build(witnessKeys, ledger)
+    let witness = Witness.build(witnessKeys, @[], ledger)
 
     check:
       witness.state.len() > 0
@@ -91,7 +91,7 @@ suite "Stateless: Witness Generation":
     let witnessKeys = ledger.getWitnessKeys()
     check witnessKeys.len() == 2
 
-    let witness = Witness.build(witnessKeys, ledger)
+    let witness = Witness.build(witnessKeys, @[], ledger)
 
     check:
       witness.state.len() > 0
@@ -107,7 +107,7 @@ suite "Stateless: Witness Generation":
     let witnessKeys = ledger.getWitnessKeys()
     check witnessKeys.len() == 2
 
-    let witness = Witness.build(witnessKeys, ledger)
+    let witness = Witness.build(witnessKeys, @[], ledger)
 
     check:
       witness.state.len() > 0
@@ -126,7 +126,7 @@ suite "Stateless: Witness Generation":
     let witnessKeys = ledger.getWitnessKeys()
     check witnessKeys.len() == 4
 
-    let witness = Witness.build(witnessKeys, ledger)
+    let witness = Witness.build(witnessKeys, @[], ledger)
 
     check:
       witness.state.len() > 0
@@ -147,7 +147,7 @@ suite "Stateless: Witness Generation":
     witnessKeys[(addr1, Opt.some(slot3))] = false
     check witnessKeys.len() == 5
 
-    let witness = Witness.build(witnessKeys, ledger)
+    let witness = Witness.build(witnessKeys, @[], ledger)
 
     check:
       witness.keys.len() == 5

--- a/tests/test_stateless_witness_verification.nim
+++ b/tests/test_stateless_witness_verification.nim
@@ -63,7 +63,7 @@ suite "Stateless: Witness Verification":
     let witnessKeys = ledger.getWitnessKeys()
     check witnessKeys.len() == 8
 
-    var witness = Witness.build(witnessKeys, ledger)
+    var witness = Witness.build(witnessKeys, @[], ledger)
     witness.addHeaderHash(header1.computeRlpHash())
     witness.addHeaderHash(header2.computeRlpHash())
     witness.addHeaderHash(header3.computeRlpHash())


### PR DESCRIPTION
This PR adds a trie node to the witness for the case where a branch collapse occurs on delete. A branch node with only two children will collapse when one of the two is deleted. The surviving sibling gets promoted up to take the branch its place. Both the deleted leaf and the branch node disappear from the trie.

The stateless execution (and thus witness) needs the sibling node when collapsing the branch. Without it cannot be reconstructed.


This is an architecturally cleaner version of https://github.com/status-im/nimbus-eth1/pull/4176

Fits better into how the witness building currently already works as it doesn't use aristo internals into the witness generation code.

Performance might differ somewhat but unless that becomes an issue, go for clean approach.