### PR TITLE
Parallel state root computation disabled by default

### DIFF
--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -355,7 +355,7 @@ type
 
     parallelStateRootComputation* {.
       hidden
-      defaultValue: true
+      defaultValue: false
       desc: "Compute state root in parallel using multiple threads"
       name: "debug-parallel-state-root".}: bool
 

--- a/tests/test_configuration.nim
+++ b/tests/test_configuration.nim
@@ -361,7 +361,7 @@ proc configurationMain*() =
       check config.rdbPrintStats == true
       check config.rewriteDatadirId == true
       check config.eagerStateRootCheck == false
-      check config.parallelStateRootComputation == true
+      check config.parallelStateRootComputation == false
       check config.statelessProviderEnabled == true
       check config.statelessWitnessValidation == true
 


### PR DESCRIPTION
Refc's thread local heaps causes a reasonable increase in memory usage when the parallel features are enabled. 

If we want to still run on less than 16G of RAM we should keep this disabled (for now). 