### PR TITLE
EVM system call has it's own setupComputation

### DIFF
--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -159,7 +159,6 @@ proc processBeaconBlockRoot*(vmState: BaseVMState, beaconRoot: Hash32) =
       vmState  : vmState,
       sender   : SYSTEM_ADDRESS,
       gasLimit : 30_000_000.GasInt,
-      gasPrice : 0.GasInt,
       to       : BEACON_ROOTS_ADDRESS,
       input    : @(beaconRoot.data),
     )
@@ -175,7 +174,6 @@ proc processParentBlockHash*(vmState: BaseVMState, prevHash: Hash32) =
       vmState  : vmState,
       sender   : SYSTEM_ADDRESS,
       gasLimit : 30_000_000.GasInt,
-      gasPrice : 0.GasInt,
       to       : HISTORY_STORAGE_ADDRESS,
       input    : @(prevHash.data),
     )
@@ -191,7 +189,6 @@ proc processDequeueWithdrawalRequests*(vmState: BaseVMState): Result[seq[byte], 
       vmState  : vmState,
       sender   : SYSTEM_ADDRESS,
       gasLimit : 30_000_000.GasInt,
-      gasPrice : 0.GasInt,
       to       : WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS,
     )
 
@@ -208,7 +205,6 @@ proc processDequeueConsolidationRequests*(vmState: BaseVMState): Result[seq[byte
       vmState  : vmState,
       sender   : SYSTEM_ADDRESS,
       gasLimit : 30_000_000.GasInt,
-      gasPrice : 0.GasInt,
       to       : CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS,
     )
 

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -128,18 +128,18 @@ proc preExecComputation(call: CallParams): int64 =
 
   gasRefund
 
-proc setupComputation*(call: CallParams, gasRefund: int64, keepStack: bool): Computation =
+proc setupComputation(call: CallParams, gasRefund: int64, keepStack: bool): Computation =
   let
     vmState = call.vmState
     fork = vmState.fork
   vmState.txCtx = TxContext(
-    origin         : call.origin.get(call.sender),
+    origin         : call.sender,
     gasPrice       : call.gasPrice,
     versionedHashes: call.versionedHashes,
     blobBaseFee    : getBlobBaseFee(vmState.blockCtx.excessBlobGas, vmState.com, fork),
   )
 
-  # reset global gasRefund counter each time
+  # reset global gasRefunded counter each time
   # EVM called for a new transaction
   vmState.gasRefunded = 0
 
@@ -192,8 +192,7 @@ proc setupComputation*(call: CallParams, gasRefund: int64, keepStack: bool): Com
   vmState.captureStart(computation, call.sender, call.to,
                        call.isCreate, call.input,
                        call.gasLimit, call.value)
-
-  return computation
+  computation
 
 # FIXME-awkwardFactoring: the factoring out of the pre and
 # post parts feels awkward to me, but for now I'd really like

--- a/execution_chain/transaction/call_types.nim
+++ b/execution_chain/transaction/call_types.nim
@@ -25,7 +25,6 @@ type
   # Standard call parameters.
   CallParams* = object
     vmState*:      BaseVMState          # Chain, database, state, block, fork.
-    origin*:       Opt[addresses.Address] # Default origin is `sender`.
     gasPrice*:     GasInt               # Gas price for this call.
     gasLimit*:     GasInt               # Maximum gas available for this call.
     sender*:       addresses.Address    # Sender account.

--- a/execution_chain/transaction/system_call.nim
+++ b/execution_chain/transaction/system_call.nim
@@ -10,14 +10,42 @@
 {.push raises: [].}
 
 import
-  ../evm/[types, state, computation, code_stream, interpreter_dispatch],
-  ./call_common,
+  ../evm/[types, state, computation, message, interpreter_dispatch],
   ./call_types
 
 export
   call_types
 
-proc sysCallGasUsed(c: Computation): GasInt =
+proc setupComputation(call: CallParams): Computation =
+  let
+    vmState = call.vmState
+    stateGas = 0.GasInt
+    msg = Message(
+      kind:            CallKind.Call,
+      gas:             call.gasLimit,
+      stateGas:        stateGas,
+      contractAddress: call.to,
+      codeAddress:     call.to,
+      sender:          call.sender,
+      value:           call.value,
+      data:            call.input,
+    )
+    code = getCallCode(vmState, msg.codeAddress)
+    computation = newComputation(vmState, false, msg, code)
+
+  vmState.txCtx = TxContext(
+    origin: call.sender,
+  )
+
+  # reset global gasRefunded counter each time
+  # EVM called for a new transaction
+  vmState.gasRefunded = 0
+  vmState.captureStart(computation, call.sender, call.to,
+                       call.isCreate, call.input,
+                       call.gasLimit, call.value)
+  computation
+
+func sysCallGasUsed(c: Computation): GasInt =
   c.msg.gas - c.gasMeter.gasRemaining - c.gasMeter.stateGasLeft
 
 proc finishRunningComputation(c: Computation, T: type): T =
@@ -39,7 +67,7 @@ proc finishRunningComputation(c: Computation, T: type): T =
 proc systemCall*(call: CallParams, T: type): T =
   let
     ledger = call.vmState.ledger
-    c = setupComputation(call, 0, false)
+    c = setupComputation(call)
 
   # Pre-execution sanity checks
   c.preExecComputation()


### PR DESCRIPTION
EIP-8037 change regular gas calculation and add state gas to both EVM system call and regular EVM call.

And it's quite confusing if EVM system call share the same setupComputation with regular EVM call when their
gas requirements is calculated differently.