### PR TITLE
Remove ref types from account and storage leaf caches

### DIFF
--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -129,7 +129,7 @@ type
 
     txRef*: AristoTxRef              ## Bottom-most in-memory frame
 
-    accLeaves*: LruCache[Hash32, AccLeafRef]
+    accLeaves*: LruCache[Hash32, CachedAccLeaf]
       ## Account path to payload cache - accounts are frequently accessed by
       ## account path when contracts interact with them - this cache ensures
       ## that we don't have to re-traverse the storage trie for every such
@@ -137,7 +137,7 @@ type
       ## TODO a better solution would probably be to cache this in a type
       ## exposed to the high-level API
 
-    stoLeaves*: LruCache[Hash32, StoLeafRef]
+    stoLeaves*: LruCache[Hash32, CachedStoLeaf]
       ## Mixed account/storage path to payload cache - same as above but caches
       ## the full lookup of storage slots
 

--- a/execution_chain/db/aristo/aristo_desc/desc_structural.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_structural.nim
@@ -66,6 +66,23 @@ type
   StoLeafRef* = ref object of LeafRef
     stoData*: UInt256
 
+  CachedAccLeaf* = object
+    case empty*: bool
+    of false:
+      pfx*: NibblesBuf
+      account*: AristoAccount
+      stoID*: StorageID
+    of true:
+      discard
+
+  CachedStoLeaf* = object
+    case empty*: bool
+    of false:
+      pfx*: NibblesBuf
+      stoData*: UInt256
+    of true:
+      discard
+
   NodeRef* = ref object of RootRef
     ## Combined record for a *traditional* ``Merkle Patricia Tree` node merged
     ## with a structural `VertexRef` type object.

--- a/execution_chain/db/aristo/aristo_desc/desc_structural.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_structural.nim
@@ -68,20 +68,20 @@ type
 
   CachedAccLeaf* = object
     case empty*: bool
+    of true:
+      discard
     of false:
       pfx*: NibblesBuf
       account*: AristoAccount
       stoID*: StorageID
-    of true:
-      discard
 
   CachedStoLeaf* = object
     case empty*: bool
+    of true:
+      discard
     of false:
       pfx*: NibblesBuf
       stoData*: UInt256
-    of true:
-      discard
 
   NodeRef* = ref object of RootRef
     ## Combined record for a *traditional* ``Merkle Patricia Tree` node merged

--- a/execution_chain/db/aristo/aristo_desc/desc_structural.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_structural.nim
@@ -66,6 +66,9 @@ type
   StoLeafRef* = ref object of LeafRef
     stoData*: UInt256
 
+  ## NOTE: Leaf cache values are stored as value types so the cache can be safely 
+  ## written from background pre-fetch threads under refc (which uses thread-local heaps).
+  
   CachedAccLeaf* = object
     case empty*: bool
     of true:
@@ -132,6 +135,48 @@ template init*(
     _: type ExtBranchRef, pfxp: NibblesBuf, startVidp: VertexID, usedp: uint16
 ): ExtBranchRef =
   ExtBranchRef(vType: ExtBranch, pfx: pfxp, startVid: startVidp, used: usedp)
+
+template init*(
+    T: type CachedAccLeaf, pfxp: NibblesBuf, accountp: AristoAccount, stoIDp: StorageID): T =
+  T(empty: false, pfx: pfxp, account: accountp, stoID: stoIDp)
+
+template init*(
+    T: type CachedStoLeaf, pfxp: NibblesBuf, stoDatap: UInt256): T =
+  T(empty: false, pfx: pfxp, stoData: stoDatap)
+
+template initEmpty(T: type CachedAccLeaf): T =
+  T(empty: true)
+
+template initEmpty(T: type CachedStoLeaf): T =
+  T(empty: true)
+
+const
+  emptyCachedAccLeaf* = CachedAccLeaf.initEmpty()
+  emptyCachedStoLeaf* = CachedStoLeaf.initEmpty()
+
+func toCached*(v: AccLeafRef): CachedAccLeaf =
+  if v.isNil: 
+    emptyCachedAccLeaf
+  else: 
+    CachedAccLeaf.init(v.pfx, v.account, v.stoID)
+
+func toCached*(v: StoLeafRef): CachedStoLeaf =
+  if v.isNil: 
+    emptyCachedStoLeaf
+  else: 
+    CachedStoLeaf.init(v.pfx, v.stoData)
+
+func toLeaf*(c: CachedAccLeaf): AccLeafRef =
+  if c.empty: 
+    AccLeafRef(nil) 
+  else: 
+    AccLeafRef.init(c.pfx, c.account, c.stoID)
+
+func toLeaf*(c: CachedStoLeaf): StoLeafRef =
+  if c.empty: 
+    StoLeafRef(nil) 
+  else: 
+    StoLeafRef.init(c.pfx, c.stoData)
 
 const emptyNibbles = NibblesBuf()
 

--- a/execution_chain/db/aristo/aristo_desc/desc_structural.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_structural.nim
@@ -154,17 +154,8 @@ const
   emptyCachedAccLeaf* = CachedAccLeaf.initEmpty()
   emptyCachedStoLeaf* = CachedStoLeaf.initEmpty()
 
-func toCached*(v: AccLeafRef): CachedAccLeaf =
-  if v.isNil: 
-    emptyCachedAccLeaf
-  else: 
-    CachedAccLeaf.init(v.pfx, v.account, v.stoID)
-
-func toCached*(v: StoLeafRef): CachedStoLeaf =
-  if v.isNil: 
-    emptyCachedStoLeaf
-  else: 
-    CachedStoLeaf.init(v.pfx, v.stoData)
+template isEmpty*(c: CachedAccLeaf | CachedStoLeaf): bool =
+  c.empty
 
 func toLeaf*(c: CachedAccLeaf): AccLeafRef =
   if c.empty: 
@@ -177,6 +168,18 @@ func toLeaf*(c: CachedStoLeaf): StoLeafRef =
     StoLeafRef(nil) 
   else: 
     StoLeafRef.init(c.pfx, c.stoData)
+
+func toStoData*(c: CachedStoLeaf): UInt256 =
+  if c.empty: 
+    0'u256
+  else:
+    c.stoData
+
+func toStoData*(v: StoLeafRef): UInt256 =
+  if v.isNil():
+    0'u256
+  else:
+    v.stoData
 
 const emptyNibbles = NibblesBuf()
 

--- a/execution_chain/db/aristo/aristo_fetch.nim
+++ b/execution_chain/db/aristo/aristo_fetch.nim
@@ -166,7 +166,6 @@ proc retrieveAccLeaf(
   let accLeaf = AccLeafRef(leafVtx)
   db.db.accLeaves.put(accPath, CachedAccLeaf(
     empty: false, pfx: accLeaf.pfx, account: accLeaf.account, stoID: accLeaf.stoID))
-  db.layersPutAccLeaf(accPath, accLeaf)
 
   ok accLeaf
 
@@ -303,7 +302,6 @@ proc fetchSlot*(
   if leafVtx.isValid():
     db.db.stoLeaves.put(mixPath, CachedStoLeaf(
       empty: false, pfx: leafVtx.pfx, stoData: leafVtx.stoData))
-    db.layersPutStoLeaf(mixPath, leafVtx)
   else:
     db.db.stoLeaves.put(mixPath, CachedStoLeaf(empty: true))
 

--- a/execution_chain/db/aristo/aristo_fetch.nim
+++ b/execution_chain/db/aristo/aristo_fetch.nim
@@ -44,14 +44,16 @@ proc cachedAccLeaf*(db: AristoTxRef; accPath: Hash32): Opt[AccLeafRef] =
   # Return vertex from layers or cache, `nil` if it's known to not exist and
   # none otherwise
   db.layersGetAccLeaf(accPath) or
-    db.db.accLeaves.get(accPath) or
+    db.db.accLeaves.get(accPath).map(proc(c: CachedAccLeaf): AccLeafRef =
+      if c.empty: AccLeafRef(nil) else: AccLeafRef.init(c.pfx, c.account, c.stoID)) or
     Opt.none(AccLeafRef)
 
 proc cachedStoLeaf*(db: AristoTxRef; mixPath: Hash32): Opt[StoLeafRef] =
   # Return vertex from layers or cache, `nil` if it's known to not exist and
   # none otherwise
   db.layersGetStoLeaf(mixPath) or
-    db.db.stoLeaves.get(mixPath) or
+    db.db.stoLeaves.get(mixPath).map(proc(c: CachedStoLeaf): StoLeafRef =
+      if c.empty: StoLeafRef(nil) else: StoLeafRef.init(c.pfx, c.stoData)) or
     Opt.none(StoLeafRef)
 
 proc retrieveAccStatic(
@@ -139,11 +141,12 @@ proc retrieveAccLeaf(
 
   let (staticVtx, path, next) = db.retrieveAccStatic(accPath).valueOr:
     if error == FetchPathNotFound:
-      db.db.accLeaves.put(accPath, nil)
+      db.db.accLeaves.put(accPath, CachedAccLeaf(empty: true))
     return err(error)
 
   if staticVtx.isValid():
-    db.db.accLeaves.put(accPath, staticVtx)
+    db.db.accLeaves.put(accPath, CachedAccLeaf(
+      empty: false, pfx: staticVtx.pfx, account: staticVtx.account, stoID: staticVtx.stoID))
     return ok staticVtx
 
   # Updated payloads are stored in the layers so if we didn't find them there,
@@ -155,14 +158,17 @@ proc retrieveAccLeaf(
         # meaning that it was a hit - else searches for non-existing paths would
         # skew the results towards more depth than exists in the MPT
         db.db.lookups.hits += 1
-        db.db.accLeaves.put(accPath, nil)
+        db.db.accLeaves.put(accPath, CachedAccLeaf(empty: true))
       return err(error)
 
   db.db.lookups.higher += 1
 
-  db.db.accLeaves.put(accPath, AccLeafRef(leafVtx))
+  let accLeaf = AccLeafRef(leafVtx)
+  db.db.accLeaves.put(accPath, CachedAccLeaf(
+    empty: false, pfx: accLeaf.pfx, account: accLeaf.account, stoID: accLeaf.stoID))
+  db.layersPutAccLeaf(accPath, accLeaf)
 
-  ok AccLeafRef(leafVtx)
+  ok accLeaf
 
 proc retrieveMerkleHash(
     db: AristoTxRef;
@@ -289,12 +295,17 @@ proc fetchSlot*(
       stoID = ?db.fetchStorageID(accPath)
 
     if not stoID.isValid():
-      db.db.stoLeaves.put(mixPath, nil)
+      db.db.stoLeaves.put(mixPath, CachedStoLeaf(empty: true))
       return ok 0'u256
 
     StoLeafRef(db.retrieveLeaf(stoID, NibblesBuf.fromBytes(stoPath.data)).valueOr(nil))
 
-  db.db.stoLeaves.put(mixPath, leafVtx)
+  if leafVtx.isValid():
+    db.db.stoLeaves.put(mixPath, CachedStoLeaf(
+      empty: false, pfx: leafVtx.pfx, stoData: leafVtx.stoData))
+    db.layersPutStoLeaf(mixPath, leafVtx)
+  else:
+    db.db.stoLeaves.put(mixPath, CachedStoLeaf(empty: true))
 
   ok if leafVtx.isValid:
     leafVtx.stoData

--- a/execution_chain/db/aristo/aristo_fetch.nim
+++ b/execution_chain/db/aristo/aristo_fetch.nim
@@ -43,16 +43,12 @@ proc retrieveLeaf(
 proc cachedAccLeaf*(db: AristoTxRef; accPath: Hash32): Opt[AccLeafRef] =
   # Return vertex from layers or cache, `nil` if it's known to not exist and
   # none otherwise
-  db.layersGetAccLeaf(accPath) or
-    db.db.accLeaves.get(accPath).map(toLeaf) or
-    Opt.none(AccLeafRef)
+  db.layersGetAccLeaf(accPath) or db.db.accLeaves.get(accPath).map(toLeaf)
 
 proc cachedStoLeaf*(db: AristoTxRef; mixPath: Hash32): Opt[StoLeafRef] =
   # Return vertex from layers or cache, `nil` if it's known to not exist and
   # none otherwise
-  db.layersGetStoLeaf(mixPath) or
-    db.db.stoLeaves.get(mixPath).map(toLeaf) or
-    Opt.none(StoLeafRef)
+  db.layersGetStoLeaf(mixPath) or db.db.stoLeaves.get(mixPath).map(toLeaf)
 
 proc retrieveAccStatic(
     db: AristoTxRef;
@@ -280,27 +276,30 @@ proc fetchSlot*(
   ## from the database indexed by `path`. Returns err(FetchPathNotFound) if the
   ## account does not exist and 0'u256 if the account has not stored anything
   ## at the given slot
-  ##
-  let mixPath = mixUp(accPath, stoPath)
-
-  let leafVtx = db.cachedStoLeaf(mixPath).valueOr:
-    # Updated payloads are stored in the layers so if we didn't find them there,
-    # it must have been in the database
-    let
-      stoID = ?db.fetchStorageID(accPath)
-
-    if not stoID.isValid():
-      db.db.stoLeaves.put(mixPath, emptyCachedStoLeaf)
-      return ok 0'u256
-
-    StoLeafRef(db.retrieveLeaf(stoID, NibblesBuf.fromBytes(stoPath.data)).valueOr(nil))
+  let 
+    mixPath = mixUp(accPath, stoPath)
+    leafVtx = db.layersGetStoLeaf(mixPath)
   
-  db.db.stoLeaves.put(mixPath, leafVtx.toCached())
-
-  ok if leafVtx.isValid:
-    leafVtx.stoData
+  if leafVtx.isSome():
+    # Found in the layers so we don't need to copy into the cache 
+    # because the value will be updated from the layers during persist
+    ok leafVtx[].toStoData()
   else:
-    0'u256
+    let cached = db.db.stoLeaves.get(mixPath)
+    if cached.isSome():
+      ok cached[].toStoData()
+    else:
+      # Updated payloads are stored in the layers so if we didn't find them there,
+      # it must have been in the database
+      let stoID = ?db.fetchStorageID(accPath)
+
+      if stoID.isValid():
+        let leaf = StoLeafRef(db.retrieveLeaf(stoID, NibblesBuf.fromBytes(stoPath.data)).valueOr(nil))
+        db.db.stoLeaves.put(mixPath, if leaf.isValid(): CachedStoLeaf.init(leaf.pfx, leaf.stoData) else: emptyCachedStoLeaf)
+        ok leaf.toStoData()
+      else:
+        db.db.stoLeaves.put(mixPath, emptyCachedStoLeaf)
+        ok 0'u256
 
 proc fetchStorageRoot*(
     db: AristoTxRef;

--- a/execution_chain/db/aristo/aristo_fetch.nim
+++ b/execution_chain/db/aristo/aristo_fetch.nim
@@ -44,16 +44,14 @@ proc cachedAccLeaf*(db: AristoTxRef; accPath: Hash32): Opt[AccLeafRef] =
   # Return vertex from layers or cache, `nil` if it's known to not exist and
   # none otherwise
   db.layersGetAccLeaf(accPath) or
-    db.db.accLeaves.get(accPath).map(proc(c: CachedAccLeaf): AccLeafRef =
-      if c.empty: AccLeafRef(nil) else: AccLeafRef.init(c.pfx, c.account, c.stoID)) or
+    db.db.accLeaves.get(accPath).map(toLeaf) or
     Opt.none(AccLeafRef)
 
 proc cachedStoLeaf*(db: AristoTxRef; mixPath: Hash32): Opt[StoLeafRef] =
   # Return vertex from layers or cache, `nil` if it's known to not exist and
   # none otherwise
   db.layersGetStoLeaf(mixPath) or
-    db.db.stoLeaves.get(mixPath).map(proc(c: CachedStoLeaf): StoLeafRef =
-      if c.empty: StoLeafRef(nil) else: StoLeafRef.init(c.pfx, c.stoData)) or
+    db.db.stoLeaves.get(mixPath).map(toLeaf) or
     Opt.none(StoLeafRef)
 
 proc retrieveAccStatic(
@@ -141,12 +139,11 @@ proc retrieveAccLeaf(
 
   let (staticVtx, path, next) = db.retrieveAccStatic(accPath).valueOr:
     if error == FetchPathNotFound:
-      db.db.accLeaves.put(accPath, CachedAccLeaf(empty: true))
+      db.db.accLeaves.put(accPath, emptyCachedAccLeaf)
     return err(error)
 
   if staticVtx.isValid():
-    db.db.accLeaves.put(accPath, CachedAccLeaf(
-      empty: false, pfx: staticVtx.pfx, account: staticVtx.account, stoID: staticVtx.stoID))
+    db.db.accLeaves.put(accPath, CachedAccLeaf.init(staticVtx.pfx, staticVtx.account, staticVtx.stoID))
     return ok staticVtx
 
   # Updated payloads are stored in the layers so if we didn't find them there,
@@ -158,14 +155,13 @@ proc retrieveAccLeaf(
         # meaning that it was a hit - else searches for non-existing paths would
         # skew the results towards more depth than exists in the MPT
         db.db.lookups.hits += 1
-        db.db.accLeaves.put(accPath, CachedAccLeaf(empty: true))
+        db.db.accLeaves.put(accPath, emptyCachedAccLeaf)
       return err(error)
 
   db.db.lookups.higher += 1
 
   let accLeaf = AccLeafRef(leafVtx)
-  db.db.accLeaves.put(accPath, CachedAccLeaf(
-    empty: false, pfx: accLeaf.pfx, account: accLeaf.account, stoID: accLeaf.stoID))
+  db.db.accLeaves.put(accPath, CachedAccLeaf.init(accLeaf.pfx, accLeaf.account, accLeaf.stoID))
 
   ok accLeaf
 
@@ -294,16 +290,12 @@ proc fetchSlot*(
       stoID = ?db.fetchStorageID(accPath)
 
     if not stoID.isValid():
-      db.db.stoLeaves.put(mixPath, CachedStoLeaf(empty: true))
+      db.db.stoLeaves.put(mixPath, emptyCachedStoLeaf)
       return ok 0'u256
 
     StoLeafRef(db.retrieveLeaf(stoID, NibblesBuf.fromBytes(stoPath.data)).valueOr(nil))
-
-  if leafVtx.isValid():
-    db.db.stoLeaves.put(mixPath, CachedStoLeaf(
-      empty: false, pfx: leafVtx.pfx, stoData: leafVtx.stoData))
-  else:
-    db.db.stoLeaves.put(mixPath, CachedStoLeaf(empty: true))
+  
+  db.db.stoLeaves.put(mixPath, leafVtx.toCached())
 
   ok if leafVtx.isValid:
     leafVtx.stoData

--- a/execution_chain/db/aristo/aristo_init/init_common.nim
+++ b/execution_chain/db/aristo/aristo_init/init_common.nim
@@ -90,8 +90,8 @@ proc initInstance*(
   when compileOption("threads"):
     db.txRef.lock = ReadWriteLock.init()
 
-  db.accLeaves = LruCache[Hash32, AccLeafRef].init(ACC_LRU_SIZE)
-  db.stoLeaves = LruCache[Hash32, StoLeafRef].init(ACC_LRU_SIZE)
+  db.accLeaves = LruCache[Hash32, CachedAccLeaf].init(ACC_LRU_SIZE)
+  db.stoLeaves = LruCache[Hash32, CachedStoLeaf].init(ACC_LRU_SIZE)
   db.maxSnapshots = maxSnapshots
   db.parallelStateRootComputation = parallelStateRootComputation
   

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -267,30 +267,26 @@ proc persist*(db: AristoDbRef, batch: PutHdlRef, txFrame: AristoTxRef) =
     if v[0] == nil:
       db.accLeaves.del(accPath)
     else:
-      let cached = CachedAccLeaf(empty: false, pfx: v[0].pfx, account: v[0].account, stoID: v[0].stoID)
-      discard db.accLeaves.update(accPath, cached)
+      discard db.accLeaves.update(accPath, CachedAccLeaf(empty: false, pfx: v[0].pfx, account: v[0].account, stoID: v[0].stoID))
 
   for mixPath, v in txFrame.snapshot.sto:
     if v[0] == nil:
       db.stoLeaves.del(mixPath)
     else:
-      let cached = CachedStoLeaf(empty: false, pfx: v[0].pfx, stoData: v[0].stoData)
-      discard db.stoLeaves.update(mixPath, cached)
+      discard db.stoLeaves.update(mixPath, CachedStoLeaf(empty: false, pfx: v[0].pfx, stoData: v[0].stoData))
 
   # Copy cached values from the txFrame
   for accPath, vtx in txFrame.accLeaves:
     if vtx == nil:
       db.accLeaves.del(accPath)
     else:
-      let cached = CachedAccLeaf(empty: false, pfx: vtx.pfx, account: vtx.account, stoID: vtx.stoID)
-      discard db.accLeaves.update(accPath, cached)
+      discard db.accLeaves.update(accPath, CachedAccLeaf(empty: false, pfx: vtx.pfx, account: vtx.account, stoID: vtx.stoID))
 
   for mixPath, vtx in txFrame.stoLeaves:
     if vtx == nil:
       db.stoLeaves.del(mixPath)
     else:
-      let cached = CachedStoLeaf(empty: false, pfx: vtx.pfx, stoData: vtx.stoData)
-      discard db.stoLeaves.update(mixPath, cached)
+      discard db.stoLeaves.update(mixPath, CachedStoLeaf(empty: false, pfx: vtx.pfx, stoData: vtx.stoData))
 
   # Remove snapshot data that has been persisted to disk to save memory.
   # All snapshot records with a level lower than the current base level

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -267,26 +267,26 @@ proc persist*(db: AristoDbRef, batch: PutHdlRef, txFrame: AristoTxRef) =
     if v[0] == nil:
       db.accLeaves.del(accPath)
     else:
-      discard db.accLeaves.update(accPath, CachedAccLeaf(empty: false, pfx: v[0].pfx, account: v[0].account, stoID: v[0].stoID))
+      discard db.accLeaves.update(accPath, CachedAccLeaf.init(v[0].pfx, v[0].account, v[0].stoID))
 
   for mixPath, v in txFrame.snapshot.sto:
     if v[0] == nil:
       db.stoLeaves.del(mixPath)
     else:
-      discard db.stoLeaves.update(mixPath, CachedStoLeaf(empty: false, pfx: v[0].pfx, stoData: v[0].stoData))
+      discard db.stoLeaves.update(mixPath, CachedStoLeaf.init(v[0].pfx, v[0].stoData))
 
   # Copy cached values from the txFrame
   for accPath, vtx in txFrame.accLeaves:
     if vtx == nil:
       db.accLeaves.del(accPath)
     else:
-      discard db.accLeaves.update(accPath, CachedAccLeaf(empty: false, pfx: vtx.pfx, account: vtx.account, stoID: vtx.stoID))
+      discard db.accLeaves.update(accPath, CachedAccLeaf.init(vtx.pfx, vtx.account, vtx.stoID))
 
   for mixPath, vtx in txFrame.stoLeaves:
     if vtx == nil:
       db.stoLeaves.del(mixPath)
     else:
-      discard db.stoLeaves.update(mixPath, CachedStoLeaf(empty: false, pfx: vtx.pfx, stoData: vtx.stoData))
+      discard db.stoLeaves.update(mixPath, CachedStoLeaf.init(vtx.pfx, vtx.stoData))
 
   # Remove snapshot data that has been persisted to disk to save memory.
   # All snapshot records with a level lower than the current base level

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -267,26 +267,30 @@ proc persist*(db: AristoDbRef, batch: PutHdlRef, txFrame: AristoTxRef) =
     if v[0] == nil:
       db.accLeaves.del(accPath)
     else:
-      discard db.accLeaves.update(accPath, v[0])
+      let cached = CachedAccLeaf(empty: false, pfx: v[0].pfx, account: v[0].account, stoID: v[0].stoID)
+      discard db.accLeaves.update(accPath, cached)
 
   for mixPath, v in txFrame.snapshot.sto:
     if v[0] == nil:
       db.stoLeaves.del(mixPath)
     else:
-      discard db.stoLeaves.update(mixPath, v[0])
+      let cached = CachedStoLeaf(empty: false, pfx: v[0].pfx, stoData: v[0].stoData)
+      discard db.stoLeaves.update(mixPath, cached)
 
   # Copy cached values from the txFrame
   for accPath, vtx in txFrame.accLeaves:
     if vtx == nil:
       db.accLeaves.del(accPath)
     else:
-      discard db.accLeaves.update(accPath, vtx)
+      let cached = CachedAccLeaf(empty: false, pfx: vtx.pfx, account: vtx.account, stoID: vtx.stoID)
+      discard db.accLeaves.update(accPath, cached)
 
   for mixPath, vtx in txFrame.stoLeaves:
     if vtx == nil:
       db.stoLeaves.del(mixPath)
     else:
-      discard db.stoLeaves.update(mixPath, vtx)
+      let cached = CachedStoLeaf(empty: false, pfx: vtx.pfx, stoData: vtx.stoData)
+      discard db.stoLeaves.update(mixPath, cached)
 
   # Remove snapshot data that has been persisted to disk to save memory.
   # All snapshot records with a level lower than the current base level


### PR DESCRIPTION
The goal here is to remove the ref types from the account and storage leaf caches so that we can implement batch IO / pre-fetching of accounts and storage slots in background thread/s. The background threads doing the pre-fetching will need to write to the shared lru caches but refc uses thread local heaps which means refs allocated and written to the lru caches from background threads will cause memory corruption issues. Using value types in the caches solves this problem.

The current VertexBuf cache in the rocksdb backend may sometimes duplicate the leaf data that is already stored in the leaf cache so it would perhaps be possible to remove the leaf caches but my preference is to keep them because the pre-fetching will perform much better when the leaf data is converted and stored in the required format. Fetching from the VertexBuf cache would require an allocation and deserialization to convert into the vertex ref type for every call which is not ideal.

In practice, leaf vertex refs are not shared between the txFrame layers and the LRU leaf caches so converting the caches to use value types shouldn't increase memory usage due to duplication. In fact memory usage might go down since we no longer hold the ref pointer in the caches and just store the object directly.