### PR TITLE
add metrics version

### DIFF
--- a/execution_chain/version_info.nim
+++ b/execution_chain/version_info.nim
@@ -37,3 +37,10 @@ const
   ClientId* = &"{NimbusName}/{FullVersionStr}/{CpuInfo}"
 
   ShortClientId* = NimbusName & "/" & FullVersionStr
+
+when not defined(nimscript):
+  import metrics
+  declareGauge nec_version,
+    "Nimbus execution client version info (as metric labels)",
+    ["version", "commit"], name = "nec_version"
+  nec_version.set(1, labelValues = [FullVersionStr, GitRevision])

--- a/execution_chain/version_info.nim
+++ b/execution_chain/version_info.nim
@@ -10,12 +10,17 @@
 
 import
   std/[os, strutils, strformat],
+  metrics,
   stew/byteutils,
   beacon_chain/buildinfo,
   ./compile_info,
   ./version
 
 export version
+
+declareGauge nec_version,
+  "Nimbus execution client version info (as metric labels)",
+  ["version", "commit"], name = "nec_version"
 
 const
   NimbusName* = "Nimbus"
@@ -38,9 +43,4 @@ const
 
   ShortClientId* = NimbusName & "/" & FullVersionStr
 
-when not defined(nimscript):
-  import metrics
-  declareGauge nec_version,
-    "Nimbus execution client version info (as metric labels)",
-    ["version", "commit"], name = "nec_version"
-  nec_version.set(1, labelValues = [FullVersionStr, GitRevision])
+nec_version.set(1, labelValues = [FullVersionStr, GitRevision])


### PR DESCRIPTION
```js
# HELP nec_version Nimbus execution client version info (as metric labels)
# TYPE nec_version gauge
nec_version{version="v0.3.0-18423051",commit="18423051"} 1.0
```