### PR TITLE
TxPool: fix feeRecipient reward issue and fix ordered list cleanup issue

### DIFF
--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -76,6 +76,7 @@ proc commitOrRollbackDependingOnGasUsed(
     vmState.balTracker.trackAddBalanceChange(vmState.coinbase(), txFee)
     vmState.balTracker.commitCallFrame()
 
+  callResult.txFee = txFee
   vmState.ledger.addBalance(vmState.coinbase(), txFee, checkEmptyAccount = vmState.fork < FkParis)
   vmState.ledger.commit(savePoint)
   vmState.cumulativeGasUsed += gasUsed

--- a/execution_chain/core/tx_pool/tx_desc.nim
+++ b/execution_chain/core/tx_pool/tx_desc.nim
@@ -60,7 +60,6 @@ type
     rmHash   : Hash32
     pos      : PosPayloadAttr
     blobTab  : BlobLookupTab
-    orderedList: seq[TxItemRef]
     flags    : set[TxPoolFlags]
 
 const
@@ -301,7 +300,8 @@ proc getItem*(xp: TxPoolRef, id: Hash32): Result[TxItemRef, TxError] =
 proc removeTx*(xp: TxPoolRef, id: Hash32) =
   let item = xp.getItem(id).valueOr:
     return
-  xp.removeFromSenderTab(item)
+  if XP_ORDERED notin xp.flags:
+    xp.removeFromSenderTab(item)
   xp.idTab.del(id)
   xp.blobTab.removeLookup(item)
 
@@ -383,9 +383,7 @@ proc addTx*(xp: TxPoolRef, ptx: PooledTransaction): Result[void, TxError] =
     return err(txErrorPoolIsFull)
 
   let item = TxItemRef.new(ptx, id, sender)
-  if XP_ORDERED in xp.flags:
-    xp.orderedList.add(item)
-  else:
+  if XP_ORDERED notin xp.flags:
     ?xp.insertToSenderTab(item)
   xp.idTab[item.id] = item
   xp.blobTab.addLookup(item)
@@ -419,7 +417,7 @@ iterator allItems*(xp: TxPoolRef): TxItemRef =
     yield item
 
 iterator byOrder*(xp: TxPoolRef): TxItemRef =
-  for item in xp.orderedList:
+  for _, item in xp.idTab:
     yield item
 
 func isOrdered*(xp: TxPoolRef): bool =

--- a/execution_chain/core/tx_pool/tx_packer.nim
+++ b/execution_chain/core/tx_pool/tx_packer.nim
@@ -84,7 +84,7 @@ proc vmExecInit(xp: TxPoolRef): Result[TxPacker, string] =
     packer = TxPacker(
       vmState: vmState,
       numBlobPerBlock: 0,
-      blockValue: vmState.ledger.getBalance(xp.feeRecipient),
+      blockValue: 0.u256,
       stateRoot: vmState.parent.stateRoot,
     )
 
@@ -155,6 +155,7 @@ proc vmExecGrabItem(pst: var TxPacker; item: TxItemRef, xp: TxPoolRef): bool =
 
   pst.packedTxs.add item
   pst.numBlobPerBlock += item.tx.versionedHashes.len
+  pst.blockValue += rc.value.txFee
 
   ContinueWithNextAccount
 
@@ -189,8 +190,7 @@ proc vmExecCommit(pst: var TxPacker, xp: TxPoolRef): Result[void, string] =
 
   # Update flexi-array, set proper length
   vmState.receipts.setLen(pst.packedTxs.len)
-
-  pst.blockValue = vmState.ledger.getBalance(xp.feeRecipient) - pst.blockValue
+  
   pst.receiptsRoot = vmState.receipts.calcReceiptsRoot
   pst.logsBloom = vmState.receipts.createBloom
   pst.stateRoot = vmState.ledger.getStateRoot()

--- a/execution_chain/core/tx_pool/tx_tabs.nim
+++ b/execution_chain/core/tx_pool/tx_tabs.nim
@@ -31,7 +31,7 @@ type
 
   TxSenderTab* = Table[Address, TxSenderNonceRef]
 
-  TxIdTab* = Table[Hash32, TxItemRef]
+  TxIdTab* = OrderedTable[Hash32, TxItemRef]
 
   BlobLookup* = object
     item*: TxItemRef

--- a/execution_chain/transaction/call_types.nim
+++ b/execution_chain/transaction/call_types.nim
@@ -54,6 +54,7 @@ type
     gasUsed*: GasInt
     blockRegularGasUsed*: GasInt
     blockStateGasUsed*: GasInt
+    txFee*: UInt256
 
   OutputResult* = object
     error*:   string


### PR DESCRIPTION
1. Replace call to `ledger.getBalance` with `callResult.txFee` when calculating `blockValue`. This will reduce state access and also prevent interfering with ledger based BAL tracker.
2. Reuse `txpool.idTab` to store ordered list of transactions instead of using a new list. It also solve the problem when transaction removed from txpool without additional logic.