### PR TITLE
Reduce repeated call to intrinsicGas

### DIFF
--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -16,7 +16,8 @@ import
   ../../common/common,
   ../../db/ledger,
   ../../transaction/call_evm,
-  ../../transaction/call_common,
+  ../../transaction/system_call,
+  ../../transaction/call_types,
   ../../transaction,
   ../../evm/state,
   ../../evm/types,
@@ -27,7 +28,7 @@ import
   ../validate
 
 
-export results, call_common
+export results, call_types
 
 # ------------------------------------------------------------------------------
 # Private functions
@@ -111,6 +112,8 @@ proc processTransaction*(
     priorityFee = min(tx.maxPriorityFeePerGasNorm(), tx.maxFeePerGasNorm() - baseFee)
     excessBlobGas = vmState.blockCtx.excessBlobGas
     regularGasAvailable = vmState.blockCtx.gasLimit - vmState.blockRegularGasUsed
+    intrinsic = tx.intrinsicGas(fork, vmState.blockCtx.gasLimit)
+    com = vmState.com
 
   # Regular gas is capped at TX_MAX_GAS_LIMIT per EIP-7825.
   # State gas is not checked per-tx; block-end validation enforces
@@ -127,6 +130,8 @@ proc processTransaction*(
     return err("blobGasUsed " & $blobGasUsed &
       " exceeds maximum allowance " & $maxBlobGasPerBlock)
 
+  ? validateTxBasic(com, tx, intrinsic, fork)
+
   # Actually, the EIP-1559 reference does not mention an early exit.
   #
   # Even though database was not changed yet but, a `persist()` directive
@@ -134,7 +139,6 @@ proc processTransaction*(
   # of the `processTransaction()` function. So there is no `return err()`
   # statement, here.
   let
-    com = vmState.com
     txRes = roDB.validateTransaction(tx, sender, vmState.blockCtx.gasLimit, baseFee256, excessBlobGas, com, fork)
     res = if txRes.isOk:
       # Execute the transaction.
@@ -144,7 +148,7 @@ proc processTransaction*(
         vmState.balTracker.beginCallFrame()
       let savePoint = vmState.ledger.beginSavePoint()
 
-      var callResult = tx.txCallEvm(sender, vmState, baseFee)
+      var callResult = tx.txCallEvm(sender, vmState, baseFee, intrinsic)
       vmState.captureTxEnd(tx.gasLimit - callResult.gasUsed)
 
       let tmp = commitOrRollbackDependingOnGasUsed(
@@ -176,12 +180,10 @@ proc processBeaconBlockRoot*(vmState: BaseVMState, beaconRoot: Hash32):
       gasPrice : 0.GasInt,
       to       : BEACON_ROOTS_ADDRESS,
       input    : @(beaconRoot.data),
-      sysCall  : true,
     )
 
-  # runComputation a.k.a syscall/evm.call
   # EIP-4788: fail silently
-  call.runComputation(void)
+  call.systemCall(void)
   ledger.persist(clearEmptyAccount = true)
   ok()
 
@@ -198,12 +200,10 @@ proc processParentBlockHash*(vmState: BaseVMState, prevHash: Hash32):
       gasPrice : 0.GasInt,
       to       : HISTORY_STORAGE_ADDRESS,
       input    : @(prevHash.data),
-      sysCall  : true,
     )
 
-  # runComputation a.k.a syscall/evm.call
   # EIP-2923: fail silently
-  call.runComputation(void)
+  call.systemCall(void)
   ledger.persist(clearEmptyAccount = true)
   ok()
 
@@ -218,15 +218,13 @@ proc processDequeueWithdrawalRequests*(vmState: BaseVMState): Result[seq[byte], 
       gasLimit : 30_000_000.GasInt,
       gasPrice : 0.GasInt,
       to       : WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS,
-      sysCall  : true,
     )
 
-  # runComputation a.k.a syscall/evm.call
-  let res = call.runComputation(OutputResult)
+  var res = call.systemCall(OutputResult)
   if res.error.len > 0:
     return err("processDequeueWithdrawalRequests: " & res.error)
   ledger.persist(clearEmptyAccount = true)
-  ok(res.output)
+  ok(move(res.output))
 
 proc processDequeueConsolidationRequests*(vmState: BaseVMState): Result[seq[byte], string] =
   ## processDequeueConsolidationRequests applies the EIP-7251 system call
@@ -239,15 +237,13 @@ proc processDequeueConsolidationRequests*(vmState: BaseVMState): Result[seq[byte
       gasLimit : 30_000_000.GasInt,
       gasPrice : 0.GasInt,
       to       : CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS,
-      sysCall  : true,
     )
 
-  # runComputation a.k.a syscall/evm.call
-  let res = call.runComputation(OutputResult)
+  var res = call.systemCall(OutputResult)
   if res.error.len > 0:
     return err("processDequeueConsolidationRequests: " & res.error)
   ledger.persist(clearEmptyAccount = true)
-  ok(res.output)
+  ok(move(res.output))
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/core/tx_pool/tx_desc.nim
+++ b/execution_chain/core/tx_pool/tx_desc.nim
@@ -24,6 +24,7 @@ import
   ../../constants,
   ../../transaction,
   ../../core/eip8037,
+  ../../transaction/call_types,
   ../chain/forked_chain,
   ../pow/header,
   ../eip4844,
@@ -365,10 +366,13 @@ proc addTx*(xp: TxPoolRef, ptx: PooledTransaction): Result[void, TxError] =
     debug "Transaction already known", txHash = id
     return err(txErrorAlreadyKnown)
 
+  let
+    intrinsic = ptx.tx.intrinsicGas(xp.nextFork, xp.gasLimit)
+
   validateTxBasic(
     xp.com,
     ptx.tx,
-    xp.gasLimit,
+    intrinsic,
     xp.nextFork,
     validateFork = true).isOkOr:
     debug "Invalid transaction: Basic validation failed",

--- a/execution_chain/core/validate.nim
+++ b/execution_chain/core/validate.nim
@@ -239,7 +239,7 @@ func gasCost*(tx: Transaction): UInt256 =
 func validateTxBasic*(
     com:      CommonRef,
     tx:       Transaction;     ## tx to validate
-    gasLimit: GasInt;
+    intrinsic:IntrinsicGas;
     fork:     EVMFork,
     validateFork: bool = true): Result[void, string] =
 
@@ -269,7 +269,6 @@ func validateTxBasic*(
 
   if fork >= FkAmsterdam:
     let
-      intrinsic = tx.intrinsicGas(fork, gasLimit)
       intrinsicGas = intrinsic.regular + intrinsic.state
       minGasLimit = max(intrinsicGas, intrinsic.floorDataGas)
       minRegularGasLimit = max(intrinsic.regular, intrinsic.floorDataGas)
@@ -285,7 +284,6 @@ func validateTxBasic*(
       return err("tx.gasLimit " & $tx.gasLimit & " exceeds maximum " & $TX_GAS_LIMIT)
 
     let
-      intrinsic = tx.intrinsicGas(fork, gasLimit)
       minGasLimit = max(intrinsic.regular, intrinsic.floorDataGas)
 
     if tx.gasLimit < minGasLimit:
@@ -354,8 +352,6 @@ proc validateTransaction*(
     excessBlobGas: uint64;     ## excessBlobGas from parent block header
     com:      CommonRef,
     fork:     EVMFork): Result[void, string] =
-
-  ? validateTxBasic(com, tx, gasLimit, fork)
 
   let
     balance = ledger.getBalance(sender)

--- a/execution_chain/evm/interpreter/gas_costs.nim
+++ b/execution_chain/evm/interpreter/gas_costs.nim
@@ -71,7 +71,7 @@ type
     nonZeroVal*: bool
     gasCost1*: GasInt
     isNewAccount*: proc(): bool {.gcsafe, raises: [].}
-    gasLeft*: GasInt    
+    gasLeft*: GasInt
     gasCallDelegate*: GasProc
     contractGas*: UInt256
 

--- a/execution_chain/evm/interpreter_dispatch.nim
+++ b/execution_chain/evm/interpreter_dispatch.nim
@@ -93,11 +93,6 @@ proc afterExecCall(c: Computation) =
       # Special case to account for geth+parity bug
       c.vmState.ledger.ripemdSpecial()
 
-  if c.isSuccess:
-    c.commit()
-  else:
-    c.rollback()
-
 proc beforeExecCreate(c: Computation): bool =
   c.vmState.mutateLedger:
     let nonce = ledger.getNonce(c.msg.sender)
@@ -168,11 +163,6 @@ proc afterExecCreate(c: Computation) =
     # right cases, particularly important with EVMC where it must be cleared.
     c.output.reset()
 
-  if c.isSuccess:
-    c.commit()
-  else:
-    c.rollback()
-
 const MsgKindToOp: array[CallKind, Op] =
   [Call, DelegateCall, CallCode, Create, Create2]
 
@@ -204,6 +194,11 @@ proc afterExec(c: Computation) =
     c.afterExecCall()
   else:
     c.afterExecCreate()
+
+  if c.isSuccess:
+    c.commit()
+  else:
+    c.rollback()
 
   if c.msg.depth > 0:
     let gasUsed = c.msg.gas - c.gasMeter.gasRemaining
@@ -295,9 +290,8 @@ func preExecComputation*(c: Computation) =
     c.msg.contractAddress == CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS
   ):
     # EIP-7002 and EIP-7215 dicates that the code must be present, or else block is invalid
-    if c.code.bytes.len <= 0:
+    if c.code.len <= 0:
       c.setError("No code found for withdrawal or consolidation requests contract")
-
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/rpc/params.nim
+++ b/execution_chain/rpc/params.nim
@@ -28,8 +28,10 @@ func sender*(args: TransactionArgs): Address =
 func destination*(args: TransactionArgs): Address =
   args.to.get(ZeroAddr)
 
-proc toCallParams*(vmState: BaseVMState, args: TransactionArgs,
-                   globalGasCap: GasInt, baseFee: Opt[UInt256]): EvmResult[CallParams] =
+proc toCallParams*(vmState: BaseVMState,
+                   args: TransactionArgs,
+                   globalGasCap: GasInt,
+                   header: Header): EvmResult[CallParams] =
 
   # Reject invalid combinations of pre- and post-1559 fee styles
   if args.gasPrice.isSome and
@@ -51,7 +53,7 @@ proc toCallParams*(vmState: BaseVMState, args: TransactionArgs,
       gasLimit = globalGasCap
 
   var gasPrice = GasInt args.gasPrice.get(0.Quantity)
-  if baseFee.isSome:
+  if header.baseFeePerGas.isSome:
     # A basefee is provided, necessitating EIP-1559-type execution
     let
         feeNormTx = Transaction(
@@ -69,7 +71,7 @@ proc toCallParams*(vmState: BaseVMState, args: TransactionArgs,
 
     # Backfill the legacy gasPrice for EVM execution, unless we're all zeroes
     if maxPriorityFee > 0 or maxFee > 0:
-      let baseFee = baseFee.get().truncate(GasInt)
+      let baseFee = header.baseFeePerGas.value.truncate(GasInt)
       let priorityFee = min(maxPriorityFee, maxFee - baseFee)
       gasPrice = priorityFee + baseFee
 
@@ -79,7 +81,7 @@ proc toCallParams*(vmState: BaseVMState, args: TransactionArgs,
     else:
       @[]
 
-  ok(CallParams(
+  var res = CallParams(
     vmState:         vmState,
     sender:          args.sender,
     to:              args.destination,
@@ -91,6 +93,9 @@ proc toCallParams*(vmState: BaseVMState, args: TransactionArgs,
     accessList:      args.accessList.get(@[]),
     versionedHashes: args.versionedHashes,
     authorizationList: args.authorizationList.get(@[]),
-  ))
+  )
+  
+  res.intrinsic = res.intrinsicGas(vmState.fork, header.gasLimit)
+  ok(move(res))
 
 {.pop.}

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -25,13 +25,6 @@ export
   call_types
 
 type
-  TransactionHost = ref object
-    vmState:         BaseVMState
-    computation:     Computation
-    floorDataGas:    GasInt
-    intrinsicRegularGas: GasInt
-    intrinsicStateGas: GasInt
-
   GasUsed = object
     evmGasUsed: GasInt
     txGasUsed: GasInt
@@ -71,9 +64,11 @@ proc initialAccessListEIP2929(call: CallParams) =
       for key in account.storageKeys:
         ledger.accessList(account.address, key.to(UInt256))
 
-proc preExecComputation(vmState: BaseVMState, call: CallParams): int64 =
+proc preExecComputation(call: CallParams): int64 =
   var gasRefund = 0'i64
-  let ledger = vmState.ledger
+  let
+    vmState = call.vmState
+    ledger = vmState.ledger
 
   if not call.isCreate:
     if vmState.balTrackerEnabled:
@@ -133,7 +128,7 @@ proc preExecComputation(vmState: BaseVMState, call: CallParams): int64 =
 
   gasRefund
 
-proc setupHost(call: CallParams, keepStack: bool): TransactionHost =
+proc setupComputation*(call: CallParams, gasRefund: int64, keepStack: bool): Computation =
   let
     vmState = call.vmState
     fork = vmState.fork
@@ -150,38 +145,24 @@ proc setupHost(call: CallParams, keepStack: bool): TransactionHost =
 
   let
     isAmsterdamOrLater = fork >= FkAmsterdam
-    intrinsic = if call.sysCall: IntrinsicGas()
-                else: intrinsicGas(call, fork, vmState.blockCtx.gasLimit)
-    gasRefund = if call.sysCall: 0'i64
-                else: preExecComputation(vmState, call)
-    intrinsicGas = intrinsic.regular + intrinsic.state
+    intrinsicGas = call.intrinsic.regular + call.intrinsic.state
 
     # Prevent underflow which can occur when gasLimit is less than intrinsicGas.
     # Note that this is only a short term fix. In the longer term we need to
     # implement validation on all fields in the Message before executing in the EVM.
     # TODO: Implement full validation on all fields. See related issue: https://github.com/status-im/nimbus-eth1/issues/1524
     executionGas = if call.gasLimit < intrinsicGas: 0.GasInt else: call.gasLimit - intrinsicGas
-    regularGasBudget = TX_GAS_LIMIT - intrinsic.regular
+    regularGasBudget = TX_GAS_LIMIT - call.intrinsic.regular
 
   var
     gasLeft = executionGas
-    intrinsicStateGas = 0.GasInt
     stateGas = 0.GasInt
 
   if isAmsterdamOrLater:
     gasLeft = min(regularGasBudget, executionGas)
-    intrinsicStateGas = intrinsic.state - gasRefund.GasInt
     stateGas = executionGas - gasLeft + gasRefund.GasInt
 
   let
-    host = TransactionHost(
-      vmState: vmState,
-      floorDataGas: intrinsic.floorDataGas,
-      intrinsicRegularGas: intrinsic.regular,
-      intrinsicStateGas: intrinsicStateGas,
-      # All other defaults in `TransactionHost` are fine.
-    )
-
     msg = Message(
       kind:            if call.isCreate:
                          CallKind.Create
@@ -198,39 +179,41 @@ proc setupHost(call: CallParams, keepStack: bool): TransactionHost =
     )
 
     code = if call.isCreate:
-             msg.contractAddress = generateContractAddress(call.vmState, CallKind.Create, call.sender)
+             msg.contractAddress = generateContractAddress(vmState, CallKind.Create, call.sender)
              CodeBytesRef.init(call.input)
            else:
              msg.data = call.input
-             getCallCode(host.vmState, msg.codeAddress)
+             getCallCode(vmState, msg.codeAddress)
 
-  host.computation = newComputation(vmState, keepStack, msg, code)
+    computation = newComputation(vmState, keepStack, msg, code)
+
   if not isAmsterdamOrLater:
-    host.computation.addRefund(gasRefund)
-  vmState.captureStart(host.computation, call.sender, call.to,
+    computation.addRefund(gasRefund)
+  vmState.captureStart(computation, call.sender, call.to,
                        call.isCreate, call.input,
                        call.gasLimit, call.value)
 
-  return host
+  return computation
 
 # FIXME-awkwardFactoring: the factoring out of the pre and
 # post parts feels awkward to me, but for now I'd really like
 # not to have too much duplicated code between sync and async.
 # --Adam
 
-proc prepareToRunComputation(host: TransactionHost, call: CallParams) =
-  # Must come after `setupHost` for correct fork.
+proc prepareToRunComputation(c: Computation, call: CallParams) =
+  # Must come after `setupComputation` for correct fork.
   initialAccessListEIP2929(call)
 
   # Charge for gas.
   let
-    vmState = host.vmState
+    vmState = c.vmState
     fork = vmState.fork
 
   vmState.mutateLedger:
+    let gasFee = call.gasLimit.u256 * call.gasPrice.u256
     if vmState.balTrackerEnabled:
-      vmState.balTracker.trackSubBalanceChange(call.sender, call.gasLimit.u256 * call.gasPrice.u256)
-    ledger.subBalance(call.sender, call.gasLimit.u256 * call.gasPrice.u256)
+      vmState.balTracker.trackSubBalanceChange(call.sender, gasFee)
+    ledger.subBalance(call.sender, gasFee)
 
     # EIP-4844
     if fork >= FkCancun:
@@ -240,11 +223,10 @@ proc prepareToRunComputation(host: TransactionHost, call: CallParams) =
         vmState.balTracker.trackSubBalanceChange(call.sender, blobFee)
       ledger.subBalance(call.sender, blobFee)
 
-proc calculateAndPossiblyRefundGas(host: TransactionHost, call: CallParams): GasUsed =
+proc calculateAndPossiblyRefundGas(c: Computation, call: CallParams, gasRefund: int64): GasUsed =
   let
-    c = host.computation
-    vmState = host.vmState
-    fork = host.vmState.fork
+    vmState = c.vmState
+    fork = c.vmState.fork
 
   # EIP-3529: Reduction in refunds
   let MaxRefundQuotient = if fork >= FkLondon:
@@ -267,13 +249,15 @@ proc calculateAndPossiblyRefundGas(host: TransactionHost, call: CallParams): Gas
     blockStateGasUsed = 0.GasInt
 
   if fork >= FkAmsterdam:
-    txGasUsed = max(txGasUsedAfterRefund, host.floorDataGas)
-    let txRegularGas = host.intrinsicRegularGas + c.gasMeter.regularGasUsed
-    blockRegularGasUsed = max(txRegularGas, host.floorDataGas)
-    blockStateGasUsed = host.intrinsicStateGas + c.gasMeter.stateGasUsed
+    txGasUsed = max(txGasUsedAfterRefund, call.intrinsic.floorDataGas)
+    let
+      txRegularGas = call.intrinsic.regular + c.gasMeter.regularGasUsed
+      intrinsicStateGas = call.intrinsic.state - gasRefund.GasInt
+    blockRegularGasUsed = max(txRegularGas, call.intrinsic.floorDataGas)
+    blockStateGasUsed = intrinsicStateGas + c.gasMeter.stateGasUsed
     debug "EIP-8037 gas accounting",
-      intrinsicRegular = host.intrinsicRegularGas,
-      intrinsicState = host.intrinsicStateGas,
+      intrinsicRegular = call.intrinsic.regular,
+      intrinsicState = intrinsicStateGas,
       regularGasUsed = c.gasMeter.regularGasUsed,
       stateGasUsed = c.gasMeter.stateGasUsed,
       gasRemaining = c.gasMeter.gasRemaining,
@@ -282,9 +266,9 @@ proc calculateAndPossiblyRefundGas(host: TransactionHost, call: CallParams): Gas
       blockRegularGasUsed = blockRegularGasUsed,
       blockStateGasUsed = blockStateGasUsed,
       txGasUsed = txGasUsed,
-      floorDataGas = host.floorDataGas
+      floorDataGas = call.intrinsic.floorDataGas
   elif fork >= FkPrague:
-    txGasUsed = max(txGasUsedAfterRefund, host.floorDataGas)
+    txGasUsed = max(txGasUsedAfterRefund, call.intrinsic.floorDataGas)
     blockRegularGasUsed = txGasUsed
 
   # Refund for unused gas.
@@ -303,25 +287,13 @@ proc calculateAndPossiblyRefundGas(host: TransactionHost, call: CallParams): Gas
     blockStateGasUsed: blockStateGasUsed,
   )
 
-proc sysCallGasUsed(host: TransactionHost, call: CallParams): GasUsed =
-  let
-    c = host.computation
-    txGasUsed = call.gasLimit - c.gasMeter.gasRemaining - c.gasMeter.stateGasLeft
-  GasUsed(
-    evmGasUsed: c.msg.gas - c.gasMeter.gasRemaining - c.gasMeter.stateGasLeft,
-    txGasUsed: txGasUsed,
-    blockRegularGasUsed: txGasUsed,
-  )
-
 proc finishRunningComputation(
-    host: TransactionHost, call: CallParams, T: type): T =
+    c: Computation, call: CallParams, gasRefund: int64, T: type): T =
   let
-    c = host.computation
-    gasUsed = if call.sysCall: sysCallGasUsed(host, call)
-              else: calculateAndPossiblyRefundGas(host, call)
+    gasUsed = calculateAndPossiblyRefundGas(c, call, gasRefund)
 
   # evm gas used without intrinsic gas
-  host.vmState.captureEnd(c, c.output, gasUsed.evmGasUsed, c.errorOpt)
+  c.vmState.captureEnd(c, c.output, gasUsed.evmGasUsed, c.errorOpt)
 
   when T is CallResult|DebugCallResult:
     # Collecting the result can be unnecessarily expensive when (re)-processing
@@ -338,44 +310,24 @@ proc finishRunningComputation(
       result.memory = move(c.memory)
       if c.isSuccess:
         result.logEntries = move(c.logEntries)
-  elif T is GasInt:
-    result = gasUsed.txGasUsed
   elif T is LogResult:
     result.gasUsed = gasUsed.txGasUsed
     result.blockRegularGasUsed = gasUsed.blockRegularGasUsed
     result.blockStateGasUsed = gasUsed.blockStateGasUsed
     if c.isSuccess:
       result.logEntries = move(c.logEntries)
-  elif T is string:
-    if c.isError:
-      result = c.error.info
-  elif T is seq[byte]:
-    result = move(c.output)
-  elif T is OutputResult:
-    if c.isError:
-      result.error = c.error.info
-    result.output = move(c.output)
-  elif T is void:
-    discard
   else:
     {.error: "Unknown computation output".}
 
 proc runComputation*(call: CallParams, T: type): T =
-  let host = setupHost(call, keepStack = T is DebugCallResult)
-  if not call.sysCall:
-    prepareToRunComputation(host, call)
+  let
+    gasRefund = preExecComputation(call)
+    c = setupComputation(call, gasRefund, keepStack = T is DebugCallResult)
 
+  prepareToRunComputation(c, call)
   # Pre-execution sanity checks
-  host.computation.preExecComputation()
-  if host.computation.isError:
-    when T is void:
-      finishRunningComputation(host, call, T)
-      return
-    else:
-      return finishRunningComputation(host, call, T)
-
-  host.computation.execCallOrCreate()
-  if not call.sysCall:
-    host.computation.postExecComputation()
-
-  finishRunningComputation(host, call, T)
+  c.preExecComputation()
+  if c.isSuccess:
+    c.execCallOrCreate()
+    c.postExecComputation()
+  finishRunningComputation(c, call, gasRefund, T)

--- a/execution_chain/transaction/call_evm.nim
+++ b/execution_chain/transaction/call_evm.nim
@@ -20,7 +20,9 @@ import
 export
   call_common
 
-proc callParamsForTx(tx: Transaction, sender: Address, vmState: BaseVMState, baseFee: GasInt): CallParams =
+proc callParamsForTx(tx: Transaction, sender: Address,
+                     vmState: BaseVMState, baseFee: GasInt,
+                     intrinsic: IntrinsicGas): CallParams =
   # Is there a nice idiom for this kind of thing? Should I
   # just be writing this as a bunch of assignment statements?
   result = CallParams(
@@ -31,28 +33,8 @@ proc callParamsForTx(tx: Transaction, sender: Address, vmState: BaseVMState, bas
     to:           tx.destination,
     isCreate:     tx.contractCreation,
     value:        tx.value,
-    input:        tx.payload
-  )
-  if tx.txType > TxLegacy:
-    assign(result.accessList, tx.accessList)
-
-  if tx.txType == TxEip4844:
-    assign(result.versionedHashes, tx.versionedHashes)
-
-  if tx.txType == TxEip7702:
-    assign(result.authorizationList, tx.authorizationList)
-
-proc callParamsForTest(tx: Transaction, sender: Address, vmState: BaseVMState): CallParams =
-  result = CallParams(
-    vmState:      vmState,
-    gasPrice:     tx.gasPrice,
-    gasLimit:     tx.gasLimit,
-    sender:       sender,
-    to:           tx.destination,
-    isCreate:     tx.contractCreation,
-    value:        tx.value,
     input:        tx.payload,
-    sysCall:      true,
+    intrinsic:    intrinsic
   )
   if tx.txType > TxLegacy:
     assign(result.accessList, tx.accessList)
@@ -65,13 +47,17 @@ proc callParamsForTest(tx: Transaction, sender: Address, vmState: BaseVMState): 
 
 proc txCallEvm*(tx: Transaction,
                 sender: Address,
-                vmState: BaseVMState, baseFee: GasInt): LogResult =
+                vmState: BaseVMState,
+                baseFee: GasInt,
+                intrinsic: IntrinsicGas): LogResult =
   let
-    call = callParamsForTx(tx, sender, vmState, baseFee)
+    call = callParamsForTx(tx, sender, vmState, baseFee, intrinsic)
   runComputation(call, LogResult)
 
 proc testCallEvm*(tx: Transaction,
                   sender: Address,
                   vmState: BaseVMState): DebugCallResult =
-  let call = callParamsForTest(tx, sender, vmState)
+  let 
+    baseFee = vmState.blockCtx.baseFeePerGas.get(0.u256).truncate(GasInt)
+    call = callParamsForTx(tx, sender, vmState, baseFee, IntrinsicGas())
   runComputation(call, DebugCallResult)

--- a/execution_chain/transaction/call_evm_rpc.nim
+++ b/execution_chain/transaction/call_evm_rpc.nim
@@ -43,8 +43,9 @@ proc rpcCallEvm*(
   defer:
     txFrame.dispose() # always dispose state changes
 
-  let vmState = BaseVMState.new(header, topHeader, com, txFrame)
-  let params = ?toCallParams(vmState, args, globalGasCap, header.baseFeePerGas)
+  let
+    vmState = BaseVMState.new(header, topHeader, com, txFrame)
+    params = ?toCallParams(vmState, args, globalGasCap, header)
 
   ok(runComputation(params, CallResult))
 
@@ -52,7 +53,8 @@ proc rpcCallEvm*(
     args: TransactionArgs, header: Header, vmState: BaseVMState, globalGasCap = 0.GasInt
 ): EvmResult[CallResult] =
   # TODO: globalGasCap should configurable by user
-  let params = ?toCallParams(vmState, args, globalGasCap, header.baseFeePerGas)
+  let
+    params = ?toCallParams(vmState, args, globalGasCap, header)
   ok(runComputation(params, CallResult))
 
 proc rpcEstimateGas*(
@@ -60,7 +62,7 @@ proc rpcEstimateGas*(
 ): Result[GasInt, (EvmErrorObj, OutputResult)] =
   # Binary search the gas requirement, as it may be higher than the amount used
   let fork = vmState.fork
-  var params = toCallParams(vmState, args, gasCap, header.baseFeePerGas).valueOr:
+  var params = toCallParams(vmState, args, gasCap, header).valueOr:
     return err((evmErr(EvmInvalidParam), OutputResult()))
 
   var

--- a/execution_chain/transaction/call_types.nim
+++ b/execution_chain/transaction/call_types.nim
@@ -36,7 +36,7 @@ type
     accessList*:   AccessList           # EIP-2930 (Berlin) tx access list.
     versionedHashes*: seq[VersionedHash]   # EIP-4844 (Cancun) blob versioned hashes
     authorizationList*: seq[Authorization] # EIP-7702 (Prague) authorization list
-    sysCall*:      bool                 # System call or ordinary call
+    intrinsic*:    IntrinsicGas
 
   # Standard call result.
   CallResult* = object of RootObj

--- a/execution_chain/transaction/system_call.nim
+++ b/execution_chain/transaction/system_call.nim
@@ -1,0 +1,46 @@
+# nimbus-execution-client
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [].}
+
+import
+  ../evm/[types, state, computation, code_stream, interpreter_dispatch],
+  ./call_common,
+  ./call_types
+
+export
+  call_types
+
+proc sysCallGasUsed(c: Computation): GasInt =
+  c.msg.gas - c.gasMeter.gasRemaining - c.gasMeter.stateGasLeft
+
+proc finishRunningComputation(c: Computation, T: type): T =
+  let
+    gasUsed = sysCallGasUsed(c)
+
+  # evm gas used without intrinsic gas
+  c.vmState.captureEnd(c, c.output, gasUsed, c.errorOpt)
+
+  when T is OutputResult:
+    if c.isError:
+      result.error = c.error.info
+    result.output = move(c.output)
+  elif T is void:
+    discard
+  else:
+    {.error: "Unknown systemCall output".}
+
+proc systemCall*(call: CallParams, T: type): T =
+  let c = setupComputation(call, 0, false)
+
+  # Pre-execution sanity checks
+  c.preExecComputation()
+  if c.isSuccess:
+    c.execCallOrCreate()
+  finishRunningComputation(c, T)

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -294,7 +294,8 @@ proc initVMEnv*(network: string): BaseVMState =
       coinbase: coinbase,
       timestamp: EthTime(0x1234),
       difficulty: 1003.u256,
-      gasLimit: 100_000
+      gasLimit: 100_000,
+      baseFeePerGas: Opt.some(1.u256),
     )
 
   BaseVMState.new(parent, header, com, com.db.baseTxFrame())
@@ -407,6 +408,7 @@ proc createSignedTx(payload: seq[byte], chainId: ChainId): Transaction =
     nonce: 0,
     gasPrice: 1.GasInt,
     gasLimit: 500_000_000.GasInt,
+    maxFeePerGas: 1.GasInt,
     to: Opt.some codeAddress,
     value: 500.u256,
     payload: payload,

--- a/tests/test_op_custom.nim
+++ b/tests/test_op_custom.nim
@@ -201,22 +201,27 @@ proc opCustomMain*() =
       title: "EIP2929 BALANCE_1 WARM"
       setup:
         vmState.mutateLedger:
+          # make `codeAddress` WARM
           ledger.accessList(codeAddress)
       code:
-        Address
-        Balance
+        Address  # gas: 2
+        Balance  # gas: 100 (WARM)
       stack: "0x00000000000000000000000000000000000000000000000000000000000f4434"
       fork: Berlin
       gasused: 102
 
     assembler:
       title: "EIP2929 BALANCE_1 COLD"
+      setup:
+        vmState.mutateLedger:
+          # introduce a new COLD address not in access list
+          ledger.setBalance(address"0x0000000000000000000000000000000000889911", 0xabcd.u256)
       code:
-        Address
-        Balance
-      stack: "0x00000000000000000000000000000000000000000000000000000000000f4434"
+        Push20 "0x0000000000000000000000000000000000889911" # gas: 3
+        Balance                                             # gas: 2600 (COLD)
+      stack: "0x000000000000000000000000000000000000000000000000000000000000abcd"
       fork: Berlin
-      gasused: 2602
+      gasused: 2603
 
     assembler: # ORIGIN OP
       title: "ORIGIN_1"

--- a/tests/test_op_memory.nim
+++ b/tests/test_op_memory.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2019-2025 Status Research & Development GmbH
+# Copyright (c) 2019-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -544,7 +544,13 @@ proc opMemoryMain*() =
       title: "Sstore_NET_3"
       code: "60016000556000600055"
       fork: Constantinople
-      gasUsed: 20212
+      gasUsed: 10106           # 20212 div 2 = 10106, got 50% refund
+      # [0]     Push1   0x01   # gas: 3
+      # [2]     Push1   0x00   # gas: 3
+      # [4]     Sstore         # gas: 20000 (create slot)
+      # [5]     Push1   0x00   # gas: 3
+      # [7]     Push1   0x00   # gas: 3
+      # [9]     Sstore         # gas: 200 (constantinople no op)
 
     assembler: # Sstore EIP1283
       title: "Sstore_NET_4"
@@ -557,15 +563,6 @@ proc opMemoryMain*() =
       code: "60016000556001600055"
       fork: Constantinople
       gasUsed: 20212
-
-    # Sets Storage row on "cow" address:
-    # 0: 1
-    # private void setStorageToOne(VM vm) {
-    #       # Sets storage value to 1 and commits
-    #           code: "60006000556001600055"
-    #           fork: Constantinople
-    #       invoke.getRepository().commit()
-    #       invoke.setOrigRepository(invoke.getRepository())
 
     assembler: # Sstore EIP1283
       title: "Sstore_NET_6"
@@ -589,7 +586,13 @@ proc opMemoryMain*() =
       title: "Sstore_NET_9"
       code: "60026000556000600055"
       fork: Constantinople
-      gasUsed: 20212
+      gasUsed: 10106          # 20212 div 2 = 10106, got 50% refund
+      # [0]     Push1   0x02  # gas: 3
+      # [2]     Push1   0x00  # gas: 3
+      # [4]     Sstore        # gas: 20000 (create slot)
+      # [5]     Push1   0x00  # gas: 3
+      # [7]     Push1   0x00  # gas: 3
+      # [9]     Sstore        # gas: 200 (constantinople no op)
 
     assembler: # Sstore EIP1283
       title: "Sstore_NET_10"
@@ -609,11 +612,17 @@ proc opMemoryMain*() =
       fork: Constantinople
       gasUsed: 20212
 
-    assembler: # Sstore EIP1283
+    assembler: # Sstore EIP2929
       title: "Sstore_NET_13"
-      code: "60016000556000600055"
-      fork: Constantinople
-      gasUsed: 20212
+      code:
+        Push1 "0x01" # gas: 3
+        Push1 "0x00" # gas: 3
+        Sstore       # gas: 22100 = 20000 (create slot) + 2100 (cold access)
+        Push1 "0x00" # gas: 3
+        Push1 "0x00" # gas: 3
+        Sstore       # gas: 100 (berlin no op)
+      fork: Berlin
+      gasUsed: 11106
 
     assembler: # Sstore EIP1283
       title: "Sstore_NET_14"
@@ -628,16 +637,34 @@ proc opMemoryMain*() =
       gasUsed: 20212
 
     assembler: # Sstore EIP1283
-      title: "Sstore_NET_16"
+      title: "Sstore_NET_16 refund smaller than 50%"
       code: "600160005560006000556001600055"
       fork: Constantinople
-      gasUsed: 40218
+      gasUsed: 20418          # 40218 - min(refund, 50%): 40218 - 19800
+      # [0]     Push1   0x01  # gas: 3
+      # [2]     Push1   0x00  # gas: 3
+      # [4]     Sstore        # gas: 20000 (create slot)
+      # [5]     Push1   0x00  # gas: 3
+      # [7]     Push1   0x00  # gas: 3
+      # [9]     Sstore        # gas: 200 (constantinople no op) + refund 19800 (reset to original inexistent slot)
+      # [10]    Push1   0x01  # gas: 3
+      # [12]    Push1   0x00  # gas: 3
+      # [14]    Sstore        # gas: 20000 (create slot)
 
     assembler: # Sstore EIP1283
-      title: "Sstore_NET_17"
+      title: "Sstore_NET_17 refund bigger than 50%"
       code: "600060005560016000556000600055"
       fork: Constantinople
-      gasUsed: 20418
+      gasUsed: 10209          # 20418 - min(refund, 50%): 20418 - (50%) 10209
+      # [0]     Push1   0x00  # gas: 3
+      # [2]     Push1   0x00  # gas: 3
+      # [4]     Sstore        # gas: 200 (no op)
+      # [5]     Push1   0x01  # gas: 3
+      # [7]     Push1   0x00  # gas: 3
+      # [9]     Sstore        # gas: 20000 (create slot)
+      # [10]    Push1   0x00  # gas: 3
+      # [12]    Push1   0x00  # gas: 3
+      # [14]    Sstore        # gas: 200 (no op) + refund 19800 (reset to original inexistent slot)
 
     assembler: # Sload OP
       title: "Sload_1"

--- a/tests/test_transaction_json.nim
+++ b/tests/test_transaction_json.nim
@@ -19,6 +19,7 @@ import
   ../execution_chain/db/core_db,
   ../execution_chain/common/common,
   ../execution_chain/transaction,
+  ../execution_chain/transaction/call_types,
   ../execution_chain/core/validate,
   ../execution_chain/utils/utils
 
@@ -41,8 +42,10 @@ proc testTxByFork(tx: Transaction, forkData: JsonNode, forkName: string, testSta
     config = getChainConfig(forkName)
     memDB  = newCoreDbRef DefaultDbMemory
     com    = CommonRef.new(memDB, config)
+    fork   = nameToFork[forkName]
+    intrinsic = tx.intrinsicGas(fork, 10_000_000)
 
-  validateTxBasic(com, tx, 10_000_000, nameToFork[forkName]).isOkOr:
+  validateTxBasic(com, tx, intrinsic, fork).isOkOr:
     return
 
   if forkData.len > 0 and "sender" in forkData:

--- a/tools/txparse/txparse.nim
+++ b/tools/txparse/txparse.nim
@@ -15,6 +15,7 @@ import
   ../common/helpers,
   ../../execution_chain/db/core_db/memory_only,
   ../../execution_chain/transaction,
+  ../../execution_chain/transaction/call_types,
   ../../execution_chain/core/validate,
   ../../execution_chain/common/evmforks,
   ../../execution_chain/common/common
@@ -25,8 +26,10 @@ proc parseTx(com: CommonRef, hexLine: string) =
       bytes = hexToSeqByte(hexLine)
       tx = decodeTx(bytes)
       address = tx.recoverSender().expect("valid signature")
+      fork = FkPrague
+      intrinsic = tx.intrinsicGas(fork, 10_000_000)
 
-    validateTxBasic(com, tx, 10_000_000, FkPrague).isOkOr:
+    validateTxBasic(com, tx, intrinsic, fork).isOkOr:
       echo "err: ", error
 
     # everything ok


### PR DESCRIPTION
`intrinsicGas` is called twice when calling `processTransaction`. Once by `validateTxBasic`, and the other one called by `setupHost`.

And in txpool, the same call is 3x because validateTxBasic is called twice. This commit reduce `intrinsicGas` call to one in `processTransaction`.

And in txpool become 2x, but will soon refactored too.

PS: This PR remove `TransactionHost` and rename `setupHost` to `setupComputation` because they were relics from EVMC era. We also have a `systemCall` beside `runComputation`.