### PR TITLE
stateless: fix branch collapse on nil-vtx surviving child

### DIFF
--- a/execution_chain/db/aristo/aristo_blobify.nim
+++ b/execution_chain/db/aristo/aristo_blobify.nim
@@ -195,8 +195,8 @@ proc blobifyTo*(vtx: VertexRef, key: HashKey, data: var VertexBuf) =
 
   let bits =
     case vtx.vType
-    of ExtNode:
-      raiseAssert "ExtNode is stateless-only and must never be persisted"
+    of BoundaryNode:
+      raiseAssert "BoundaryNode is stateless-only and must never be persisted"
     of Branches:
       let
         vtx = BranchRef(vtx)

--- a/execution_chain/db/aristo/aristo_check/check_top.nim
+++ b/execution_chain/db/aristo/aristo_check/check_top.nim
@@ -37,8 +37,8 @@ proc checkTopStrict*(
 
     elif key.isValid:
       # So `vtx` and `key` exist
-      if vtx.vType == ExtNode:
-        # ExtNode has branch absent (not part of witness), so pre-computed key is trusted
+      if vtx.vType == BoundaryNode:
+        # BoundaryNode has branch absent (not part of witness), so pre-computed key is trusted
         continue
       let node = vtx.toNode(rvid.root, db).valueOr:
         # not all sub-keys might be ready du to lazy hashing
@@ -63,8 +63,8 @@ proc checkTopProofMode*(
     if key.isValid:                              # Otherwise to be deleted
       let vtx = db.getVtx rvid
       if vtx.isValid:
-        # ExtNode has branch absent (not part of witness), so pre-computed key is trusted
-        if vtx.vType == ExtNode:
+        # BoundaryNode has branch absent (not part of witness), so pre-computed key is trusted
+        if vtx.vType == BoundaryNode:
           continue
         let node = vtx.toNode(rvid.root, db).valueOr:
           continue
@@ -101,7 +101,7 @@ proc checkTopCommon*(
               return err((stoVid,CheckAnyVidDeadStorageRoot))
             stoRoots.incl stoVid
       of StoLeaf: discard
-      of ExtNode: discard
+      of BoundaryNode: discard
       of Branches:
         block check42Links:
           var seen = false

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -213,7 +213,7 @@ template childVid(vp: VertexRef): VertexID =
   of Branch, ExtBranch:
     let v = BranchRef(v)
     v.startVid
-  of ExtNode, StoLeaf:
+  of BoundaryNode, StoLeaf:
     default(VertexID)
 
 proc computeKeyImplTask(
@@ -277,11 +277,11 @@ proc computeKeyImpl(
     of StoLeaf:
       let vtx = StoLeafRef(vtx)
       rlpEncodeStoLeaf(vtx.pfx, vtx.stoData).digestTo(HashKey)
-    of ExtNode:
+    of BoundaryNode:
       # Boundary node from a witness (no branch): pfx and childKey (absent branch
       # hash) are sufficient to get the extension RLP. putSubtrie set the key
       # so normally this branch is not reached.
-      let ev = ExtNodeRef(vtx)
+      let ev = BoundaryNodeRef(vtx)
       rlpEncodeExt(ev.pfx, ev.childKey).digestTo(HashKey)
     of Branches:
       # For branches, we need to load the vertices before recursing into them

--- a/execution_chain/db/aristo/aristo_delete.nim
+++ b/execution_chain/db/aristo/aristo_delete.nim
@@ -19,7 +19,7 @@ import
   eth/common/hashes,
   results,
   ./aristo_delete/delete_subtree,
-  "."/[aristo_desc, aristo_fetch, aristo_get, aristo_hike, aristo_layers]
+  "."/[aristo_desc, aristo_fetch, aristo_get, aristo_hike, aristo_layers, aristo_serialise]
 
 # ------------------------------------------------------------------------------
 # Private heplers
@@ -86,7 +86,26 @@ proc deleteImpl(
       vid = brVtx.bVid(uint8 nbl)
       nxt = db.getVtx (hike.root, vid)
     if not nxt.isValid:
-      return err(DelVidStaleVtx)
+      # In stateless mode the surviving child may be a nil vertex boundary,
+      # absent from the witness but with a known hash in kMap. Collapse the
+      # branch into a BoundaryNode (prefix + boundary hash) so state root
+      # computation stays correct.
+      # In a full node this should be unreachable: every referenced child vid
+      # should always have a non zero vertex.
+      let childKey = db.layersGetKeyOrVoid((hike.root, vid))
+      doAssert childKey.isValid,
+        "nil surviving child without boundary hash, this is not a valid stateless boundary"
+      let pfx =
+        if brVtx.vType == Branch:
+          NibblesBuf.nibble(nbl.byte)
+        else:
+          ExtBranchRef(brVtx).pfx & NibblesBuf.nibble(nbl.byte)
+      let newExt = BoundaryNodeRef.init(pfx, childKey)
+      db.layersPutKey(
+        (hike.root, br.vid), newExt,
+        rlpEncodeExt(pfx, childKey).digestTo(HashKey))
+      db.layersResVtx((hike.root, vid))
+      return ok(VertexRef(newExt))
 
     db.layersResVtx((hike.root, vid))
     let
@@ -109,9 +128,9 @@ proc deleteImpl(
         of ExtBranch:
           let nxt = ExtBranchRef(nxt)
           ExtBranchRef.init(pfx & nxt.pfx, nxt.startVid, nxt.used)
-        of ExtNode:
-          let nxt = ExtNodeRef(nxt)
-          ExtNodeRef.init(pfx & nxt.pfx, nxt.childKey)
+        of BoundaryNode:
+          let nxt = BoundaryNodeRef(nxt)
+          BoundaryNodeRef.init(pfx & nxt.pfx, nxt.childKey)
 
     # Put the new vertex at the id of the obsolete branch
     db.layersPutVtx((hike.root, br.vid), vtx)
@@ -156,8 +175,8 @@ proc deleteAccount*(
         Hash32(getBytes(NibblesBuf.fromBytes(accPath.data).replaceSuffix(AccLeafRef(otherVtx).pfx)))
       db.layersPutAccLeaf(sibAccPath, AccLeafRef(otherVtx))
       if db.collectWitness:
-        db.collapsedSiblings.add((sibAccPath, Opt.none(Hash32)))
-    elif db.collectWitness:
+        db.collapsedSiblings.add((sibAccPath, Opt.none(Hash32), VertexID(0), VertexID(0)))
+    elif db.collectWitness and otherVtx.vType in Branches:
       # Branch collapse with non-leaf sibling: the witness must include the
       # sibling branch node so stateless execution can read it. This builds a
       # proof path for it: root prefix + extBranch.pfx (rest is arbitrary).
@@ -172,7 +191,7 @@ proc deleteAccount*(
         sibAccPath = Hash32(
           getBytes(accNibbles.slice(0, branchDepth) & ExtBranchRef(otherVtx).pfx)
         )
-      db.collapsedSiblings.add((sibAccPath, Opt.none(Hash32)))
+      db.collapsedSiblings.add((sibAccPath, Opt.none(Hash32), VertexID(0), VertexID(0)))
 
   ok()
 
@@ -230,8 +249,13 @@ proc deleteSlot*(
         leafMixPath = mixUp(accPath, sibStoPath)
       db.layersPutStoLeaf(leafMixPath, StoLeafRef(otherVtx))
       if db.collectWitness:
-        db.collapsedSiblings.add((accPath, Opt.some(sibStoPath)))
-    elif db.collectWitness:
+        # Record the collapsed branch vid so we can check after all transactions
+        # whether the collapse was re-expanded by a later insertion.
+        db.collapsedSiblings.add((
+            accPath, Opt.some(sibStoPath),
+            stoID.vid,
+            stoHike.legs[^2].wp.vid))
+    elif db.collectWitness and otherVtx.vType in Branches:
       # Branch collapse with non-leaf sibling: the witness must include the
       # sibling branch node so stateless execution can read it. This builds a
       # proof path for it: root prefix + extBranch.pfx (rest is arbitrary).
@@ -244,7 +268,7 @@ proc deleteSlot*(
         sibStoPath = Hash32(
           getBytes(stoNibbles.slice(0, branchDepth) & ExtBranchRef(otherVtx).pfx)
         )
-      db.collapsedSiblings.add((accPath, Opt.some(sibStoPath)))
+      db.collapsedSiblings.add((accPath, Opt.some(sibStoPath), VertexID(0), VertexID(0)))
 
   # If there was only one item (that got deleted), update the account as well
   if stoHike.legs.len == 1:

--- a/execution_chain/db/aristo/aristo_delete/delete_subtree.nim
+++ b/execution_chain/db/aristo/aristo_delete/delete_subtree.nim
@@ -36,7 +36,7 @@ proc delStoTreeNow(
     let vtx = BranchRef(vtx)
     for n, subvid in vtx.pairs():
       ?db.delStoTreeNow((rvid.root, subvid), accPath, stoPath & NibblesBuf.nibble(n))
-  of ExtNode:
+  of BoundaryNode:
     discard # stateless only boundary node has no subvids to recurse into
   of ExtBranch:
     let vtx = ExtBranchRef(vtx)

--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -80,13 +80,18 @@ type
       ## When true, records collapsed siblings during deletion for witness
       ## generation.
 
-    collapsedSiblings*: seq[tuple[sibAccPath: Hash32, sibStoPath: Opt[Hash32]]]
-      ## Records path pairs for each surviving sibling when a branch collapses
-      ## during deletion. `sibAccPath` is the account path (used to look up the
-      ## storage trie root); `sibStoPath` is the sibling's own path hash. For
-      ## account-trie collapses, sibStoPath is none. Used by witness
-      ## generation to include the sibling node in the witness for stateless
-      ## execution. Only populated when collectWitness is true.
+    collapsedSiblings*: seq[
+      tuple[
+        sibAccPath: Hash32, sibStoPath: Opt[Hash32], stoRoot: VertexID, brVid: VertexID
+      ]
+    ]
+      ## Records collapsed siblings for witness generation. For each entry:
+      ## `sibAccPath` is the account path; `sibStoPath` is the sibling storage
+      ## path (none for account-trie collapses). When `brVid` is valid, the
+      ## entry is a deferred StoLeaf collapse. On witness building the
+      ## `getCollapsedSiblings` checks the vertex type at (stoRoot, brVid)
+      ## in the final trie before including it.
+      ## Only populated when collectWitness is true.
 
     snapshot*: Snapshot
       ## Optional snapshot containing the cumulative changes from ancestors and

--- a/execution_chain/db/aristo/aristo_desc/desc_structural.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_structural.nim
@@ -29,7 +29,7 @@ type
     StoLeaf
     Branch
     ExtBranch
-    ExtNode # Stateless only type
+    BoundaryNode # Stateless only type
 
   AristoAccount* = object
     ## Application relevant part of an Ethereum account. Note that the storage
@@ -57,11 +57,15 @@ type
   ExtBranchRef* = ref object of BranchRef
     pfx*: NibblesBuf
 
-  ExtNodeRef* = ref object of VertexRef
-    ## Stateless only type, represents a standard MPT Extension node:
-    ## pfx as usual path prefix, childKey is the hash of the absent branch child.
-    ## Created from witness by putSubtrie for non-membership proof boundaries.
-    ## Never created / used during full-node execution.
+  BoundaryNodeRef* = ref object of VertexRef
+    ## Stateless-only type. Represents a path prefix leading to an absent
+    ## subtrie whose hash is known. Used in two scenarios:
+    ##   1. Non-membership proof boundaries: `putSubtrie` puts a BoundaryNode
+    ##      where the witness ends at a known hash but the subtrie is absent.
+    ##   2. Branch collapse during delete: when a branch collapses to a single
+    ##      nil vtx boundary child, the branch is replaced by a BoundaryNode
+    ##      (prefix + boundary hash).
+    ## Should never be created or used during full-node execution.
     pfx*: NibblesBuf
     childKey*: HashKey
 
@@ -117,7 +121,7 @@ type
 const
   Leaves* = {VertexType.AccLeaf, VertexType.StoLeaf}
   Branches* = {VertexType.Branch, VertexType.ExtBranch}
-  VertexTypes* = Leaves + Branches + {VertexType.ExtNode}
+  VertexTypes* = Leaves + Branches + {VertexType.BoundaryNode}
 
 # ------------------------------------------------------------------------------
 # Public helpers (misc)
@@ -139,8 +143,8 @@ template init*(
 ): ExtBranchRef =
   ExtBranchRef(vType: ExtBranch, pfx: pfxp, startVid: startVidp, used: usedp)
 
-template init*(_: type ExtNodeRef, pfxp: NibblesBuf, childKeyp: HashKey): ExtNodeRef =
-  ExtNodeRef(vType: ExtNode, pfx: pfxp, childKey: childKeyp)
+template init*(_: type BoundaryNodeRef, pfxp: NibblesBuf, childKeyp: HashKey): BoundaryNodeRef =
+  BoundaryNodeRef(vType: BoundaryNode, pfx: pfxp, childKey: childKeyp)
 
 template init*(
     T: type CachedAccLeaf, pfxp: NibblesBuf, accountp: AristoAccount, stoIDp: StorageID): T =
@@ -191,8 +195,8 @@ template pfx*(vtx: VertexRef): NibblesBuf =
     LeafRef(vtx).pfx
   of ExtBranch:
     ExtBranchRef(vtx).pfx
-  of ExtNode:
-    ExtNodeRef(vtx).pfx
+  of BoundaryNode:
+    BoundaryNodeRef(vtx).pfx
   of Branch:
     emptyNibbles
 
@@ -243,15 +247,15 @@ proc `==`*(a, b: VertexRef): bool =
       BranchRef(a)[] == BranchRef(b)[]
     of ExtBranch:
       ExtBranchRef(a)[] == ExtBranchRef(b)[]
-    of ExtNode:
-      ExtNodeRef(a)[] == ExtNodeRef(b)[]
+    of BoundaryNode:
+      BoundaryNodeRef(a)[] == BoundaryNodeRef(b)[]
   else:
     true
 
 iterator pairs*(vtx: VertexRef): tuple[nibble: uint8, vid: VertexID] =
-  ## Iterates over the sub-vids of a branch (does nothing for leaves or ExtNode)
+  ## Iterates over the sub-vids of a branch (does nothing for leaves or BoundaryNode)
   case vtx.vType
-  of Leaves, ExtNode:
+  of Leaves, BoundaryNode:
     discard
   of Branches:
     let vtx = BranchRef(vtx)
@@ -260,10 +264,10 @@ iterator pairs*(vtx: VertexRef): tuple[nibble: uint8, vid: VertexID] =
         yield (n, VertexID(uint64(vtx.startVid) + n))
 
 iterator allPairs*(vtx: VertexRef): tuple[nibble: uint8, vid: VertexID] =
-  ## Iterates over the sub-vids of a branch (does nothing for leaves or ExtNode)
+  ## Iterates over the sub-vids of a branch (does nothing for leaves or BoundaryNode)
   ## including currently unset nodes
   case vtx.vType
-  of Leaves, ExtNode:
+  of Leaves, BoundaryNode:
     discard
   of Branches:
     let vtx = BranchRef(vtx)
@@ -310,9 +314,9 @@ func dup*(vtx: VertexRef): VertexRef =
     of ExtBranch:
       let vtx = ExtBranchRef(vtx)
       ExtBranchRef.init(vtx.pfx, vtx.startVid, vtx.used)
-    of ExtNode:
-      let vtx = ExtNodeRef(vtx)
-      ExtNodeRef.init(vtx.pfx, vtx.childKey)
+    of BoundaryNode:
+      let vtx = BoundaryNodeRef(vtx)
+      BoundaryNodeRef.init(vtx.pfx, vtx.childKey)
 
 template dup*(vtx: StoLeafRef): StoLeafRef =
   StoLeafRef(VertexRef(vtx).dup())
@@ -326,8 +330,8 @@ template dup*(vtx: BranchRef): BranchRef =
 template dup*(vtx: ExtBranchRef): ExtBranchRef =
   ExtBranchRef(VertexRef(vtx).dup())
 
-template dup*(vtx: ExtNodeRef): ExtNodeRef =
-  ExtNodeRef(VertexRef(vtx).dup())
+template dup*(vtx: BoundaryNodeRef): BoundaryNodeRef =
+  BoundaryNodeRef(VertexRef(vtx).dup())
 
 func `$`*(aa: AristoAccount): string =
   $aa.nonce & "," & $aa.balance & "," &
@@ -364,11 +368,11 @@ func `$`*(vtx: ExtBranchRef): string =
   else:
     "E(" & $vtx.pfx & ":"  & $vtx.startVid & "+" & toBin(BiggestInt(vtx.used), 16) & ")"
 
-func `$`*(vtx: ExtNodeRef): string =
+func `$`*(vtx: BoundaryNodeRef): string =
   if vtx == nil:
-    "EN(nil)"
+    "BN(nil)"
   else:
-    "EN(" & $vtx.pfx & ":" & $vtx.childKey & ")"
+    "BN(" & $vtx.pfx & ":" & $vtx.childKey & ")"
 
 func `$`*(vtx: VertexRef): string =
   if vtx == nil:
@@ -383,8 +387,8 @@ func `$`*(vtx: VertexRef): string =
       $(BranchRef(vtx)[])
     of ExtBranch:
       $(ExtBranchRef(vtx)[])
-    of ExtNode:
-      $(ExtNodeRef(vtx)[])
+    of BoundaryNode:
+      $(BoundaryNodeRef(vtx)[])
 
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/db/aristo/aristo_fetch.nim
+++ b/execution_chain/db/aristo/aristo_fetch.nim
@@ -91,8 +91,8 @@ proc retrieveAccStatic(
           err FetchPathNotFound
         else:
           ok (vtx, path, next)
-    of ExtNode:
-      # Stateless-only boundary: child branch absent from witness, not traversable.
+    of BoundaryNode:
+      # Stateless-only boundary: child absent from witness, not traversable.
       countHitOrLower()
       return err FetchPathNotFound
     of ExtBranch:

--- a/execution_chain/db/aristo/aristo_hike.nim
+++ b/execution_chain/db/aristo/aristo_hike.nim
@@ -39,8 +39,8 @@ func getNibblesImpl(hike: Hike; start = 0; maxLen = high(int)): NibblesBuf =
     of ExtBranch:
       let vtx = ExtBranchRef(leg.wp.vtx)
       result = result & vtx.pfx & NibblesBuf.nibble(leg.nibble.byte)
-    of ExtNode:
-      discard # ExtNode never successfully steps forward
+    of BoundaryNode:
+      discard # BoundaryNode never successfully steps forward
     of Leaves:
       let vtx = LeafRef(leg.wp.vtx)
       result = result & vtx.pfx
@@ -113,8 +113,8 @@ proc step*(
 
     ok (vtx, vtx.pfx.len + 1, nextVid)
 
-  of ExtNode:
-    # branch absent from witness, no reachable child VID
+  of BoundaryNode:
+    # child absent from witness, no reachable child VID
     return err(HikeBranchMissingEdge)
 
 
@@ -188,8 +188,8 @@ proc hikeUp*[LeafType](
     of ExtBranch:
       let vtx = ExtBranchRef(vtx)
       hike.legs.add Leg(wp: wp, nibble: int8 path[vtx.pfx.len])
-    of ExtNode:
-      discard # step() always fails for ExtNode thus this is unreachable
+    of BoundaryNode:
+      discard # step() always fails for BoundaryNode thus this is unreachable
 
     path = path.slice(common)
     vid = next

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_desc.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_desc.nim
@@ -109,7 +109,7 @@ template to*(v: VertexType, T: type RdbVertexType): RdbVertexType =
   of VertexType.AccLeaf, VertexType.StoLeaf: RdbVertexType.Leaf
   of VertexType.Branch: RdbVertexType.Branch
   of VertexType.ExtBranch: RdbVertexType.ExtBranch
-  of VertexType.ExtNode: raiseAssert "ExtNode is stateless-only and never persisted"
+  of VertexType.BoundaryNode: raiseAssert "BoundaryNode is stateless-only and never persisted"
 
 template inc*(v: var RdbLruCounter, hit: bool) =
   discard v[hit].fetchAdd(1, moRelaxed)

--- a/execution_chain/db/aristo/aristo_layers.nim
+++ b/execution_chain/db/aristo/aristo_layers.nim
@@ -149,7 +149,7 @@ func layersPutKey*(
 func layersPutKey*(
     db: AristoTxRef;
     rvid: RootedVertexID;
-    vtx: ExtNodeRef,
+    vtx: BoundaryNodeRef,
     key: HashKey;
       ) =
   ## Stores the live vertex so mergePayloadImpl can read pfx/childKey on split.

--- a/execution_chain/db/aristo/aristo_merge.nim
+++ b/execution_chain/db/aristo/aristo_merge.nim
@@ -198,16 +198,16 @@ proc mergePayloadImpl[LeafType, T](
         resetKeys()
         return ok((leafVtx, nil, nil))
 
-    of ExtNode:
-      let evtx = ExtNodeRef(vtx)
+    of BoundaryNode:
+      let evtx = BoundaryNodeRef(vtx)
       if n == evtx.pfx.len:
         # Full prefix match: the new key would traverse into the absent branch
         # child. This is not supported in partial-trie / stateless mode.
         return err(MergeHikeFailed)
       else:
-        # Partial prefix match: split the ExtNode at the divergence point,
+        # Partial prefix match: split the BoundaryNode at the divergence point,
         # creating a new branch. This is similar as for leaves except that
-        # the existing ExtNode is moved down one level.
+        # the existing BoundaryNode is moved down one level.
         let
           startVid =
             if root == STATE_ROOT_VID:
@@ -220,13 +220,13 @@ proc mergePayloadImpl[LeafType, T](
             else:
               BranchRef.init(startVid, 0)
 
-        # Place the existing ExtNode content at its new position
+        # Place the existing BoundaryNode content at its new position
         let
           local = branch.setUsed(evtx.pfx[n], true)
           pfx = evtx.pfx.slice(n + 1)
         if pfx.len > 0:
-          # Remaining prefix: create new ExtNode pointing to the same child.
-          let newExt = ExtNodeRef.init(pfx, evtx.childKey)
+          # Remaining prefix: create new BoundaryNode pointing to the same child.
+          let newExt = BoundaryNodeRef.init(pfx, evtx.childKey)
           db.layersPutKey(
             (root, local), newExt,
             rlpEncodeExt(pfx, evtx.childKey).digestTo(HashKey))

--- a/execution_chain/db/aristo/aristo_nearby.nim
+++ b/execution_chain/db/aristo/aristo_nearby.nim
@@ -49,8 +49,8 @@ iterator rightPairs*(
         var x = hike.legs[^1]
 
         case x.wp.vtx.vType
-        of ExtNode:
-          discard # ExtNode never appears in hike legs (step always fails for it)
+        of BoundaryNode:
+          discard # BoundaryNode never appears in hike legs (step always fails for it)
         of Branches:
           let vtx = BranchRef(x.wp.vtx)
           for i in uint8(x.nibble + 1) ..< 16u8:

--- a/execution_chain/db/aristo/aristo_proof.nim
+++ b/execution_chain/db/aristo/aristo_proof.nim
@@ -59,10 +59,10 @@ proc chainRlpNodes(
 
   # Follow up child node
   case vtx.vType:
-  of ExtNode:
-    # Proof generation is only called on full nodes; ExtNode (stateless
+  of BoundaryNode:
+    # Proof generation is only called on full nodes; BoundaryNode (stateless
     # boundary) must never appear here.
-    raiseAssert "ExtNode in proof generation"
+    raiseAssert "BoundaryNode in proof generation"
 
   of Leaves:
     chain.add(rlpNodes[0])
@@ -419,11 +419,11 @@ proc convertSubtrie(
             key: childNode.key,
             vtx: ExtBranchRef.init(segm, childBranch.startVid, childBranch.used))
         else:
-          # Branch absent from witness (proof boundary): represent as an
-          # ExtNode carrying the branch hash as childKey.
+          # Child absent from witness (proof boundary): represent as a
+          # BoundaryNode carrying the child hash as childKey.
           NodeRef(
             key: default(array[16, HashKey]),
-            vtx: ExtNodeRef.init(segm, k))
+            vtx: BoundaryNodeRef.init(segm, k))
 
     of 17: # Branch node
       var key: array[16, HashKey]
@@ -477,9 +477,9 @@ proc putSubtrie(
     of StoLeaf:
       discard
 
-    of ExtNode:
+    of BoundaryNode:
       # Store vertex and pre-computed extension hash
-      db.layersPutKey(rvid, ExtNodeRef(node.vtx), key)
+      db.layersPutKey(rvid, BoundaryNodeRef(node.vtx), key)
       return ok()
 
     of Branch, ExtBranch:

--- a/execution_chain/db/aristo/aristo_serialise.nim
+++ b/execution_chain/db/aristo/aristo_serialise.nim
@@ -89,8 +89,8 @@ proc to*(node: NodeRef, T: type array[2, seq[byte]]): T =
   ## and branch vertex argument, there will be a double item list result.
   ##
   case node.vtx.vType
-  of ExtNode:
-    let ev = ExtNodeRef(node.vtx)
+  of BoundaryNode:
+    let ev = BoundaryNodeRef(node.vtx)
     [@(rlpEncodeExt(ev.pfx, ev.childKey)), @[]]
   of Branches:
     let brData = @(rlpEncodeBranch(BranchRef(node.vtx), node.key[n]))
@@ -111,8 +111,8 @@ proc digestTo*(node: NodeRef, T: type HashKey): T =
   ## that a `Dummy` node is encoded as as a `Leaf`.
   ##
   case node.vtx.vType
-  of ExtNode:
-    let ev = ExtNodeRef(node.vtx)
+  of BoundaryNode:
+    let ev = BoundaryNodeRef(node.vtx)
     rlpEncodeExt(ev.pfx, ev.childKey).digestTo(HashKey)
   of Branches:
     let brKey = rlpEncodeBranch(BranchRef(node.vtx), node.key[n]).digestTo(HashKey)

--- a/execution_chain/db/aristo/aristo_utils.nim
+++ b/execution_chain/db/aristo/aristo_utils.nim
@@ -55,7 +55,7 @@ proc toNode*(
     # Need to resolve storage root for account leaf
     return ok node
 
-  of ExtNode:
+  of BoundaryNode:
     # No child vids to resolve as the branch child is absent by design
     let node = NodeRef(vtx: vtx.dup())
     return ok node
@@ -76,7 +76,7 @@ iterator subVids*(vtx: VertexRef): VertexID =
     if stoID.isValid:
       yield stoID.vid
 
-  of StoLeaf, ExtNode:
+  of StoLeaf, BoundaryNode:
     discard
   of Branches:
     for _, subvid in vtx.pairs():
@@ -89,7 +89,7 @@ iterator subVidKeys*(node: NodeRef): (VertexID,HashKey) =
     let stoID = AccLeafRef(node.vtx).stoID
     if stoID.isValid:
       yield (stoID.vid, node.key[0])
-  of StoLeaf, ExtNode:
+  of StoLeaf, BoundaryNode:
     discard
   of Branches:
     for n, subvid in node.vtx.pairs():

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -20,7 +20,7 @@ import
   ../evm/code_bytes,
   ../constants,
   ./[access_list as ac_access_list, core_db, storage_types],
-  ./aristo/aristo_blobify
+  ./aristo/[aristo_blobify, aristo_desc, aristo_get]
 
 export
   code_bytes, core_db.computeAccPath, core_Db.computeSlotKey
@@ -664,10 +664,23 @@ proc clearEmptyAccounts(ledger: LedgerRef) =
 template getWitnessKeys*(ledger: LedgerRef): WitnessTable =
   ledger.witnessKeys
 
-template getCollapsedSiblings*(
+proc getCollapsedSiblings*(
     ledger: LedgerRef
 ): seq[tuple[sibAccPath: Hash32, sibStoPath: Opt[Hash32]]] =
-  ledger.txFrame.aTx.collapsedSiblings
+  ## Collapsed siblings for witness generation. StoLeaf collapses (brVid
+  ## valid) are only included if brVid is still a StoLeaf in the final trie.
+  ## A branch there means a later insertion expanded it again, no auxiliary
+  ## needed.
+  let db = ledger.txFrame.aTx
+  var res: seq[tuple[sibAccPath: Hash32, sibStoPath: Opt[Hash32]]]
+  for (accPath, sibStoPath, stoRoot, brVid) in db.collapsedSiblings:
+    if brVid.isValid:
+      let vtx = db.getVtx((stoRoot, brVid))
+      if vtx.isValid and vtx.vType == StoLeaf:
+        res.add((accPath, sibStoPath))
+    else:
+      res.add((accPath, sibStoPath))
+  res
 
 template clearWitnessKeys*(ledger: LedgerRef) =
   ledger.witnessKeys.clear()

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -28,11 +28,6 @@ const skipFiles = [
   #
   # --- eest_zkevm files with failures ---
   #
-  # persistStorage(): Unspecified(Aristo, ctx=, error=DelVidStaleVtx) [AssertionDefect]
-  # -> on execution with test vector witness
-  # generated witness has an extra state node, stateless execution works with it
-  "witness_state_block_diff_delete_insert_before_delete_order.json",
-  #
   # Witness codes mismatch -> codes optimisation: implemented in
   # https://github.com/status-im/nimbus-eth1/pull/4099
   "witness_codes_create_same_hash_then_read.json",


### PR DESCRIPTION
This fix consists of two parts:

- part 1: stateless execution when a storage branch collapses to a single surviving child and that child is only known by its hash (as it is not provided in full by the witness), `deleteImpl` crashed with `DelVidStaleVtx`. The fix creates a `BoundaryNode` (path prefix + known hash) at the branch its vid instead, which is used to encode the absent subtrie for state root computation.

- part 2: witness generation: when a branch collapses to a single StoLeaf during a tx but a later tx inserts a slot that re-expands the same branch, the collapsed sibling was still being included in the witness as an auxiliary node. This differs from the witnesses provided by EEST test vectors. `collapsedSiblings` now stores the collapsed branch its vid and the sibling path. At witness building, `getCollapsedSiblings` checks whether that vid is still a StoLeaf in the final trie. if it became a branch, the insertion undid the collapse and no auxiliary node is needed in the witness. Note that this is more of an "efficiency" of the witness change/fix.

Also rename `ExtNode`/`ExtNodeRef` to `BoundaryNode`/`BoundaryNodeRef`. The old names implied a standard MPT extension node (which always points to a branch), but a BoundaryNode can point to any absent subtrie including a leaf.