### PR TITLE
EIP-7928 BAL: Fix for EIP-7702 account call

### DIFF
--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -18,7 +18,6 @@ import
   eth/common/[addresses, hashes],
   ../utils/[mergeutils, utils],
   ../evm/code_bytes,
-  ../core/eip7702,
   ../constants,
   ./[access_list as ac_access_list, core_db, storage_types],
   ./aristo/aristo_blobify
@@ -473,12 +472,6 @@ proc getCodeSize*(ledger: LedgerRef, address: Address): int =
 
   acc.code.len()
 
-proc resolveCode*(ledger: LedgerRef, address: Address): CodeBytesRef =
-  let code = ledger.getCode(address)
-  let delegateTo = parseDelegationAddress(code).valueOr:
-    return code
-  ledger.getCode(delegateTo)
-
 proc getCommittedStorage*(ledger: LedgerRef, address: Address, slot: UInt256): UInt256 =
   let acc = ledger.getAccount(address, false)
 
@@ -837,7 +830,6 @@ proc isEmptyAccount*(ledger: ReadOnlyLedger, address: Address): bool = isEmptyAc
 proc getCommittedStorage*(ledger: ReadOnlyLedger, address: Address, slot: UInt256): UInt256 = getCommittedStorage(distinctBase ledger, address, slot)
 proc inAccessList*(ledger: ReadOnlyLedger, address: Address): bool = inAccessList(distinctBase ledger, address)
 proc inAccessList*(ledger: ReadOnlyLedger, address: Address, slot: UInt256): bool = inAccessList(distinctBase ledger, address)
-proc resolveCode*(ledger: ReadOnlyLedger, address: Address): CodeBytesRef = resolveCode(distinctBase ledger, address)
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/evm/computation.nim
+++ b/execution_chain/evm/computation.nim
@@ -336,16 +336,9 @@ proc execSelfDestruct*(c: Computation, beneficiary: Address) =
       if c.fork >= FkAmsterdam:
         c.emitSelfDestructLog(beneficiary, localBalance, newContract)
     else:
-      if c.balTrackerEnabled:
-        # Transfer to beneficiary
-        c.vmState.balTracker.trackAddBalanceChange(beneficiary, localBalance)
-        ledger.addBalance(beneficiary, localBalance)
-        c.vmState.balTracker.trackSelfDestruct(c.msg.contractAddress)
-        ledger.selfDestruct(c.msg.contractAddress)
-      else:
-        # Transfer to beneficiary
-        ledger.addBalance(beneficiary, localBalance)
-        ledger.selfDestruct(c.msg.contractAddress)
+      # Transfer to beneficiary
+      ledger.addBalance(beneficiary, localBalance)
+      ledger.selfDestruct(c.msg.contractAddress)
 
     trace "SELFDESTRUCT",
       contractAddress = c.msg.contractAddress.toHex,

--- a/execution_chain/evm/interpreter/op_handlers/oph_call.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_call.nim
@@ -34,7 +34,6 @@ import
   stew/assign2,
   stint,
   ../../state,
-  ../../message,
   ../../../db/ledger
 
 # ------------------------------------------------------------------------------
@@ -96,11 +95,19 @@ proc gasCallEIP2929(c: Computation, codeAddress: Address): GasProc =
 proc gasCallDelegate(c: Computation, codeAddress: Address): GasProc =
   if FkPrague <= c.fork:
     GasProc proc(): GasInt =
+      # When the target is a 7702-delegated EOA both target and
+      # delegation target appear in the BAL even though sender has insufficient funds.
+      # But in OOG case, only `codeAddress` appear in BAL.
+      if c.balTrackerEnabled:
+        c.vmState.balTracker.trackAddressAccess(codeAddress)
       let delegateTo = parseDelegationAddress(c.getCode(codeAddress)).valueOr:
+        c.delegateTo = codeAddress
         return 0.GasInt
+      c.delegateTo = delegateTo
       delegateResolutionCost(c, delegateTo)
   else:
     GasProc proc(): GasInt =
+      c.delegateTo = codeAddress
       0.GasInt
 
 
@@ -183,7 +190,7 @@ proc execSubCall(c: Computation; childMsg: Message; memPos, memLen: int) =
   # need to provide explicit <c> and <child> for capturing in chainTo proc()
   # <memPos> and <memLen> are provided by value and need not be captured
   var
-    code = getCallCode(c.vmState, childMsg.codeAddress)
+    code = c.vmState.readOnlyLedger.getCode(c.delegateTo)
     child = newComputation(
       c.vmState, keepStack = false, childMsg, code)
 
@@ -267,6 +274,10 @@ proc callOp(cpt: VmCpt): EvmResultVoid =
   ? cpt.opcodeGasCost(Call, gasCost, reason = $Call)
   cpt.gasMeter.escrowSubcallRegularGas(childGasLimit)
 
+  if cpt.balTrackerEnabled:
+    # If OOG, `delegateTo` is not added to BAL
+    cpt.vmState.balTracker.trackAddressAccess(cpt.delegateTo)
+
   cpt.returnData.setLen(0)
 
   if cpt.msg.depth >= MaxCallDepth:
@@ -337,6 +348,10 @@ proc callCodeOp(cpt: VmCpt): EvmResultVoid =
 
   ? cpt.opcodeGasCost(CallCode, gasCost, reason = $CallCode)
   cpt.gasMeter.escrowSubcallRegularGas(childGasLimit)
+
+  if cpt.balTrackerEnabled:
+    # If OOG, `delegateTo` is not added to BAL
+    cpt.vmState.balTracker.trackAddressAccess(cpt.delegateTo)
 
   cpt.returnData.setLen(0)
 
@@ -409,6 +424,10 @@ proc delegateCallOp(cpt: VmCpt): EvmResultVoid =
   ? cpt.opcodeGasCost(DelegateCall, gasCost, reason = $DelegateCall)
   cpt.gasMeter.escrowSubcallRegularGas(childGasLimit)
 
+  if cpt.balTrackerEnabled:
+    # If OOG, `delegateTo` is not added to BAL
+    cpt.vmState.balTracker.trackAddressAccess(cpt.delegateTo)
+
   cpt.returnData.setLen(0)
   if cpt.msg.depth >= MaxCallDepth:
     debug "Computation Failure",
@@ -472,6 +491,10 @@ proc staticCallOp(cpt: VmCpt): EvmResultVoid =
 
   ? cpt.opcodeGasCost(StaticCall, gasCost, reason = $StaticCall)
   cpt.gasMeter.escrowSubcallRegularGas(childGasLimit)
+
+  if cpt.balTrackerEnabled:
+    # If OOG, `delegateTo` is not added to BAL
+    cpt.vmState.balTracker.trackAddressAccess(cpt.delegateTo)
 
   cpt.returnData.setLen(0)
 

--- a/execution_chain/evm/interpreter/op_handlers/oph_create.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_create.nim
@@ -157,7 +157,6 @@ proc createOp(cpt: VmCpt): EvmResultVoid =
       sender: cpt.msg.contractAddress,
       contractAddress: generateContractAddress(
         cpt.vmState,
-        CallKind.Create,
         cpt.msg.contractAddress),
       value:  endowment)
     code = CodeBytesRef.init(cpt.memory.read(memPos, memLen))
@@ -251,12 +250,10 @@ proc create2Op(cpt: VmCpt): EvmResultVoid =
       gas:    createMsgGas,
       stateGas: stateGas,
       sender: cpt.msg.contractAddress,
-      contractAddress: generateContractAddress(
-        cpt.vmState,
-        CallKind.Create2,
+      contractAddress: generateSafeAddress(
         cpt.msg.contractAddress,
         salt,
-        code),
+        code.bytes),
       value:  endowment)
   cpt.execSubCreate(childMsg, code)
   ok()

--- a/execution_chain/evm/interpreter/op_handlers/oph_memory.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_memory.nim
@@ -44,8 +44,6 @@ proc sstoreImpl(c: Computation, slot, newValue: UInt256): EvmResultVoid =
   ? c.opcodeGasCost(Sstore, res.gasCost, "SSTORE")
   c.gasMeter.refundGas(res.gasRefund)
 
-  if c.balTrackerEnabled:
-    c.vmState.balTracker.trackStorageWrite(c.msg.contractAddress, slot, newValue)
   c.vmState.mutateLedger:
     ledger.setStorage(c.msg.contractAddress, slot, newValue)
   ok()

--- a/execution_chain/evm/interpreter_dispatch.nim
+++ b/execution_chain/evm/interpreter_dispatch.nim
@@ -136,10 +136,9 @@ proc beforeExecCreate(c: Computation): bool =
       c.vmState.balTracker.trackAddBalanceChange(c.msg.contractAddress, c.msg.value)
       ledger.addBalance(c.msg.contractAddress, c.msg.value)
       ledger.clearStorage(c.msg.contractAddress)
-      if c.fork >= FkSpurious:
-        # EIP161 nonce incrementation
-        c.vmState.balTracker.trackIncNonceChange(c.msg.contractAddress)
-        ledger.incNonce(c.msg.contractAddress)
+      # no need to check c.fork >= FkSpurious, it's FkAmsterdam
+      c.vmState.balTracker.trackIncNonceChange(c.msg.contractAddress)
+      ledger.incNonce(c.msg.contractAddress)
     else:
       ledger.subBalance(c.msg.sender, c.msg.value)
       ledger.addBalance(c.msg.contractAddress, c.msg.value)

--- a/execution_chain/evm/message.nim
+++ b/execution_chain/evm/message.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -39,16 +39,16 @@ proc getCallCode*(vmState: BaseVMState, codeAddress: Address): CodeBytesRef =
   if isPrecompile:
     return CodeBytesRef(nil)
 
+  # `codeAddress` is not BAL tracked here but in `gasCallDelegate`
+  # before check for balance. See the comment there.
+  # And delegateTo need tracking for a message call.
+  var resolvedAddress = codeAddress
   if vmState.fork >= FkPrague:
-    if vmState.balTrackerEnabled:
-      vmState.balTracker.trackAddressAccess(codeAddress)
-      let
-        code = vmState.readOnlyLedger.getCode(codeAddress)
-        delegateTo = parseDelegationAddress(code)
-      if delegateTo.isSome():
-        vmState.balTracker.trackAddressAccess(delegateTo.get())
-    vmState.readOnlyLedger.resolveCode(codeAddress)
-  else:
-    if vmState.balTrackerEnabled:
-      vmState.balTracker.trackAddressAccess(codeAddress)
-    vmState.readOnlyLedger.getCode(codeAddress)
+    let
+      code = vmState.readOnlyLedger.getCode(codeAddress)
+      delegateTo = parseDelegationAddress(code)
+    if delegateTo.isSome():
+      if vmState.balTrackerEnabled:
+        vmState.balTracker.trackAddressAccess(delegateTo.value)
+      resolvedAddress = delegateTo.value
+  vmState.readOnlyLedger.getCode(resolvedAddress)

--- a/execution_chain/evm/message.nim
+++ b/execution_chain/evm/message.nim
@@ -22,26 +22,17 @@ proc isCreate*(message: Message): bool =
   message.kind in {CallKind.Create, CallKind.Create2}
 
 proc generateContractAddress*(vmState: BaseVMState,
-                              kind: CallKind,
-                              sender: Address,
-                              salt = ZERO_CONTRACTSALT,
-                              code = CodeBytesRef(nil)): Address =
-  if kind == CallKind.Create:
-    if vmState.balTrackerEnabled:
-      vmState.balTracker.trackAddressAccess(sender)
-    let creationNonce = vmState.readOnlyLedger().getNonce(sender)
-    generateAddress(sender, creationNonce)
-  else:
-    generateSafeAddress(sender, salt, code.bytes)
+                              sender: Address): Address =
+  # `sender` is BAL tracked in `prepareToRunComputation`
+  let creationNonce = vmState.readOnlyLedger().getNonce(sender)
+  generateAddress(sender, creationNonce)
 
 proc getCallCode*(vmState: BaseVMState, codeAddress: Address): CodeBytesRef =
   let isPrecompile = getPrecompile(vmState.fork, codeAddress).isSome()
   if isPrecompile:
     return CodeBytesRef(nil)
 
-  # `codeAddress` is not BAL tracked here but in `gasCallDelegate`
-  # before check for balance. See the comment there.
-  # And delegateTo need tracking for a message call.
+  # `codeAddress` is BAL tracked in `initialAccessListEIP2929`
   var resolvedAddress = codeAddress
   if vmState.fork >= FkPrague:
     let

--- a/execution_chain/evm/types.nim
+++ b/execution_chain/evm/types.nim
@@ -82,6 +82,7 @@ type
     keepStack*:             bool
     finalStack*:            seq[UInt256]
     balTrackerEnabled*:     bool
+    delegateTo*:            Address
 
   StatusCode* {.pure.} = enum
     None

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -12,6 +12,7 @@ import
   eth/common/eth_types, stint,
   results,
   chronicles,
+  stew/assign2,
   ../evm/[types, state],
   ../evm/[message, precompiles, internals, interpreter_dispatch],
   ../db/ledger,
@@ -182,7 +183,7 @@ proc setupComputation(call: CallParams, gasRefund: int64, keepStack: bool): Comp
              msg.contractAddress = generateContractAddress(vmState, CallKind.Create, call.sender)
              CodeBytesRef.init(call.input)
            else:
-             msg.data = call.input
+             assign(msg.data, call.input)
              getCallCode(vmState, msg.codeAddress)
 
     computation = newComputation(vmState, keepStack, msg, code)

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -180,7 +180,7 @@ proc setupComputation(call: CallParams, gasRefund: int64, keepStack: bool): Comp
     )
 
     code = if call.isCreate:
-             msg.contractAddress = generateContractAddress(vmState, CallKind.Create, call.sender)
+             msg.contractAddress = generateContractAddress(vmState, call.sender)
              CodeBytesRef.init(call.input)
            else:
              assign(msg.data, call.input)
@@ -210,18 +210,15 @@ proc prepareToRunComputation(c: Computation, call: CallParams) =
     fork = vmState.fork
 
   vmState.mutateLedger:
-    let gasFee = call.gasLimit.u256 * call.gasPrice.u256
+    var gasFee = call.gasLimit.u256 * call.gasPrice.u256
+    # EIP-4844
+    if fork >= FkCancun:
+      gasFee += calcDataFee(call.versionedHashes.len,
+        vmState.blockCtx.excessBlobGas, vmState.com, fork)
+
     if vmState.balTrackerEnabled:
       vmState.balTracker.trackSubBalanceChange(call.sender, gasFee)
     ledger.subBalance(call.sender, gasFee)
-
-    # EIP-4844
-    if fork >= FkCancun:
-      let blobFee = calcDataFee(call.versionedHashes.len,
-        vmState.blockCtx.excessBlobGas, vmState.com, fork)
-      if vmState.balTrackerEnabled:
-        vmState.balTracker.trackSubBalanceChange(call.sender, blobFee)
-      ledger.subBalance(call.sender, blobFee)
 
 proc calculateAndPossiblyRefundGas(c: Computation, call: CallParams, gasRefund: int64): GasUsed =
   let

--- a/execution_chain/transaction/system_call.nim
+++ b/execution_chain/transaction/system_call.nim
@@ -10,7 +10,8 @@
 {.push raises: [].}
 
 import
-  ../evm/[types, state, computation, message, interpreter_dispatch],
+  ../evm/[types, state, computation, interpreter_dispatch],
+  ../db/ledger,
   ./call_types
 
 export
@@ -30,7 +31,7 @@ proc setupComputation(call: CallParams): Computation =
       value:           call.value,
       data:            call.input,
     )
-    code = getCallCode(vmState, msg.codeAddress)
+    code = vmState.ledger.getCode(msg.codeAddress)
     computation = newComputation(vmState, false, msg, code)
 
   vmState.txCtx = TxContext(

--- a/execution_chain/utils/debug_bal.nim
+++ b/execution_chain/utils/debug_bal.nim
@@ -8,6 +8,8 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   std/[json, strutils],
   stint,
@@ -25,7 +27,7 @@ proc `@@`(x: Address): JsonNode =
 proc `@@`(x: Bytes): JsonNode =
   %("0x" & x.toHex)
 
-proc `@@`(x: uint16 | uint64): JsonNode =
+proc `@@`(x: uint16 | uint32 | uint64): JsonNode =
   %("0x" & x.toHex)
 
 proc `@@`(x: UInt256): JsonNode =


### PR DESCRIPTION
- Low balance, both target and delegated target in BAL.
- Message call delegated, no more multiple parseDelegation, only one call.
- OOG Case, only `codeAddress` in BAL.

Tests for these cases are in tests-bal@v7.1.1.
But this commit can be safely extracted from bal-devnet-7 branch because it does not depends on EIP-8037.