### PR TITLE
improve `eth_getTransactionReceipt` performance

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -1108,6 +1108,27 @@ proc receiptsByBlockHash*(c: ForkedChainRef, blockHash: Hash32): Result[seq[Stor
 
   c.baseTxFrame.getReceipts(header.receiptsRoot)
 
+proc receiptByBlockHashAndIndex*(c: ForkedChainRef, blockHash: Hash32, index: uint64): Result[StoredReceipt, string] =
+  if blockHash != c.base.hash:
+    c.hashToBlock.withValue(blockHash, loc):
+      let header = ?loc[].txFrame.getBlockHeader(loc[].hash)
+      return loc[].txFrame.getReceiptByIndex(header.receiptsRoot, index.uint16)
+
+  let header = c.baseTxFrame.getBlockHeader(blockHash).valueOr:
+    return err("Block header not found")
+
+  c.baseTxFrame.getReceiptByIndex(header.receiptsRoot, index.uint16)
+
+proc txByBlockHashAndIndex*(c: ForkedChainRef, blockHash: Hash32, index: uint64): Result[Transaction, string] =
+  if blockHash != c.base.hash:
+    c.hashToBlock.withValue(blockHash, loc):
+      return loc[].txFrame.getTransactionByIndex(loc[].header.txRoot, index.uint16)
+
+  let header = c.baseTxFrame.getBlockHeader(blockHash).valueOr:
+    return err("Block header not found")
+
+  c.baseTxFrame.getTransactionByIndex(header.txRoot, index.uint16)
+
 proc payloadBodyV1InMemory*(c: ForkedChainRef,
                             first: BlockNumber,
                             last: BlockNumber,

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -530,6 +530,23 @@ proc getReceipts*(
       receipts.add(r)
     return ok(receipts)
 
+proc getReceiptByIndex*(
+    db: CoreDbTxRef;
+    receiptsRoot: Hash32;
+    index: uint16;
+      ): Result[StoredReceipt, string] =
+  const
+    info = "getReceiptByIndex()"
+
+  let key = hashIndexKey(receiptsRoot, index)
+  let data = db.getOrEmpty(key).valueOr:
+    return err($$error)
+  if data.len == 0:
+    return err("receipt data is empty for root=" & $receiptsRoot & " and index=" & $index)
+
+  wrapRlpException info:
+    return ok(rlp.decode(data, StoredReceipt))
+
 proc persistScore(
     db: CoreDbTxRef;
     blockHash: Hash32;

--- a/execution_chain/rpc/server_api.nim
+++ b/execution_chain/rpc/server_api.nim
@@ -341,18 +341,22 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
       txHash = data
       (blockHash, txid) = api.chain.txDetailsByTxHash(txHash).valueOr:
         return nil
-      blk = api.chain.blockByHash(blockHash).valueOr:
+      header = api.chain.headerByHash(blockHash).valueOr:
         return nil
-      receipts = api.chain.receiptsByBlockHash(blockHash).valueOr:
+      tx = api.chain.txByBlockHashAndIndex(blockHash, txid).valueOr:
         return nil
+      receipt = api.chain.receiptByBlockHashAndIndex(blockHash, txid).valueOr:
+        return nil
+      prevGasUsed =
+        if txid == 0:
+          0'u64
+        else:
+          let prev = api.chain.receiptByBlockHashAndIndex(blockHash, txid - 1).valueOr:
+            return nil
+          prev.cumulativeGasUsed
 
-    var prevGasUsed = 0'u64
-    for idx, receipt in receipts:
-      let gasUsed = receipt.cumulativeGasUsed - prevGasUsed
-      prevGasUsed = receipt.cumulativeGasUsed
-
-      if txid == uint64(idx):
-        return populateReceipt(receipt, gasUsed, blk.transactions[txid], txid, blk.header, api.com)
+    return populateReceipt(receipt, receipt.cumulativeGasUsed - prevGasUsed,
+                           tx, txid, header, api.com)
 
   server.rpc("eth_estimateGas") do(args: TransactionArgs) -> Quantity:
     ## Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.

--- a/kurtosis-network-params.yml
+++ b/kurtosis-network-params.yml
@@ -18,8 +18,6 @@ participants:
     use_separate_vc: false
 additional_services:
   - assertoor
-  - spamoor
-  - dora
 mev_type: null
 assertoor_params:
   image: "ethpandaops/assertoor"


### PR DESCRIPTION
Issue started with high usage of the API endpoint giving 
```bash
DBG ... Processing  JSON-RPC request  methodName=eth_getTransactionReceipt
DBG ... Processed   JSON-RPC request  methodName=eth_getTransactionReceipt len=1042
DBG ... Internal error while processing JSON-RPC call
        msg="Unable to send response headers, reason: Stream finished or remote side dropped connection"
```

The old handler did three expensive things:
1. `blockByHash(blockHash)` — loaded the **entire block**, including every
   transaction, via per-index KVT reads + RLP decode for each tx.
2. `receiptsByBlockHash(blockHash)` — loaded **every receipt** in the block,
   same per-index pattern (`getReceipts` iterator).
3. Linearly scanned the receipts to find the one matching `txid`, summing
   `cumulativeGasUsed` along the way.

For a mainnet block with ~150 transactions that's ≈300 KVT lookups + ≈300 RLP decodes — for a query that ultimately returns *one* receipt and references *one* transaction. 

Receipts are already stored per-index by the writer `db.put(hashIndexKey(receiptsRoot, idx), …)`, and the analogous read helper for transactions, `getTransactionByIndex`, already exists. There just wasn't an `O(1)` read path for receipts, and the handler wasn't using the `O(1)` path for transactions either.


## Fixes
1. Per-index receipt read at the storage layer
2. wrappers next to the existing `receiptsByBlockHash`, both honoring the same in-memory cache / base-frame split
3. RPC request handling
     - `prevGasUsed` is computed from the previous receipt's `cumulativeGasUsed`
rather than by accumulating from index 0 — that's all the loop in the old
code was actually doing for the gas math, so swapping in a single delta read
preserves semantics.