### PR TITLE
Enable parallel state root computation by default

### DIFF
--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -354,7 +354,7 @@ type
 
     parallelStateRootComputation* {.
       hidden
-      defaultValue: false
+      defaultValue: true
       desc: "Compute state root in parallel using multiple threads"
       name: "debug-parallel-state-root".}: bool
 

--- a/tests/test_configuration.nim
+++ b/tests/test_configuration.nim
@@ -360,8 +360,8 @@ proc configurationMain*() =
       check config.rdbBranchCacheSize == 39
       check config.rdbPrintStats == true
       check config.rewriteDatadirId == true
-      check config.eagerStateRootCheck ==  false
-      check config.parallelStateRootComputation ==  false
+      check config.eagerStateRootCheck == false
+      check config.parallelStateRootComputation == true
       check config.statelessProviderEnabled == true
       check config.statelessWitnessValidation == true
 


### PR DESCRIPTION
I've been testing the parallel state root computation for a while now and it has been running well so far. Perhaps now is a good time to enable it by default.

It can cause an increase in memory usage in some scenarios and in the worst case goes from around 16G when the caches are full to around 24G.

The speed up is somewhere between 2-4x when using 16 cores/threads. For the large stateroot computation on startup the speed up is around 2x because writing to the database is the bottleneck in that case but when most keys are in memory we can get 3-4x speedup.
