### PR TITLE
explicitly disable nim stack traces with libbacktrace

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -143,10 +143,11 @@ switch("define", "withoutPCRE")
 
 when not defined(disable_libbacktrace):
   --define:nimStackTraceOverride
+  switch("stacktrace", "off")
   switch("import", "libbacktrace")
 else:
-  --stacktrace:on
-  --linetrace:on
+  switch("stacktrace", "on")
+  switch("linetrace", "on")
 
 var canEnableDebuggingSymbols = true
 if defined(macosx):


### PR DESCRIPTION
They are enabled by default in non-release builds resulting in two stack trace mechanisms when compiling using regular nim