### PR TITLE
BAL state prefetching (batch IO)

### DIFF
--- a/execution_chain/block_access_list/block_access_list_validation.nim
+++ b/execution_chain/block_access_list/block_access_list_validation.nim
@@ -81,6 +81,8 @@ func validate*(
     var changedSlots: HashSet[StorageKey]
     for slotChanges in accountChanges.storageChanges:
       changedSlots.incl(slotChanges.slot)
+      if slotChanges.changes.len == 0:
+        return err("Each slot in storage changes must have at least one change")
       if not slotChanges.changes.isSorted(balIndexCmpTreatEqualAsGreater):
         return err("Slot changes should be unique and sorted by blockAccessIndex")
 

--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -108,6 +108,15 @@ type
       ## Optimistically pre-execute the transactions of a block on background
       ## threads to warm database caches before the main thread executes them.
 
+    balStatePrefetch*: bool
+      ## Use the supplied block access list to prefetch the accounts and storage
+      ## slots of a block on background threads to warm database caches before
+      ## the main thread executes the block.
+
+    balStatePrefetchWorkers*: int
+      ## Number of background worker tasks used for block access list state
+      ## prefetching. 0 means use all available taskpool threads.
+
 # ------------------------------------------------------------------------------
 # Private helper functions
 # ------------------------------------------------------------------------------
@@ -181,7 +190,9 @@ proc init(com         : CommonRef,
           initializeDb: bool,
           statelessProviderEnabled: bool,
           statelessWitnessValidation: bool,
-          optimisticStatePrefetch: bool) =
+          optimisticStatePrefetch: bool,
+          balStatePrefetch: bool,
+          balStatePrefetchWorkers: int) =
 
 
   config.daoCheck()
@@ -221,6 +232,8 @@ proc init(com         : CommonRef,
   com.statelessProviderEnabled = statelessProviderEnabled
   com.statelessWitnessValidation = statelessWitnessValidation
   com.optimisticStatePrefetch = optimisticStatePrefetch
+  com.balStatePrefetch = balStatePrefetch
+  com.balStatePrefetchWorkers = balStatePrefetchWorkers
 
 proc isBlockAfterTtd(com: CommonRef, header: Header, txFrame: CoreDbTxRef): bool =
   if com.config.terminalTotalDifficulty.isNone:
@@ -246,6 +259,8 @@ proc new*(
     statelessProviderEnabled = false;
     statelessWitnessValidation = false;
     optimisticStatePrefetch = false;
+    balStatePrefetch = false;
+    balStatePrefetchWorkers = 0;
       ): CommonRef =
 
   ## If genesis data is present, the forkIds will be initialized
@@ -259,7 +274,9 @@ proc new*(
     initializeDb,
     statelessProviderEnabled,
     statelessWitnessValidation,
-    optimisticStatePrefetch)
+    optimisticStatePrefetch,
+    balStatePrefetch,
+    balStatePrefetchWorkers)
 
 proc new*(
     _: type CommonRef;
@@ -270,6 +287,8 @@ proc new*(
     statelessProviderEnabled = false;
     statelessWitnessValidation = false;
     optimisticStatePrefetch = false;
+    balStatePrefetch = false;
+    balStatePrefetchWorkers = 0;
       ): CommonRef =
 
   ## There is no genesis data present
@@ -283,7 +302,9 @@ proc new*(
     initializeDb,
     statelessProviderEnabled,
     statelessWitnessValidation,
-    optimisticStatePrefetch)
+    optimisticStatePrefetch,
+    balStatePrefetch,
+    balStatePrefetchWorkers)
 
 func clone*(com: CommonRef, db: CoreDbRef): CommonRef =
   ## clone but replace the db
@@ -298,7 +319,9 @@ func clone*(com: CommonRef, db: CoreDbRef): CommonRef =
     networkId    : com.networkId,
     statelessProviderEnabled: com.statelessProviderEnabled,
     statelessWitnessValidation: com.statelessWitnessValidation,
-    optimisticStatePrefetch: com.optimisticStatePrefetch
+    optimisticStatePrefetch: com.optimisticStatePrefetch,
+    balStatePrefetch: com.balStatePrefetch,
+    balStatePrefetchWorkers: com.balStatePrefetchWorkers
   )
 
 func clone*(com: CommonRef): CommonRef =

--- a/execution_chain/common/common.nim
+++ b/execution_chain/common/common.nim
@@ -110,12 +110,12 @@ type
 
     balStatePrefetch*: bool
       ## Use the supplied block access list to prefetch the accounts and storage
-      ## slots of a block on background threads to warm database caches before
-      ## the main thread executes the block.
+      ## slots of a block on background threads.
 
     balStatePrefetchWorkers*: int
       ## Number of background worker tasks used for block access list state
-      ## prefetching. 0 means use all available taskpool threads.
+      ## prefetching. 0 means use the same number of workers as the number of
+      ## available taskpool threads.
 
 # ------------------------------------------------------------------------------
 # Private helper functions

--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -52,6 +52,10 @@ const
   defaultAdminListenAddressDesc = $defaultAdminListenAddress & ", meaning local host only"
   logLevelDesc = getLogLevels()
   defaultOptimisticStatePrefetch* = false
+  defaultBalStatePrefetch* = false
+  defaultBalStatePrefetchWorkers* = 0
+    ## Number of background worker tasks used for block access list state
+    ## prefetching. 0 means use all available taskpool threads.
 
 template defaultListenAddress(): IpAddress =
   getAutoAddress(Port(0)).toIpAddress()
@@ -365,6 +369,20 @@ type
       desc: "Optimistically pre-execute block transactions on background " &
         "threads to warm DB caches"
       name: "debug-optimistic-state-prefetch".}: bool
+
+    balStatePrefetch* {.
+      hidden
+      defaultValue: defaultBalStatePrefetch
+      desc: "Use the supplied block access list to prefetch state on " &
+        "background threads to warm DB caches"
+      name: "debug-bal-state-prefetch".}: bool
+
+    balStatePrefetchWorkers* {.
+      hidden
+      defaultValue: defaultBalStatePrefetchWorkers
+      desc: "Number of background worker tasks used for block access list " &
+        "state prefetching (0 = use all taskpool threads)"
+      name: "debug-bal-state-prefetch-workers".}: int
 
     eagerStateRootCheck* {.
       hidden
@@ -826,7 +844,7 @@ func dbOptions*(config: ExecutionClientConf, noKeyCache = false): DbOptions =
     rdbPrintStats = config.rdbPrintStats,
     maxSnapshots = config.aristoDbMaxSnapshots,
     parallelStateRootComputation = config.parallelStateRootComputation,
-    threadSafeCaches = config.optimisticStatePrefetch,
+    threadSafeCaches = config.optimisticStatePrefetch or config.balStatePrefetch,
     blockCacheType = config.rocksdbBlockCacheType,
   )
 

--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -54,8 +54,6 @@ const
   defaultOptimisticStatePrefetch* = false
   defaultBalStatePrefetch* = false
   defaultBalStatePrefetchWorkers* = 0
-    ## Number of background worker tasks used for block access list state
-    ## prefetching. 0 means use all available taskpool threads.
 
 template defaultListenAddress(): IpAddress =
   getAutoAddress(Port(0)).toIpAddress()
@@ -381,7 +379,7 @@ type
       hidden
       defaultValue: defaultBalStatePrefetchWorkers
       desc: "Number of background worker tasks used for block access list " &
-        "state prefetching (0 = use all taskpool threads)"
+        "state prefetching (0 = use number equal to the taskpool threads count)"
       name: "debug-bal-state-prefetch-workers".}: int
 
     eagerStateRootCheck* {.

--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -94,6 +94,7 @@ proc processBlock*(
   template processBlock(): auto =
     vmState.processBlock(
       blk,
+      blockAccessList = blockAccessList,
       skipValidation = false,
       skipReceipts = false,
       skipUncles = true,

--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -164,7 +164,7 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
     # Generate receipts for storage or validation but skip them otherwise
     ?vmState.processBlock(
       blk,
-      skipValidation,
+      skipValidation = skipValidation,
       skipReceipts = skipValidation and PersistReceipts notin p.flags,
       skipUncles = PersistUncles notin p.flags,
       skipStateRootCheck = skipValidation,

--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -11,6 +11,7 @@
 {.push raises: [], gcsafe.}
 
 import
+  std/algorithm,
   ../../common/common,
   ../../constants,
   ../../utils/utils,
@@ -50,9 +51,14 @@ when compileOption("threads"):
       com: CommonRef
       txFrame: CoreDbTxRef
 
+    BalPrefetchCtx = object
+      finished: Atomic[bool]
+      nextIndex: Atomic[int]
+      balPtr: ptr BlockAccessList
+      txFrame: CoreDbTxRef
+
   proc recoverAndPrefetchTask(
       e: ptr Entry, ctx: ptr PrefetchCtx, tx: ptr Transaction): bool {.nimcall.} =
-
     # Recover the sender from the signature. `default(Address)` signals sig
     # check failure.
     let
@@ -106,15 +112,13 @@ when compileOption("threads"):
 
   template withSenderParallel(
       vmState: BaseVMState, txs: openArray[Transaction], body: untyped) =
-    doAssert not vmState.com.taskpool.isNil()
-
+    # Execute transactions offloading the signature checking to the task pool
     var
       entries = newSeq[Entry](txs.len)
       ctx: PrefetchCtx
       ctxPtr: ptr PrefetchCtx = nil
 
-    if vmState.com.optimisticStatePrefetch and vmState.com.taskpool.numThreads > 1 and
-        not vmState.balPrefetchActive:
+    if vmState.com.optimisticStatePrefetch and not vmState.balPrefetchActive:
       ctx.parent = vmState.parent
       ctx.blockCtx = vmState.blockCtx
       ctx.com = vmState.com
@@ -155,46 +159,39 @@ when compileOption("threads"):
       for e in entries.mitems():
         discard sync(e.fut)
 
-  type
-    BalPrefetchCtx = object
-      finished: Atomic[bool]     ## set true when block processing completes
-      nextIndex: Atomic[int]     ## lock-free work cursor into accs[]
-      accs: ptr BlockAccessList  ## caller-owned, read-only seq[AccountChanges]
-      txFrame: CoreDbTxRef       ## parent frame; used as a borrowed proc arg only
+  func firstBalIndex(sc: SlotChanges): BlockAccessIndex =
+    ## Earliest block access index at which the slot was written. 
+    ## Block access list validation guarantees `changes` is non-empty.
+    assert sc.changes.len > 0
+    sc.changes[0].blockAccessIndex
 
   proc balPrefetchWorker(ctx: ptr BalPrefetchCtx): bool {.nimcall.} =
-    # Read straight through the parent frame. The txFrame is only ever used as a
-    # borrowed proc argument (no refcount change) and is never bound to a ref
-    # local or stored in a heap object, so there is no cross-thread refcount race
-    # and no need for borrowRef.
-    let len = ctx[].accs[].len
+    let len = ctx[].balPtr[].len
     while true:
-      # Stop between items if block processing has already finished.
       if ctx[].finished.load(moAcquire):
         break
-      # Claim the next accountChanges without locking.
+
       let i = ctx[].nextIndex.fetchAdd(1, moRelaxed)
       if i >= len:
         break
 
       let
-        acc = addr ctx[].accs[][i]
-        accPath = acc[].address.computeAccPath
+        accChanges = addr ctx[].balPtr[][i]
+        accPath = accChanges[].address.computeAccPath
 
-      # No storage to prefetch: just warm the account and continue.
-      if acc[].storageChanges.len == 0 and acc[].storageReads.len == 0:
+      if accChanges[].storageChanges.len == 0 and accChanges[].storageReads.len == 0:
         discard ctx[].txFrame.fetchAccount(accPath)
         continue
 
-      # First the storage writes, in seq order (lowest index to highest). Index
-      # access avoids copying each slot's inner changes seq (only the slot key is
-      # needed here).
-      for j in 0 ..< acc[].storageChanges.len:
-        discard ctx[].txFrame.fetchSlot(
-          accPath, computeSlotKey(acc[].storageChanges[j].slot))
-      # ...then the storage reads.
-      for j in 0 ..< acc[].storageReads.len:
-        discard ctx[].txFrame.fetchSlot(accPath, computeSlotKey(acc[].storageReads[j]))
+      # Prefetch the written slots ordered by the earliest block access index at
+      # which each was written, so they are warmed in roughly the order the block
+      # touches them.
+      for slotChanges in sorted(accChanges[].storageChanges,
+          proc(a, b: SlotChanges): int = cmp(firstBalIndex(a), firstBalIndex(b))):
+        discard ctx[].txFrame.fetchSlot(accPath, computeSlotKey(slotChanges.slot))
+
+      for stoRead in accChanges[].storageReads:
+        discard ctx[].txFrame.fetchSlot(accPath, computeSlotKey(stoRead))
 
     true
 
@@ -206,14 +203,11 @@ when compileOption("threads"):
       futs: seq[Flowvar[bool]]
 
     if vmState.com.balStatePrefetch and bal.isSome() and
-        not vmState.com.taskpool.isNil() and
         vmState.com.isAmsterdamOrLater(vmState.blockCtx.timestamp):
-      # The BAL describes exactly what the block accesses, so disable the per-tx
-      # optimistic prefetch (sender recovery still runs in parallel).
       vmState.balPrefetchActive = true
 
       let balRef = bal.get()
-      ctx.accs = balRef[].addr
+      ctx.balPtr = balRef[].addr
       # Read through the parent frame because the current frame is written to
       # during block execution; this avoids locking on the frame data structures.
       ctx.txFrame = vmState.ledger.txFrame.parent()
@@ -226,8 +220,7 @@ when compileOption("threads"):
         configured = vmState.com.balStatePrefetchWorkers
         numWorkers = if configured <= 0: n else: min(configured, n)
       futs = newSeq[Flowvar[bool]](numWorkers)
-      # Submit a configurable number of workers (1..numThreads) that each pull
-      # accountChanges objects from the shared work cursor until none remain.
+
       for i in 0 ..< numWorkers:
         futs[i] = vmState.com.taskpool.spawn balPrefetchWorker(ctxPtr)
 
@@ -248,22 +241,20 @@ template withSenderSerial(txs: openArray[Transaction], body: untyped) =
 
 template withSender(vmState: BaseVMState, txs: openArray[Transaction], body: untyped) =
   when compileOption("threads"):
-    # Execute transactions offloading the signature checking to the task pool if
-    # it's available
-    if vmState.com.taskpool == nil:
-      withSenderSerial(txs, body)
-    else:
+    if not vmState.com.taskpool.isNil() and vmState.com.taskpool.numThreads > 1:
       withSenderParallel(vmState, txs, body)
+    else:
+      withSenderSerial(txs, body)
   else:
     withSenderSerial(txs, body)
 
 template withBalPrefetch(
     vmState: BaseVMState, bal: Opt[BlockAccessListRef], body: untyped) =
-  ## Run `body` (block processing) while background workers prefetch the state
-  ## described by the supplied block access list. Collects all prefetch tasks
-  ## before returning, including on the error/early-return path.
   when compileOption("threads"):
-    withBalPrefetchParallel(vmState, bal, body)
+    if not vmState.com.taskpool.isNil() and vmState.com.taskpool.numThreads > 1:
+      withBalPrefetchParallel(vmState, bal, body)
+    else:
+      body
   else:
     body
 
@@ -535,7 +526,7 @@ proc procBlkEpilogue(
 proc processBlock*(
     vmState: BaseVMState, ## Parent environment of header/body block
     blk: Block, ## Header/body block to add to the blockchain
-    blockAccessList = Opt.none(BlockAccessListRef), ## Validated BAL, when supplied, used for state prefetching
+    blockAccessList = Opt.none(BlockAccessListRef),
     skipValidation = false,
     skipReceipts = false,
     skipUncles = false,
@@ -543,6 +534,7 @@ proc processBlock*(
     skipPostExecBalCheck = false,
 ): Result[void, string] =
   ## Generalised function to processes `blk` for any network.
+
   vmState.withBalPrefetch(blockAccessList):
     ?vmState.procBlkPreamble(blk, skipValidation, skipReceipts, skipUncles)
 

--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -15,6 +15,7 @@ import
   ../../constants,
   ../../utils/utils,
   ../../db/ledger,
+  ../../db/core_db,
   ../../transaction,
   ../../evm/state,
   ../../evm/types,
@@ -112,7 +113,8 @@ when compileOption("threads"):
       ctx: PrefetchCtx
       ctxPtr: ptr PrefetchCtx = nil
 
-    if vmState.com.optimisticStatePrefetch and vmState.com.taskpool.numThreads > 1:
+    if vmState.com.optimisticStatePrefetch and vmState.com.taskpool.numThreads > 1 and
+        not vmState.balPrefetchActive:
       ctx.parent = vmState.parent
       ctx.blockCtx = vmState.blockCtx
       ctx.com = vmState.com
@@ -153,6 +155,92 @@ when compileOption("threads"):
       for e in entries.mitems():
         discard sync(e.fut)
 
+  type
+    BalPrefetchCtx = object
+      finished: Atomic[bool]     ## set true when block processing completes
+      nextIndex: Atomic[int]     ## lock-free work cursor into accs[]
+      accs: ptr BlockAccessList  ## caller-owned, read-only seq[AccountChanges]
+      txFrame: CoreDbTxRef       ## parent frame; used as a borrowed proc arg only
+
+  proc balPrefetchWorker(ctx: ptr BalPrefetchCtx): bool {.nimcall.} =
+    # Read straight through the parent frame. The txFrame is only ever used as a
+    # borrowed proc argument (no refcount change) and is never bound to a ref
+    # local or stored in a heap object, so there is no cross-thread refcount race
+    # and no need for borrowRef.
+    let len = ctx[].accs[].len
+    while true:
+      # Stop between items if block processing has already finished.
+      if ctx[].finished.load(moAcquire):
+        break
+      # Claim the next accountChanges without locking.
+      let i = ctx[].nextIndex.fetchAdd(1, moRelaxed)
+      if i >= len:
+        break
+
+      let
+        acc = addr ctx[].accs[][i]
+        accPath = acc[].address.computeAccPath
+
+      # No storage to prefetch: just warm the account and continue.
+      if acc[].storageChanges.len == 0 and acc[].storageReads.len == 0:
+        discard ctx[].txFrame.fetchAccount(accPath)
+        continue
+
+      # First the storage writes, in seq order (lowest index to highest). Index
+      # access avoids copying each slot's inner changes seq (only the slot key is
+      # needed here).
+      for j in 0 ..< acc[].storageChanges.len:
+        discard ctx[].txFrame.fetchSlot(
+          accPath, computeSlotKey(acc[].storageChanges[j].slot))
+      # ...then the storage reads.
+      for j in 0 ..< acc[].storageReads.len:
+        discard ctx[].txFrame.fetchSlot(accPath, computeSlotKey(acc[].storageReads[j]))
+
+    true
+
+  template withBalPrefetchParallel(
+      vmState: BaseVMState, bal: Opt[BlockAccessListRef], body: untyped) =
+    var
+      ctx: BalPrefetchCtx
+      ctxPtr: ptr BalPrefetchCtx = nil
+      futs: seq[Flowvar[bool]]
+
+    if vmState.com.balStatePrefetch and bal.isSome() and
+        not vmState.com.taskpool.isNil() and
+        vmState.com.isAmsterdamOrLater(vmState.blockCtx.timestamp):
+      # The BAL describes exactly what the block accesses, so disable the per-tx
+      # optimistic prefetch (sender recovery still runs in parallel).
+      vmState.balPrefetchActive = true
+
+      let balRef = bal.get()
+      ctx.accs = balRef[].addr
+      # Read through the parent frame because the current frame is written to
+      # during block execution; this avoids locking on the frame data structures.
+      ctx.txFrame = vmState.ledger.txFrame.parent()
+      ctx.nextIndex.store(0, moRelease)
+      ctx.finished.store(false, moRelease)
+      ctxPtr = ctx.addr
+
+      let
+        n = vmState.com.taskpool.numThreads
+        configured = vmState.com.balStatePrefetchWorkers
+        numWorkers = if configured <= 0: n else: min(configured, n)
+      futs = newSeq[Flowvar[bool]](numWorkers)
+      # Submit a configurable number of workers (1..numThreads) that each pull
+      # accountChanges objects from the shared work cursor until none remain.
+      for i in 0 ..< numWorkers:
+        futs[i] = vmState.com.taskpool.spawn balPrefetchWorker(ctxPtr)
+
+    try:
+      body
+    finally:
+      if not ctxPtr.isNil():
+        # Signal completion so workers stop claiming new items, then collect all
+        # so that no worker outlives the data it references.
+        ctxPtr[].finished.store(true, moRelease)
+        for f in futs.mitems():
+          discard sync(f)
+
 template withSenderSerial(txs: openArray[Transaction], body: untyped) =
   for txIndex {.inject.}, tx {.inject.} in txs:
     let sender {.inject.} = tx.recoverSender().valueOr(default(Address))
@@ -168,6 +256,16 @@ template withSender(vmState: BaseVMState, txs: openArray[Transaction], body: unt
       withSenderParallel(vmState, txs, body)
   else:
     withSenderSerial(txs, body)
+
+template withBalPrefetch(
+    vmState: BaseVMState, bal: Opt[BlockAccessListRef], body: untyped) =
+  ## Run `body` (block processing) while background workers prefetch the state
+  ## described by the supplied block access list. Collects all prefetch tasks
+  ## before returning, including on the error/early-return path.
+  when compileOption("threads"):
+    withBalPrefetchParallel(vmState, bal, body)
+  else:
+    body
 
 # Factored this out of procBlkPreamble so that it can be used directly for
 # stateless execution of specific transactions.
@@ -437,6 +535,7 @@ proc procBlkEpilogue(
 proc processBlock*(
     vmState: BaseVMState, ## Parent environment of header/body block
     blk: Block, ## Header/body block to add to the blockchain
+    blockAccessList = Opt.none(BlockAccessListRef), ## Validated BAL, when supplied, used for state prefetching
     skipValidation = false,
     skipReceipts = false,
     skipUncles = false,
@@ -444,13 +543,14 @@ proc processBlock*(
     skipPostExecBalCheck = false,
 ): Result[void, string] =
   ## Generalised function to processes `blk` for any network.
-  ?vmState.procBlkPreamble(blk, skipValidation, skipReceipts, skipUncles)
+  vmState.withBalPrefetch(blockAccessList):
+    ?vmState.procBlkPreamble(blk, skipValidation, skipReceipts, skipUncles)
 
-  # EIP-3675: no reward for miner in POA/POS
-  if not vmState.com.proofOfStake(blk.header, vmState.ledger.txFrame):
-    vmState.calculateReward(blk.header, blk.uncles)
+    # EIP-3675: no reward for miner in POA/POS
+    if not vmState.com.proofOfStake(blk.header, vmState.ledger.txFrame):
+      vmState.calculateReward(blk.header, blk.uncles)
 
-  ?vmState.procBlkEpilogue(blk, skipValidation, skipReceipts, skipStateRootCheck, skipPostExecBalCheck)
+    ?vmState.procBlkEpilogue(blk, skipValidation, skipReceipts, skipStateRootCheck, skipPostExecBalCheck)
 
   ok()
 

--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -197,42 +197,35 @@ when compileOption("threads"):
 
   template withBalPrefetchParallel(
       vmState: BaseVMState, bal: Opt[BlockAccessListRef], body: untyped) =
-    var
-      ctx: BalPrefetchCtx
-      ctxPtr: ptr BalPrefetchCtx = nil
-      futs: seq[Flowvar[bool]]
+      
+    let balRef = bal.get()
 
-    if vmState.com.balStatePrefetch and bal.isSome() and
-        vmState.com.isAmsterdamOrLater(vmState.blockCtx.timestamp):
-      vmState.balPrefetchActive = true
+    var ctx: BalPrefetchCtx
+    ctx.balPtr = balRef[].addr
+    # Read through the parent frame because the current frame is written to
+    # during block execution; this avoids locking on the frame data structures.
+    ctx.txFrame = vmState.ledger.txFrame.parent()
+    ctx.nextIndex.store(0, moRelease)
+    ctx.finished.store(false, moRelease)
 
-      let balRef = bal.get()
-      ctx.balPtr = balRef[].addr
-      # Read through the parent frame because the current frame is written to
-      # during block execution; this avoids locking on the frame data structures.
-      ctx.txFrame = vmState.ledger.txFrame.parent()
-      ctx.nextIndex.store(0, moRelease)
-      ctx.finished.store(false, moRelease)
+    let 
       ctxPtr = ctx.addr
-
-      let
-        n = vmState.com.taskpool.numThreads
-        configured = vmState.com.balStatePrefetchWorkers
-        numWorkers = if configured <= 0: n else: min(configured, n)
-      futs = newSeq[Flowvar[bool]](numWorkers)
-
-      for i in 0 ..< numWorkers:
-        futs[i] = vmState.com.taskpool.spawn balPrefetchWorker(ctxPtr)
+      n = vmState.com.taskpool.numThreads
+      configured = vmState.com.balStatePrefetchWorkers
+      numWorkers = if configured <= 0: n else: min(configured, n)
+    
+    var futs = newSeq[Flowvar[bool]](numWorkers)
+    for i in 0 ..< numWorkers:
+      futs[i] = vmState.com.taskpool.spawn balPrefetchWorker(ctxPtr)
 
     try:
       body
     finally:
-      if not ctxPtr.isNil():
-        # Signal completion so workers stop claiming new items, then collect all
-        # so that no worker outlives the data it references.
-        ctxPtr[].finished.store(true, moRelease)
-        for f in futs.mitems():
-          discard sync(f)
+      # Signal completion so workers stop claiming new items, then collect all
+      # so that no worker outlives the data it references.
+      ctxPtr[].finished.store(true, moRelease)
+      for f in futs.mitems():
+        discard sync(f)
 
 template withSenderSerial(txs: openArray[Transaction], body: untyped) =
   for txIndex {.inject.}, tx {.inject.} in txs:
@@ -251,7 +244,11 @@ template withSender(vmState: BaseVMState, txs: openArray[Transaction], body: unt
 template withBalPrefetch(
     vmState: BaseVMState, bal: Opt[BlockAccessListRef], body: untyped) =
   when compileOption("threads"):
-    if not vmState.com.taskpool.isNil() and vmState.com.taskpool.numThreads > 1:
+    if bal.isSome() and vmState.com.balStatePrefetch and
+        vmState.com.isAmsterdamOrLater(vmState.blockCtx.timestamp) and
+        not vmState.com.taskpool.isNil() and vmState.com.taskpool.numThreads > 1:
+
+      vmState.balPrefetchActive = true
       withBalPrefetchParallel(vmState, bal, body)
     else:
       body

--- a/execution_chain/evm/types.nim
+++ b/execution_chain/evm/types.nim
@@ -63,8 +63,6 @@ type
     gasRefunded*      : int64    # Global gasRefunded counter
     balTracker*       : BlockAccessListTrackerRef
     balPrefetchActive*: bool
-      # Set while block access list state prefetching is running for this block,
-      # in which case the per-tx optimistic prefetch is suppressed.
 
   Computation* = ref object
     # The execution computation

--- a/execution_chain/evm/types.nim
+++ b/execution_chain/evm/types.nim
@@ -62,6 +62,9 @@ type
     allLogs*          : seq[Log] # EIP-6110
     gasRefunded*      : int64    # Global gasRefunded counter
     balTracker*       : BlockAccessListTrackerRef
+    balPrefetchActive*: bool
+      # Set while block access list state prefetching is running for this block,
+      # in which case the per-tx optimistic prefetch is suppressed.
 
   Computation* = ref object
     # The execution computation

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -288,7 +288,9 @@ proc setupCommonRef*(config: ExecutionClientConf): (CommonRef, bool) =
     params = config.networkParams,
     statelessProviderEnabled = config.statelessProviderEnabled,
     statelessWitnessValidation = config.statelessWitnessValidation,
-    optimisticStatePrefetch = config.optimisticStatePrefetch)
+    optimisticStatePrefetch = config.optimisticStatePrefetch,
+    balStatePrefetch = config.balStatePrefetch,
+    balStatePrefetchWorkers = config.balStatePrefetchWorkers)
 
   if config.extraData.len > 32:
     warn "ExtraData exceeds 32 bytes limit, truncate",

--- a/tests/eest/eest_helpers.nim
+++ b/tests/eest/eest_helpers.nim
@@ -262,7 +262,8 @@ proc prepareEnv*(
       com = CommonRef.new(memDB, config,
         statelessProviderEnabled = statelessEnabled,
         statelessWitnessValidation = false, # Running stateless execution separately in test runner
-        optimisticStatePrefetch = defaultOptimisticStatePrefetch)
+        optimisticStatePrefetch = parallelEnabled,
+        balStatePrefetch = parallelEnabled)
 
     if parallelEnabled:
       let taskpool =

--- a/tests/test_block_access_list_validation.nim
+++ b/tests/test_block_access_list_validation.nim
@@ -124,6 +124,16 @@ suite "Block access list validation":
     bal[0].storageChanges.insert bal[0].storageChanges[0] # duplicate the first item
     check bal.validate(bal[].computeBlockAccessListHash()).isErr()
 
+  test "Slot with no changes should fail validation":
+    builder.addStorageWrite(address1, slot1, 1, 1.u256)
+    builder.addStorageWrite(address1, slot2, 2, 2.u256)
+    builder.addStorageWrite(address1, slot3, 3, 3.u256)
+
+    var bal = builder.buildBlockAccessList()
+    check bal.validate(bal[].computeBlockAccessListHash()).isOk()
+    bal[0].storageChanges[0].changes.setLen(0) # remove all changes for the slot
+    check bal.validate(bal[].computeBlockAccessListHash()).isErr()
+
   test "Slot changes out of order should fail validation":
     builder.addStorageWrite(address1, slot1, 0, 0.u256)
     builder.addStorageWrite(address1, slot1, 1, 1.u256)


### PR DESCRIPTION
This implements state prefetching using the read (and storage write) locations in the block access list. The prefetching runs on background threads, similar to the optimistic state prefetching. 

The bal prefetching is disabled by default for now and can be enabled using the  `--debug-bal-state-prefetch=true` parameter. 

The prefetching reads each account when no storage reads or writes exist in the BAL since storage reads would implicitly read the account anyway. The storage writes are sorted by the first block access index and then read in that order so the state of earlier accessed slots will be available first. 

The number of workers (level of parallelism) is configurable using the `--debug-bal-state-prefetch-workers=<number>` parameter. The default value for this parameter will be tuned later once we implement parallel execution using BALs (coming soon).