### PR TITLE
fix stateless execution for proofs at extension boundaries

### DIFF
--- a/execution_chain/db/aristo/aristo_blobify.nim
+++ b/execution_chain/db/aristo/aristo_blobify.nim
@@ -195,6 +195,8 @@ proc blobifyTo*(vtx: VertexRef, key: HashKey, data: var VertexBuf) =
 
   let bits =
     case vtx.vType
+    of ExtNode:
+      raiseAssert "ExtNode is stateless-only and must never be persisted"
     of Branches:
       let
         vtx = BranchRef(vtx)

--- a/execution_chain/db/aristo/aristo_check/check_top.nim
+++ b/execution_chain/db/aristo/aristo_check/check_top.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023-2025 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -37,6 +37,9 @@ proc checkTopStrict*(
 
     elif key.isValid:
       # So `vtx` and `key` exist
+      if vtx.vType == ExtNode:
+        # ExtNode has branch absent (not part of witness), so pre-computed key is trusted
+        continue
       let node = vtx.toNode(rvid.root, db).valueOr:
         # not all sub-keys might be ready du to lazy hashing
         continue
@@ -53,7 +56,6 @@ proc checkTopStrict*(
 
   ok()
 
-
 proc checkTopProofMode*(
     db: AristoTxRef;                               # Database, top layer
       ): Result[void,(VertexID,AristoError)] =
@@ -61,12 +63,14 @@ proc checkTopProofMode*(
     if key.isValid:                              # Otherwise to be deleted
       let vtx = db.getVtx rvid
       if vtx.isValid:
+        # ExtNode has branch absent (not part of witness), so pre-computed key is trusted
+        if vtx.vType == ExtNode:
+          continue
         let node = vtx.toNode(rvid.root, db).valueOr:
           continue
         if key != node.digestTo(HashKey):
           return err((rvid.vid,CheckRlxVtxKeyMismatch))
   ok()
-
 
 proc checkTopCommon*(
     db: AristoTxRef;                   # Database, top layer
@@ -97,6 +101,7 @@ proc checkTopCommon*(
               return err((stoVid,CheckAnyVidDeadStorageRoot))
             stoRoots.incl stoVid
       of StoLeaf: discard
+      of ExtNode: discard
       of Branches:
         block check42Links:
           var seen = false
@@ -123,4 +128,3 @@ proc checkTopCommon*(
 # ------------------------------------------------------------------------------
 # End
 # ------------------------------------------------------------------------------
-

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -220,7 +220,7 @@ template childVid(vp: VertexRef): VertexID =
   of Branch, ExtBranch:
     let v = BranchRef(v)
     v.startVid
-  of StoLeaf:
+  of ExtNode, StoLeaf:
     default(VertexID)
 
 proc computeKeyImplTask(
@@ -284,6 +284,12 @@ proc computeKeyImpl(
     of StoLeaf:
       let vtx = StoLeafRef(vtx)
       rlpEncodeStoLeaf(vtx.pfx, vtx.stoData).digestTo(HashKey)
+    of ExtNode:
+      # Boundary node from a witness (no branch): pfx and childKey (absent branch
+      # hash) are sufficient to get the extension RLP. putSubtrie set the key
+      # so normally this branch is not reached.
+      let ev = ExtNodeRef(vtx)
+      rlpEncodeExt(ev.pfx, ev.childKey).digestTo(HashKey)
     of Branches:
       # For branches, we need to load the vertices before recursing into them
       # to exploit their on-disk order

--- a/execution_chain/db/aristo/aristo_delete.nim
+++ b/execution_chain/db/aristo/aristo_delete.nim
@@ -109,6 +109,9 @@ proc deleteImpl(
         of ExtBranch:
           let nxt = ExtBranchRef(nxt)
           ExtBranchRef.init(pfx & nxt.pfx, nxt.startVid, nxt.used)
+        of ExtNode:
+          let nxt = ExtNodeRef(nxt)
+          ExtNodeRef.init(pfx & nxt.pfx, nxt.childKey)
 
     # Put the new vertex at the id of the obsolete branch
     db.layersPutVtx((hike.root, br.vid), vtx)

--- a/execution_chain/db/aristo/aristo_delete/delete_subtree.nim
+++ b/execution_chain/db/aristo/aristo_delete/delete_subtree.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023-2025 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -36,6 +36,8 @@ proc delStoTreeNow(
     let vtx = BranchRef(vtx)
     for n, subvid in vtx.pairs():
       ?db.delStoTreeNow((rvid.root, subvid), accPath, stoPath & NibblesBuf.nibble(n))
+  of ExtNode:
+    discard # stateless only boundary node has no subvids to recurse into
   of ExtBranch:
     let vtx = ExtBranchRef(vtx)
     for n, subvid in vtx.pairs():

--- a/execution_chain/db/aristo/aristo_desc/desc_structural.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_structural.nim
@@ -29,6 +29,7 @@ type
     StoLeaf
     Branch
     ExtBranch
+    ExtNode # Stateless only type
 
   AristoAccount* = object
     ## Application relevant part of an Ethereum account. Note that the storage
@@ -55,6 +56,14 @@ type
 
   ExtBranchRef* = ref object of BranchRef
     pfx*: NibblesBuf
+
+  ExtNodeRef* = ref object of VertexRef
+    ## Stateless only type, represents a standard MPT Extension node:
+    ## pfx as usual path prefix, childKey is the hash of the absent branch child.
+    ## Created from witness by putSubtrie for non-membership proof boundaries.
+    ## Never created / used during full-node execution.
+    pfx*: NibblesBuf
+    childKey*: HashKey
 
   LeafRef* = ref object of VertexRef
     pfx*: NibblesBuf
@@ -110,7 +119,7 @@ type
 const
   Leaves* = {VertexType.AccLeaf, VertexType.StoLeaf}
   Branches* = {VertexType.Branch, VertexType.ExtBranch}
-  VertexTypes* = Leaves + Branches
+  VertexTypes* = Leaves + Branches + {VertexType.ExtNode}
 
 # ------------------------------------------------------------------------------
 # Public helpers (misc)
@@ -131,6 +140,9 @@ template init*(
     _: type ExtBranchRef, pfxp: NibblesBuf, startVidp: VertexID, usedp: uint16
 ): ExtBranchRef =
   ExtBranchRef(vType: ExtBranch, pfx: pfxp, startVid: startVidp, used: usedp)
+
+template init*(_: type ExtNodeRef, pfxp: NibblesBuf, childKeyp: HashKey): ExtNodeRef =
+  ExtNodeRef(vType: ExtNode, pfx: pfxp, childKey: childKeyp)
 
 template init*(
     T: type CachedAccLeaf, pfxp: NibblesBuf, accountp: AristoAccount, stoIDp: StorageID): T =
@@ -181,6 +193,8 @@ template pfx*(vtx: VertexRef): NibblesBuf =
     LeafRef(vtx).pfx
   of ExtBranch:
     ExtBranchRef(vtx).pfx
+  of ExtNode:
+    ExtNodeRef(vtx).pfx
   of Branch:
     emptyNibbles
 
@@ -231,13 +245,15 @@ proc `==`*(a, b: VertexRef): bool =
       BranchRef(a)[] == BranchRef(b)[]
     of ExtBranch:
       ExtBranchRef(a)[] == ExtBranchRef(b)[]
+    of ExtNode:
+      ExtNodeRef(a)[] == ExtNodeRef(b)[]
   else:
     true
 
 iterator pairs*(vtx: VertexRef): tuple[nibble: uint8, vid: VertexID] =
-  ## Iterates over the sub-vids of a branch (does nothing for leaves)
+  ## Iterates over the sub-vids of a branch (does nothing for leaves or ExtNode)
   case vtx.vType
-  of Leaves:
+  of Leaves, ExtNode:
     discard
   of Branches:
     let vtx = BranchRef(vtx)
@@ -246,10 +262,10 @@ iterator pairs*(vtx: VertexRef): tuple[nibble: uint8, vid: VertexID] =
         yield (n, VertexID(uint64(vtx.startVid) + n))
 
 iterator allPairs*(vtx: VertexRef): tuple[nibble: uint8, vid: VertexID] =
-  ## Iterates over the sub-vids of a branch (does nothing for leaves) including
-  ## currently unset nodes
+  ## Iterates over the sub-vids of a branch (does nothing for leaves or ExtNode)
+  ## including currently unset nodes
   case vtx.vType
-  of Leaves:
+  of Leaves, ExtNode:
     discard
   of Branches:
     let vtx = BranchRef(vtx)
@@ -296,6 +312,9 @@ func dup*(vtx: VertexRef): VertexRef =
     of ExtBranch:
       let vtx = ExtBranchRef(vtx)
       ExtBranchRef.init(vtx.pfx, vtx.startVid, vtx.used)
+    of ExtNode:
+      let vtx = ExtNodeRef(vtx)
+      ExtNodeRef.init(vtx.pfx, vtx.childKey)
 
 template dup*(vtx: StoLeafRef): StoLeafRef =
   StoLeafRef(VertexRef(vtx).dup())
@@ -308,6 +327,9 @@ template dup*(vtx: BranchRef): BranchRef =
 
 template dup*(vtx: ExtBranchRef): ExtBranchRef =
   ExtBranchRef(VertexRef(vtx).dup())
+
+template dup*(vtx: ExtNodeRef): ExtNodeRef =
+  ExtNodeRef(VertexRef(vtx).dup())
 
 func `$`*(aa: AristoAccount): string =
   $aa.nonce & "," & $aa.balance & "," &
@@ -344,6 +366,12 @@ func `$`*(vtx: ExtBranchRef): string =
   else:
     "E(" & $vtx.pfx & ":"  & $vtx.startVid & "+" & toBin(BiggestInt(vtx.used), 16) & ")"
 
+func `$`*(vtx: ExtNodeRef): string =
+  if vtx == nil:
+    "EN(nil)"
+  else:
+    "EN(" & $vtx.pfx & ":" & $vtx.childKey & ")"
+
 func `$`*(vtx: VertexRef): string =
   if vtx == nil:
     "V(nil)"
@@ -357,6 +385,8 @@ func `$`*(vtx: VertexRef): string =
       $(BranchRef(vtx)[])
     of ExtBranch:
       $(ExtBranchRef(vtx)[])
+    of ExtNode:
+      $(ExtNodeRef(vtx)[])
 
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/db/aristo/aristo_fetch.nim
+++ b/execution_chain/db/aristo/aristo_fetch.nim
@@ -91,6 +91,10 @@ proc retrieveAccStatic(
           err FetchPathNotFound
         else:
           ok (vtx, path, next)
+    of ExtNode:
+      # Stateless-only boundary: child branch absent from witness, not traversable.
+      countHitOrLower()
+      return err FetchPathNotFound
     of ExtBranch:
       let vtx = ExtBranchRef(vtx[0])
 

--- a/execution_chain/db/aristo/aristo_hike.nim
+++ b/execution_chain/db/aristo/aristo_hike.nim
@@ -39,6 +39,8 @@ func getNibblesImpl(hike: Hike; start = 0; maxLen = high(int)): NibblesBuf =
     of ExtBranch:
       let vtx = ExtBranchRef(leg.wp.vtx)
       result = result & vtx.pfx & NibblesBuf.nibble(leg.nibble.byte)
+    of ExtNode:
+      discard # ExtNode never successfully steps forward
     of Leaves:
       let vtx = LeafRef(leg.wp.vtx)
       result = result & vtx.pfx
@@ -111,6 +113,10 @@ proc step*(
 
     ok (vtx, vtx.pfx.len + 1, nextVid)
 
+  of ExtNode:
+    # branch absent from witness, no reachable child VID
+    return err(HikeBranchMissingEdge)
+
 
 iterator stepUp*(
     path: NibblesBuf;                            # Partial path
@@ -182,6 +188,8 @@ proc hikeUp*[LeafType](
     of ExtBranch:
       let vtx = ExtBranchRef(vtx)
       hike.legs.add Leg(wp: wp, nibble: int8 path[vtx.pfx.len])
+    of ExtNode:
+      discard # step() always fails for ExtNode thus this is unreachable
 
     path = path.slice(common)
     vid = next

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -109,6 +109,7 @@ template to*(v: VertexType, T: type RdbVertexType): RdbVertexType =
   of VertexType.AccLeaf, VertexType.StoLeaf: RdbVertexType.Leaf
   of VertexType.Branch: RdbVertexType.Branch
   of VertexType.ExtBranch: RdbVertexType.ExtBranch
+  of VertexType.ExtNode: raiseAssert "ExtNode is stateless-only and never persisted"
 
 template inc*(v: var RdbLruCounter, hit: bool) =
   discard v[hit].fetchAdd(1, moRelaxed)

--- a/execution_chain/db/aristo/aristo_layers.nim
+++ b/execution_chain/db/aristo/aristo_layers.nim
@@ -146,6 +146,19 @@ func layersPutKey*(
   if db.snapshot.level.isSome():
     db.snapshot.vtx[rvid] = (VertexRef(vtx), key, db.level)
 
+func layersPutKey*(
+    db: AristoTxRef;
+    rvid: RootedVertexID;
+    vtx: ExtNodeRef,
+    key: HashKey;
+      ) =
+  ## Stores the live vertex so mergePayloadImpl can read pfx/childKey on split.
+  let vtx = db.layersPrepareUpdate(rvid, vtx)
+  db.kMap[rvid] = key
+
+  if db.snapshot.level.isSome():
+    db.snapshot.vtx[rvid] = (VertexRef(vtx), key, db.level)
+
 func layersMergeKey*(
     db: AristoTxRef;
     rvid: RootedVertexID;

--- a/execution_chain/db/aristo/aristo_merge.nim
+++ b/execution_chain/db/aristo/aristo_merge.nim
@@ -28,7 +28,7 @@ import
   std/typetraits,
   eth/common/hashes,
   results,
-  "."/[aristo_desc, aristo_fetch, aristo_get, aristo_layers, aristo_vid]
+  "."/[aristo_desc, aristo_fetch, aristo_get, aristo_layers, aristo_serialise, aristo_vid]
 
 proc layersPutLeaf[T](
     db: AristoTxRef, rvid: RootedVertexID, path: NibblesBuf, payload: T
@@ -195,6 +195,51 @@ proc mergePayloadImpl[LeafType, T](
 
         db.layersPutVtx((root, cur), branch)
 
+        resetKeys()
+        return ok((leafVtx, nil, nil))
+
+    of ExtNode:
+      let evtx = ExtNodeRef(vtx)
+      if n == evtx.pfx.len:
+        # Full prefix match: the new key would traverse into the absent branch
+        # child. This is not supported in partial-trie / stateless mode.
+        return err(MergeHikeFailed)
+      else:
+        # Partial prefix match: split the ExtNode at the divergence point,
+        # creating a new branch. This is similar as for leaves except that
+        # the existing ExtNode is moved down one level.
+        let
+          startVid =
+            if root == STATE_ROOT_VID:
+              db.accVidFetch(path.slice(0, pos + n) & NibblesBuf.nibble(0), 16)
+            else:
+              db.vidFetch(16)
+          branch =
+            if n > 0:
+              ExtBranchRef.init(psuffix.slice(0, n), startVid, 0)
+            else:
+              BranchRef.init(startVid, 0)
+
+        # Place the existing ExtNode content at its new position
+        let
+          local = branch.setUsed(evtx.pfx[n], true)
+          pfx = evtx.pfx.slice(n + 1)
+        if pfx.len > 0:
+          # Remaining prefix: create new ExtNode pointing to the same child.
+          let newExt = ExtNodeRef.init(pfx, evtx.childKey)
+          db.layersPutKey(
+            (root, local), newExt,
+            rlpEncodeExt(pfx, evtx.childKey).digestTo(HashKey))
+        else:
+          # No remaining prefix: store a nil as vertex with the known branch hash.
+          # computeKeyImpl still works via kMap
+          db.layersPutKey((root, local), BranchRef(nil), evtx.childKey)
+
+        let leafVtx = block: # Add the new entry
+          let local = branch.setUsed(psuffix[n], true)
+          db.layersPutLeaf((root, local), psuffix.slice(n + 1), payload)
+
+        db.layersPutVtx((root, cur), branch)
         resetKeys()
         return ok((leafVtx, nil, nil))
 

--- a/execution_chain/db/aristo/aristo_nearby.nim
+++ b/execution_chain/db/aristo/aristo_nearby.nim
@@ -49,6 +49,8 @@ iterator rightPairs*(
         var x = hike.legs[^1]
 
         case x.wp.vtx.vType
+        of ExtNode:
+          discard # ExtNode never appears in hike legs (step always fails for it)
         of Branches:
           let vtx = BranchRef(x.wp.vtx)
           for i in uint8(x.nibble + 1) ..< 16u8:

--- a/execution_chain/db/aristo/aristo_proof.nim
+++ b/execution_chain/db/aristo/aristo_proof.nim
@@ -48,20 +48,24 @@ proc chainRlpNodes(
   ## Inspired by the `getBranchAux()` function from `hexary.nim`
   let (vtx, _) = ?db.getVtxRc(rvid)
 
+  var rlpNodes: array[2, seq[byte]]
   nodesCache.withValue(rvid, value):
-    chain.appendNodes(value[])
+    rlpNodes = value[]
   do:
     let node = vtx.toNode(rvid.root, db).valueOr:
       return err(PartChnNodeConvError)
-
-    # Save rpl encoded node(s)
-    let rlpNodes = node.to(array[2, seq[byte]])
+    rlpNodes = node.to(array[2, seq[byte]])
     nodesCache[rvid] = rlpNodes
-    chain.appendNodes(rlpNodes)
 
   # Follow up child node
   case vtx.vType:
+  of ExtNode:
+    # Proof generation is only called on full nodes; ExtNode (stateless
+    # boundary) must never appear here.
+    raiseAssert "ExtNode in proof generation"
+
   of Leaves:
+    chain.add(rlpNodes[0])
     if path != vtx.pfx:
       err(PartChnLeafPathMismatch)
     else:
@@ -70,18 +74,28 @@ proc chainRlpNodes(
   of Branches:
     let vtx = BranchRef(vtx)
     let nChewOff = sharedPrefixLen(vtx.pfx, path)
+
+    # Extension node always added
+    chain.add(rlpNodes[0])
+    # Branch node added only when path enters the branch (prefix fully matches).
+    # For diverging paths the extension alone proves non-membership so the
+    # branch is omitted
+    if rlpNodes[1].len() > 0 and nChewOff == vtx.pfx.len:
+      chain.add(rlpNodes[1])
+
     if nChewOff != vtx.pfx.len:
-      err(PartChnExtPfxMismatch)
-    elif path.len == nChewOff:
-      err(PartChnBranchPathExhausted)
-    else:
-      let
-        nibble = path[nChewOff]
-        rest = path.slice(nChewOff+1)
-      if not vtx.bVid(nibble).isValid:
-        return err(PartChnBranchVoidEdge)
-      # Recursion!
-      db.chainRlpNodes((rvid.root,vtx.bVid(nibble)), rest, chain, nodesCache)
+      return err(PartChnExtPfxMismatch)
+
+    if path.len == nChewOff:
+      return err(PartChnBranchPathExhausted)
+
+    let
+      nibble = path[nChewOff]
+      rest = path.slice(nChewOff+1)
+    if not vtx.bVid(nibble).isValid:
+      return err(PartChnBranchVoidEdge)
+    # Recursion!
+    db.chainRlpNodes((rvid.root,vtx.bVid(nibble)), rest, chain, nodesCache)
 
 proc makeProof(
     db: AristoTxRef;
@@ -392,18 +406,24 @@ proc convertSubtrie(
 
         # Convert the child branch node which will be merged with this extension node
         ?convertSubtrie(k.to(Hash32), src, dst, isStorage)
-        doAssert(dst.contains(k))
 
-        let
-          childNode = dst.getOrDefault(k)
-          childBranch = BranchRef(childNode.vtx)
+        if dst.contains(k):
+          let
+            childNode = dst.getOrDefault(k)
+            childBranch = BranchRef(childNode.vtx)
 
-        # Remove the childNode because it's branch was copied into this node
-        dst.del(k)
+          # Remove the childNode because it's branch was copied into this node
+          dst.del(k)
 
-        NodeRef(
-          key: childNode.key,
-          vtx: ExtBranchRef.init(segm, childBranch.startVid, childBranch.used))
+          NodeRef(
+            key: childNode.key,
+            vtx: ExtBranchRef.init(segm, childBranch.startVid, childBranch.used))
+        else:
+          # Branch absent from witness (proof boundary): represent as an
+          # ExtNode carrying the branch hash as childKey.
+          NodeRef(
+            key: default(array[16, HashKey]),
+            vtx: ExtNodeRef.init(segm, k))
 
     of 17: # Branch node
       var key: array[16, HashKey]
@@ -456,6 +476,11 @@ proc putSubtrie(
 
     of StoLeaf:
       discard
+
+    of ExtNode:
+      # Store vertex and pre-computed extension hash
+      db.layersPutKey(rvid, ExtNodeRef(node.vtx), key)
+      return ok()
 
     of Branch, ExtBranch:
       let bvtx = BranchRef(node.vtx)

--- a/execution_chain/db/aristo/aristo_serialise.nim
+++ b/execution_chain/db/aristo/aristo_serialise.nim
@@ -89,6 +89,9 @@ proc to*(node: NodeRef, T: type array[2, seq[byte]]): T =
   ## and branch vertex argument, there will be a double item list result.
   ##
   case node.vtx.vType
+  of ExtNode:
+    let ev = ExtNodeRef(node.vtx)
+    [@(rlpEncodeExt(ev.pfx, ev.childKey)), @[]]
   of Branches:
     let brData = @(rlpEncodeBranch(BranchRef(node.vtx), node.key[n]))
     if node.vtx.vType == ExtBranch:
@@ -108,6 +111,9 @@ proc digestTo*(node: NodeRef, T: type HashKey): T =
   ## that a `Dummy` node is encoded as as a `Leaf`.
   ##
   case node.vtx.vType
+  of ExtNode:
+    let ev = ExtNodeRef(node.vtx)
+    rlpEncodeExt(ev.pfx, ev.childKey).digestTo(HashKey)
   of Branches:
     let brKey = rlpEncodeBranch(BranchRef(node.vtx), node.key[n]).digestTo(HashKey)
     if node.vtx.vType == ExtBranch:

--- a/execution_chain/db/aristo/aristo_utils.nim
+++ b/execution_chain/db/aristo/aristo_utils.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023-2025 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -55,6 +55,11 @@ proc toNode*(
     # Need to resolve storage root for account leaf
     return ok node
 
+  of ExtNode:
+    # No child vids to resolve as the branch child is absent by design
+    let node = NodeRef(vtx: vtx.dup())
+    return ok node
+
   of Branch, ExtBranch:
     let node = NodeRef(vtx: vtx.dup())
     for n, subvid in vtx.pairs():
@@ -71,7 +76,7 @@ iterator subVids*(vtx: VertexRef): VertexID =
     if stoID.isValid:
       yield stoID.vid
 
-  of StoLeaf:
+  of StoLeaf, ExtNode:
     discard
   of Branches:
     for _, subvid in vtx.pairs():
@@ -84,7 +89,7 @@ iterator subVidKeys*(node: NodeRef): (VertexID,HashKey) =
     let stoID = AccLeafRef(node.vtx).stoID
     if stoID.isValid:
       yield (stoID.vid, node.key[0])
-  of StoLeaf:
+  of StoLeaf, ExtNode:
     discard
   of Branches:
     for n, subvid in node.vtx.pairs():

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -28,17 +28,6 @@ const skipFiles = [
   #
   # --- eest_zkevm files with failures ---
   #
-  # `dst.contains(k)`  [AssertionDefect] -> on execution of test vector witness
-  #  generated witness has an extra state node, stateless execution works with it
-  "varying_calldata_costs.json",
-  "witness_headers_blockhash_boundary.json",
-  "genesis_hash_available.json",
-  "scenarios.json",
-  "withdrawal_requests.json",
-  "consolidation_requests.json",
-  "multiple_withdrawals_same_address.json",
-  "return_bounds.json",
-  #
   # persistStorage(): Unspecified(Aristo, ctx=, error=DelVidStaleVtx) [AssertionDefect]
   # -> on execution with test vector witness
   # generated witness has an extra state node, stateless execution works with it


### PR DESCRIPTION
The error case that we are fixing here is any new account or storage slot whose path branches off the extension prefix rather than entering it.

The fix exists out of two parts: one for the witness generation and one for the loading of the witness.

* part one:

When building a proof, both the extension and the branch for every `ExtBranch` was added. For non-membership (boundary) proofs where the lookup path diverges before entering the branch, the branch node should be omitted

* part two:

When loading a witness via `putSubtrie`, an extension node whose branch child is absent from the witness (a proof boundary) could not be represented in Aristo. A standard ExtBranchRef requires both the extension prefix and a full set of 16 branch child vids

We add `ExtNode` / `ExtNodeRef` a stateless-only VertexType that represents an MPT Extension node: a prefix and the absent branch's hash (childKey).