### PR TITLE
Skip empty account check in ledger addBalance post merge

### DIFF
--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -371,10 +371,10 @@ proc procBlkPreamble(
     if vmState.balTrackerEnabled:
       for withdrawal in blk.withdrawals.get:
         vmState.balTracker.trackAddBalanceChange(withdrawal.address, withdrawal.weiAmount)
-        vmState.ledger.addBalance(withdrawal.address, withdrawal.weiAmount)
+        vmState.ledger.addBalance(withdrawal.address, withdrawal.weiAmount, checkEmptyAccount = false)
     else:
       for withdrawal in blk.withdrawals.get:
-        vmState.ledger.addBalance(withdrawal.address, withdrawal.weiAmount)
+        vmState.ledger.addBalance(withdrawal.address, withdrawal.weiAmount, checkEmptyAccount = false)
   else:
     if header.withdrawalsRoot.isSome:
       return err("Pre-Shanghai block header must not have withdrawalsRoot")

--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -76,7 +76,7 @@ proc commitOrRollbackDependingOnGasUsed(
     vmState.balTracker.trackAddBalanceChange(vmState.coinbase(), txFee)
     vmState.balTracker.commitCallFrame()
 
-  vmState.ledger.addBalance(vmState.coinbase(), txFee)
+  vmState.ledger.addBalance(vmState.coinbase(), txFee, checkEmptyAccount = vmState.fork < FkParis)
   vmState.ledger.commit(savePoint)
   vmState.cumulativeGasUsed += gasUsed
   vmState.blockRegularGasUsed += callResult.blockRegularGasUsed

--- a/execution_chain/core/tx_pool/tx_packer.nim
+++ b/execution_chain/core/tx_pool/tx_packer.nim
@@ -173,10 +173,10 @@ proc vmExecCommit(pst: var TxPacker, xp: TxPoolRef): Result[void, string] =
     if vmState.balTrackerEnabled:
       for withdrawal in xp.withdrawals:
         vmState.balTracker.trackAddBalanceChange(withdrawal.address, withdrawal.weiAmount)
-        ledger.addBalance(withdrawal.address, withdrawal.weiAmount)
+        ledger.addBalance(withdrawal.address, withdrawal.weiAmount, checkEmptyAccount = false)
     else:
       for withdrawal in xp.withdrawals:
-        ledger.addBalance(withdrawal.address, withdrawal.weiAmount)
+        ledger.addBalance(withdrawal.address, withdrawal.weiAmount, checkEmptyAccount = false)
 
   # EIP-6110, EIP-7002, EIP-7251
   if vmState.fork >= FkPrague:

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -532,13 +532,21 @@ proc setBalance*(ledger: LedgerRef, address: Address, balance: UInt256) =
   if acc.statement.balance != balance:
     ledger.makeDirty(address).statement.balance = balance
 
-proc addBalance*(ledger: LedgerRef, address: Address, delta: UInt256) =
+proc addBalance*(
+    ledger: LedgerRef,
+    address: Address,
+    delta: UInt256,
+    checkEmptyAccount: bool = true,
+) =
   # EIP161: We must check emptiness for the objects such that the account
-  # clearing (0,0,0 objects) can take effect.
+  # clearing (0,0,0 objects) can take effect. This is not required for hardforks
+  # starting at the merge because by then no empty accounts remain in the state,
+  # so callers in that regime can skip the lookup via checkEmptyAccount = false.
   if delta.isZero:
-    let acc = ledger.getAccount(address)
-    if acc.isEmpty:
-      ledger.makeDirty(address).flags.incl Touched
+    if checkEmptyAccount:
+      let acc = ledger.getAccount(address)
+      if acc.isEmpty:
+        ledger.makeDirty(address).flags.incl Touched
     return
   ledger.setBalance(address, ledger.getBalance(address) + delta)
 

--- a/execution_chain/evm/computation.nim
+++ b/execution_chain/evm/computation.nim
@@ -320,7 +320,7 @@ proc execSelfDestruct*(c: Computation, beneficiary: Address) =
         ledger.subBalance(c.msg.contractAddress, localBalance)
         # Transfer to beneficiary
         c.vmState.balTracker.trackAddBalanceChange(beneficiary, localBalance)
-        ledger.addBalance(beneficiary, localBalance)
+        ledger.addBalance(beneficiary, localBalance, checkEmptyAccount = c.fork < FkParis)
         if ledger.selfDestruct6780(c.msg.contractAddress):
           c.vmState.balTracker.trackInTransactionSelfDestruct(c.msg.contractAddress)
           newContract = true
@@ -328,14 +328,14 @@ proc execSelfDestruct*(c: Computation, beneficiary: Address) =
         # Zeroing contract balance except beneficiary is the same address
         ledger.subBalance(c.msg.contractAddress, localBalance)
         # Transfer to beneficiary
-        ledger.addBalance(beneficiary, localBalance)
+        ledger.addBalance(beneficiary, localBalance, checkEmptyAccount = c.fork < FkParis)
         newContract = ledger.selfDestruct6780(c.msg.contractAddress)
 
       if c.fork >= FkAmsterdam:
         c.emitSelfDestructLog(beneficiary, localBalance, newContract)
     else:
       # Transfer to beneficiary
-      ledger.addBalance(beneficiary, localBalance)
+      ledger.addBalance(beneficiary, localBalance, checkEmptyAccount = c.fork < FkParis)
       ledger.selfDestruct(c.msg.contractAddress)
 
     trace "SELFDESTRUCT",

--- a/execution_chain/evm/interpreter_dispatch.nim
+++ b/execution_chain/evm/interpreter_dispatch.nim
@@ -75,10 +75,10 @@ proc beforeExecCall(c: Computation) =
         c.vmState.balTracker.trackSubBalanceChange(c.msg.sender, c.msg.value)
         ledger.subBalance(c.msg.sender, c.msg.value)
         c.vmState.balTracker.trackAddBalanceChange(c.msg.contractAddress, c.msg.value)
-        ledger.addBalance(c.msg.contractAddress, c.msg.value)
+        ledger.addBalance(c.msg.contractAddress, c.msg.value, checkEmptyAccount = c.fork < FkParis)
       else:
         ledger.subBalance(c.msg.sender, c.msg.value)
-        ledger.addBalance(c.msg.contractAddress, c.msg.value)
+        ledger.addBalance(c.msg.contractAddress, c.msg.value, checkEmptyAccount = c.fork < FkParis)
 
     if c.fork >= FkAmsterdam:
       # EIP-7708: Emit transfer log for ETH-tx or contract call and CALL op code
@@ -136,14 +136,14 @@ proc beforeExecCreate(c: Computation): bool =
       c.vmState.balTracker.trackSubBalanceChange(c.msg.sender, c.msg.value)
       ledger.subBalance(c.msg.sender, c.msg.value)
       c.vmState.balTracker.trackAddBalanceChange(c.msg.contractAddress, c.msg.value)
-      ledger.addBalance(c.msg.contractAddress, c.msg.value)
+      ledger.addBalance(c.msg.contractAddress, c.msg.value, checkEmptyAccount = c.fork < FkParis)
       ledger.clearStorage(c.msg.contractAddress)
       # no need to check c.fork >= FkSpurious, it's FkAmsterdam
       c.vmState.balTracker.trackIncNonceChange(c.msg.contractAddress)
       ledger.incNonce(c.msg.contractAddress)
     else:
       ledger.subBalance(c.msg.sender, c.msg.value)
-      ledger.addBalance(c.msg.contractAddress, c.msg.value)
+      ledger.addBalance(c.msg.contractAddress, c.msg.value, checkEmptyAccount = c.fork < FkParis)
       ledger.clearStorage(c.msg.contractAddress)
       if c.fork >= FkSpurious:
         # EIP161 nonce incrementation

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -275,7 +275,7 @@ proc calculateAndPossiblyRefundGas(c: Computation, call: CallParams, gasRefund: 
     if vmState.balTrackerEnabled:
       vmState.balTracker.trackAddBalanceChange(call.sender, gasRefundAmount)
     vmState.mutateLedger:
-      ledger.addBalance(call.sender, gasRefundAmount)
+      ledger.addBalance(call.sender, gasRefundAmount, checkEmptyAccount = fork < FkParis)
 
   GasUsed(
     evmGasUsed: c.msg.gas - txGasLeft,


### PR DESCRIPTION
Don't load account for empty check post merge when adding zero balance. 

This can be skipped because in practice there are no empty accounts remaining in the state at the merge hardfork.