### PR TITLE
nix: use TMPDIR for cache locations

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -88,8 +88,13 @@ in stdenv.mkDerivation rec {
     patchShebangs scripts vendor >/dev/null
   '';
 
-  # Generate the nimbus-build-system.paths file with vendor module paths.
   configurePhase = ''
+    # Avoid Nim cache permission errors.
+    export XDG_CACHE_HOME="$TMPDIR/.cache"
+    export NIMBLE_DIR="$TMPDIR/.nimble"
+    export NIMCACHE="$TMPDIR/nimcache"
+
+    # Generate the nimbus-build-system.paths file with vendor module paths.
     make nimbus-build-system-paths
   '';
 


### PR DESCRIPTION
Hardcoding `/tmp` is fine for Linux but on macOS hosts due to lackluster sandboxing weird errors due to corrupted Nim cache can appear.
```
Error: cannot open '/tmp/nim/koch_d/@psystem@sexceptions.nim.c'
```
Updating NBS to include the same fix for Nim build.

- https://github.com/status-im/nimbus-build-system/pull/126