### PR TITLE
Make a bunch of UX tweaks to nimbus_history_exporter tool

### DIFF
--- a/portal/bridge/history/portal_history_bridge.nim
+++ b/portal/bridge/history/portal_history_bridge.nim
@@ -168,6 +168,8 @@ proc runBackfillLoopSyncMode(
     blockLowerBound = startEra * EPOCH_SIZE # inclusive
     blockUpperBound = ((endEra + 1) * EPOCH_SIZE) - 1 # inclusive
     blockNumberQueue = newAsyncQueue[uint64](50)
+  defer:
+    db.dispose()
 
   proc blockWorker() {.async: (raises: [CancelledError]).} =
     while true:
@@ -224,6 +226,8 @@ proc runBackfillLoopAuditMode(
     blockLowerBound = startEra * EPOCH_SIZE # inclusive
     blockUpperBound = ((endEra + 1) * EPOCH_SIZE) - 1 # inclusive
     blockRange = blockUpperBound - blockLowerBound
+  defer:
+    db.dispose()
 
   var blockTuple: BlockTuple
   while true:

--- a/portal/database/era1_db.nim
+++ b/portal/database/era1_db.nim
@@ -69,6 +69,12 @@ proc new*(
     mergeBlockNumber: mergeBlockNumber,
   )
 
+proc dispose*(db: Era1DB) =
+  for f in db.files:
+    if f != nil:
+      f.close()
+  db.files.reset()
+
 proc getBlockHeader*(
     db: Era1DB, blockNumber: uint64, res: var Header
 ): Result[void, string] =

--- a/tools/nimbus_history_exporter/README.md
+++ b/tools/nimbus_history_exporter/README.md
@@ -39,12 +39,22 @@ Without `--debug-store-bodies` and `--debug-store-receipts`, the database will b
 
 `exportEre` reads block data directly from the Nimbus execution client's data directory to produce `ere` files.
 
+Export all available eras (default behaviour):
+
+```sh
+nimbus_history_exporter exportEre \
+  --el-data-dir:/path/to/nimbus/mainnet \
+  --era-dir:/path/to/nimbus/mainnet/era
+```
+
+Export a specific range:
+
 ```sh
 nimbus_history_exporter exportEre \
   --el-data-dir:/path/to/nimbus/mainnet \
   --era-dir:/path/to/nimbus/mainnet/era \
-  --start-era:0 \
-  --end-era:2400
+  --era:100 \
+  --era-count:500
 ```
 
 `ere` files are written to `<el-data-dir>/ere/` by default.
@@ -78,9 +88,7 @@ If the EL database is not available, pre-merge `ere` files can be produced from 
 
 ```sh
 nimbus_history_exporter exportEreFromEra1 \
-  --era1-dir:/path/to/era1 \
-  --start-era:0 \
-  --end-era:1896
+  --era1-dir:/path/to/era1
 ```
 
 `ere` files are written to `<era1-dir>/../ere/` by default, or to `--ere-dir` if specified.
@@ -95,8 +103,6 @@ nimbus_history_exporter exportEreFromEra1 \
 ```sh
 nimbus_history_exporter exportEra1 \
   --el-data-dir:/path/to/nimbus/mainnet \
-  --start-era:0 \
-  --end-era:1896 \
   --era1-dir:/path/to/output/era1
 ```
 

--- a/tools/nimbus_history_exporter/era1_export.nim
+++ b/tools/nimbus_history_exporter/era1_export.nim
@@ -87,7 +87,12 @@ proc exportEra1*(config: HistoryExportConf) =
     mergeBlockNumber = mergeBlockNumber(config.networkId())
     networkName = config.network
     mergeEra = era1.era(mergeBlockNumber)
-    preMergeEndEra = min(Era1(config.endEraEra1Export), mergeEra - 1)
+    startEra1 = Era1(config.eraEra1Export)
+    endEra1 =
+      if config.eraCountEra1Export == 0:
+        mergeEra
+      else:
+        min(Era1(config.eraEra1Export + config.eraCountEra1Export - 1), mergeEra)
     outputDir = config.era1OutputDirPath()
 
   createPath(outputDir).isOkOr:
@@ -99,7 +104,7 @@ proc exportEra1*(config: HistoryExportConf) =
     coreDb.close()
   let db = coreDb.baseTxFrame()
 
-  for era in Era1(config.startEraEra1Export) .. preMergeEndEra:
+  for era in startEra1 .. endEra1:
     exportEra1File(era, db, networkName, mergeBlockNumber, outputDir).isOkOr:
       fatal "Error exporting era1 file",
         era = era.uint64,

--- a/tools/nimbus_history_exporter/ere_export.nim
+++ b/tools/nimbus_history_exporter/ere_export.nim
@@ -48,12 +48,16 @@ proc exportEreFileFromEra1(
   var header: headers.Header
   ?db.getBlockHeader(endNumber, header)
 
-  let
-    filename =
-      outputDir /
-      ereFileName(networkName, era, header.computeRlpHash(), noProofs, noReceipts)
-    e2 = openFile(filename, {OpenFlags.Write, OpenFlags.Create, OpenFlags.Truncate}).valueOr:
-      return err(ioErrorMsg(error))
+  let filename =
+    outputDir /
+    ereFileName(networkName, era, header.computeRlpHash(), noProofs, noReceipts)
+
+  if isFile(filename):
+    debug "Ere file already exists", era, file = filename
+    return ok()
+
+  let e2 = openFile(filename, {OpenFlags.Write, OpenFlags.Create, OpenFlags.Truncate}).valueOr:
+    return err(ioErrorMsg(error))
   defer:
     discard closeFile(e2)
 
@@ -151,9 +155,12 @@ proc exportEreFile(
     filename =
       outputDir / ereFileName(networkName, era, endHeaderHash, noProofs, noReceipts)
 
-    e2 = openFile(filename, {OpenFlags.Write, OpenFlags.Create, OpenFlags.Truncate}).valueOr:
-      return err(ioErrorMsg(error))
+  if isFile(filename):
+    debug "Ere file already exists", era, file = filename
+    return ok()
 
+  let e2 = openFile(filename, {OpenFlags.Write, OpenFlags.Create, OpenFlags.Truncate}).valueOr:
+    return err(ioErrorMsg(error))
   defer:
     discard closeFile(e2)
 
@@ -255,7 +262,12 @@ proc exportEre*(config: HistoryExportConf) =
     mergeBlockNumber = mergeBlockNumber(config.networkId())
     networkName = config.network
     mergeEra = ere.era(mergeBlockNumber)
-    requestedEndEra = ere.Era(config.endEra)
+    startEra = ere.Era(config.era)
+    endEra =
+      if config.eraCount == 0:
+        ere.Era(high(uint64))
+      else:
+        ere.Era(config.era + config.eraCount - 1)
     ereOutputDir = config.ereOutputDir()
 
   createPath(ereOutputDir).isOkOr:
@@ -264,7 +276,7 @@ proc exportEre*(config: HistoryExportConf) =
     quit(QuitFailure)
 
   var beaconBuilder = Opt.none(BeaconProofBuilder)
-  if not config.noProofs and requestedEndEra >= mergeEra:
+  if not config.noProofs and endEra >= mergeEra:
     let builder = BeaconProofBuilder.init(config.eraDirPath(), networkName).valueOr:
       fatal "Failed to initialise BeaconProofBuilder", error = error
       quit(QuitFailure)
@@ -274,8 +286,13 @@ proc exportEre*(config: HistoryExportConf) =
   defer:
     coreDb.close()
   let txFrame = coreDb.baseTxFrame()
+  let highestBlock = txFrame.stateBlockNumber()
 
-  for era in ere.Era(config.startEra) .. requestedEndEra:
+  for era in startEra .. endEra:
+    if era.endNumber() > highestBlock:
+      notice "Written all complete eras", era, highestBlock
+      break
+
     exportEreFile(
       era, txFrame, networkName, mergeBlockNumber, beaconBuilder, ereOutputDir,
       config.noProofs, config.noReceipts,
@@ -295,7 +312,12 @@ proc exportEreFromEra1*(config: HistoryExportConf) =
     mergeBlockNumber = mergeBlockNumber(config.networkId())
     networkName = config.network
     mergeEra = ere.era(mergeBlockNumber)
-    preMergeEndEra = min(ere.Era(config.endEraEra1), mergeEra - 1)
+    startEraFromEra1 = ere.Era(config.eraEra1)
+    endEraFromEra1 =
+      if config.eraCountEra1 == 0:
+        mergeEra - 1
+      else:
+        min(ere.Era(config.eraEra1 + config.eraCountEra1 - 1), mergeEra - 1)
     ereOutputDir = config.ereOutputDir()
 
   createPath(ereOutputDir).isOkOr:
@@ -303,10 +325,13 @@ proc exportEreFromEra1*(config: HistoryExportConf) =
       ereOutputDir, error = ioErrorMsg(error)
     quit(QuitFailure)
 
-  let era1DB =
-    Era1DB.new(config.era1DirPath(), networkName, loadAccumulator(networkName), mergeBlockNumber)
+  let era1DB = Era1DB.new(
+    config.era1DirPath(), networkName, loadAccumulator(networkName), mergeBlockNumber
+  )
+  defer:
+    era1DB.dispose()
 
-  for era in ere.Era(config.startEraEra1) .. preMergeEndEra:
+  for era in startEraFromEra1 .. endEraFromEra1:
     exportEreFileFromEra1(
       era, era1DB, networkName, mergeBlockNumber, ereOutputDir, config.noProofsEra1,
       config.noReceiptsEra1,

--- a/tools/nimbus_history_exporter/nimbus_history_exporter_conf.nim
+++ b/tools/nimbus_history_exporter/nimbus_history_exporter_conf.nim
@@ -74,9 +74,11 @@ type
 
     case cmd* {.command.}: HistoryExportCmd
     of HistoryExportCmd.exportEre:
-      startEra* {.desc: "Number of the first era to be exported", name: "start-era".}:
+      era* {.desc: "Number of first era to export", defaultValue: 0, name: "era".}:
         uint64
-      endEra* {.desc: "Number of the last era to be exported", name: "end-era".}: uint64
+      eraCount* {.
+        desc: "Number of eras to export (0 = all)", defaultValue: 0, name: "era-count"
+      .}: uint64
       noProofs* {.
         desc: "Omit proof entries from the ere file (produces a noproofs profile)",
         defaultValue: false,
@@ -98,11 +100,14 @@ type
         defaultValueDesc: "<data-dir>/era1",
         name: "era1-dir"
       .}: Option[InputDir]
-      startEraEra1* {.
-        desc: "Number of the first era to be exported", name: "start-era"
-      .}: uint64
-      endEraEra1* {.desc: "Number of the last era to be exported", name: "end-era".}:
+      eraEra1* {.desc: "Number of first era to export", defaultValue: 0, name: "era".}:
         uint64
+      eraCountEra1* {.
+        desc:
+          "Number of eras to export (0 = all pre-merge eras, excluding the merge era)",
+        defaultValue: 0,
+        name: "era-count"
+      .}: uint64
       noProofsEra1* {.
         desc: "Omit proof entries from the ere file (produces a noproofs profile)",
         defaultValue: false,
@@ -126,11 +131,14 @@ type
       ereFile* {.desc: "Path to the ere file to be verified", name: "ere-file".}:
         InputFile
     of HistoryExportCmd.exportEra1:
-      startEraEra1Export* {.
-        desc: "Number of the first era to be exported", name: "start-era"
+      eraEra1Export* {.
+        desc: "Number of first era to export", defaultValue: 0, name: "era"
       .}: uint64
-      endEraEra1Export* {.
-        desc: "Number of the last era to be exported", name: "end-era"
+      eraCountEra1Export* {.
+        desc:
+          "Number of eras to export (0 = all pre-merge eras, including the merge era)",
+        defaultValue: 0,
+        name: "era-count"
       .}: uint64
       era1OutputDir* {.
         desc: "Directory to write .era1 files to",


### PR DESCRIPTION
- CLI flags start-era and end-era replace with era and era-count to be consistent with ncli_db UX.
- Don't generate ere files if they already exist (this was already there for era1 generation)
- update docs

And also for era1DB: add dispose() and use where we use era1DB