### PR TITLE
inline for perf improvement in push

### DIFF
--- a/execution_chain/evm/stack.nim
+++ b/execution_chain/evm/stack.nim
@@ -118,7 +118,8 @@ func popAux(stack: EvmStack, T: type): EvmResult[T] =
 # ------------------------------------------------------------------------------
 
 func push*(stack: EvmStack,
-           value: EvmStackElement | EvmStackInts | UInt256 | Address | Hash32): EvmResultVoid =
+           value: EvmStackElement | EvmStackInts | UInt256 | Address | Hash32): 
+          EvmResultVoid {.inline.} =
   let len = stack.len
   if len > 1023:
     return err(stackErr(StackFull))

--- a/tests/bench_evm_push.nim
+++ b/tests/bench_evm_push.nim
@@ -1,0 +1,123 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+## EVM PUSH hot-path microbenchmark.
+##
+## Isolates the impact of `{.inline.}` on `stack.push`. The "before" row routes
+## every push through a {.noinline.} wrapper to force a real call frame at the
+## push site (mimicking the pre-change codegen, where `push_s256` showed up as
+## its own VTune symbol). The "after" row calls `stack.push` directly, letting
+## the {.inline.} hint propagate.
+##
+## Build & run:
+##   ./env.sh nim c -d:release -r -o:build/bench_evm_push tests/bench_evm_push.nim
+
+{.used.}
+
+import
+  std/[monotimes, strformat, strutils, times],
+  stint,
+  ../execution_chain/evm/[stack, code_stream, code_bytes, evm_errors]
+
+const
+  pushesPerBatch = 1000          # < 1024 EVM stack limit
+  batches = 10_000
+  totalPushes = pushesPerBatch * batches
+
+proc reportTiming(label: string; ops: int; ns: float): float =
+  let nsPerOp = ns / ops.float
+  let mops = ops.float / (ns / 1e9) / 1e6
+  echo &"{label:<46} {nsPerOp:>8.2f} ns/op   {mops:>8.2f} Mops/s"
+  nsPerOp
+
+# {.noinline.} forces the C compiler to keep this as a real call site even
+# though `stack.push` itself is `{.inline.}`. That gives us a faithful proxy
+# for the pre-change behavior, where `push` had no inline hint and showed
+# up as its own symbol in profiles.
+proc pushBoxed(stack: EvmStack, v: UInt256): EvmResultVoid {.noinline.} =
+  stack.push(v)
+
+proc makeImmBytes(nBytes: int): seq[byte] =
+  result = newSeq[byte](nBytes)
+  for i in 0 ..< nBytes:
+    result[i] = byte((i * 31 + 7) and 0xff)
+
+proc benchBefore(n: static int): float {.noinline.} =
+  ## Before {.inline.}: every push goes through a real call frame.
+  let codeBytes = makeImmBytes(n * pushesPerBatch + 32)
+  var c = CodeStream.init(CodeBytesRef.init(codeBytes))
+  let stack = EvmStack.init()
+  defer: stack.dispose()
+
+  # Warm up so the first batch doesn't get charged for page faults.
+  for _ in 0 ..< pushesPerBatch:
+    doAssert pushBoxed(stack, c.readVmWord(n)).isOk
+  stack.len = 0
+  c.pc = 0
+
+  var sink: uint64 = 0
+  let t0 = getMonoTime()
+  for _ in 0 ..< batches:
+    stack.len = 0
+    c.pc = 0
+    for _ in 0 ..< pushesPerBatch:
+      doAssert pushBoxed(stack, c.readVmWord(n)).isOk
+    # Force the writes to be observed so the C compiler can't elide them.
+    sink = sink xor stack.lsPeekInt(^1).limbs[0]
+  let ns = (getMonoTime() - t0).inNanoseconds.float
+  let label = &"BEFORE PUSH{n} (noinline call to push)"
+  result = reportTiming(label, totalPushes, ns)
+  echo &"  (sink={sink:#x})"
+
+proc benchAfter(n: static int): float {.noinline.} =
+  ## After {.inline.}: push folds into the caller, no call frame.
+  let codeBytes = makeImmBytes(n * pushesPerBatch + 32)
+  var c = CodeStream.init(CodeBytesRef.init(codeBytes))
+  let stack = EvmStack.init()
+  defer: stack.dispose()
+
+  for _ in 0 ..< pushesPerBatch:
+    doAssert stack.push(c.readVmWord(n)).isOk
+  stack.len = 0
+  c.pc = 0
+
+  var sink: uint64 = 0
+  let t0 = getMonoTime()
+  for _ in 0 ..< batches:
+    stack.len = 0
+    c.pc = 0
+    for _ in 0 ..< pushesPerBatch:
+      doAssert stack.push(c.readVmWord(n)).isOk
+    sink = sink xor stack.lsPeekInt(^1).limbs[0]
+  let ns = (getMonoTime() - t0).inNanoseconds.float
+  let label = &"AFTER  PUSH{n} (inline push)"
+  result = reportTiming(label, totalPushes, ns)
+  echo &"  (sink={sink:#x})"
+
+proc runFor(n: static int) =
+  echo &"--- PUSH{n} ---"
+  let beforeNs = benchBefore(n)
+  let afterNs = benchAfter(n)
+  let speedup = beforeNs / afterNs
+  let pctSaved = (1.0 - afterNs / beforeNs) * 100.0
+  echo &"  speedup: {speedup:.2f}x   (saved {pctSaved:.1f}% per push)"
+  echo ""
+
+proc main() =
+  echo &"PUSH inline benchmark — {totalPushes} pushes per measurement"
+  echo "-".repeat(78)
+  runFor(1)
+  runFor(2)
+  runFor(8)
+  runFor(20)
+  runFor(32)
+
+when isMainModule:
+  main()


### PR DESCRIPTION
Just benchmarking shows

```bash
Before vs after {.inline.} on stack.push (10M pushes per measurement, -d:release):

  ┌────────┬────────────────────────┬────────────────┬─────────┬────────┐
  │ Opcode │ Before (noinline call) │ After (inline) │ Speedup │ Saved  │
  ├────────┼────────────────────────┼────────────────┼─────────┼────────┤
  │ PUSH1  │            12.34 ns/op │     7.50 ns/op │   1.64x │ −39.2% │
  ├────────┼────────────────────────┼────────────────┼─────────┼────────┤
  │ PUSH2  │            12.94 ns/op │     7.49 ns/op │   1.73x │ −42.1% │
  ├────────┼────────────────────────┼────────────────┼─────────┼────────┤
  │ PUSH8  │            12.43 ns/op │     7.37 ns/op │   1.69x │ −40.7% │
  ├────────┼────────────────────────┼────────────────┼─────────┼────────┤
  │ PUSH20 │            13.30 ns/op │     7.91 ns/op │   1.68x │ −40.6% │
  ├────────┼────────────────────────┼────────────────┼─────────┼────────┤
  │ PUSH32 │             7.18 ns/op │     3.20 ns/op │   2.24x │ −55.4% │
  └────────┴────────────────────────┴────────────────┴─────────┴────────┘

```

A short benchmark of 2M block import shows 

```bash
noinlinemaster.csv vs inlinepush.csv
                       bps_x      bps_y      tps_x      tps_y time_x time_y    bpsd    tpsd    timed
block_number                                                                                        
(499713, 666411]    7,140.76  10,984.03  10,821.84  16,608.30    24s    17s  60.20%  60.20%  -19.89%
(666411, 833110]    3,494.74   5,431.22   7,654.91  11,795.17    56s    36s  57.71%  57.71%  -34.82%
(833110, 999809]    4,486.37   6,269.34  12,777.10  17,764.27    39s    28s  40.66%  40.66%  -28.09%
(999809, 1166507]   3,799.64   5,374.50  16,230.17  22,993.42    45s    30s  45.78%  45.78%  -29.59%
(1166507, 1333206]  3,232.86   4,283.25  17,771.04  23,472.47    51s    39s  33.35%  33.35%  -23.48%
(1333206, 1499905]  3,737.77   4,380.25  22,655.38  26,458.05    46s    40s  17.31%  17.31%  -13.79%
(1499905, 1666603]  3,091.48   3,601.22  22,435.75  26,033.18    54s    47s  16.38%  16.38%  -11.84%
(1666603, 1833302]  2,458.55   2,914.42  17,580.08  20,805.46  1m59s  1m46s  17.56%  17.56%  -14.51%
(1833302, 2000001]  2,807.38   3,578.74  20,768.13  26,717.07   1m8s    55s  26.94%  26.94%  -20.36%

blocks: 1492096, baseline: 8m26s, contender: 6m43s
Time (total): -1m42s, -20.32%

bpsd = blocks per sec diff (+), tpsd = txs per sec diff, timed = time to process diff (-)
+ = more is better, - = less is better

```