### PR TITLE
Validate block access list code changes

### DIFF
--- a/execution_chain/block_access_list/block_access_list_validation.nim
+++ b/execution_chain/block_access_list/block_access_list_validation.nim
@@ -15,6 +15,7 @@ import
   stint,
   results,
   ../constants,
+  ../core/eip7702,
   ./block_access_list_utils
 
 export block_access_lists, hashes, results
@@ -30,6 +31,19 @@ export block_access_lists, hashes, results
 
 const BAL_ITEM_COST = 2000.GasInt
 
+func checkCodeChange(newCode: openArray[byte]): Result[void, string] =
+  if newCode.len > EIP7954_MAX_CODE_SIZE:
+    return err("Code change exceeds the maximum contract code size")
+
+  # EIP-3541 forbids new contract code starting with the 0xEF byte. The only
+  # valid code beginning with 0xEF is an EIP-7702 delegation designator.
+  if newCode.len > 0 and newCode[0] == 0xEF.byte and not newCode.isDelegation():
+    return err(
+      "Code change starting with 0xEF must be a valid EIP-7702 delegation (EIP-3541)"
+    )
+
+  ok()
+
 func checkBalSize(
     bal: BlockAccessListRef, blockGasLimit: GasInt
 ): Result[void, string] =
@@ -39,14 +53,11 @@ func checkBalSize(
   # This is fine because BALs with duplicates will get rejected in the other
   # validations anyway.
 
-  let addressCount = bal[].len()
-
   var storageKeysCount = 0
   for changes in bal[]:
     storageKeysCount += changes.storageChanges.len() + changes.storageReads.len()
 
-  let balItemCount = addressCount + storageKeysCount
-
+  let balItemCount = bal[].len() + storageKeysCount
   if balItemCount.GasInt <= blockGasLimit div BAL_ITEM_COST:
     ok()
   else:
@@ -106,6 +117,10 @@ func validate*(
     # Check code changes
     if not accountChanges.codeChanges.isSorted(balIndexCmpTreatEqualAsGreater):
       return err("Code changes should be unique and sorted by blockAccessIndex")
+
+    # Validate the bytecode recorded by each code change.
+    for codeChange in accountChanges.codeChanges:
+      ?checkCodeChange(codeChange.newCode)
 
   # Check that the block access list matches the expected hash.
   if bal[].computeBlockAccessListHash() != expectedHash:

--- a/execution_chain/constants.nim
+++ b/execution_chain/constants.nim
@@ -71,6 +71,12 @@ const
   # - Update initcode size limit of 48KiB(0xC000 bytes) to 64KiB(0x10000 bytes).
   EIP7954_MAX_CODE_SIZE* =                  0x8000
   EIP7954_MAX_INITCODE_SIZE* =              0x10000
+
+  # See EIP-7702 (https://eips.ethereum.org/EIPS/eip-7702). When an EOA delegates
+  # via a SETCODE transaction its code is set to a "delegation designator": the
+  # 3-byte prefix 0xef0100 followed by the 20-byte delegate address (23 bytes).
+  EIP7702_DELEGATION_PREFIX* =              [0xEF.byte, 0x01, 0x00]
+  EIP7702_DELEGATION_SIZE* =                23
   
   # EIP
   MaxPrecompilesAddr* =                     0xFFFF

--- a/execution_chain/core/eip7702.nim
+++ b/execution_chain/core/eip7702.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2024-2025 Status Research & Development GmbH
+# Copyright (c) 2024-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/execution_chain/core/eip7702.nim
+++ b/execution_chain/core/eip7702.nim
@@ -58,7 +58,7 @@ func isDelegation*(code: openArray[byte]): bool =
     code[1] == EIP7702_DELEGATION_PREFIX[1] and
     code[2] == EIP7702_DELEGATION_PREFIX[2]
 
-template parseDelegation*(code: CodeBytesRef): bool =
+template isDelegation*(code: CodeBytesRef): bool =
   isDelegation(code.bytes())
 
 func addressToDelegation*(auth: Address): array[EIP7702_DELEGATION_SIZE, byte] =

--- a/execution_chain/core/eip7702.nim
+++ b/execution_chain/core/eip7702.nim
@@ -20,10 +20,6 @@ import
   eth/common/keys
 
 const
-  # the last 0x00 is the version
-  DelegationPrefix = [0xef.byte, 0x01, 0x00]
-
-const
   PER_AUTH_BASE_COST* = 12500
   PER_EMPTY_ACCOUNT_COST* = 25000
 
@@ -53,24 +49,24 @@ func authority*(auth: Authorization): Opt[Address] =
 
   ok(pubkey.toCanonicalAddress())
 
-func parseDelegation*(code: CodeBytesRef): bool =
-  if code.len != 23:
-    return false
+func isDelegation*(code: openArray[byte]): bool =
+  ## Returns true if `code` is a well-formed EIP-7702 delegation designator: the
+  ## EIP7702_DELEGATION_PREFIX (0xef0100) followed by a 20-byte address, for
+  ## EIP7702_DELEGATION_SIZE (23) bytes total.
+  code.len == EIP7702_DELEGATION_SIZE and
+    code[0] == EIP7702_DELEGATION_PREFIX[0] and
+    code[1] == EIP7702_DELEGATION_PREFIX[1] and
+    code[2] == EIP7702_DELEGATION_PREFIX[2]
 
-  if not code.hasPrefix(DelegationPrefix):
-    return false
+template parseDelegation*(code: CodeBytesRef): bool =
+  isDelegation(code.bytes())
 
-  true
-
-func addressToDelegation*(auth: Address): array[23, byte] =
-  assign(result.toOpenArray(0, 2), DelegationPrefix)
+func addressToDelegation*(auth: Address): array[EIP7702_DELEGATION_SIZE, byte] =
+  assign(result.toOpenArray(0, 2), EIP7702_DELEGATION_PREFIX)
   assign(result.toOpenArray(3, 22), auth.data)
 
 func parseDelegationAddress*(code: CodeBytesRef): Opt[Address] =
-  if code.len != 23:
-    return Opt.none(Address)
-
-  if not code.hasPrefix(DelegationPrefix):
+  if not isDelegation(code.bytes()):
     return Opt.none(Address)
 
   Opt.some(Address(slice[20](code, 3, 22)))

--- a/execution_chain/core/validate.nim
+++ b/execution_chain/core/validate.nim
@@ -399,7 +399,7 @@ proc validateTransaction*(
   # EOA = Externally Owned Account
   let
     code = ledger.getCode(sender)
-    delegated = code.parseDelegation()
+    delegated = code.isDelegation()
   if code.len > 0 and not delegated:
     return err(&"invalid tx: sender is not an EOA. sender={sender.toHex}, codeLen={code.len}")
 

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -83,7 +83,7 @@ proc setDelegation(call: CallParams): int64 =
       vmState.balTracker.trackAddressAccess(authority)
     let code = ledger.getCode(authority)
     if code.len > 0:
-      if not parseDelegation(code):
+      if not isDelegation(code):
         continue
 
     # 6. Verify the nonce of authority is equal to nonce.

--- a/tests/test_block_access_list_validation.nim
+++ b/tests/test_block_access_list_validation.nim
@@ -13,6 +13,7 @@
 import
   unittest2,
   eth/common/block_access_lists_rlp,
+  ../execution_chain/constants,
   ../execution_chain/block_access_list/[block_access_list_builder, block_access_list_validation]
 
 const
@@ -232,6 +233,78 @@ suite "Block access list validation":
     var bal = builder.buildBlockAccessList()
     check bal.validate(bal[].computeBlockAccessListHash()).isOk()
     bal[0].codeChanges.insert bal[0].codeChanges[0] # duplicate the first item
+    check bal.validate(bal[].computeBlockAccessListHash()).isErr()
+
+  test "Code change with empty bytecode should validate":
+    builder.addCodeChange(address1, 0, newSeq[byte](0))
+
+    let bal = builder.buildBlockAccessList()
+    check bal.validate(bal[].computeBlockAccessListHash()).isOk()
+
+  test "Code change with bytecode at the max size should validate":
+    builder.addCodeChange(address1, 0, newSeq[byte](EIP7954_MAX_CODE_SIZE))
+
+    let bal = builder.buildBlockAccessList()
+    check bal.validate(bal[].computeBlockAccessListHash()).isOk()
+
+  test "Code change with bytecode exceeding the max size should fail validation":
+    builder.addCodeChange(address1, 0, newSeq[byte](EIP7954_MAX_CODE_SIZE + 1))
+
+    let bal = builder.buildBlockAccessList()
+    check bal.validate(bal[].computeBlockAccessListHash()).isErr()
+
+  test "Code change with a valid EIP-7702 delegation designator should validate":
+    # 0xef0100 prefix followed by a 20-byte address (23 bytes total).
+    let delegation = @[0xEF.byte, 0x01, 0x00] & newSeq[byte](20)
+    builder.addCodeChange(address1, 0, delegation)
+
+    let bal = builder.buildBlockAccessList()
+    check bal.validate(bal[].computeBlockAccessListHash()).isOk()
+
+  test "Code change starting with 0xEF that is not a delegation should fail (EIP-3541)":
+    builder.addCodeChange(address1, 0, @[0xEF.byte, 0x60, 0x00])
+
+    let bal = builder.buildBlockAccessList()
+    check bal.validate(bal[].computeBlockAccessListHash()).isErr()
+
+  test "Code change with a malformed EIP-7702 delegation should fail (EIP-3541)":
+    # Correct 0xef0100 prefix but the wrong total length (22 instead of 23 bytes).
+    let malformed = @[0xEF.byte, 0x01, 0x00] & newSeq[byte](19)
+    builder.addCodeChange(address1, 0, malformed)
+
+    let bal = builder.buildBlockAccessList()
+    check bal.validate(bal[].computeBlockAccessListHash()).isErr()
+
+  test "Code change with a wrong EIP-7702 version byte should fail (EIP-3541)":
+    # 23 bytes starting with 0xef01 but a non-zero version byte is not a valid
+    # delegation designator.
+    let badVersion = @[0xEF.byte, 0x01, 0x01] & newSeq[byte](20)
+    builder.addCodeChange(address1, 0, badVersion)
+
+    let bal = builder.buildBlockAccessList()
+    check bal.validate(bal[].computeBlockAccessListHash()).isErr()
+
+  test "Code change with a wrong EIP-7702 second prefix byte should fail (EIP-3541)":
+    # 23 bytes with the 0xEF prefix but a wrong second byte (0xef02..) is not a
+    # valid delegation designator.
+    let badPrefix = @[0xEF.byte, 0x02, 0x00] & newSeq[byte](20)
+    builder.addCodeChange(address1, 0, badPrefix)
+
+    let bal = builder.buildBlockAccessList()
+    check bal.validate(bal[].computeBlockAccessListHash()).isErr()
+
+  test "Code change with single 0xEF byte should fail (EIP-3541)":
+    # Too short to be a delegation designator; the length guard must short-circuit
+    # before the prefix bytes are indexed.
+    builder.addCodeChange(address1, 0, @[0xEF.byte])
+
+    let bal = builder.buildBlockAccessList()
+    check bal.validate(bal[].computeBlockAccessListHash()).isErr()
+
+  test "Code change with two byte 0xef01 should fail (EIP-3541)":
+    builder.addCodeChange(address1, 0, @[0xEF.byte, 0x01])
+
+    let bal = builder.buildBlockAccessList()
     check bal.validate(bal[].computeBlockAccessListHash()).isErr()
 
 when ENABLE_BENCHMARKS:


### PR DESCRIPTION
Add additional validations to check bytecode in the BAL and fail early instead of during block execution.