### PR TITLE
Stateless: more lenient witness.headers compare for eest

### DIFF
--- a/tests/eest/eest_blockchain.nim
+++ b/tests/eest/eest_blockchain.nim
@@ -131,16 +131,10 @@ proc compare(
 ): Result[void, string] =
   ## Compare witness state, nodes and headers, not comparing keys as these
   ## are not included in the test vectors.
-  ## When strict is false, allow generated witness state and codes to be a
-  ## subset of expected. This is because some test vectors include extra unused
-  ## state nodes and code in the witness to test that stateless execution still
-  ## works. Same counts for the lexicographical order.
-  # Always comparing headers to be identical, including order
-  if generated.headers != expected.headers:
-    return err(
-      "Witness headers mismatch, got: " & $generated.shortLog & " expected: " &
-        $expected.shortLog
-    )
+  ## When strict is false, allow generated witness state, codes and headers to
+  ## be a subset of expected. This is because some test vectors include extra
+  ## unused state nodes, code and headers in the witness to test that stateless
+  ## execution still works. Same counts for the lexicographical order.
 
   if strict:
     # when strict enabled, also compare state and codes to be identical
@@ -152,6 +146,11 @@ proc compare(
     if generated.codes != expected.codes:
       return err(
         "Witness codes mismatch, got: " & $generated.shortLog & " expected: " &
+          $expected.shortLog
+      )
+    if generated.headers != expected.headers:
+      return err(
+        "Witness headers mismatch, got: " & $generated.shortLog & " expected: " &
           $expected.shortLog
       )
   else:
@@ -167,6 +166,13 @@ proc compare(
       if code notin expected.codes:
         return err(
           "Witness code missing from expected, got: " & $generated.shortLog &
+            " expected: " & $expected.shortLog
+        )
+
+    for header in generated.headers:
+      if header notin expected.headers:
+        return err(
+          "Witness header missing from expected, got: " & $generated.shortLog &
             " expected: " & $expected.shortLog
         )
 

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -36,7 +36,6 @@ const skipFiles = [
   "witness_codes_delegated_eoa_insufficient_balance.json", # blockAccessListHash mismatch
   "witness_codes_create_same_hash_then_read.json", # Witness codes mismatch
   "witness_headers_blockhash_boundary.json", # Witness state mismatch
-  "witness_headers_extra_unused_older_ancestor.json", # Witness headers mismatch
   "witness_state_block_diff_delete_insert_before_delete_order.json", # persistStorage assert
   "genesis_hash_available.json", # Witness state mismatch
   "scenarios.json", # Witness state mismatch + stateRoot mismatch


### PR DESCRIPTION
EEST zkevm stateless/witness tests have a test case where on purpose unneeded header data is added to see if it causes issues with stateless execution. We need to soften up our headers compare because of this.

test case:
./eest_zkevm/blockchain_tests/for_amsterdam/amsterdam/eip8025_optional_proofs/witness_headers/witness_headers_extra_unused_older_ancestor.json