### PR TITLE
Remove BPO forks from EVMFork

### DIFF
--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -306,6 +306,9 @@ func toHardFork*(com: CommonRef, timestamp: EthTime): HardFork =
     if com.forkTransitionTable.timeThresholds[fork].isSome and timestamp >= com.forkTransitionTable.timeThresholds[fork].get:
       return fork
 
+func toHardFork*(com: CommonRef, header: Header): HardFork =
+  com.toHardFork(forkDeterminationInfo(header))
+
 func toEVMFork*(com: CommonRef, timestamp: EthTime): EVMFork =
   ## similar to toHardFork, but produce EVMFork
   let fork = com.toHardFork(timestamp)
@@ -315,6 +318,9 @@ func toEVMFork*(com: CommonRef, forkDeterminer: ForkDeterminationInfo): EVMFork 
   ## similar to toFork, but produce EVMFork
   let fork = com.toHardFork(forkDeterminer)
   ToEVMFork[fork]
+
+func toEVMFork*(com: CommonRef, header: Header): EVMFork =
+  com.toEVMFork(forkDeterminationInfo(header))
 
 func nextFork*(com: CommonRef, currentFork: HardFork): Opt[HardFork] =
   ## Returns the next hard fork after the given one
@@ -336,9 +342,6 @@ func lastFork*(com: CommonRef, currentFork: HardFork): Opt[HardFork] =
 func activationTime*(com: CommonRef, fork: HardFork): Opt[EthTime] =
   ## Returns the activation time of the given hard fork
   com.forkTransitionTable.timeThresholds[fork]
-
-func toEVMFork*(com: CommonRef, header: Header): EVMFork =
-  com.toEVMFork(forkDeterminationInfo(header))
 
 func isSpuriousOrLater*(com: CommonRef, number: BlockNumber, time: EthTime): bool =
   com.toHardFork(forkDeterminationInfo(number, time)) >= Spurious

--- a/execution_chain/common/evmforks.nim
+++ b/execution_chain/common/evmforks.nim
@@ -25,11 +25,6 @@ type
     FkCancun
     FkPrague
     FkOsaka
-    FkBpo1
-    FkBpo2
-    FkBpo3
-    FkBpo4
-    FkBpo5
     FkAmsterdam
     FkBogota
 

--- a/execution_chain/common/hardforks.nim
+++ b/execution_chain/common/hardforks.nim
@@ -330,11 +330,11 @@ const
     FkCancun,         # Cancun
     FkPrague,         # Prague
     FkOsaka,          # Osaka
-    FkBpo1,           # Bpo1
-    FkBpo2,           # Bpo2
-    FkBpo3,           # Bpo3
-    FkBpo4,           # Bpo4
-    FkBpo5,           # Bpo5
+    FkOsaka,          # Bpo1
+    FkOsaka,          # Bpo2
+    FkOsaka,          # Bpo3
+    FkOsaka,          # Bpo4
+    FkOsaka,          # Bpo5
     FkAmsterdam,      # Amsterdam
     FkBogota,         # Bogota
   ]

--- a/execution_chain/core/eip4844.nim
+++ b/execution_chain/core/eip4844.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2025 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/execution_chain/core/eip4844.nim
+++ b/execution_chain/core/eip4844.nim
@@ -106,8 +106,8 @@ proc getTotalBlobGas*(versionedHashesLen: int): uint64 =
   GAS_PER_BLOB * versionedHashesLen.uint64
 
 # getBlobBaseFee implements get_data_gas_price from EIP-4844
-func getBlobBaseFee*(excessBlobGas: uint64, com: CommonRef, fork: EVMFork): UInt256 =
-  if fork >= FkCancun:
+func getBlobBaseFee*(excessBlobGas: uint64, com: CommonRef, fork: HardFork): UInt256 =
+  if fork >= Cancun:
     let blobBaseFeeUpdateFraction = com.getBlobBaseFeeUpdateFraction(fork).u256
     fakeExponential(
       MIN_BLOB_GASPRICE.u256,
@@ -119,7 +119,7 @@ func getBlobBaseFee*(excessBlobGas: uint64, com: CommonRef, fork: EVMFork): UInt
 
 proc calcDataFee*(versionedHashesLen: int,
                   excessBlobGas: uint64,
-                  com: CommonRef, fork: EVMFork): UInt256 =
+                  com: CommonRef, fork: HardFork): UInt256 =
   getTotalBlobGas(versionedHashesLen).u256 *
     getBlobBaseFee(excessBlobGas, com, fork)
 
@@ -128,7 +128,7 @@ func blobGasUsed(txs: openArray[Transaction]): uint64 =
     result += tx.getTotalBlobGas
 
 # calcExcessBlobGas implements calc_excess_data_gas from EIP-4844
-proc calcExcessBlobGas*(com: CommonRef, parent: Header, fork: EVMFork): uint64 =
+proc calcExcessBlobGas*(com: CommonRef, parent: Header, fork: HardFork): uint64 =
   let
     excessBlobGas = parent.excessBlobGas.get(0'u64)
     blobGasUsed = parent.blobGasUsed.get(0'u64)
@@ -139,7 +139,7 @@ proc calcExcessBlobGas*(com: CommonRef, parent: Header, fork: EVMFork): uint64 =
     return 0'u64
 
   # https://eips.ethereum.org/EIPS/eip-7918
-  if fork >= FkOsaka and (BLOB_BASE_COST.u256 * parent.baseFeePerGas.get(0.u256)) > GAS_PER_BLOB.u256 * getBlobBaseFee(excessBlobGas, com, fork):
+  if fork >= Osaka and (BLOB_BASE_COST.u256 * parent.baseFeePerGas.get(0.u256)) > GAS_PER_BLOB.u256 * getBlobBaseFee(excessBlobGas, com, fork):
     return excessBlobGas + blobGasUsed * (maxBlobsPerBlock - targetBlobsPerBlock) div maxBlobsPerBlock
 
   return excessBlobGas + blobGasUsed - targetBlobGasPerBlock
@@ -165,7 +165,7 @@ func validateEip4844Header*(
     return err("expect EIP-4844 excessBlobGas in block header")
 
   let
-    fork = com.toEVMFork(header)
+    fork = com.toHardFork(header)
     headerBlobGasUsed = header.blobGasUsed.get()
     blobGasUsed = blobGasUsed(txs)
     headerExcessBlobGas = header.excessBlobGas.get

--- a/execution_chain/core/eip7691.nim
+++ b/execution_chain/core/eip7691.nim
@@ -13,37 +13,22 @@
 import
   ../constants,
   ../common/hardforks,
-  ../common/evmforks,
   ../common/common
 
-const
-  EVMForkToFork: array[FkCancun..FkLatest, HardFork] = [
-    Cancun,
-    Prague,
-    Osaka,
-    Bpo1,
-    Bpo2,
-    Bpo3,
-    Bpo4,
-    Bpo5,
-    Amsterdam,
-    Bogota
-  ]
-
-func getMaxBlobsPerBlock*(com: CommonRef, fork: EVMFork): uint64 =
-  if fork < FkCancun:
+func getMaxBlobsPerBlock*(com: CommonRef, fork: HardFork): uint64 =
+  if fork < Cancun:
     return 0
-  com.maxBlobsPerBlock(EVMForkToFork[fork])
+  com.maxBlobsPerBlock(fork)
 
-func getTargetBlobsPerBlock*(com: CommonRef, fork: EVMFork): uint64 =
-  if fork < FkCancun:
+func getTargetBlobsPerBlock*(com: CommonRef, fork: HardFork): uint64 =
+  if fork < Cancun:
     return 0
-  com.targetBlobsPerBlock(EVMForkToFork[fork])
+  com.targetBlobsPerBlock(fork)
 
-func getBlobBaseFeeUpdateFraction*(com: CommonRef, fork: EVMFork): uint64 =
-  if fork < FkCancun:
+func getBlobBaseFeeUpdateFraction*(com: CommonRef, fork: HardFork): uint64 =
+  if fork < Cancun:
     return 0
-  com.baseFeeUpdateFraction(EVMForkToFork[fork])
+  com.baseFeeUpdateFraction(fork)
 
-func getMaxBlobGasPerBlock*(com: CommonRef, fork: EVMFork): uint64 =
+func getMaxBlobGasPerBlock*(com: CommonRef, fork: HardFork): uint64 =
   com.getMaxBlobsPerBlock(fork) * GAS_PER_BLOB

--- a/execution_chain/core/executor/calculate_reward.nim
+++ b/execution_chain/core/executor/calculate_reward.nim
@@ -47,11 +47,6 @@ const
     eth0, # Cancun
     eth0, # Prague
     eth0, # Osaka
-    eth0, # Bpo1
-    eth0, # Bpo2
-    eth0, # Bpo3
-    eth0, # Bpo4
-    eth0, # Bpo5
     eth0, # Amsterdam
     eth0, # Bogota
   ]

--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -103,8 +103,7 @@ proc processTransaction*(
 
   let
     com = vmState.com
-    fork = vmState.fork
-    hardFork = vmState.hardFork
+    fork = vmState.hardFork
     regularGasAvailable = vmState.blockCtx.gasLimit - vmState.blockRegularGasUsed
     intrinsic = tx.intrinsicGas(fork, vmState.blockCtx.gasLimit)
 
@@ -118,12 +117,12 @@ proc processTransaction*(
   # blobGasUsed will be added to vmState.blobGasUsed if the tx is ok.
   let
     blobGasUsed = tx.getTotalBlobGas
-    maxBlobGasPerBlock = getMaxBlobGasPerBlock(com, hardFork)
+    maxBlobGasPerBlock = getMaxBlobGasPerBlock(com, fork)
   if vmState.blobGasUsed + blobGasUsed > maxBlobGasPerBlock:
     return err("blobGasUsed " & $blobGasUsed &
       " exceeds maximum allowance " & $maxBlobGasPerBlock)
 
-  ? validateTxBasic(com, tx, intrinsic, hardFork)
+  ? validateTxBasic(com, tx, intrinsic, fork)
 
   vmState.validateTransaction(tx, sender).isOkOr:
     return err(error)
@@ -146,7 +145,7 @@ proc processTransaction*(
     else:
       ok(move(callResult))
 
-  vmState.ledger.persist(clearEmptyAccount = fork >= FkSpurious)
+  vmState.ledger.persist(clearEmptyAccount = fork >= Spurious)
 
   res
 

--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -104,6 +104,7 @@ proc processTransaction*(
   let
     com = vmState.com
     fork = vmState.fork
+    hardFork = vmState.hardFork
     regularGasAvailable = vmState.blockCtx.gasLimit - vmState.blockRegularGasUsed
     intrinsic = tx.intrinsicGas(fork, vmState.blockCtx.gasLimit)
 
@@ -117,12 +118,12 @@ proc processTransaction*(
   # blobGasUsed will be added to vmState.blobGasUsed if the tx is ok.
   let
     blobGasUsed = tx.getTotalBlobGas
-    maxBlobGasPerBlock = getMaxBlobGasPerBlock(com, fork)
+    maxBlobGasPerBlock = getMaxBlobGasPerBlock(com, hardFork)
   if vmState.blobGasUsed + blobGasUsed > maxBlobGasPerBlock:
     return err("blobGasUsed " & $blobGasUsed &
       " exceeds maximum allowance " & $maxBlobGasPerBlock)
 
-  ? validateTxBasic(com, tx, intrinsic, fork)
+  ? validateTxBasic(com, tx, intrinsic, hardFork)
 
   vmState.validateTransaction(tx, sender).isOkOr:
     return err(error)

--- a/execution_chain/core/tx_pool/tx_desc.nim
+++ b/execution_chain/core/tx_pool/tx_desc.nim
@@ -91,7 +91,7 @@ proc setupVMState(com: CommonRef;
                   pos: PosPayloadAttr,
                   parentFrame: CoreDbTxRef): BaseVMState =
   let
-    fork = com.toEVMFork(pos.timestamp)
+    fork = com.toHardFork(pos.timestamp)
     gasLimit = getGasLimit(com, parent)
 
   BaseVMState.new(
@@ -189,7 +189,7 @@ proc classifyValid(xp: TxPoolRef; tx: Transaction, sender: Address): bool =
   if tx.txType == TxEip4844:
     let
       excessBlobGas = xp.excessBlobGas
-      blobGasPrice = getBlobBaseFee(excessBlobGas, xp.vmState.com, xp.vmState.fork)
+      blobGasPrice = getBlobBaseFee(excessBlobGas, xp.vmState.com, xp.vmState.hardFork)
     if tx.maxFeePerBlobGas < blobGasPrice:
       debug "Invalid transaction: maxFeePerBlobGas lower than blobGasPrice",
         maxFeePerBlobGas = tx.maxFeePerBlobGas,
@@ -282,6 +282,9 @@ func vmState*(xp: TxPoolRef): BaseVMState =
 func nextFork*(xp: TxPoolRef): EVMFork =
   xp.vmState.fork
 
+func hardFork*(xp: TxPoolRef): HardFork =
+  xp.vmState.hardFork
+
 template chain*(xp: TxPoolRef): ForkedChainRef =
   xp.chain
 
@@ -370,7 +373,7 @@ proc addTx*(xp: TxPoolRef, ptx: PooledTransaction): Result[void, TxError] =
     xp.com,
     ptx.tx,
     intrinsic,
-    xp.nextFork,
+    xp.hardFork,
     validateFork = true).isOkOr:
     debug "Invalid transaction: Basic validation failed",
       txHash = id,

--- a/execution_chain/core/tx_pool/tx_desc.nim
+++ b/execution_chain/core/tx_pool/tx_desc.nim
@@ -367,7 +367,7 @@ proc addTx*(xp: TxPoolRef, ptx: PooledTransaction): Result[void, TxError] =
     return err(txErrorAlreadyKnown)
 
   let
-    intrinsic = ptx.tx.intrinsicGas(xp.nextFork, xp.gasLimit)
+    intrinsic = ptx.tx.intrinsicGas(xp.hardFork, xp.gasLimit)
 
   validateTxBasic(
     xp.com,

--- a/execution_chain/core/tx_pool/tx_packer.nim
+++ b/execution_chain/core/tx_pool/tx_packer.nim
@@ -122,7 +122,7 @@ proc vmExecGrabItem(pst: var TxPacker; item: TxItemRef, xp: TxPoolRef): bool =
 
     let
       maxBlobs = vmState.com.maxBlobs
-      maxForkBlobsPerBlock = getMaxBlobsPerBlock(vmState.com, vmState.fork)
+      maxForkBlobsPerBlock = getMaxBlobsPerBlock(vmState.com, vmState.hardFork)
       maxBlobsPerBlock =
         if maxBlobs.isSome:
           # https://eips.ethereum.org/EIPS/eip-7872#specification

--- a/execution_chain/core/validate.nim
+++ b/execution_chain/core/validate.nim
@@ -199,7 +199,7 @@ proc validateUncles(com: CommonRef; header: Header; txFrame: CoreDbTxRef,
 # Public function, extracted from executor
 # ------------------------------------------------------------------------------
 
-func validateLegacySignatureForm(tx: Transaction, fork: EVMFork): bool =
+func validateLegacySignatureForm(tx: Transaction, fork: HardFork): bool =
   var
     vMin = 27'u64
     vMax = 28'u64
@@ -216,7 +216,7 @@ func validateLegacySignatureForm(tx: Transaction, fork: EVMFork): bool =
   isValid = isValid and tx.S < SECPK1_N
   isValid = isValid and tx.R < SECPK1_N
 
-  if fork >= FkHomestead:
+  if fork >= Homestead:
     isValid = isValid and tx.S < SECPK1_N div 2
 
   isValid
@@ -240,24 +240,24 @@ func validateTxBasic*(
     com:      CommonRef,
     tx:       Transaction;     ## tx to validate
     intrinsic:IntrinsicGas;
-    fork:     EVMFork,
+    fork:     HardFork,
     validateFork: bool = true): Result[void, string] =
 
   if validateFork:
-    if tx.txType == TxEip2930 and fork < FkBerlin:
+    if tx.txType == TxEip2930 and fork < Berlin:
       return err("invalid tx: EIP-2930 Tx type detected before Berlin")
 
-    if tx.txType == TxEip1559 and fork < FkLondon:
+    if tx.txType == TxEip1559 and fork < London:
       return err("invalid tx: EIP-1559 Tx type detected before London")
 
-    if tx.txType == TxEip4844 and fork < FkCancun:
+    if tx.txType == TxEip4844 and fork < Cancun:
       return err("invalid tx: EIP-4844 Tx type detected before Cancun")
 
-    if tx.txType == TxEip7702 and fork < FkPrague:
+    if tx.txType == TxEip7702 and fork < Prague:
       return err("invalid tx: EIP-7702 Tx type detected before Prague")
 
-  if fork >= FkShanghai and tx.contractCreation:
-    if fork >= FkAmsterdam:
+  if fork >= Shanghai and tx.contractCreation:
+    if fork >= Amsterdam:
       if tx.payload.len > EIP7954_MAX_INITCODE_SIZE:
         return err("invalid tx: initcode size exceeds EIP-7954 maximum")
     elif tx.payload.len > EIP3860_MAX_INITCODE_SIZE:
@@ -267,7 +267,7 @@ func validateTxBasic*(
   if tx.maxFeePerGasNorm < tx.maxPriorityFeePerGasNorm:
     return err(&"invalid tx: maxFee is smaller than maxPriorityFee. maxFee={tx.maxFeePerGas}, maxPriorityFee={tx.maxPriorityFeePerGasNorm}")
 
-  if fork >= FkAmsterdam:
+  if fork >= Amsterdam:
     let
       intrinsicGas = intrinsic.regular + intrinsic.state
       minGasLimit = max(intrinsicGas, intrinsic.floorDataGas)
@@ -280,7 +280,7 @@ func validateTxBasic*(
       return err(&"invalid tx: Intrinsic regular or calldata floor exceeds TX_GAS_LIMIT={TX_GAS_LIMIT}, require={minRegularGasLimit}")
   else:
     # https://eips.ethereum.org/EIPS/eip-7825
-    if fork >= FkOsaka and tx.gasLimit > TX_GAS_LIMIT:
+    if fork >= Osaka and tx.gasLimit > TX_GAS_LIMIT:
       return err("tx.gasLimit " & $tx.gasLimit & " exceeds maximum " & $TX_GAS_LIMIT)
 
     let
@@ -289,7 +289,7 @@ func validateTxBasic*(
     if tx.gasLimit < minGasLimit:
       return err(&"invalid tx: not enough gas to perform calculation. avail={tx.gasLimit}, require={minGasLimit}")
 
-  if fork >= FkCancun:
+  if fork >= Cancun:
     if tx.payload.len > MAX_CALLDATA_SIZE:
       return err(&"invalid tx: payload len exceeds MAX_CALLDATA_SIZE. len={tx.payload.len}")
 
@@ -320,7 +320,7 @@ func validateTxBasic*(
     # After Osaka the blob counts per block is increased with BPO, but
     # the blobs per transaction is capped at MAX_BLOBS_PER_TX=6.
     let maxBlobsPerTx =
-      if fork >= FkOsaka:
+      if fork >= Osaka:
         MAX_BLOBS_PER_TX
       else:
         getMaxBlobsPerBlock(com, fork)
@@ -405,7 +405,7 @@ proc validateTransaction*(
     # ensure that the user was willing to at least pay the current data gasprice
     let
       excessBlobGas = vmState.blockCtx.excessBlobGas
-      blobGasPrice = getBlobBaseFee(excessBlobGas, vmState.com, vmState.fork)
+      blobGasPrice = getBlobBaseFee(excessBlobGas, vmState.com, vmState.hardFork)
     if tx.maxFeePerBlobGas < blobGasPrice:
       return err("invalid tx: maxFeePerBlobGas smaller than blobGasPrice. " &
         &"maxFeePerBlobGas={tx.maxFeePerBlobGas}, blobGasPrice={blobGasPrice}")

--- a/execution_chain/evm/interpreter/gas_costs.nim
+++ b/execution_chain/evm/interpreter/gas_costs.nim
@@ -815,11 +815,6 @@ const
     FkCancun: ShanghaiGasFees,
     FkPrague: ShanghaiGasFees,
     FkOsaka: ShanghaiGasFees,
-    FkBpo1: ShanghaiGasFees,
-    FkBpo2: ShanghaiGasFees,
-    FkBpo3: ShanghaiGasFees,
-    FkBpo4: ShanghaiGasFees,
-    FkBpo5: ShanghaiGasFees,
     FkAmsterdam: AmsterdamGasFees,
     FkBogota: AmsterdamGasFees,
   ]

--- a/execution_chain/evm/state.nim
+++ b/execution_chain/evm/state.nim
@@ -14,7 +14,7 @@ import
   std/[options, sets, strformat],
   stew/assign2,
   ../db/ledger,
-  ../common/[common, evmforks],
+  ../common/common,
   ../block_access_list/block_access_list_tracker,
   ../core/eip8037,
   ./interpreter/[op_codes, gas_costs],
@@ -24,8 +24,8 @@ import
 func forkDeterminationInfoForVMState(vmState: BaseVMState): ForkDeterminationInfo =
   forkDeterminationInfo(vmState.parent.number + 1, vmState.blockCtx.timestamp)
 
-func determineFork(vmState: BaseVMState): EVMFork =
-  vmState.com.toEVMFork(vmState.forkDeterminationInfoForVMState)
+func determineFork(vmState: BaseVMState): HardFork =
+  vmState.com.toHardFork(vmState.forkDeterminationInfoForVMState)
 
 proc init(
       self:         BaseVMState;
@@ -45,7 +45,8 @@ proc init(
   const txCtx = default(TxContext)
   assign(self.txCtx, txCtx)
   self.flags = flags
-  self.fork = self.determineFork
+  self.hardFork = self.determineFork
+  self.fork = ToEVMFork[self.hardFork]
   self.tracer = tracer
   self.receipts.setLen(0)
   self.cumulativeGasUsed = 0

--- a/execution_chain/evm/types.nim
+++ b/execution_chain/evm/types.nim
@@ -18,6 +18,8 @@ import
   ../common/[common, evmforks],
   ../block_access_list/block_access_list_tracker
 
+from ../common/hardforks import HardFork
+
 export stack, memory, transient_storage, block_access_list_tracker
 
 type
@@ -50,6 +52,7 @@ type
     txCtx*            : TxContext
     flags*            : set[VMFlag]
     fork*             : EVMFork
+    hardFork*         : HardFork
     tracer*           : TracerRef
     receipts*         : seq[StoredReceipt]
     cumulativeGasUsed*: GasInt

--- a/execution_chain/rpc/oracle.nim
+++ b/execution_chain/rpc/oracle.nim
@@ -97,7 +97,7 @@ func calcBaseFee(com: CommonRef, bc: BlockContent): UInt256 =
 proc processBlock(oracle: Oracle, bc: BlockContent, percentiles: openArray[float64]): ProcessedFees =
   let
     com = oracle.com
-    fork = com.toEVMFork(bc.header)
+    fork = com.toHardFork(bc.header)
     maxBlobGasPerBlock = getMaxBlobGasPerBlock(com, fork)
   result = ProcessedFees(
     baseFee: bc.header.baseFeePerGas.get(0.u256),

--- a/execution_chain/rpc/params.nim
+++ b/execution_chain/rpc/params.nim
@@ -94,8 +94,8 @@ proc toCallParams*(vmState: BaseVMState,
     versionedHashes: args.versionedHashes,
     authorizationList: args.authorizationList.get(@[]),
   )
-  
-  res.intrinsic = res.intrinsicGas(vmState.fork, header.gasLimit)
+
+  res.intrinsic = res.intrinsicGas(vmState.hardFork, header.gasLimit)
   ok(move(res))
 
 {.pop.}

--- a/execution_chain/rpc/rpc_utils.nim
+++ b/execution_chain/rpc/rpc_utils.nim
@@ -261,7 +261,7 @@ proc populateReceipt*(rec: StoredReceipt, gasUsed: GasInt, tx: Transaction,
 
   if tx.txType == TxEip4844:
     res.blobGasUsed = Opt.some(Quantity(tx.versionedHashes.len.uint64 * GAS_PER_BLOB.uint64))
-    res.blobGasPrice = Opt.some(getBlobBaseFee(header.excessBlobGas.get(0'u64), com, com.toEVMFork(header)))
+    res.blobGasPrice = Opt.some(getBlobBaseFee(header.excessBlobGas.get(0'u64), com, com.toHardFork(header)))
 
   return res
 

--- a/execution_chain/rpc/server_api.nim
+++ b/execution_chain/rpc/server_api.nim
@@ -706,7 +706,7 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
       if header.excessBlobGas.isNone:
         raise newException(ValueError, "excessBlobGas missing from latest header")
       let blobBaseFee =
-        getBlobBaseFee(header.excessBlobGas.get, api.com, api.com.toEVMFork(header))
+        getBlobBaseFee(header.excessBlobGas.get, api.com, api.com.toHardFork(header))
       if blobBaseFee > high(uint64).u256:
         raise newException(ValueError, "blobBaseFee is bigger than uint64.max")
       return w3Qty blobBaseFee.truncate(uint64)

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -131,7 +131,7 @@ proc preExecComputation(call: CallParams): int64 =
 proc setupComputation(call: CallParams, gasRefund: int64, keepStack: bool): Computation =
   let
     vmState = call.vmState
-    fork = vmState.fork
+    fork = vmState.hardFork
   vmState.txCtx = TxContext(
     origin         : call.sender,
     gasPrice       : call.gasPrice,
@@ -144,7 +144,7 @@ proc setupComputation(call: CallParams, gasRefund: int64, keepStack: bool): Comp
   vmState.gasRefunded = 0
 
   let
-    isAmsterdamOrLater = fork >= FkAmsterdam
+    isAmsterdamOrLater = fork >= Amsterdam
     intrinsicGas = call.intrinsic.regular + call.intrinsic.state
 
     # Prevent underflow which can occur when gasLimit is less than intrinsicGas.
@@ -206,7 +206,7 @@ proc prepareToRunComputation(c: Computation, call: CallParams) =
   # Charge for gas.
   let
     vmState = c.vmState
-    fork = vmState.fork
+    fork = vmState.hardFork
 
   vmState.mutateLedger:
     let gasFee = call.gasLimit.u256 * call.gasPrice.u256
@@ -215,7 +215,7 @@ proc prepareToRunComputation(c: Computation, call: CallParams) =
     ledger.subBalance(call.sender, gasFee)
 
     # EIP-4844
-    if fork >= FkCancun:
+    if fork >= Cancun:
       let blobFee = calcDataFee(call.versionedHashes.len,
         vmState.blockCtx.excessBlobGas, vmState.com, fork)
       if vmState.balTrackerEnabled:

--- a/execution_chain/transaction/call_evm_rpc.nim
+++ b/execution_chain/transaction/call_evm_rpc.nim
@@ -112,7 +112,7 @@ proc rpcEstimateGas*(
     hi = gasCap
 
   let
-    intrinsic = intrinsicGas(params, fork, vmState.blockCtx.gasLimit)
+    intrinsic = intrinsicGas(params, vmState.hardFork, vmState.blockCtx.gasLimit)
     minGasLimit = max(intrinsic.regular, intrinsic.floorDataGas)
 
   # Create a helper to check if a gas allowance results in an executable transaction

--- a/execution_chain/transaction/call_types.nim
+++ b/execution_chain/transaction/call_types.nim
@@ -14,7 +14,7 @@ import
   eth/common/transactions,
   eth/common/addresses,
   eth/common/receipts,
-  ../common/evmforks,
+  ../common/hardforks,
   ../evm/types,
   ../evm/internals,
   ../core/[eip7702, eip8037]
@@ -76,12 +76,13 @@ func isError*(cr: CallResult): bool =
 const
   TOTAL_COST_FLOOR_PER_TOKEN = 10
 
-func intrinsicGas*(call: CallParams | Transaction, fork: EVMFork, gasLimit: GasInt): IntrinsicGas =
+func intrinsicGas*(call: CallParams | Transaction, hardFork: HardFork, gasLimit: GasInt): IntrinsicGas =
   # Compute the baseline gas cost for this transaction.  This is the amount
   # of gas needed to send this transaction (but that is not actually used
   # for computation).
   let
     costPerStateByte = stateGasPerByte(gasLimit)
+    fork = ToEVMFork[hardFork]
 
   var
     regularGas = TX_BASE_COST
@@ -91,11 +92,11 @@ func intrinsicGas*(call: CallParams | Transaction, fork: EVMFork, gasLimit: GasI
 
   # EIP-2 (Homestead) extra intrinsic gas for contract creations.
   if call.isCreate:
-    if fork >= FkAmsterdam:
+    if hardFork >= Amsterdam:
       stateGas += STATE_BYTES_PER_NEW_ACCOUNT * costPerStateByte
 
     regularGas += gasFees[fork][GasTXCreate]
-    if fork >= FkShanghai:
+    if hardFork >= Shanghai:
       regularGas += (gasFees[fork][GasInitcodeWord] * call.input.len.wordCount)
 
   # Input data cost, reduced in EIP-2028 (Istanbul).
@@ -111,13 +112,13 @@ func intrinsicGas*(call: CallParams | Transaction, fork: EVMFork, gasLimit: GasI
 
 
   # EIP-2930 (Berlin) intrinsic gas for transaction access list.
-  if fork >= FkBerlin:
+  if hardFork >= Berlin:
     for account in call.accessList:
       regularGas += ACCESS_LIST_ADDRESS_COST
       regularGas += account.storageKeys.len * ACCESS_LIST_STORAGE_KEY_COST
 
-  if fork >= FkPrague:
-    if fork >= FkAmsterdam:
+  if hardFork >= Prague:
+    if hardFork >= Amsterdam:
       regularGas += REGULAR_PER_AUTH_BASE_COST * call.authorizationList.len
       stateGas += (STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) * costPerStateByte * GasInt(call.authorizationList.len)
     else:

--- a/nimbus_verified_proxy/engine/rpc_frontend.nim
+++ b/nimbus_verified_proxy/engine/rpc_frontend.nim
@@ -505,7 +505,7 @@ proc getExecutionApiFrontend*(engine: RpcVerificationEngine): ExecutionApiFronte
         (UnavailableDataError, "excessBlobGas missing from latest header", UNTAGGED)
       )
     let blobBaseFee =
-      getBlobBaseFee(header.excessBlobGas.get, com, com.toEVMFork(header)) *
+      getBlobBaseFee(header.excessBlobGas.get, com, com.toHardFork(header)) *
       header.blobGasUsed.get.u256
 
     ok(blobBaseFee)

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -37,11 +37,6 @@ const
     "Cancun",               # FkCancun
     "Prague",               # FkPrague
     "Osaka",                # FkOsaka
-    "Bpo1",                 # FkBpo1
-    "Bpo2",                 # FkBpo2
-    "Bpo3",                 # FkBpo3
-    "Bpo4",                 # FkBpo4
-    "Bpo5",                 # FkBpo5
     "Amsterdam",            # FkAmsterdam
     "Bogota",               # FkBogota
   ]

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -15,33 +15,26 @@ import
   ../execution_chain/networking/[netkeys, p2p],
   ./eest/path_handler
 
-func revTable(list: array[FkFrontier..FkLatest, string]): Table[string, EVMFork] =
-  for k, v in list:
-    result[v] = k
-
 const
-  # from https://ethereum-tests.readthedocs.io/en/latest/test_types/state_tests.html
-  ForkToName: array[FkFrontier..FkLatest, string] = [
-    "Frontier",             # FkFrontier
-    "Homestead",            # FkHomestead
-    "EIP150",               # FkTangerine
-    "EIP158",               # FkSpurious
-    "Byzantium",            # FkByzantium
-    "Constantinople",       # FkConstantinople
-    "ConstantinopleFix",    # FkPetersburg
-    "Istanbul",             # FkIstanbul
-    "Berlin",               # FkBerlin
-    "London",               # FkLondon
-    "Merge",                # FkParis
-    "Shanghai",             # FkShanghai
-    "Cancun",               # FkCancun
-    "Prague",               # FkPrague
-    "Osaka",                # FkOsaka
-    "Amsterdam",            # FkAmsterdam
-    "Bogota",               # FkBogota
-  ]
-
-  nameToFork* = ForkToName.revTable
+  nameToFork* = {
+    "Frontier"         : Frontier,
+    "Homestead"        : Homestead,
+    "EIP150"           : Tangerine,
+    "EIP158"           : Spurious,
+    "Byzantium"        : Byzantium,
+    "Constantinople"   : Constantinople,
+    "ConstantinopleFix": Petersburg,
+    "Istanbul"         : Istanbul,
+    "Berlin"           : Berlin,
+    "London"           : London,
+    "Merge"            : MergeFork,
+    "Shanghai"         : Shanghai,
+    "Cancun"           : Cancun,
+    "Prague"           : Prague,
+    "Osaka"            : Osaka,
+    "Amsterdam"        : Amsterdam,
+    "Bogota"           : Bogota,
+  }.toTable
 
 func skipNothing*(folder: string, name: string): bool = false
 

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -352,7 +352,7 @@ proc exec(ctx: TransContext,
   if ctx.env.currentExcessBlobGas.isSome:
     excessBlobGas = ctx.env.currentExcessBlobGas
   elif ctx.env.parentExcessBlobGas.isSome and ctx.env.parentBlobGasUsed.isSome:
-    excessBlobGas = Opt.some calcExcessBlobGas(vmState.com, vmState.parent, vmState.fork)
+    excessBlobGas = Opt.some calcExcessBlobGas(vmState.com, vmState.parent, vmState.hardFork)
 
   if excessBlobGas.isSome:
     result.result.blobGasUsed = Opt.some vmState.blobGasUsed
@@ -537,7 +537,7 @@ proc transitionAction*(ctx: var TransContext, conf: T8NConf) =
       # If it is not explicitly defined, but we have the parent values, we try
       # to calculate it ourselves.
       if parent.excessBlobGas.isSome and parent.blobGasUsed.isSome:
-        ctx.env.currentExcessBlobGas = Opt.some com.calcExcessBlobGas(parent, com.toEVMFork(ctx.env.currentTimestamp))
+        ctx.env.currentExcessBlobGas = Opt.some com.calcExcessBlobGas(parent, com.toHardFork(ctx.env.currentTimestamp))
 
     let header  = envToHeader(ctx.env)
 

--- a/tools/txparse/txparse.nim
+++ b/tools/txparse/txparse.nim
@@ -17,7 +17,7 @@ import
   ../../execution_chain/transaction,
   ../../execution_chain/transaction/call_types,
   ../../execution_chain/core/validate,
-  ../../execution_chain/common/evmforks,
+  ../../execution_chain/common/hardforks,
   ../../execution_chain/common/common
 
 proc parseTx(com: CommonRef, hexLine: string) =
@@ -26,7 +26,7 @@ proc parseTx(com: CommonRef, hexLine: string) =
       bytes = hexToSeqByte(hexLine)
       tx = decodeTx(bytes)
       address = tx.recoverSender().expect("valid signature")
-      fork = FkPrague
+      fork = HardFork.Prague
       intrinsic = tx.intrinsicGas(fork, 10_000_000)
 
     validateTxBasic(com, tx, intrinsic, fork).isOkOr:


### PR DESCRIPTION
BPO forks are not used internally by EVM interpreter. They are pretty much similar to glacier forks.
If they stay in the EVMFork, it will bloat the VM interpreter dispatch generator with no benefits.

This PR removes those BPO forks from EVMFork but still allow both current correct evmFork and hardFork accessible by those who need them.