### PR TITLE
Don't load code for delegation when the address is a precompile

### DIFF
--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -20,6 +20,7 @@ import
   ../../transaction,
   ../../evm/state,
   ../../evm/types,
+  ../../evm/precompiles,
   ../../evm/interpreter/gas_costs,
   ../../block_access_list/block_access_list_validation,
   ../../concurrency/utils,
@@ -56,6 +57,7 @@ when compileOption("threads"):
       nextIndex: Atomic[int]
       balPtr: ptr BlockAccessList
       txFrame: CoreDbTxRef
+      fork: EVMFork
 
   proc recoverAndPrefetchTask(
       e: ptr Entry, ctx: ptr PrefetchCtx, tx: ptr Transaction): bool {.nimcall.} =
@@ -175,9 +177,18 @@ when compileOption("threads"):
       if i >= len:
         break
 
-      let
-        accChanges = addr ctx[].balPtr[][i]
-        accPath = accChanges[].address.computeAccPath
+      let accChanges = addr ctx[].balPtr[][i]
+
+      # Precompile contracts don't exist in the state trie and don't get loaded
+      # when called so we don't prefetch them. The BAL can contain precompile addresses 
+      # but in most cases the state trie account is not actually fetched. The edge
+      # case here is when a precompile contract receives a value transfer which will
+      # load the account to update the balance but unfortunately we can't determine
+      # if this was the case or not from the information in the BAL so we ignore this.
+      if isPrecompile(ctx[].fork, accChanges[].address):
+        continue
+
+      let accPath = accChanges[].address.computeAccPath
 
       if accChanges[].storageChanges.len == 0 and accChanges[].storageReads.len == 0:
         discard ctx[].txFrame.fetchAccount(accPath)
@@ -205,6 +216,7 @@ when compileOption("threads"):
     # Read through the parent frame because the current frame is written to
     # during block execution; this avoids locking on the frame data structures.
     ctx.txFrame = vmState.ledger.txFrame.parent()
+    ctx.fork = vmState.fork
     ctx.nextIndex.store(0, moRelease)
     ctx.finished.store(false, moRelease)
 

--- a/execution_chain/evm/interpreter/op_handlers/oph_call.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_call.nim
@@ -74,6 +74,9 @@ proc updateStackAndParams(q: var LocalParams; c: Computation) =
     q.memOffset = q.memOutPos
     q.memLength = q.memOutLen
 
+  if isPrecompile(c.vmState.fork, q.codeAddress):
+    q.flags.incl MsgFlags.Precompile
+
 # EIP2929: This came before old gas calculator
 #           because it will affect `c.gasMeter.gasRemaining`
 #           and further `childGasLimit`
@@ -93,7 +96,7 @@ proc gasCallEIP2929(c: Computation, codeAddress: Address): GasProc =
     GasProc proc(): GasInt =
       0.GasInt
 
-proc gasCallDelegate(c: Computation, codeAddress: Address): GasProc =
+proc gasCallDelegate(c: Computation, codeAddress: Address, flags: set[MsgFlags]): GasProc =
   if FkPrague <= c.fork:
     GasProc proc(): GasInt =
       # When the target is a 7702-delegated EOA both target and
@@ -105,7 +108,7 @@ proc gasCallDelegate(c: Computation, codeAddress: Address): GasProc =
       # Code does not need to be loaded for precompile addresses because the
       # precompile doesn't exist in the state trie and can never be a 7702
       # delegation, so resolving the delegation target is a no-op.
-      if isPrecompile(c.vmState.fork, codeAddress):
+      if MsgFlags.Precompile in flags:
         c.delegateTo = codeAddress
         return 0.GasInt
 
@@ -193,9 +196,9 @@ proc staticCallParams(c: Computation, res: var LocalParams): EvmResult[void] =
   res.updateStackAndParams(c)
   ok()
 
-proc getCallCode(c: Computation): CodeBytesRef =
+proc getCallCode(c: Computation, childMsg: Message): CodeBytesRef =
   # Avoid accessing ledger if it's a precompile address
-  if isPrecompile(c.vmState.fork, c.msg.codeAddress):
+  if MsgFlags.Precompile in childMsg.flags:
     return CodeBytesRef(nil)
   c.vmState.readOnlyLedger.getCode(c.delegateTo)
 
@@ -205,7 +208,7 @@ proc execSubCall(c: Computation; childMsg: Message; memPos, memLen: int) =
   # need to provide explicit <c> and <child> for capturing in chainTo proc()
   # <memPos> and <memLen> are provided by value and need not be captured
   var
-    code = c.getCallCode()
+    code = c.getCallCode(childMsg)
     child = newComputation(
       c.vmState, keepStack = false, childMsg, code)
 
@@ -288,7 +291,7 @@ proc callOp(cpt: VmCpt): EvmResultVoid =
         gasCost1:        gasCost1,
         isNewAccount:    isNewAccount,
         gasLeft:         cpt.gasMeter.gasRemaining,
-        gasCallDelegate: cpt.gasCallDelegate(p.codeAddress),
+        gasCallDelegate: cpt.gasCallDelegate(p.codeAddress, p.flags),
         contractGas:     p.gas))
 
   ? cpt.opcodeGasCost(Call, gasCost, reason = $Call)
@@ -363,7 +366,7 @@ proc callCodeOp(cpt: VmCpt): EvmResultVoid =
         gasCost1:        gasCost1,
         isNewAccount:    isNewAccount,
         gasLeft:         cpt.gasMeter.gasRemaining,
-        gasCallDelegate: cpt.gasCallDelegate(p.codeAddress),
+        gasCallDelegate: cpt.gasCallDelegate(p.codeAddress, p.flags),
         contractGas:     p.gas))
 
   ? cpt.opcodeGasCost(CallCode, gasCost, reason = $CallCode)
@@ -438,7 +441,7 @@ proc delegateCallOp(cpt: VmCpt): EvmResultVoid =
         gasCost1:        gasCost1,
         isNewAccount:    isNewAccount,
         gasLeft:         cpt.gasMeter.gasRemaining,
-        gasCallDelegate: cpt.gasCallDelegate(p.codeAddress),
+        gasCallDelegate: cpt.gasCallDelegate(p.codeAddress, p.flags),
         contractGas:     p.gas))
 
   ? cpt.opcodeGasCost(DelegateCall, gasCost, reason = $DelegateCall)
@@ -506,7 +509,7 @@ proc staticCallOp(cpt: VmCpt): EvmResultVoid =
         gasCost1:        gasCost1,
         isNewAccount:    isNewAccount,
         gasLeft:         cpt.gasMeter.gasRemaining,
-        gasCallDelegate: cpt.gasCallDelegate(p.codeAddress),
+        gasCallDelegate: cpt.gasCallDelegate(p.codeAddress, p.flags),
         contractGas:     p.gas))
 
   ? cpt.opcodeGasCost(StaticCall, gasCost, reason = $StaticCall)

--- a/execution_chain/evm/interpreter/op_handlers/oph_call.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_call.nim
@@ -101,6 +101,14 @@ proc gasCallDelegate(c: Computation, codeAddress: Address): GasProc =
       # But in OOG case, only `codeAddress` appear in BAL.
       if c.balTrackerEnabled:
         c.vmState.balTracker.trackAddressAccess(codeAddress)
+
+      # Code does not need to be loaded for precompile addresses because the
+      # precompile doesn't exist in the state trie and can never be a 7702
+      # delegation, so resolving the delegation target is a no-op.
+      if getPrecompile(c.vmState.fork, codeAddress).isSome:
+        c.delegateTo = codeAddress
+        return 0.GasInt
+
       let delegateTo = parseDelegationAddress(c.getCode(codeAddress)).valueOr:
         c.delegateTo = codeAddress
         return 0.GasInt

--- a/execution_chain/evm/interpreter/op_handlers/oph_call.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_call.nim
@@ -105,7 +105,7 @@ proc gasCallDelegate(c: Computation, codeAddress: Address): GasProc =
       # Code does not need to be loaded for precompile addresses because the
       # precompile doesn't exist in the state trie and can never be a 7702
       # delegation, so resolving the delegation target is a no-op.
-      if getPrecompile(c.vmState.fork, codeAddress).isSome:
+      if isPrecompile(c.vmState.fork, codeAddress):
         c.delegateTo = codeAddress
         return 0.GasInt
 
@@ -195,7 +195,7 @@ proc staticCallParams(c: Computation, res: var LocalParams): EvmResult[void] =
 
 proc getCallCode(c: Computation): CodeBytesRef =
   # Avoid accessing ledger if it's a precompile address
-  if getPrecompile(c.vmState.fork, c.msg.codeAddress).isSome:
+  if isPrecompile(c.vmState.fork, c.msg.codeAddress):
     return CodeBytesRef(nil)
   c.vmState.readOnlyLedger.getCode(c.delegateTo)
 

--- a/execution_chain/evm/interpreter_dispatch.nim
+++ b/execution_chain/evm/interpreter_dispatch.nim
@@ -221,8 +221,8 @@ proc executeOpcodes*(c: Computation) =
   block blockOne:
     let cont = c.continuation
     if cont.isNil:
-      let precompile = c.fork.getPrecompile(c.msg.codeAddress)
-      if precompile.isSome:
+      if MsgFlags.Precompile in c.msg.flags:
+        let precompile = c.fork.getPrecompile(c.msg.codeAddress)
         c.execPrecompile(precompile[])
         break blockOne
     else:

--- a/execution_chain/evm/message.nim
+++ b/execution_chain/evm/message.nim
@@ -27,20 +27,21 @@ proc generateContractAddress*(vmState: BaseVMState,
   let creationNonce = vmState.readOnlyLedger().getNonce(sender)
   generateAddress(sender, creationNonce)
 
-proc getCallCode*(vmState: BaseVMState, codeAddress: Address): CodeBytesRef =
+proc getCallCode*(vmState: BaseVMState, msg: Message): CodeBytesRef =
   # Avoid accessing ledger if it's a precompile address
-  if isPrecompile(vmState.fork, codeAddress):
+  if isPrecompile(vmState.fork, msg.codeAddress):
+    msg.flags.incl MsgFlags.Precompile
     return CodeBytesRef(nil)
 
   # For contract creations the EVM will add the contract address to the
   # access list itself, after calculating the new contract address.
   if vmState.fork >= FkBerlin:
-    vmState.ledger.accessList(codeAddress)
+    vmState.ledger.accessList(msg.codeAddress)
     if vmState.balTrackerEnabled:
-      vmState.balTracker.trackAddressAccess(codeAddress)
+      vmState.balTracker.trackAddressAccess(msg.codeAddress)
 
   # `codeAddress` is BAL tracked in `initialAccessListEIP2929`
-  let code = vmState.readOnlyLedger.getCode(codeAddress)
+  let code = vmState.readOnlyLedger.getCode(msg.codeAddress)
   if vmState.fork < FkPrague:
     return code
 

--- a/execution_chain/evm/message.nim
+++ b/execution_chain/evm/message.nim
@@ -29,7 +29,7 @@ proc generateContractAddress*(vmState: BaseVMState,
 
 proc getCallCode*(vmState: BaseVMState, codeAddress: Address): CodeBytesRef =
   # Avoid accessing ledger if it's a precompile address
-  if getPrecompile(vmState.fork, codeAddress).isSome:
+  if isPrecompile(vmState.fork, codeAddress):
     return CodeBytesRef(nil)
 
   # For contract creations the EVM will add the contract address to the

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -755,13 +755,44 @@ func activePrecompilesList*(fork: EVMFork): seq[Address] =
   for address in activePrecompiles(fork):
     result.add address
 
-proc getPrecompile*(fork: EVMFork, codeAddress: Address): Opt[Precompiles] =
-  let maxPrecompile = getMaxPrecompile(fork)
-  for c in Precompiles.low..maxPrecompile:
-    if precompileAddrs[c] == codeAddress:
-      return Opt.some(c)
+# Every precompile address has only its low two bytes populated (the largest
+# is P256VERIFY at 0x0100), so an address can be reverse-mapped to its
+# precompile via a small array indexed by that 16-bit value. A `0` entry means 
+# "no precompile maps to this value"; any other entry is `ord(precompile) + 1`.
+const precompileForKey: array[0 .. 0x0100, byte] = static:
+  var arr: array[0 .. 0x0100, byte]
+  for c in Precompiles:
+    let data = precompileAddrs[c].data
+    arr[(data[18].int shl 8) or data[19].int] = byte(ord(c) + 1)
+  arr
 
-  Opt.none(Precompiles)
+func precompileKey(codeAddress: Address): int =
+  ## Reduce a precompile address to its 16-bit lookup key, or -1 when the address
+  ## is outside the precompile range (i.e. any of the high 18 bytes are set).
+  var hi0, hi1: uint64
+  copyMem(addr hi0, unsafeAddr codeAddress.data[0], sizeof(hi0))
+  copyMem(addr hi1, unsafeAddr codeAddress.data[8], sizeof(hi1))
+  if (hi0 or hi1) != 0 or codeAddress.data[16] != 0 or codeAddress.data[17] != 0:
+    return -1
+  (codeAddress.data[18].int shl 8) or codeAddress.data[19].int
+
+func getPrecompile*(fork: EVMFork, codeAddress: Address): Opt[Precompiles] =
+  let key = codeAddress.precompileKey
+  if key notin 0 .. precompileForKey.high:
+    return Opt.none(Precompiles)
+  let v = precompileForKey[key]
+  if v == 0:
+    return Opt.none(Precompiles)
+
+  # A precompile is only active once its introducing fork has been reached.
+  let precompile = Precompiles(v - 1)
+  if precompile <= getMaxPrecompile(fork):
+    Opt.some(precompile)
+  else:
+    Opt.none(Precompiles)
+
+template isPrecompile*(fork: EVMFork, codeAddress: Address): bool =
+  getPrecompile(fork, codeAddress).isSome
 
 proc execPrecompile*(c: Computation, precompile: Precompiles) =
   if c.balTrackerEnabled:

--- a/execution_chain/evm/types.nim
+++ b/execution_chain/evm/types.nim
@@ -117,6 +117,7 @@ type
 
   MsgFlags* {.pure.} = enum
     Static
+    Precompile
 
   Message* = ref object
     kind*:             CallKind

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -174,7 +174,7 @@ proc setupComputation(call: CallParams, gasRefund: int64, keepStack: bool): Comp
              CodeBytesRef.init(call.input)
            else:
              assign(msg.data, call.input)
-             getCallCode(vmState, msg.codeAddress)
+             getCallCode(vmState, msg)
 
     computation = newComputation(vmState, keepStack, msg, code)
 


### PR DESCRIPTION
Changes in this PR:
- Skip loading of code for delegation when the address is a pre-compile.
- Optimise performance of getPrecompile.
- Use isPrecompile template at call sites.
- Don't load precompiles in the bal state prefetch workers.