### PR TITLE
Add tracking of EIP-7702 delegation target in BAL on aborted calls

### DIFF
--- a/execution_chain/block_access_list/block_access_list_tracker.nim
+++ b/execution_chain/block_access_list/block_access_list_tracker.nim
@@ -14,6 +14,7 @@ import
   eth/common/addresses,
   stint,
   ../db/ledger,
+  ../core/eip7702,
   ./block_access_list_builder
 
 export addresses, block_access_list_builder, ledger, stint
@@ -388,6 +389,16 @@ proc trackCodeChange*(
   tracker.trackAddressAccess(address)
   tracker.capturePreCode(address)
   tracker.pendingCallFrame.codeChanges[address] = newCode
+
+proc trackDelegationTarget*(tracker: BlockAccessListTrackerRef, codeAddress: Address) =
+  ## Track the delegation target address for a call to a delegated EOA.
+  ## Called after gas has been successfully charged (i.e. after the access_cost check)
+  ## but before the sub-call executes in order to cover the case where the sub-call
+  ## is aborted (i.e. depth exceeded and insufficient balance) and getCallCode never
+  ## runs to track the target itself.
+  let delegateTo = parseDelegationAddress(tracker.ledger.getCode(codeAddress))
+  if delegateTo.isSome():
+    tracker.trackAddressAccess(delegateTo.get())
 
 proc trackSelfDestruct*(tracker: BlockAccessListTrackerRef, address: Address) =
   tracker.trackBalanceChange(address, 0.u256)

--- a/execution_chain/evm/interpreter/op_handlers/oph_call.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_call.nim
@@ -264,6 +264,8 @@ proc callOp(cpt: VmCpt): EvmResultVoid =
         gasCallDelegate: cpt.gasCallDelegate(p.codeAddress),
         contractGas:     p.gas))
 
+  if cpt.balTrackerEnabled:
+    cpt.vmState.balTracker.trackDelegationTarget(p.codeAddress)
   ? cpt.opcodeGasCost(Call, gasCost, reason = $Call)
   cpt.gasMeter.escrowSubcallRegularGas(childGasLimit)
 
@@ -335,6 +337,8 @@ proc callCodeOp(cpt: VmCpt): EvmResultVoid =
         gasCallDelegate: cpt.gasCallDelegate(p.codeAddress),
         contractGas:     p.gas))
 
+  if cpt.balTrackerEnabled:
+    cpt.vmState.balTracker.trackDelegationTarget(p.codeAddress)
   ? cpt.opcodeGasCost(CallCode, gasCost, reason = $CallCode)
   cpt.gasMeter.escrowSubcallRegularGas(childGasLimit)
 
@@ -406,6 +410,8 @@ proc delegateCallOp(cpt: VmCpt): EvmResultVoid =
         gasCallDelegate: cpt.gasCallDelegate(p.codeAddress),
         contractGas:     p.gas))
 
+  if cpt.balTrackerEnabled:
+    cpt.vmState.balTracker.trackDelegationTarget(p.codeAddress)
   ? cpt.opcodeGasCost(DelegateCall, gasCost, reason = $DelegateCall)
   cpt.gasMeter.escrowSubcallRegularGas(childGasLimit)
 
@@ -470,6 +476,8 @@ proc staticCallOp(cpt: VmCpt): EvmResultVoid =
         gasCallDelegate: cpt.gasCallDelegate(p.codeAddress),
         contractGas:     p.gas))
 
+  if cpt.balTrackerEnabled:
+    cpt.vmState.balTracker.trackDelegationTarget(p.codeAddress)
   ? cpt.opcodeGasCost(StaticCall, gasCost, reason = $StaticCall)
   cpt.gasMeter.escrowSubcallRegularGas(childGasLimit)
 

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -33,7 +33,6 @@ const skipFiles = [
   # --- eest_zkevm files with failures ---
   #
   "varying_calldata_costs.json", # Witness state mismatch
-  "witness_codes_delegated_eoa_insufficient_balance.json", # blockAccessListHash mismatch
   "witness_codes_create_same_hash_then_read.json", # Witness codes mismatch
   "witness_headers_blockhash_boundary.json", # Witness state mismatch
   "witness_state_block_diff_delete_insert_before_delete_order.json", # persistStorage assert
@@ -43,7 +42,6 @@ const skipFiles = [
   "consolidation_requests.json", # Witness state mismatch
   "multiple_withdrawals_same_address.json", # Witness state mismatch
   "return_bounds.json", # Witness state mismatch
-  "validation_codes_missing_delegated_code_on_insufficient_balance_call.json", # blockAccessListHash mismatch
 ]
 
 runEESTSuite(


### PR DESCRIPTION
EEST zkevm tests have shown a blockAccessListHash mismatch in two test vectors which do a EIP-7702 call to delegated EOA that gets aborted. Currently in this scenario the delegation address does not get recorded in the BAL currently.

As per EIP-7928 spec, the delegation target must be recorded in the BAL once the access_cost check passes inside gas calculation, regardless of whether the call actually executes.

---

At https://eips.ethereum.org/EIPS/eip-7928#eip-7702-delegation:

> When a call target has an [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) delegation, the target is accessed to resolve the delegation. If a delegation exists, the delegated address requires its own access_cost check before being accessed. If this check fails, the delegated address MUST NOT appear in the BAL, though the original call target is included (having been accessed to resolve the delegation).

> Note: Delegated accounts cannot be empty, so GAS_NEW_ACCOUNT never applies when resolving delegations."

So anything after the access_cost check should be added, also if the call does not execute.


