### PR TITLE
disable LTO on Windows

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -28,7 +28,8 @@ switch("nimcache", nimCachePath)
 
 # `-flto` gives a significant improvement in processing speed, specially hash tree and state transition (basically any CPU-bound code implemented in nim)
 # With LTO enabled, optimization flags should be passed to both compiler and linker!
-if defined(release) and not defined(disableLTO):
+# Windows LTO seems to increase CI time to 4+ hours
+if defined(release) and not defined(disableLTO) and not defined(windows):
   # TODO https://github.com/nim-lang/Nim/issues/25847
   # https://github.com/nim-lang/Nim/blob/bfeb3146d1638b39f69007a4ae5a23e23ae4e5ef/config/nim.cfg#L331
   template extend(name, value) = put(name, get(name) & value)
@@ -174,6 +175,8 @@ switch("warningAsError", "CaseTransition:on")
 switch("warningAsError", "ImplicitDefaultValue:on")
 switch("warningAsError", "ImplicitTemplateRedefinition:on")
 switch("warningAsError", "LongLiterals:on")
+switch("warningAsError", "ProveField:on")
+switch("warningAsError", "UnreachableCode:on")
 switch("warningAsError", "UnusedImport:on")
 switch("hintAsError", "ConvFromXtoItselfNotNeeded:on")
 switch("hintAsError", "DuplicateModuleImport:on")


### PR DESCRIPTION
Followup to:
- #4278

This increases Windows CI times by 3x or 4x.

Commit before #4278:
<img width="630" height="454" alt="2026-06-04T19:51:08,084235634+00:00" src="https://github.com/user-attachments/assets/4cec0772-b183-461f-8848-d44b7a7aac8e" />

#4278 and later; it's consistent:
<img width="630" height="446" alt="2026-06-04T19:51:52,460586295+00:00" src="https://github.com/user-attachments/assets/9e1933bf-5772-4851-a3ce-bfbeda8ca2b6" />