### PR TITLE
fix network argument to be a string and not a list

### DIFF
--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -146,12 +146,11 @@ type
         "- mainnet/1       : Ethereum main network\n" &
         "- sepolia/11155111: Testnet for smart contract testing\n" &
         "- hoodi/560048    : Testnet for staking and hard forks\n" &
-        "- custom/path     : /path/to/genesis-or-network-configuration.json\n" &
-        "Both --network: name/path --network:id can be set at the same time to override network id number"
-      defaultValue: @[] # the default value is set in makeConfig
+        "- custom/path     : /path/to/genesis-or-network-configuration.json"
+      defaultValue: none(string) # the default value is set in makeConfig
       defaultValueDesc: "mainnet(1)"
       abbr: "i"
-      name: "network" .}: seq[string]
+      name: "network" .}: Option[string]
 
     customNetwork {.
       ignore
@@ -692,7 +691,7 @@ proc parseNetworkParams(network: string): (NetworkParams, bool) =
     (params, true)
 
 proc processNetworkParamsAndNetworkId(config: var ExecutionClientConf) =
-  if config.network.len == 0 and config.customNetwork.isNone:
+  if config.network.isNone and config.customNetwork.isNone:
     # Default value if none is set
     config.networkId = MainNet
     config.networkParams = networkParams(MainNet)
@@ -703,16 +702,11 @@ proc processNetworkParamsAndNetworkId(config: var ExecutionClientConf) =
     id: Opt[NetworkId]
     simulatedCustomNetwork = false
 
-  for network in config.network:
+  if config.network.isSome:
+    let network = config.network.get
     if decOrHex(network):
-      if id.isSome:
-        warn "Network ID already set, ignore new value", id=network
-        continue
       id = Opt.some parseNetworkId(network)
     else:
-      if params.isSome:
-        warn "Network configuration already set, ignore new value", network
-        continue
       let (parsedParams, custom) = parseNetworkParams(network)
       params = Opt.some parsedParams
       # Simulate --custom-network while it is still not disabled.

--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -860,6 +860,15 @@ func jwtSecretOpt*(config: ExecutionClientConf): Opt[InputFile] =
   else:
     Opt.none InputFile
 
+proc readValue*(r: var TomlReader, value: var seq[string]) {.raises: [IOError, SerializationError].} =
+  mixin readValue
+  case r.tokKind
+  of TomlTokKind.Array:
+    r.parseList():
+      value.add r.parseAsString()
+  else:
+    value.add r.parseAsString()
+
 {.pop.}
 
 #-------------------------------------------------------------------

--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -146,11 +146,12 @@ type
         "- mainnet/1       : Ethereum main network\n" &
         "- sepolia/11155111: Testnet for smart contract testing\n" &
         "- hoodi/560048    : Testnet for staking and hard forks\n" &
-        "- custom/path     : /path/to/genesis-or-network-configuration.json"
-      defaultValue: none(string) # the default value is set in makeConfig
+        "- custom/path     : /path/to/genesis-or-network-configuration.json\n" &
+        "Both --network: name/path --network:id can be set at the same time to override network id number"
+      defaultValue: @[] # the default value is set in makeConfig
       defaultValueDesc: "mainnet(1)"
       abbr: "i"
-      name: "network" .}: Option[string]
+      name: "network" .}: seq[string]
 
     customNetwork {.
       ignore
@@ -691,7 +692,7 @@ proc parseNetworkParams(network: string): (NetworkParams, bool) =
     (params, true)
 
 proc processNetworkParamsAndNetworkId(config: var ExecutionClientConf) =
-  if config.network.isNone and config.customNetwork.isNone:
+  if config.network.len == 0 and config.customNetwork.isNone:
     # Default value if none is set
     config.networkId = MainNet
     config.networkParams = networkParams(MainNet)
@@ -702,11 +703,16 @@ proc processNetworkParamsAndNetworkId(config: var ExecutionClientConf) =
     id: Opt[NetworkId]
     simulatedCustomNetwork = false
 
-  if config.network.isSome:
-    let network = config.network.get
+  for network in config.network:
     if decOrHex(network):
+      if id.isSome:
+        warn "Network ID already set, ignore new value", id=network
+        continue
       id = Opt.some parseNetworkId(network)
     else:
+      if params.isSome:
+        warn "Network configuration already set, ignore new value", network
+        continue
       let (parsedParams, custom) = parseNetworkParams(network)
       params = Opt.some parsedParams
       # Simulate --custom-network while it is still not disabled.

--- a/tests/config_file/network1.toml
+++ b/tests/config_file/network1.toml
@@ -1,0 +1,3 @@
+# Test dynamic parser with `tokKind` array mix
+
+network = ["hoodi", 777]

--- a/tests/config_file/network2.toml
+++ b/tests/config_file/network2.toml
@@ -1,0 +1,3 @@
+# Test dynamic parser with `tokKind` string
+
+network = "sepolia"

--- a/tests/config_file/network3.toml
+++ b/tests/config_file/network3.toml
@@ -1,0 +1,3 @@
+# Test dynamic parser with `tokKind`  number
+
+network = 666

--- a/tests/test_configuration.nim
+++ b/tests/test_configuration.nim
@@ -382,4 +382,15 @@ proc configurationMain*() =
       check config.allowedOrigins == ["*"]
       check config.jwtSecret.get.string == "basic_jwt_secret_file"
 
+    test "TOML --network":
+      privateAccess(ExecutionClientConf)
+      let c1 = makeConfig(@["--config-file:tests/config_file/network1.toml"])
+      check c1.network == @["hoodi", "777"]
+
+      let c2 = makeConfig(@["--config-file:tests/config_file/network2.toml"])
+      check c2.network == @["sepolia"]
+
+      let c3 = makeConfig(@["--config-file:tests/config_file/network3.toml"])
+      check c3.network == @["666"]
+
 configurationMain()


### PR DESCRIPTION
Tried using TOML config format and encountered this unexpected error:
```
Failed to load secondary sources: 'nimbus-execution-client.toml(17, 11) expected '"["''
```