### PR TITLE
Exclude nim upstream/version-2-2 from release and nightly build matrix

### DIFF
--- a/.github/workflows/matrix_config.json
+++ b/.github/workflows/matrix_config.json
@@ -1,31 +1,29 @@
-{
-  "include": [
-    {
-      "os": "linux",
-      "cpu": "amd64",
-      "builder": "ubuntu-22.04"
-    },
-    {
-      "os": "linux",
-      "cpu": "amd64",
-      "branch": "upstream/version-2-2",
-      "branch-short": "version-2-2",
-      "builder": "ubuntu-22.04"
-    },
-    {
-      "os": "linux",
-      "cpu": "arm64",
-      "builder": "ubuntu-22.04-arm"
-    },
-    {
-      "os": "windows",
-      "cpu": "amd64",
-      "builder": "windows-2025-vs2026"
-    },
-    {
-      "os": "macos",
-      "cpu": "arm64",
-      "builder": "macos-15"
-    }
-  ]
-}
+[
+  {
+    "os": "linux",
+    "cpu": "amd64",
+    "builder": "ubuntu-22.04"
+  },
+  {
+    "os": "linux",
+    "cpu": "amd64",
+    "branch": "upstream/version-2-2",
+    "branch-short": "version-2-2",
+    "builder": "ubuntu-22.04"
+  },
+  {
+    "os": "linux",
+    "cpu": "arm64",
+    "builder": "ubuntu-22.04-arm"
+  },
+  {
+    "os": "windows",
+    "cpu": "amd64",
+    "builder": "windows-2025-vs2026"
+  },
+  {
+    "os": "macos",
+    "cpu": "arm64",
+    "builder": "macos-15"
+  }
+]

--- a/.github/workflows/matrix_config.yml
+++ b/.github/workflows/matrix_config.yml
@@ -15,6 +15,11 @@ on:
       matrix:
         description: "The matrix configuration from a JSON file"
         value: ${{ jobs.generate_matrix_json.outputs.matrix }}
+    inputs:
+      exclude_field:
+        description: 'Exclude matrix object contains field'
+        required: false
+        default: ''
 
 jobs:
   generate_matrix_json:
@@ -34,4 +39,14 @@ jobs:
       - name: Prepare matrix JSON object
         id: prepare
         run: |
-          echo "json=$(jq -c . < .github/workflows/matrix_config.json)" >> $GITHUB_OUTPUT
+          PREFIX='json={"include":'
+          SUFFIX='}'
+          CONF='.github/workflows/matrix_config.json'
+          PARAM='${{ inputs.exclude_field }}'
+
+          if [[ '$PARAM' == '' ]]; then
+            echo "$PREFIX$(jq -c . < $CONF)$SUFFIX" >> $GITHUB_OUTPUT
+          else
+            CMD="del(.[] | select(has(\"$PARAM\")))"
+            echo "$PREFIX$(jq -c "$CMD" $CONF)$SUFFIX" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/matrix_config.yml
+++ b/.github/workflows/matrix_config.yml
@@ -20,6 +20,7 @@ on:
         description: 'Exclude matrix object contains field'
         required: false
         default: ''
+        type: string
 
 jobs:
   generate_matrix_json:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   matrix_config:
     uses: ./.github/workflows/matrix_config.yml
+    with:
+      exclude_field: "branch"
 
   build:
     needs: matrix_config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ name: Upload Release Asset
 jobs:
   matrix_config:
     uses: ./.github/workflows/matrix_config.yml
+    with:
+      exclude_field: "branch"
 
   build:
     needs: matrix_config


### PR DESCRIPTION
If not excluded, the same jobs for building `linux-amd64` binaries will run twice in nightly build and release CI.