### PR TITLE
Stateless: Fix state root mismatches for stateless execution

### DIFF
--- a/execution_chain/db/aristo/aristo_proof.nim
+++ b/execution_chain/db/aristo/aristo_proof.nim
@@ -477,7 +477,13 @@ proc putSubtrie(
           # Write the known hash key setting the vtx to nil
           db.layersPutKey(r, BranchRef(nil), k)
 
-  db.layersPutVtx(rvid, node.vtx)
+  # When writing into a storage trie, duplicate vertices before putting in
+  # the database to avoid sharing mutable NodeRef instances between different
+  # accounts that happen to share the same storage root hash in the witness.
+  if rvid.root != STATE_ROOT_VID:
+    db.layersPutVtx(rvid, node.vtx.dup())
+  else:
+    db.layersPutVtx(rvid, node.vtx)
 
   ok()
 

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -28,16 +28,7 @@ const skipFiles = [
   #
   # --- eest_develop files with failures ---
   #
-  "underflowTest.json", # stateRoot mismatch
-  "CREATE2_HighNonceDelegatecall.json", # stateRoot mismatch
-  "test_precompile_warming.json", # stateRoot mismatch
-  "gasPriceDiffPlaces.json", # stateRoot mismatch
-  "baseFeeDiffPlaces.json", # stateRoot mismatch
-  "test_scenarios.json", # stateRoot mismatch + persist assert
-  "CallcodeToPrecompileFromCalledContract.json", # stateRoot mismatch
-  "DelegatecallToPrecompileFromCalledContract.json", # stateRoot mismatch
-  "CallWithNOTZeroValueToPrecompileFromCalledContract.json", # stateRoot mismatch
-  "CallWithZeroValueToPrecompileFromCalledContract.json", # stateRoot mismatch
+  "test_scenarios.json", # persist assert
   #
   # --- eest_zkevm files with failures ---
   #
@@ -52,14 +43,7 @@ const skipFiles = [
   "withdrawal_requests.json", # persistStorage assert + Witness state mismatch
   "consolidation_requests.json", # Witness state mismatch
   "multiple_withdrawals_same_address.json", # Witness state mismatch
-  "precompile_warming.json", # stateRoot mismatch
   "return_bounds.json", # Witness state mismatch
-  "underflow_test.json", # stateRoot mismatch
-  "create2_high_nonce_delegatecall.json", # stateRoot mismatch
-  "gas_price_diff_places.json", # stateRoot mismatch
-  "base_fee_diff_places.json", # stateRoot mismatch
-  "delegatecall_to_precompile_from_called_contract.json", # stateRoot mismatch
-  "callcode_to_precompile_from_called_contract.json", # stateRoot mismatch
   "validation_codes_missing_delegated_code_on_insufficient_balance_call.json", # blockAccessListHash mismatch
 ]
 


### PR DESCRIPTION
The issue: convertSubtrie builds a hash indexed map of decoded witness nodes. For a given witness hash there is one NodeRef object in that table. In the next step, putSubtrie, these nodes get stored. However, this can/will get called for multiple account contexts, and if two accounts have the same storage root hash it will have the same NodeRef.

This obviously becomes an issue when one of these two accounts its storage gets changed due to a transaction, effectively touching both accounts and thus altering the state root.

Fix: Now always duplicate storage subtrie VertexRef in putSubtrie to prevent NodeRef reuse across different accounts that reference the same storage-root hash. This covers both leaf nodes and branch / extension nodes, not only leaves. Test cases had failures due to both.