### PR TITLE
Decouple BAL tracking in EVM from Amsterdam fork

### DIFF
--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -439,11 +439,13 @@ proc procBlkEpilogue(
     withdrawalReqs = ?processDequeueWithdrawalRequests(vmState)
     consolidationReqs = ?processDequeueConsolidationRequests(vmState)
 
+  # Commit block access list tracker changes for post‑execution system calls
+  if vmState.balTrackerEnabled:
+    vmState.balTracker.commitCallFrame()
+
   if not skipValidation:
     if not skipPostExecBalCheck and vmState.com.isAmsterdamOrLater(header.timestamp):
       doAssert vmState.balTrackerEnabled
-      # Commit block access list tracker changes for post‑execution system calls
-      vmState.balTracker.commitCallFrame()
 
       let
         bal = vmState.balTracker.getBlockAccessList().get()

--- a/execution_chain/evm/interpreter_dispatch.nim
+++ b/execution_chain/evm/interpreter_dispatch.nim
@@ -138,9 +138,9 @@ proc beforeExecCreate(c: Computation): bool =
       c.vmState.balTracker.trackAddBalanceChange(c.msg.contractAddress, c.msg.value)
       ledger.addBalance(c.msg.contractAddress, c.msg.value, checkEmptyAccount = c.fork < FkParis)
       ledger.clearStorage(c.msg.contractAddress)
-      # no need to check c.fork >= FkSpurious, it's FkAmsterdam
-      c.vmState.balTracker.trackIncNonceChange(c.msg.contractAddress)
-      ledger.incNonce(c.msg.contractAddress)
+      if c.fork >= FkSpurious:
+        c.vmState.balTracker.trackIncNonceChange(c.msg.contractAddress)
+        ledger.incNonce(c.msg.contractAddress)
     else:
       ledger.subBalance(c.msg.sender, c.msg.value)
       ledger.addBalance(c.msg.contractAddress, c.msg.value, checkEmptyAccount = c.fork < FkParis)


### PR DESCRIPTION
Bal tracker should run correctly independent of fork. This is useful for the bal performance testing on pre-amsterdam blocks.