### PR TITLE
Add historical_hashes_accumulator export and era1 export

### DIFF
--- a/tools/nimbus_history_exporter/accumulator_export.nim
+++ b/tools/nimbus_history_exporter/accumulator_export.nim
@@ -1,0 +1,100 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [], gcsafe.}
+
+import
+  std/[os, strformat],
+  chronicles,
+  stew/[byteutils, io2],
+  ssz_serialization,
+  ../../portal/eth_history/block_proofs/historical_hashes_accumulator,
+  ../../portal/eth_history/history_data_ssz_e2s, # readAccumulator, TODO: Move?
+  ../../execution_chain/db/core_db,
+  ../../execution_chain/db/core_db/persistent,
+  ../../execution_chain/db/opts,
+  ./nimbus_history_exporter_conf
+
+proc exportAccumulator*(config: HistoryExportConf) =
+  let
+    mergeBlock = mergeBlockNumber(config.networkId())
+    outputDir = string config.accumulatorOutputDir
+
+  createPath(outputDir).isOkOr:
+    fatal "Failed to create accumulator output directory",
+      outputDir, error = ioErrorMsg(error)
+    quit(QuitFailure)
+
+  let accumulatorFile =
+    outputDir / (config.network & "_historical_hashes_accumulator.ssz")
+  if isFile(accumulatorFile):
+    notice "HistoricalHashesAccumulator file already exists", file = accumulatorFile
+    quit(QuitSuccess)
+
+  let coreDb = AristoDbRocks.newCoreDbRef(config.elDataDirPath(), DbOptions.init())
+  defer:
+    coreDb.close()
+  let db = coreDb.baseTxFrame()
+
+  var accumulator = HistoricalHashesAccumulator.init()
+
+  for blockNumber in 0'u64 ..< mergeBlock:
+    let header = db.getBlockHeader(blockNumber).valueOr:
+      fatal "Failed to get block header",
+        blockNumber,
+        error = error,
+        elDir = config.elDataDirPath(),
+        hint =
+          "Ensure the nimbus execution client is fully synced to cover the requested block range"
+      quit(QuitFailure)
+
+    updateAccumulator(accumulator, header)
+
+    if config.writeEpochRecords:
+      if accumulator.currentEpoch.len() == EPOCH_SIZE or blockNumber == mergeBlock - 1:
+        let
+          epoch = blockNumber div EPOCH_SIZE
+          epochFile = outputDir / (config.network & &"-epoch-record-{epoch:05}.ssz")
+
+        io2.writeFile(epochFile, SSZ.encode(accumulator.currentEpoch)).isOkOr:
+          error "Failed writing epoch record",
+            file = epochFile, error = ioErrorMsg(error)
+        notice "Wrote epoch record", file = epochFile
+
+    if blockNumber mod 8192 == 0:
+      info "Building accumulator", blockNumber, total = mergeBlock
+
+  let finished = finishAccumulator(accumulator)
+  let accumulatorRoot = hash_tree_root(finished)
+
+  io2.writeFile(accumulatorFile, SSZ.encode(finished)).isOkOr:
+    fatal "Failed writing HistoricalHashesAccumulator",
+      file = accumulatorFile, error = ioErrorMsg(error)
+    quit(QuitFailure)
+
+  notice "HistoricalHashesAccumulator written",
+    file = accumulatorFile, root = accumulatorRoot.data.to0xHex()
+
+proc printAccumulator*(config: HistoryExportConf) =
+  let accumulator = readAccumulator(config.accumulatorFile.string).valueOr:
+    fatal "Failed reading HistoricalHashesAccumulator",
+      file = config.accumulatorFile.string, error = error
+    quit(QuitFailure)
+
+  let root = hash_tree_root(accumulator)
+
+  echo "HistoricalHashesAccumulator:"
+  echo "-------------------"
+  echo "Root: " & root.data.to0xHex()
+  echo ""
+  echo "Historical Epochs:"
+  echo "------------------"
+  echo "Epoch Root"
+  for i, epochRoot in accumulator.historicalEpochs:
+    echo &"{i.uint64:05} 0x{epochRoot.toHex()}"

--- a/tools/nimbus_history_exporter/era1_export.nim
+++ b/tools/nimbus_history_exporter/era1_export.nim
@@ -1,0 +1,143 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [], gcsafe.}
+
+import
+  std/os,
+  chronicles,
+  stew/[io2, byteutils],
+  eth/common/[headers_rlp, blocks_rlp, receipts_rlp],
+  ../../portal/eth_history/era1,
+  ../../portal/eth_history/block_proofs/historical_hashes_accumulator,
+  ../../execution_chain/db/core_db,
+  ../../execution_chain/db/core_db/persistent,
+  ../../execution_chain/db/opts,
+  ./nimbus_history_exporter_conf
+
+from eth/common/eth_types_rlp import computeRlpHash
+
+proc exportEra1File(
+    era: Era1,
+    db: CoreDbTxRef,
+    networkName: string,
+    mergeBlockNumber: uint64,
+    outputDir: string,
+): Result[void, string] =
+  let
+    startNumber = era.startNumber()
+    endNumber = era1.endNumber(era, mergeBlockNumber)
+    tmpName = outputDir / era1FileName(networkName, era, default(Digest)) & ".tmp"
+
+  var accumulatorRoot: Digest
+  block writeBlock:
+    let e2 = openFile(tmpName, {OpenFlags.Write, OpenFlags.Create, OpenFlags.Truncate}).valueOr:
+      return err(ioErrorMsg(error))
+    defer:
+      discard closeFile(e2)
+
+    var group = ?Era1Group.init(e2, startNumber, mergeBlockNumber)
+
+    var headerRecords: seq[historical_hashes_accumulator.HeaderRecord]
+    for blockNumber in startNumber .. endNumber:
+      let
+        header = ?db.getBlockHeader(blockNumber)
+        body = ?db.getBlockBody(header)
+        storedReceipts = ?db.getReceipts(header.receiptsRoot)
+        receipts = storedReceipts.to(seq[Receipt])
+        blockHash = header.computeRlpHash()
+        td = db.getScore(blockHash).valueOr:
+          return err("No total difficulty for block " & $blockNumber)
+
+      headerRecords.add(
+        historical_hashes_accumulator.HeaderRecord(
+          blockHash: blockHash, totalDifficulty: td
+        )
+      )
+
+      ?group.update(e2, blockNumber, header, body, receipts, td)
+
+    accumulatorRoot = getEpochRecordRoot(headerRecords)
+    ?group.finish(e2, accumulatorRoot, endNumber)
+
+  let finalName = outputDir / era1FileName(networkName, era, accumulatorRoot)
+  if isFile(finalName):
+    notice "Era1 file already exists", era = era.uint64, file = finalName
+    discard io2.removeFile(tmpName)
+    return ok()
+
+  # std/os.moveFile raises Exception (not raises-annotated), so we must catch
+  # Exception here. Practically it will only ever raise OSError.
+  try:
+    moveFile(tmpName, finalName)
+  except Exception as e:
+    return err("Failed to rename era1 tmp file: " & e.msg)
+
+  notice "Exported era1 file", file = finalName
+  ok()
+
+proc exportEra1*(config: HistoryExportConf) =
+  let
+    mergeBlockNumber = mergeBlockNumber(config.networkId())
+    networkName = config.network
+    mergeEra = era1.era(mergeBlockNumber)
+    preMergeEndEra = min(Era1(config.endEraEra1Export), mergeEra - 1)
+    outputDir = config.era1OutputDirPath()
+
+  createPath(outputDir).isOkOr:
+    fatal "Failed to create era1 output directory", outputDir, error = ioErrorMsg(error)
+    quit(QuitFailure)
+
+  let coreDb = AristoDbRocks.newCoreDbRef(config.elDataDirPath(), DbOptions.init())
+  defer:
+    coreDb.close()
+  let db = coreDb.baseTxFrame()
+
+  for era in Era1(config.startEraEra1Export) .. preMergeEndEra:
+    exportEra1File(era, db, networkName, mergeBlockNumber, outputDir).isOkOr:
+      fatal "Error exporting era1 file",
+        era = era.uint64,
+        msg = error,
+        elDir = config.elDataDirPath(),
+        hint =
+          "Ensure the nimbus execution client is fully synced to cover the requested era range"
+      quit(QuitFailure)
+
+proc verifyEra1*(config: HistoryExportConf) =
+  let mergeBlockNumber = mergeBlockNumber(config.networkId())
+
+  var count = 0
+  var failed = 0
+  try:
+    for kind, path in walkDir(config.era1VerifyDir.string):
+      if kind == pcFile and path.splitFile.ext == ".era1":
+        inc count
+        let f = Era1File.open(path, mergeBlockNumber).valueOr:
+          warn "Failed to open era1 file", file = path, error = error
+          inc failed
+          continue
+        defer:
+          close(f)
+
+        let root = f.verify().valueOr:
+          warn "Verification failed", file = path, error = error
+          inc failed
+          continue
+
+        notice "Era1 file verified", accumulatorRoot = root.data.to0xHex(), file = path
+  except OSError as e:
+    fatal "Failed to read directory", dir = config.era1VerifyDir.string, error = e.msg
+    quit(QuitFailure)
+
+  if failed > 0:
+    fatal "Verification completed with failures", total = count, failed
+    quit(QuitFailure)
+  else:
+    notice "All era1 files verified successfully",
+      total = count, dir = config.era1VerifyDir.string

--- a/tools/nimbus_history_exporter/ere_export.nim
+++ b/tools/nimbus_history_exporter/ere_export.nim
@@ -248,15 +248,6 @@ proc exportEreFile(
 
   ok()
 
-func mergeBlockNumber(networkId: NetworkId): BlockNumber =
-  let cfg = chainConfigForNetwork(networkId)
-  if cfg.posBlock.isSome:
-    cfg.posBlock.value()
-  elif cfg.mergeNetsplitBlock.isSome:
-    cfg.mergeNetsplitBlock.value()
-  else:
-    BlockNumber(0)
-
 proc exportEre*(config: HistoryExportConf) =
   ## Export ere files from the Nimbus EL database.
   ## Covers pre-merge, merge, and post-merge eras.
@@ -290,8 +281,11 @@ proc exportEre*(config: HistoryExportConf) =
       config.noProofs, config.noReceipts,
     ).isOkOr:
       fatal "Error exporting ere file",
-        era = era, msg = error, elDir = config.elDataDirPath(),
-        hint = "Ensure the nimbus execution client is fully synced to cover the requested era range"
+        era = era,
+        msg = error,
+        elDir = config.elDataDirPath(),
+        hint =
+          "Ensure the nimbus execution client is fully synced to cover the requested era range"
       quit(QuitFailure)
 
 proc exportEreFromEra1*(config: HistoryExportConf) =
@@ -323,9 +317,7 @@ proc exportEreFromEra1*(config: HistoryExportConf) =
       fatal "Error exporting ere file", era = era, msg = error
       quit(QuitFailure)
 
-proc verifyEreFile(
-    ereFilename: string, v: HeaderVerifier
-): Result[void, string] =
+proc verifyEreFile(ereFilename: string, v: HeaderVerifier): Result[void, string] =
   ## Verify a single ere file using a pre-loaded HeaderVerifier.
   let
     (network, noProofs, noReceipts) = ?parseEreFileName(ereFilename)
@@ -358,9 +350,8 @@ proc buildHeaderVerifier(
         config.eraDir.get().string
       else:
         defaultDataDir("", network) / "era"
-    (historicalRoots, historicalSummaries) = ?loadHistoricalDataFromEraDir(
-      networkMetadata.cfg, eraDirPath
-    )
+    (historicalRoots, historicalSummaries) =
+      ?loadHistoricalDataFromEraDir(networkMetadata.cfg, eraDirPath)
   ok(
     HeaderVerifier(
       historicalHashes: loadAccumulator(), # TODO: network specific

--- a/tools/nimbus_history_exporter/nimbus_history_exporter.nim
+++ b/tools/nimbus_history_exporter/nimbus_history_exporter.nim
@@ -13,7 +13,9 @@ import
   chronicles,
   ../../execution_chain/compile_info,
   ./nimbus_history_exporter_conf,
-  ./ere_export
+  ./ere_export,
+  ./era1_export,
+  ./accumulator_export
 
 proc main() =
   let config = HistoryExportConf.loadWithBanners(
@@ -39,6 +41,14 @@ proc main() =
     verifyEreFile(config, config.ereFile.string).isOkOr:
       fatal "Verification of ere file failed", error = error
       quit(QuitFailure)
+  of HistoryExportCmd.exportEra1:
+    exportEra1(config)
+  of HistoryExportCmd.verifyEra1:
+    verifyEra1(config)
+  of HistoryExportCmd.exportAccumulator:
+    exportAccumulator(config)
+  of HistoryExportCmd.printAccumulator:
+    printAccumulator(config)
 
 when isMainModule:
   main()

--- a/tools/nimbus_history_exporter/nimbus_history_exporter_conf.nim
+++ b/tools/nimbus_history_exporter/nimbus_history_exporter_conf.nim
@@ -29,6 +29,10 @@ type
     exportEreFromEra1
     verifyEre
     verifyEreFile
+    exportEra1
+    verifyEra1
+    exportAccumulator
+    printAccumulator
 
   HistoryExportConf* = object
     configFile* {.
@@ -55,6 +59,12 @@ type
       name: "network"
     .}: string
 
+    elDataDir* {.
+      desc: "Nimbus execution client data directory for reading EL block data",
+      defaultValueDesc: "<data-dir>",
+      name: "el-data-dir"
+    .}: Option[InputDir]
+
     eraDir* {.
       desc:
         "Directory containing beacon chain era files (.era) for post-merge proof building or post-merge block verification",
@@ -64,11 +74,6 @@ type
 
     case cmd* {.command.}: HistoryExportCmd
     of HistoryExportCmd.exportEre:
-      elDataDir* {.
-        desc: "Nimbus execution client data directory for reading EL block data",
-        defaultValueDesc: "<data-dir>",
-        name: "el-data-dir"
-      .}: Option[InputDir]
       startEra* {.desc: "Number of the first era to be exported", name: "start-era".}:
         uint64
       endEra* {.desc: "Number of the last era to be exported", name: "end-era".}: uint64
@@ -120,6 +125,36 @@ type
     of HistoryExportCmd.verifyEreFile:
       ereFile* {.desc: "Path to the ere file to be verified", name: "ere-file".}:
         InputFile
+    of HistoryExportCmd.exportEra1:
+      startEraEra1Export* {.
+        desc: "Number of the first era to be exported", name: "start-era"
+      .}: uint64
+      endEraEra1Export* {.
+        desc: "Number of the last era to be exported", name: "end-era"
+      .}: uint64
+      era1OutputDir* {.
+        desc: "Directory to write .era1 files to",
+        defaultValueDesc: "<data-dir>/era1",
+        name: "era1-dir"
+      .}: Option[OutDir]
+    of HistoryExportCmd.verifyEra1:
+      era1VerifyDir* {.
+        desc: "Directory containing .era1 files to verify", name: "era1-dir"
+      .}: InputDir
+    of HistoryExportCmd.exportAccumulator:
+      accumulatorOutputDir* {.
+        desc: "Directory to write the accumulator SSZ file and epoch records to",
+        name: "accumulator-dir"
+      .}: OutDir
+      writeEpochRecords* {.
+        desc: "Also write individual epoch record SSZ files",
+        defaultValue: false,
+        name: "write-epoch-records"
+      .}: bool
+    of HistoryExportCmd.printAccumulator:
+      accumulatorFile* {.
+        desc: "Path to the accumulator SSZ file to print", name: "accumulator-file"
+      .}: InputFile
 
 proc eraDirPath*(config: HistoryExportConf): string =
   if config.eraDir.isSome:
@@ -128,7 +163,6 @@ proc eraDirPath*(config: HistoryExportConf): string =
     defaultDataDir("", config.network) / "era"
 
 proc elDataDirPath*(config: HistoryExportConf): string =
-  doAssert config.cmd == HistoryExportCmd.exportEre
   if config.elDataDir.isSome:
     config.elDataDir.get().string
   else:
@@ -138,6 +172,13 @@ proc era1DirPath*(config: HistoryExportConf): string =
   doAssert config.cmd == HistoryExportCmd.exportEreFromEra1
   if config.era1Dir.isSome:
     config.era1Dir.get().string
+  else:
+    defaultDataDir("", config.network) / "era1"
+
+proc era1OutputDirPath*(config: HistoryExportConf): string =
+  doAssert config.cmd == HistoryExportCmd.exportEra1
+  if config.era1OutputDir.isSome:
+    string config.era1OutputDir.get()
   else:
     defaultDataDir("", config.network) / "era1"
 
@@ -174,6 +215,15 @@ const
     "Copyright (c) 2026-" & compileYear & " Status Research & Development GmbH"
   ExporterName = "nimbus_history_exporter"
   ClientVersion* = &"{ExporterName}/{FullVersionStr}/{CpuInfo}"
+
+func mergeBlockNumber*(networkId: NetworkId): BlockNumber =
+  let cfg = chainConfigForNetwork(networkId)
+  if cfg.posBlock.isSome:
+    cfg.posBlock.value()
+  elif cfg.mergeNetsplitBlock.isSome:
+    cfg.mergeNetsplitBlock.value()
+  else:
+    BlockNumber(0)
 
 proc checkConfig*(cfg: HistoryExportConf) =
   let networkLower = cfg.network.toLowerAscii()


### PR DESCRIPTION
Add historical_hashes_accumulator export and era1 export to nimbus_history_exporter tool. This is functionality ported from the Portal eth_data_exporter tool to this tool, where instead of JSON-RPC the local nimbus database is used as data source.