### PR TITLE
fix hashIndexKey high byte always zero due to shl/shr mistake

### DIFF
--- a/execution_chain/db/storage_types.nim
+++ b/execution_chain/db/storage_types.nim
@@ -109,7 +109,7 @@ func fcuKey*(u: uint64): DbKey {.inline.} =
 func hashIndexKey*(hash: Hash32, index: uint16): HashIndexKey =
   result[0..31] = hash.data
   result[32] = byte(index and 0xFF)
-  result[33] = byte((index shl 8) and 0xFF)
+  result[33] = byte((index shr 8) and 0xFF)
 
 func beaconHeaderKey*(u: BlockNumber): DbKey =
   uint64KeyImpl(beaconHeader)

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -39,6 +39,7 @@ import
     test_rpc,
     test_snap,
     test_transaction_json,
+    test_transactions_receipts_storage,
     test_txpool,
     test_tx_frame_blobify,
     test_networking,

--- a/tests/test_transactions_receipts_storage.nim
+++ b/tests/test_transactions_receipts_storage.nim
@@ -1,0 +1,59 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+{.used.}
+
+import results, unittest2, eth/common, ../execution_chain/db/core_db/memory_only
+
+const
+  # A fixed non-empty root distinct from EMPTY_ROOT_HASH, used as the key prefix.
+  testRoot = hash32"0000000000000000000000000000000000000000000000000000000000000001"
+  # crosses the 256-index boundary
+  count = 300
+
+suite "transactions / receipts storage (>256)":
+  test "persistTransactions / getTransactions round-trips":
+    let
+      db = newCoreDbRef(AristoDbMemory)
+      txFrame = db.baseTxFrame()
+
+    var txs = newSeq[Transaction](count)
+    for i in 0 ..< count:
+      txs[i] = Transaction(nonce: AccountNonce(i))
+
+    txFrame.persistTransactions(BlockNumber(1), testRoot, txs)
+
+    let rc = txFrame.getTransactions(testRoot)
+    require rc.isOk()
+    let retrieved = rc.value
+
+    check retrieved.len == count
+
+    for i in 0 ..< count:
+      check retrieved[i].nonce == AccountNonce(i)
+
+  test "persistReceipts / getReceipts round-trips":
+    let
+      db = newCoreDbRef(AristoDbMemory)
+      txFrame = db.baseTxFrame()
+
+    var receipts = newSeq[StoredReceipt](count)
+    for i in 0 ..< count:
+      receipts[i] = StoredReceipt(cumulativeGasUsed: GasInt(i))
+
+    txFrame.persistReceipts(testRoot, receipts)
+
+    let rc = txFrame.getReceipts(testRoot)
+    require rc.isOk()
+    let retrieved = rc.value
+
+    check retrieved.len == count
+    for i in 0 ..< count:
+      check retrieved[i].cumulativeGasUsed == GasInt(i)


### PR DESCRIPTION
hashIndexKey() used `shl 8` instead of `shr 8` to extract the high byte of the index, making it always 0. This reduced the key space to 256 causing silent data corruption for any block with 256 or more transactions or receipts. The high index entries overwrote the low index ones on write and the iterator never terminated early.

On import from era1/era this could only be noticed when using the debug-store-bodies and/or receipts flags. But when following the chain normally it will also occur of course.

The fix changes the storage key layout, but since existing blocks for with >= 256 txs are already corrupt anyhow, the change does not make it worse for that data. And it will actually work for new data.

Nodes will need to resync to have actual valid data for affected blocks.