### PR TITLE
Stateless: Add emptyRoot shortpaths to fix several issues

### DIFF
--- a/execution_chain/db/aristo/aristo_proof.nim
+++ b/execution_chain/db/aristo/aristo_proof.nim
@@ -177,6 +177,13 @@ proc makeMultiProof*(
     paths: Table[Hash32, seq[Hash32]], # maps each account path to a list of storage paths
     multiProof: var seq[seq[byte]]
       ): Result[void, AristoError] =
+  # Short path for empty pre-state trie, no nodes exist
+  # Also, without the check the makeProof will fail when trying to get the root
+  # vertex as it is empty.
+  let stateRoot = ?db.fetchStateRoot()
+  if stateRoot == emptyRoot:
+    return ok()
+
   var
     nodesCache: NodesCache
     proofNodes: HashSet[seq[byte]]
@@ -478,6 +485,13 @@ proc putSubtrie*(
     db: AristoTxRef,
     stateRoot: Hash32,
     nodes: Table[Hash32, seq[byte]]): Result[void, AristoError] =
+  if stateRoot == emptyRoot:
+    # Short path for empty pre-state: fetchStateRoot returns emptyRoot when
+    # GetVtxNotFound, so nothing needed to store here.
+    # And HashKey.fromBytes(emptyRoot.data) would create an invalid 32-byte key
+    # as isValid has a emptyRoot check
+    return ok()
+
   let key = HashKey.fromBytes(stateRoot.data).valueOr:
     return err(PartTrkLinkExpected)
 

--- a/execution_chain/stateless/witness_verification.nim
+++ b/execution_chain/stateless/witness_verification.nim
@@ -115,6 +115,12 @@ func verifyHeaders*(
 func verifyState*(
     witness: ExecutionWitness, preStateRoot: Hash32
 ): Result[void, string] =
+  # Short path for emptyRoot -> empty trie: no accounts exist in the pre-state,
+  # nothing to verify.
+  # Without this check verifyProof will return an error.
+  if preStateRoot == emptyRoot:
+    return ok()
+
   # Verify state against keys in witness
   var keysTable: Table[Address, HashSet[UInt256]]
   ?keysTable.putAll(witness.keys)

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -34,9 +34,6 @@ const skipFiles = [
   "gasPriceDiffPlaces.json", # stateRoot mismatch
   "baseFeeDiffPlaces.json", # stateRoot mismatch
   "test_scenarios.json", # stateRoot mismatch + persist assert
-  "test_gas_limit_below_minimum.json", # multiproof assert
-  "test_multiple_withdrawals_same_address.json", # multiproof assert
-  "test_large_amount.json", # multiproof assert
   "CallcodeToPrecompileFromCalledContract.json", # stateRoot mismatch
   "DelegatecallToPrecompileFromCalledContract.json", # stateRoot mismatch
   "CallWithNOTZeroValueToPrecompileFromCalledContract.json", # stateRoot mismatch


### PR DESCRIPTION
In:
- makeProof for witness generation
- verifyState for witness keys vs pre-state verification
- putSubTrie for stateless execution