### PR TITLE
proxy: op-stack support

### DIFF
--- a/nimbus_verified_proxy/engine/blocks.nim
+++ b/nimbus_verified_proxy/engine/blocks.nim
@@ -91,7 +91,7 @@ func convHeader*(blk: eth_api_types.BlockObject): Header =
     requestsHash: blk.requestsHash,
   )
 
-proc walkBlocks(
+proc walkBlocks*(
     engine: RpcVerificationEngine,
     sourceNum: base.BlockNumber,
     targetNum: base.BlockNumber,
@@ -258,23 +258,13 @@ proc verifyBlock(
   if fullTransactions:
     ?verifyTransactions(header.transactionsRoot, blk.transactions)
 
-  # verify withdrawals
-  if blk.withdrawalsRoot.isSome():
-    if blk.withdrawalsRoot.get() != orderedTrieRoot(blk.withdrawals.get(@[])):
+  if blk.withdrawals.isSome() and blk.withdrawalsRoot.isSome():
+    if blk.withdrawalsRoot.get() != orderedTrieRoot(blk.withdrawals.get()):
       # untagged(-1) so the relevant backend can be tagged
       return err(
         (
           VerificationError,
           "Withdrawals within the block do not yield the same withdrawals root",
-          UNTAGGED,
-        )
-      )
-  else:
-    if blk.withdrawals.isSome():
-      # untagged(-1) so the relevant backend can be tagged
-      return err(
-        (
-          VerificationError, "Block contains withdrawals but no withdrawalsRoot",
           UNTAGGED,
         )
       )

--- a/nimbus_verified_proxy/engine/engine.nim
+++ b/nimbus_verified_proxy/engine/engine.nim
@@ -160,11 +160,42 @@ func convLCHeader*(lcHeader: ForkyLightClientHeader): Result[Header, string] =
       )
     )
 
-proc init*(
-    T: type RpcVerificationEngine, config: RpcVerificationEngineConf
+proc initCore*(
+    T: type RpcVerificationEngine,
+    chainId: UInt256,
+    networkId: UInt256,
+    maxBlockWalk: uint64,
+    parallelBlockDownloads: uint64,
+    headerStoreLen: int,
+    accountCacheLen: int,
+    codeCacheLen: int,
+    storageCacheLen: int,
 ): EngineResult[T] =
   randomize()
 
+  let engine = RpcVerificationEngine(
+    chainId: chainId,
+    maxBlockWalk: maxBlockWalk,
+    headerStore: HeaderStore.new(headerStoreLen),
+    accountsCache: AccountsCache.init(accountCacheLen),
+    codeCache: CodeCache.init(codeCacheLen),
+    storageCache: StorageCache.init(storageCacheLen),
+    parallelBlockDownloads: parallelBlockDownloads,
+    availabilityScoreFunc: defaultAvailabilityScoreFunc,
+    qualityScoreFunc: defaultQualityScoreFunc,
+  )
+
+  # since AsyncEvm requires a few transport methods (getStorage, getCode etc.)
+  # for initialization, we initialize the proxy first then the evm within it
+  engine.evm = AsyncEvm.init(engine.toAsyncEvmStateBackend(), networkId)
+
+  engine.syncLock = newAsyncLock()
+
+  ok(engine)
+
+proc init*(
+    T: type RpcVerificationEngine, config: RpcVerificationEngineConf
+): EngineResult[T] =
   let
     networkName = config.eth2Network.get("mainnet")
     metadata = getMetadataForNetwork(networkName)
@@ -181,31 +212,27 @@ proc init*(
         proc(): BeaconTime {.gcsafe, raises: [].} =
           config.freezeAtSlot.start_beacon_time(metadata.cfg.timeParams)
     forkDigests = newClone ForkDigests.init(metadata.cfg, genesis_validators_root)
+    networkId = ?chainIdToNetworkId(config.chainId)
 
-  let engine = RpcVerificationEngine(
-    chainId: config.chainId,
-    timeParams: metadata.cfg.timeParams,
-    getBeaconTime: getBeaconTime,
-    trustedBlockRoot: some(config.trustedBlockRoot),
-    lcStore: (ref ForkedLightClientStore)(),
-    maxBlockWalk: config.maxBlockWalk,
-    headerStore: HeaderStore.new(config.headerStoreLen),
-    accountsCache: AccountsCache.init(config.accountCacheLen),
-    codeCache: CodeCache.init(config.codeCacheLen),
-    storageCache: StorageCache.init(config.storageCacheLen),
-    parallelBlockDownloads: config.parallelBlockDownloads,
-    maxLightClientUpdates: config.maxLightClientUpdates,
-    availabilityScoreFunc: defaultAvailabilityScoreFunc,
-    qualityScoreFunc: defaultQualityScoreFunc,
-    cfg: metadata.cfg,
-    forkDigests: forkDigests,
+  let engine = ?RpcVerificationEngine.initCore(
+    chainId = config.chainId,
+    networkId = networkId,
+    maxBlockWalk = config.maxBlockWalk,
+    parallelBlockDownloads = config.parallelBlockDownloads,
+    headerStoreLen = config.headerStoreLen,
+    accountCacheLen = config.accountCacheLen,
+    codeCacheLen = config.codeCacheLen,
+    storageCacheLen = config.storageCacheLen,
   )
 
-  let networkId = ?chainIdToNetworkId(config.chainId)
-
-  # since AsyncEvm requires a few transport methods (getStorage, getCode etc.)
-  # for initialization, we initialize the proxy first then the evm within it
-  engine.evm = AsyncEvm.init(engine.toAsyncEvmStateBackend(), networkId)
+  # layer the beacon / light-client fields on top of the core
+  engine.timeParams = metadata.cfg.timeParams
+  engine.getBeaconTime = getBeaconTime
+  engine.trustedBlockRoot = some(config.trustedBlockRoot)
+  engine.lcStore = (ref ForkedLightClientStore)()
+  engine.maxLightClientUpdates = config.maxLightClientUpdates
+  engine.cfg = metadata.cfg
+  engine.forkDigests = forkDigests
 
   proc onStoreInitialized() =
     discard
@@ -286,8 +313,6 @@ proc init*(
     onFinalizedHeader,
     onOptimisticHeader,
   )
-
-  engine.syncLock = newAsyncLock()
 
   ok(engine)
 

--- a/nimbus_verified_proxy/engine/types.nim
+++ b/nimbus_verified_proxy/engine/types.nim
@@ -439,25 +439,6 @@ proc beaconBackendFor*(
   except KeyError:
     err((BackendError, "Chosen backend not found", UNTAGGED))
 
-proc applyPenalty*(engine: RpcVerificationEngine, e: ErrorTuple) =
-  if e.backendIdx < 0:
-    return
-  let idx = e.backendIdx
-  try:
-    case e.errType
-    of BackendFetchError, BackendDecodingError:
-      engine.scores[idx].availability =
-        engine.availabilityScoreFunc(engine.scores[idx].availability, Penalty)
-      engine.scores[idx].quality =
-        engine.qualityScoreFunc(engine.scores[idx].quality, UndoReward)
-    of VerificationError:
-      engine.scores[idx].quality =
-        engine.qualityScoreFunc(engine.scores[idx].quality, Penalty)
-    else:
-      discard
-  except KeyError:
-    discard
-
 template tagBackend*[T](r: EngineResult[T], idx: int): EngineResult[T] =
   block:
     let taggedR: EngineResult[T] = r

--- a/nimbus_verified_proxy/engine/types.nim
+++ b/nimbus_verified_proxy/engine/types.nim
@@ -439,6 +439,25 @@ proc beaconBackendFor*(
   except KeyError:
     err((BackendError, "Chosen backend not found", UNTAGGED))
 
+proc applyPenalty*(engine: RpcVerificationEngine, e: ErrorTuple) =
+  if e.backendIdx < 0:
+    return
+  let idx = e.backendIdx
+  try:
+    case e.errType
+    of BackendFetchError, BackendDecodingError:
+      engine.scores[idx].availability =
+        engine.availabilityScoreFunc(engine.scores[idx].availability, Penalty)
+      engine.scores[idx].quality =
+        engine.qualityScoreFunc(engine.scores[idx].quality, UndoReward)
+    of VerificationError:
+      engine.scores[idx].quality =
+        engine.qualityScoreFunc(engine.scores[idx].quality, Penalty)
+    else:
+      discard
+  except KeyError:
+    discard
+
 template tagBackend*[T](r: EngineResult[T], idx: int): EngineResult[T] =
   block:
     let taggedR: EngineResult[T] = r

--- a/nimbus_verified_proxy/library/bindings/go/README.md
+++ b/nimbus_verified_proxy/library/bindings/go/README.md
@@ -51,12 +51,18 @@ The proxy syncs with the beacon chain in the background. The first few calls may
 
 | Field | Description |
 |---|---|
-| `eth2Network` | Network name: `mainnet`, `sepolia`, or `hoodi` |
+| `eth2Network` | Network name: `mainnet`, `sepolia`, `hoodi`, or an OP Stack network (`op-mainnet`, `base-mainnet`, `op-sepolia`) |
 | `trustedBlockRoot` | A trusted checkpoint block root (hex) used to bootstrap the light client |
 | `executionApiUrls` | Comma-separated execution layer JSON-RPC URLs |
 | `beaconApiUrls` | Comma-separated beacon API URLs |
+| `opExecutionApiUrls` | Comma-separated L2 (op-geth) execution JSON-RPC URLs. Only used for OP Stack networks |
 | `logLevel` | Log verbosity: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL` |
 | `logStdout` | Log destination: `Auto`, `None`, or `Stdout` |
+
+When an OP Stack network is configured, the primary engine verifies the L1 the rollup
+settles to (so `eth_*` calls target L1) and a secondary L2 engine is served under the `op_`
+namespace. Call it through the same `CallRpc`, e.g.
+`ctx.CallRpc("op_getBalance", params, timeout)`.
 
 ## Custom transports
 

--- a/nimbus_verified_proxy/library/bindings/go/examples/main.go
+++ b/nimbus_verified_proxy/library/bindings/go/examples/main.go
@@ -16,10 +16,15 @@ import (
 	"github.com/status-im/nimbus-eth1/nimbus_verified_proxy/library/bindings/go/verifproxy"
 )
 
+// Selecting an "op-*" network spins up a secondary L2 engine served under the op_ namespace.
+// The primary engine then verifies the L1 the rollup settles to (here, mainnet), so eth_*
+// targets L1 and op_* targets the OP L2. "opExecutionApiUrls" points at op-geth; the same
+// transport callback handles it (just another transport).
 const configJSON = `{
   "executionApiUrls": "https://eth.blockrazor.xyz,https://eth.nimbus.xyz",
   "beaconApiUrls": "http://testing.mainnet.beacon-api.nimbus.team,http://www.lightclientdata.org",
-  "eth2Network": "mainnet",
+  "opExecutionApiUrls": "https://mainnet.optimism.io",
+  "eth2Network": "op-mainnet",
   "trustedBlockRoot": "0x1234567890123456789012345678901234567890123456789012345678901234",
   "logLevel": "DEBUG"
 }`
@@ -33,10 +38,19 @@ func main() {
 
 	time.Sleep(2 * time.Second)
 
+	// eth_* targets the L1 engine
 	params, _ := json.Marshal([]string{"0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe", "latest"})
 	result, err := ctx.CallRpc("eth_getBalance", string(params), 30*time.Second)
 	if err != nil {
 		log.Fatalf("eth_getBalance: %v", err)
 	}
 	fmt.Printf("eth_getBalance: %s\n", result)
+
+	// op_* targets the L2 (OP Stack) engine — same generic CallRpc, op_ prefix
+	opParams, _ := json.Marshal([]string{"0x4200000000000000000000000000000000000016", "safe"})
+	opResult, err := ctx.CallRpc("op_getBalance", string(opParams), 30*time.Second)
+	if err != nil {
+		log.Fatalf("op_getBalance: %v", err)
+	}
+	fmt.Printf("op_getBalance: %s\n", opResult)
 }

--- a/nimbus_verified_proxy/library/bindings/wasm/examples/index.html
+++ b/nimbus_verified_proxy/library/bindings/wasm/examples/index.html
@@ -250,6 +250,9 @@
         <option value="mainnet">mainnet</option>
         <option value="holesky">holesky</option>
         <option value="sepolia">sepolia</option>
+        <option value="op-mainnet">op-mainnet (serves op_*)</option>
+        <option value="base-mainnet">base-mainnet (serves op_*)</option>
+        <option value="op-sepolia">op-sepolia (serves op_*)</option>
       </select>
 
       <label>Trusted Block Root</label>
@@ -266,6 +269,11 @@
       <input id="cfg-beacon" type="text"
         value="http://testing.mainnet.beacon-api.nimbus.team,http://www.lightclientdata.org"
         placeholder="http://…" />
+
+      <label>OP (L2) Execution API URLs (comma-separated, only for op-* networks)</label>
+      <input id="cfg-op-exec" type="text"
+        value="https://mainnet.optimism.io"
+        placeholder="https://…" />
 
       <label>Log Level</label>
       <select id="cfg-loglevel">
@@ -320,6 +328,10 @@
         <button class="btn-clear" data-quick='["eth_gasPrice","[]"]'>eth_gasPrice</button>
         <button class="btn-clear" data-quick='["eth_getBalance","[\"0x954a86C613fd1fBaC9C7A43a071A68254C75E4AC\",\"latest\"]"]'>eth_getBalance (example addr)</button>
         <button class="btn-clear" data-quick='["eth_getBlockByNumber","[\"latest\",false]"]'>eth_getBlockByNumber (latest)</button>
+        <!-- op_* — only resolve when an op-* network is configured -->
+        <button class="btn-clear" data-quick='["op_blockNumber","[]"]'>op_blockNumber</button>
+        <button class="btn-clear" data-quick='["op_getBalance","[\"0x4200000000000000000000000000000000000016\",\"safe\"]"]'>op_getBalance (msg passer, safe)</button>
+        <button class="btn-clear" data-quick='["op_getBlockByNumber","[\"safe\",false]"]'>op_getBlockByNumber (safe)</button>
       </div>
     </section>
 
@@ -376,12 +388,13 @@
 
   function buildConfig() {
     return JSON.stringify({
-      eth2Network:       $('cfg-network').value,
-      trustedBlockRoot:  $('cfg-root').value.trim(),
-      executionApiUrls:  $('cfg-exec').value.trim(),
-      beaconApiUrls:     $('cfg-beacon').value.trim(),
-      logLevel:          $('cfg-loglevel').value,
-      logStdout:         'None',
+      eth2Network:        $('cfg-network').value,
+      trustedBlockRoot:   $('cfg-root').value.trim(),
+      executionApiUrls:   $('cfg-exec').value.trim(),
+      beaconApiUrls:      $('cfg-beacon').value.trim(),
+      opExecutionApiUrls: $('cfg-op-exec').value.trim(),
+      logLevel:           $('cfg-loglevel').value,
+      logStdout:          'None',
     });
   }
 

--- a/nimbus_verified_proxy/library/c_frontend.nim
+++ b/nimbus_verified_proxy/library/c_frontend.nim
@@ -46,6 +46,16 @@ template callbackToC(
   else:
     fut.addCallback sendResult
 
+template requireOpFrontend(ctx: ptr Context, cb: CallBackProc, userData: pointer) =
+  if ctx.opFrontend.eth_blockNumber.isNil:
+    cb(
+      ctx,
+      RET_ERROR,
+      alloc("op_ namespace unavailable (no OP network configured)"),
+      userData,
+    )
+    return
+
 proc eth_blockNumber(
     ctx: ptr Context, cb: CallBackProc, userData: pointer
 ) {.exported.} =
@@ -415,6 +425,406 @@ proc eth_sendRawTransaction(
   callbackToC(ctx, cb, userData):
     ctx.frontend.eth_sendRawTransaction(txBytes)
 
+proc op_blockNumber(
+    ctx: ptr Context, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_blockNumber()
+
+proc op_getBalance(
+    ctx: ptr Context,
+    address: cstring,
+    blockTag: cstring,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let
+    addressTyped = unpackArg($address, Address).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+    blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getBalance(addressTyped, blockTagTyped)
+
+proc op_getStorageAt(
+    ctx: ptr Context,
+    address: cstring,
+    slot: cstring,
+    blockTag: cstring,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let
+    addressTyped = unpackArg($address, Address).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+    slotTyped = unpackArg($slot, UInt256).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+    blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getStorageAt(addressTyped, slotTyped, blockTagTyped)
+
+proc op_getTransactionCount(
+    ctx: ptr Context,
+    address: cstring,
+    blockTag: cstring,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let
+    addressTyped = unpackArg($address, Address).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+    blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getTransactionCount(addressTyped, blockTagTyped)
+
+proc op_getCode(
+    ctx: ptr Context,
+    address: cstring,
+    blockTag: cstring,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let
+    addressTyped = unpackArg($address, Address).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+    blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getCode(addressTyped, blockTagTyped)
+
+proc op_getBlockByHash(
+    ctx: ptr Context,
+    blockHash: cstring,
+    fullTransactions: bool,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let blockHashTyped = unpackArg($blockHash, Hash32).valueOr:
+    cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+    return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getBlockByHash(blockHashTyped, fullTransactions)
+
+proc op_getBlockByNumber(
+    ctx: ptr Context,
+    blockTag: cstring,
+    fullTransactions: bool,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+    cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+    return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getBlockByNumber(blockTagTyped, fullTransactions)
+
+proc op_getUncleCountByBlockNumber(
+    ctx: ptr Context, blockTag: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  let blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+    cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+    return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getUncleCountByBlockNumber(blockTagTyped)
+
+proc op_getUncleCountByBlockHash(
+    ctx: ptr Context, blockHash: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  let blockHashTyped = unpackArg($blockHash, Hash32).valueOr:
+    cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+    return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getUncleCountByBlockHash(blockHashTyped)
+
+proc op_getBlockTransactionCountByNumber(
+    ctx: ptr Context, blockTag: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  let blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+    cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+    return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getBlockTransactionCountByNumber(blockTagTyped)
+
+proc op_getBlockTransactionCountByHash(
+    ctx: ptr Context, blockHash: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  let blockHashTyped = unpackArg($blockHash, Hash32).valueOr:
+    cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+    return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getBlockTransactionCountByHash(blockHashTyped)
+
+proc op_getTransactionByBlockNumberAndIndex(
+    ctx: ptr Context,
+    blockTag: cstring,
+    index: culonglong,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let
+    blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+    indexTyped = Quantity(uint64(index))
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getTransactionByBlockNumberAndIndex(blockTagTyped, indexTyped)
+
+proc op_getTransactionByBlockHashAndIndex(
+    ctx: ptr Context,
+    blockHash: cstring,
+    index: culonglong,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let
+    blockHashTyped = unpackArg($blockHash, Hash32).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+    indexTyped = Quantity(uint64(index))
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getTransactionByBlockHashAndIndex(blockHashTyped, indexTyped)
+
+proc op_call(
+    ctx: ptr Context,
+    txArgs: cstring,
+    blockTag: cstring,
+    optimisticStateFetch: bool,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let
+    txArgsTyped = unpackArg($txArgs, TransactionArgs).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+    blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_call(txArgsTyped, blockTagTyped, optimisticStateFetch)
+
+proc op_createAccessList(
+    ctx: ptr Context,
+    txArgs: cstring,
+    blockTag: cstring,
+    optimisticStateFetch: bool,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let
+    txArgsTyped = unpackArg($txArgs, TransactionArgs).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+    blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_createAccessList(
+      txArgsTyped, blockTagTyped, optimisticStateFetch
+    )
+
+proc op_estimateGas(
+    ctx: ptr Context,
+    txArgs: cstring,
+    blockTag: cstring,
+    optimisticStateFetch: bool,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let
+    txArgsTyped = unpackArg($txArgs, TransactionArgs).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+    blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_estimateGas(txArgsTyped, blockTagTyped, optimisticStateFetch)
+
+proc op_getTransactionByHash(
+    ctx: ptr Context, txHash: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  let txHashTyped = unpackArg($txHash, Hash32).valueOr:
+    cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+    return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getTransactionByHash(txHashTyped)
+
+proc op_getBlockReceipts(
+    ctx: ptr Context, blockTag: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  let blockTagTyped = unpackArg($blockTag, BlockTag).valueOr:
+    cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+    return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getBlockReceipts(blockTagTyped)
+
+proc op_getTransactionReceipt(
+    ctx: ptr Context, txHash: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  let txHashTyped = unpackArg($txHash, Hash32).valueOr:
+    cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+    return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getTransactionReceipt(txHashTyped)
+
+proc op_getLogs(
+    ctx: ptr Context, filterOptions: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  let filterOptionsTyped = unpackArg($filterOptions, FilterOptions).valueOr:
+    cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+    return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getLogs(filterOptionsTyped)
+
+proc op_newFilter(
+    ctx: ptr Context, filterOptions: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  let filterOptionsTyped = unpackArg($filterOptions, FilterOptions).valueOr:
+    cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+    return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_newFilter(filterOptionsTyped)
+
+proc op_uninstallFilter(
+    ctx: ptr Context, filterId: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_uninstallFilter($filterId)
+
+proc op_getFilterLogs(
+    ctx: ptr Context, filterId: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getFilterLogs($filterId)
+
+proc op_getFilterChanges(
+    ctx: ptr Context, filterId: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_getFilterChanges($filterId)
+
+proc op_blobBaseFee(
+    ctx: ptr Context, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_blobBaseFee()
+
+proc op_gasPrice(ctx: ptr Context, cb: CallBackProc, userData: pointer) {.exported.} =
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_gasPrice()
+
+proc op_maxPriorityFeePerGas(
+    ctx: ptr Context, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_maxPriorityFeePerGas()
+
+proc op_feeHistory(
+    ctx: ptr Context,
+    blockCount: culonglong,
+    newestBlock: cstring,
+    rewardPercentiles: cstring,
+    cb: CallBackProc,
+    userData: pointer,
+) {.exported.} =
+  let
+    blockCountTyped = Quantity(uint64(blockCount))
+    newestBlockTyped = unpackArg($newestBlock, BlockTag).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+    rewardPercentilesTyped = unpackArg($rewardPercentiles, seq[int]).valueOr:
+      cb(ctx, RET_DESER_ERROR, alloc(error), userData)
+      return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_feeHistory(
+      blockCountTyped, newestBlockTyped, rewardPercentilesTyped
+    )
+
+proc op_sendRawTransaction(
+    ctx: ptr Context, txHexBytes: cstring, cb: CallBackProc, userData: pointer
+) {.exported.} =
+  let txBytes =
+    try:
+      let temp = hexToSeqByte($txHexBytes)
+      temp
+    except ValueError as e:
+      cb(ctx, RET_DESER_ERROR, alloc(e.msg), userData)
+      return
+
+  requireOpFrontend(ctx, cb, userData)
+  callbackToC(ctx, cb, userData):
+    ctx.opFrontend.eth_sendRawTransaction(txBytes)
+
 proc proxyCall(
     ctx: ptr Context,
     name: cstring,
@@ -596,5 +1006,165 @@ proc proxyCall(
   of "eth_sendRawTransaction":
     requireParams(1)
     eth_sendRawTransaction(ctx, parsedParams[0].getStr().cstring, cb, userData)
+  of "op_blockNumber":
+    requireParams(0)
+    op_blockNumber(ctx, cb, userData)
+  of "op_getBalance":
+    requireParams(2)
+    op_getBalance(
+      ctx,
+      parsedParams[0].getStr().cstring,
+      parsedParams[1].getStr().cstring,
+      cb,
+      userData,
+    )
+  of "op_getStorageAt":
+    requireParams(3)
+    op_getStorageAt(
+      ctx,
+      parsedParams[0].getStr().cstring,
+      parsedParams[1].getStr().cstring,
+      parsedParams[2].getStr().cstring,
+      cb,
+      userData,
+    )
+  of "op_getTransactionCount":
+    requireParams(2)
+    op_getTransactionCount(
+      ctx,
+      parsedParams[0].getStr().cstring,
+      parsedParams[1].getStr().cstring,
+      cb,
+      userData,
+    )
+  of "op_getCode":
+    requireParams(2)
+    op_getCode(
+      ctx,
+      parsedParams[0].getStr().cstring,
+      parsedParams[1].getStr().cstring,
+      cb,
+      userData,
+    )
+  of "op_getBlockByHash":
+    requireParams(2)
+    op_getBlockByHash(
+      ctx, parsedParams[0].getStr().cstring, parsedParams[1].getBool(), cb, userData
+    )
+  of "op_getBlockByNumber":
+    requireParams(2)
+    op_getBlockByNumber(
+      ctx, parsedParams[0].getStr().cstring, parsedParams[1].getBool(), cb, userData
+    )
+  of "op_getUncleCountByBlockNumber":
+    requireParams(1)
+    op_getUncleCountByBlockNumber(ctx, parsedParams[0].getStr().cstring, cb, userData)
+  of "op_getUncleCountByBlockHash":
+    requireParams(1)
+    op_getUncleCountByBlockHash(ctx, parsedParams[0].getStr().cstring, cb, userData)
+  of "op_getBlockTransactionCountByNumber":
+    requireParams(1)
+    op_getBlockTransactionCountByNumber(
+      ctx, parsedParams[0].getStr().cstring, cb, userData
+    )
+  of "op_getBlockTransactionCountByHash":
+    requireParams(1)
+    op_getBlockTransactionCountByHash(
+      ctx, parsedParams[0].getStr().cstring, cb, userData
+    )
+  of "op_getTransactionByBlockNumberAndIndex":
+    requireParams(2)
+    op_getTransactionByBlockNumberAndIndex(
+      ctx,
+      parsedParams[0].getStr().cstring,
+      parsedParams[1].getBiggestInt().culonglong,
+      cb,
+      userData,
+    )
+  of "op_getTransactionByBlockHashAndIndex":
+    requireParams(2)
+    op_getTransactionByBlockHashAndIndex(
+      ctx,
+      parsedParams[0].getStr().cstring,
+      parsedParams[1].getBiggestInt().culonglong,
+      cb,
+      userData,
+    )
+  of "op_call":
+    requireParams(3)
+    op_call(
+      ctx,
+      ($parsedParams[0]).cstring,
+      parsedParams[1].getStr().cstring,
+      parsedParams[2].getBool(),
+      cb,
+      userData,
+    )
+  of "op_createAccessList":
+    requireParams(3)
+    op_createAccessList(
+      ctx,
+      ($parsedParams[0]).cstring,
+      parsedParams[1].getStr().cstring,
+      parsedParams[2].getBool(),
+      cb,
+      userData,
+    )
+  of "op_estimateGas":
+    requireParams(3)
+    op_estimateGas(
+      ctx,
+      ($parsedParams[0]).cstring,
+      parsedParams[1].getStr().cstring,
+      parsedParams[2].getBool(),
+      cb,
+      userData,
+    )
+  of "op_getTransactionByHash":
+    requireParams(1)
+    op_getTransactionByHash(ctx, parsedParams[0].getStr().cstring, cb, userData)
+  of "op_getBlockReceipts":
+    requireParams(1)
+    op_getBlockReceipts(ctx, parsedParams[0].getStr().cstring, cb, userData)
+  of "op_getTransactionReceipt":
+    requireParams(1)
+    op_getTransactionReceipt(ctx, parsedParams[0].getStr().cstring, cb, userData)
+  of "op_getLogs":
+    requireParams(1)
+    op_getLogs(ctx, ($parsedParams[0]).cstring, cb, userData)
+  of "op_newFilter":
+    requireParams(1)
+    op_newFilter(ctx, ($parsedParams[0]).cstring, cb, userData)
+  of "op_uninstallFilter":
+    requireParams(1)
+    op_uninstallFilter(ctx, parsedParams[0].getStr().cstring, cb, userData)
+  of "op_getFilterLogs":
+    requireParams(1)
+    op_getFilterLogs(ctx, parsedParams[0].getStr().cstring, cb, userData)
+  of "op_getFilterChanges":
+    requireParams(1)
+    op_getFilterChanges(ctx, parsedParams[0].getStr().cstring, cb, userData)
+  of "op_blobBaseFee":
+    requireParams(0)
+    op_blobBaseFee(ctx, cb, userData)
+  of "op_gasPrice":
+    requireParams(0)
+    op_gasPrice(ctx, cb, userData)
+  of "op_maxPriorityFeePerGas":
+    requireParams(0)
+    op_maxPriorityFeePerGas(ctx, cb, userData)
+  of "op_feeHistory":
+    requireParams(3)
+    op_feeHistory(
+      ctx,
+      parsedParams[0].getBiggestInt().culonglong,
+      parsedParams[1].getStr().cstring,
+      ($parsedParams[2]).cstring,
+      cb,
+      userData,
+    )
+  of "op_sendRawTransaction":
+    requireParams(1)
+    op_sendRawTransaction(ctx, parsedParams[0].getStr().cstring, cb, userData)
   else:
     cb(ctx, RET_DESER_ERROR, alloc("unknown method"), userData)

--- a/nimbus_verified_proxy/library/c_frontend.nim
+++ b/nimbus_verified_proxy/library/c_frontend.nim
@@ -223,7 +223,7 @@ proc eth_getTransactionByBlockNumberAndIndex(
       cb(ctx, RET_DESER_ERROR, alloc(error), userData)
       return
 
-    indexTyped = Quantity(uint64(index))
+    indexTyped = Quantity(index)
 
   callbackToC(ctx, cb, userData):
     ctx.frontend.eth_getTransactionByBlockNumberAndIndex(blockTagTyped, indexTyped)
@@ -240,7 +240,7 @@ proc eth_getTransactionByBlockHashAndIndex(
       cb(ctx, RET_DESER_ERROR, alloc(error), userData)
       return
 
-    indexTyped = Quantity(uint64(index))
+    indexTyped = Quantity(index)
 
   callbackToC(ctx, cb, userData):
     ctx.frontend.eth_getTransactionByBlockHashAndIndex(blockHashTyped, indexTyped)
@@ -603,7 +603,7 @@ proc op_getTransactionByBlockNumberAndIndex(
       cb(ctx, RET_DESER_ERROR, alloc(error), userData)
       return
 
-    indexTyped = Quantity(uint64(index))
+    indexTyped = Quantity(index)
 
   requireOpFrontend(ctx, cb, userData)
   callbackToC(ctx, cb, userData):
@@ -621,7 +621,7 @@ proc op_getTransactionByBlockHashAndIndex(
       cb(ctx, RET_DESER_ERROR, alloc(error), userData)
       return
 
-    indexTyped = Quantity(uint64(index))
+    indexTyped = Quantity(index)
 
   requireOpFrontend(ctx, cb, userData)
   callbackToC(ctx, cb, userData):
@@ -796,7 +796,7 @@ proc op_feeHistory(
     userData: pointer,
 ) {.exported.} =
   let
-    blockCountTyped = Quantity(uint64(blockCount))
+    blockCountTyped = Quantity(blockCount)
     newestBlockTyped = unpackArg($newestBlock, BlockTag).valueOr:
       cb(ctx, RET_DESER_ERROR, alloc(error), userData)
       return

--- a/nimbus_verified_proxy/library/types.nim
+++ b/nimbus_verified_proxy/library/types.nim
@@ -15,6 +15,7 @@ type
     stop*: bool
     pendingCalls*: int
     frontend*: ExecutionApiFrontend
+    opFrontend*: ExecutionApiFrontend
 
   CallBackProc* = proc(ctx: ptr Context, status: cint, res: cstring, userData: pointer) {.
     cdecl, gcsafe, raises: []

--- a/nimbus_verified_proxy/library/verifproxy.h
+++ b/nimbus_verified_proxy/library/verifproxy.h
@@ -186,6 +186,7 @@ void proxyCall(Context *ctx, char* name, char* params, CallBackProc cb, void *us
  * @param userData  pointer to user data
  */
 void eth_blockNumber(Context *ctx, CallBackProc cb, void *userData);
+void op_blockNumber(Context *ctx, CallBackProc cb, void *userData);
 
 /**
  * Retrieve the EIP-4844 blob base fee.
@@ -195,6 +196,7 @@ void eth_blockNumber(Context *ctx, CallBackProc cb, void *userData);
  * @param userData  pointer to user data
  */
 void eth_blobBaseFee(Context *ctx, CallBackProc cb, void *userData);
+void op_blobBaseFee(Context *ctx, CallBackProc cb, void *userData);
 
 /**
  * Retrieve the current gas price.
@@ -204,6 +206,7 @@ void eth_blobBaseFee(Context *ctx, CallBackProc cb, void *userData);
  * @param userData  pointer to user data
  */
 void eth_gasPrice(Context *ctx, CallBackProc cb, void *userData);
+void op_gasPrice(Context *ctx, CallBackProc cb, void *userData);
 
 /**
  * Retrieve the suggested priority fee per gas.
@@ -213,6 +216,7 @@ void eth_gasPrice(Context *ctx, CallBackProc cb, void *userData);
  * @param userData  pointer to user data
  */
 void eth_maxPriorityFeePerGas(Context *ctx, CallBackProc cb, void *userData);
+void op_maxPriorityFeePerGas(Context *ctx, CallBackProc cb, void *userData);
 
 
 /* ========================================================================== */
@@ -230,6 +234,7 @@ void eth_maxPriorityFeePerGas(Context *ctx, CallBackProc cb, void *userData);
  * @param userData  pointer to user data
  */
 void eth_getBalance(Context *ctx, char *address, char *blockTag, CallBackProc cb, void *userData);
+void op_getBalance(Context *ctx, char *address, char *blockTag, CallBackProc cb, void *userData);
 
 /**
  * Retrieve storage from a contract.
@@ -243,6 +248,7 @@ void eth_getBalance(Context *ctx, char *address, char *blockTag, CallBackProc cb
  * @param userData  pointer to user data
  */
 void eth_getStorageAt(Context *ctx, char *address, char *slot, char *blockTag, CallBackProc cb, void *userData);
+void op_getStorageAt(Context *ctx, char *address, char *slot, char *blockTag, CallBackProc cb, void *userData);
 
 /**
  * Retrieve an address's transaction count (nonce).
@@ -255,6 +261,7 @@ void eth_getStorageAt(Context *ctx, char *address, char *slot, char *blockTag, C
  * @param userData  pointer to user data
  */
 void eth_getTransactionCount(Context *ctx, char *address, char *blockTag, CallBackProc cb, void *userData);
+void op_getTransactionCount(Context *ctx, char *address, char *blockTag, CallBackProc cb, void *userData);
 
 /**
  * Retrieve bytecode stored at an address.
@@ -267,6 +274,7 @@ void eth_getTransactionCount(Context *ctx, char *address, char *blockTag, CallBa
  * @param userData  pointer to user data
  */
 void eth_getCode(Context *ctx, char *address, char *blockTag, CallBackProc cb, void *userData);
+void op_getCode(Context *ctx, char *address, char *blockTag, CallBackProc cb, void *userData);
 
 
 /* ========================================================================== */
@@ -283,6 +291,7 @@ void eth_getCode(Context *ctx, char *address, char *blockTag, CallBackProc cb, v
  * @param userData         pointer to user data
  */
 void eth_getBlockByHash(Context *ctx, char *blockHash, bool fullTransactions, CallBackProc cb, void *userData);
+void op_getBlockByHash(Context *ctx, char *blockHash, bool fullTransactions, CallBackProc cb, void *userData);
 
 /**
  * Retrieve a block by number or tag.
@@ -295,6 +304,7 @@ void eth_getBlockByHash(Context *ctx, char *blockHash, bool fullTransactions, Ca
  * @param userData         pointer to user data
  */
 void eth_getBlockByNumber(Context *ctx, char *blockTag, bool fullTransactions, CallBackProc cb, void *userData);
+void op_getBlockByNumber(Context *ctx, char *blockTag, bool fullTransactions, CallBackProc cb, void *userData);
 
 /**
  * Get the number of uncles in a block.
@@ -306,6 +316,7 @@ void eth_getBlockByNumber(Context *ctx, char *blockTag, bool fullTransactions, C
  * @param userData  pointer to user data
  */
 void eth_getUncleCountByBlockNumber(Context *ctx, char *blockTag, CallBackProc cb, void *userData);
+void op_getUncleCountByBlockNumber(Context *ctx, char *blockTag, CallBackProc cb, void *userData);
 
 /**
  * Get the number of uncles in a block.
@@ -316,6 +327,7 @@ void eth_getUncleCountByBlockNumber(Context *ctx, char *blockTag, CallBackProc c
  * @param userData  pointer to user data
  */
 void eth_getUncleCountByBlockHash(Context *ctx, char *blockHash, CallBackProc cb, void *userData);
+void op_getUncleCountByBlockHash(Context *ctx, char *blockHash, CallBackProc cb, void *userData);
 
 /**
  * Get the number of transactions in a block.
@@ -327,6 +339,7 @@ void eth_getUncleCountByBlockHash(Context *ctx, char *blockHash, CallBackProc cb
  * @param userData  pointer to user data
  */
 void eth_getBlockTransactionCountByNumber(Context *ctx, char *blockTag, CallBackProc cb, void *userData);
+void op_getBlockTransactionCountByNumber(Context *ctx, char *blockTag, CallBackProc cb, void *userData);
 
 /**
  * Get the number of transactions in a block identified by hash.
@@ -337,6 +350,7 @@ void eth_getBlockTransactionCountByNumber(Context *ctx, char *blockTag, CallBack
  * @param userData  pointer to user data
  */
 void eth_getBlockTransactionCountByHash(Context *ctx, char *blockHash, CallBackProc cb, void *userData);
+void op_getBlockTransactionCountByHash(Context *ctx, char *blockHash, CallBackProc cb, void *userData);
 
 
 /* ========================================================================== */
@@ -360,6 +374,13 @@ void eth_getTransactionByBlockNumberAndIndex(
     CallBackProc cb,
     void *userData
 );
+void op_getTransactionByBlockNumberAndIndex(
+    Context *ctx,
+    char *blockTag,
+    unsigned long long index,
+    CallBackProc cb,
+    void *userData
+);
 
 /**
  * Retrieve a transaction by block hash and index.
@@ -377,6 +398,13 @@ void eth_getTransactionByBlockHashAndIndex(
     CallBackProc cb,
     void *userData
 );
+void op_getTransactionByBlockHashAndIndex(
+    Context *ctx,
+    char *blockHash,
+    unsigned long long index,
+    CallBackProc cb,
+    void *userData
+);
 
 /**
  * Retrieve a transaction by hash.
@@ -387,6 +415,7 @@ void eth_getTransactionByBlockHashAndIndex(
  * @param userData  pointer to user data
  */
 void eth_getTransactionByHash(Context *ctx, char *txHash, CallBackProc cb, void *userData);
+void op_getTransactionByHash(Context *ctx, char *txHash, CallBackProc cb, void *userData);
 
 /**
  * Retrieve a transaction receipt by hash.
@@ -397,6 +426,7 @@ void eth_getTransactionByHash(Context *ctx, char *txHash, CallBackProc cb, void 
  * @param userData  pointer to user data
  */
 void eth_getTransactionReceipt(Context *ctx, char *txHash, CallBackProc cb, void *userData);
+void op_getTransactionReceipt(Context *ctx, char *txHash, CallBackProc cb, void *userData);
 
 
 /* ========================================================================== */
@@ -415,6 +445,14 @@ void eth_getTransactionReceipt(Context *ctx, char *txHash, CallBackProc cb, void
  * @param userData              pointer to user data
  */
 void eth_call(
+    Context *ctx,
+    char *txArgs,
+    char *blockTag,
+    bool optimisticStateFetch,
+    CallBackProc cb,
+    void *userData
+);
+void op_call(
     Context *ctx,
     char *txArgs,
     char *blockTag,
@@ -442,6 +480,14 @@ void eth_createAccessList(
     CallBackProc cb,
     void *userData
 );
+void op_createAccessList(
+    Context *ctx,
+    char *txArgs,
+    char *blockTag,
+    bool optimisticStateFetch,
+    CallBackProc cb,
+    void *userData
+);
 
 /**
  * Estimate gas for a transaction.
@@ -455,6 +501,14 @@ void eth_createAccessList(
  * @param userData              pointer to user data
  */
 void eth_estimateGas(
+    Context *ctx,
+    char *txArgs,
+    char *blockTag,
+    bool optimisticStateFetch,
+    CallBackProc cb,
+    void *userData
+);
+void op_estimateGas(
     Context *ctx,
     char *txArgs,
     char *blockTag,
@@ -477,6 +531,7 @@ void eth_estimateGas(
  * @param userData      pointer to user data
  */
 void eth_getLogs(Context *ctx, char *filterOptions, CallBackProc cb, void *userData);
+void op_getLogs(Context *ctx, char *filterOptions, CallBackProc cb, void *userData);
 
 /**
  * Create a new log filter.
@@ -487,6 +542,7 @@ void eth_getLogs(Context *ctx, char *filterOptions, CallBackProc cb, void *userD
  * @param userData      pointer to user data
  */
 void eth_newFilter(Context *ctx, char *filterOptions, CallBackProc cb, void *userData);
+void op_newFilter(Context *ctx, char *filterOptions, CallBackProc cb, void *userData);
 
 /**
  * Remove an installed filter.
@@ -497,6 +553,7 @@ void eth_newFilter(Context *ctx, char *filterOptions, CallBackProc cb, void *use
  * @param userData pointer to user data
  */
 void eth_uninstallFilter(Context *ctx, char *filterId, CallBackProc cb, void *userData);
+void op_uninstallFilter(Context *ctx, char *filterId, CallBackProc cb, void *userData);
 
 /**
  * Retrieve all logs for an installed filter.
@@ -507,6 +564,7 @@ void eth_uninstallFilter(Context *ctx, char *filterId, CallBackProc cb, void *us
  * @param userData pointer to user data
  */
 void eth_getFilterLogs(Context *ctx, char *filterId, CallBackProc cb, void *userData);
+void op_getFilterLogs(Context *ctx, char *filterId, CallBackProc cb, void *userData);
 
 /**
  * Retrieve new logs since the previous poll.
@@ -517,6 +575,7 @@ void eth_getFilterLogs(Context *ctx, char *filterId, CallBackProc cb, void *user
  * @param userData pointer to user data
  */
 void eth_getFilterChanges(Context *ctx, char *filterId, CallBackProc cb, void *userData);
+void op_getFilterChanges(Context *ctx, char *filterId, CallBackProc cb, void *userData);
 
 
 /* ========================================================================== */
@@ -533,6 +592,7 @@ void eth_getFilterChanges(Context *ctx, char *filterId, CallBackProc cb, void *u
  * @param userData  pointer to user data
  */
 void eth_getBlockReceipts(Context *ctx, char *blockTag, CallBackProc cb, void *userData);
+void op_getBlockReceipts(Context *ctx, char *blockTag, CallBackProc cb, void *userData);
 
 /**
  * Retrieve fee history.
@@ -553,6 +613,14 @@ void eth_feeHistory(
     CallBackProc cb,
     void *userData
 );
+void op_feeHistory(
+    Context *ctx,
+    unsigned long long blockCount,
+    char *newestBlock,
+    char *rewardPercentiles,
+    CallBackProc cb,
+    void *userData
+);
 
 /**
  * Send a signed transaction to the RPC provider to be relayed in the network.
@@ -563,6 +631,7 @@ void eth_feeHistory(
  * @param userData  pointer to user data
  */
 void eth_sendRawTransaction(Context *ctx, char *txHexBytes, CallBackProc cb, void *userData);
+void op_sendRawTransaction(Context *ctx, char *txHexBytes, CallBackProc cb, void *userData);
 
 #ifdef __cplusplus
 }

--- a/nimbus_verified_proxy/library/verifproxy.nim
+++ b/nimbus_verified_proxy/library/verifproxy.nim
@@ -74,8 +74,8 @@ proc load(T: type VerifiedProxyConf, configJson: string): T {.raises: [ProxyErro
   let jsonNode =
     try:
       parseJson($configJson)
-    except CatchableError as e:
-      raise newException(ProxyError, "error parsing json: " & e.msg)
+    except ValueError, IOError, OSError:
+      raise newException(ProxyError, "error parsing config json")
 
   let
     eth2Network = some(jsonNode.getOrDefault("eth2Network").getStr("mainnet"))
@@ -89,14 +89,14 @@ proc load(T: type VerifiedProxyConf, configJson: string): T {.raises: [ProxyErro
     executionApiUrls =
       try:
         parseCmdArg(UrlList, jsonNode["executionApiUrls"].getStr())
-      except CatchableError as e:
+      except ValueError as e:
         raise newException(
           ProxyError, "Couldn't parse `backendUrl` from JSON config: " & e.msg
         )
     beaconApiUrls =
       try:
         parseCmdArg(UrlList, jsonNode["beaconApiUrls"].getStr())
-      except CatchableError as e:
+      except ValueError as e:
         raise newException(
           ProxyError, "Couldn't parse `beaconApiUrls` from JSON config: " & e.msg
         )
@@ -107,7 +107,7 @@ proc load(T: type VerifiedProxyConf, configJson: string): T {.raises: [ProxyErro
           UrlList(@[])
         else:
           parseCmdArg(UrlList, rawUrls)
-      except CatchableError as e:
+      except ValueError as e:
         raise newException(
           ProxyError, "Couldn't parse `privateTxUrls` from JSON config: " & e.msg
         )
@@ -118,7 +118,7 @@ proc load(T: type VerifiedProxyConf, configJson: string): T {.raises: [ProxyErro
           UrlList(@[])
         else:
           parseCmdArg(UrlList, rawUrls)
-      except CatchableError as e:
+      except ValueError as e:
         raise newException(
           ProxyError, "Couldn't parse `opExecutionApiUrls` from JSON config: " & e.msg
         )

--- a/nimbus_verified_proxy/library/verifproxy.nim
+++ b/nimbus_verified_proxy/library/verifproxy.nim
@@ -18,10 +18,13 @@ import
   beacon_chain/nimbus_binary_common,
   ../engine/types,
   ../engine/engine,
+  ../engine/utils,
   ../engine/rpc_frontend,
   ../lc_backend,
   ../json_rpc_backend,
   ../nimbus_verified_proxy_conf,
+  ../op/op_chain_params,
+  ../op/op_frontend,
   ./types,
   ./c_execution_backend,
   ./c_beacon_backend
@@ -108,6 +111,17 @@ proc load(T: type VerifiedProxyConf, configJson: string): T {.raises: [ProxyErro
         raise newException(
           ProxyError, "Couldn't parse `privateTxUrls` from JSON config: " & e.msg
         )
+    opExecutionApiUrls =
+      try:
+        let rawUrls = jsonNode.getOrDefault("opExecutionApiUrls").getStr("")
+        if rawUrls.len == 0:
+          UrlList(@[])
+        else:
+          parseCmdArg(UrlList, rawUrls)
+      except CatchableError as e:
+        raise newException(
+          ProxyError, "Couldn't parse `opExecutionApiUrls` from JSON config: " & e.msg
+        )
     logLevel = jsonNode.getOrDefault("logLevel").getStr("INFO")
     logFormat =
       case jsonNode.getOrDefault("logFormat").getStr("None")
@@ -158,6 +172,7 @@ proc load(T: type VerifiedProxyConf, configJson: string): T {.raises: [ProxyErro
       else:
         uint64(maxLcUpdates),
     privateTxUrls: privateTxUrls,
+    opExecutionApiUrls: opExecutionApiUrls,
     syncHeaderStore: syncHeaderStore,
     freezeAtSlot: freezeAtSlot,
   )
@@ -172,10 +187,32 @@ proc run*(
 
   setupLogging(config.logLevel, config.logFormat)
 
+  let networkName = config.eth2Network.get("mainnet")
+
+  let opParams =
+    if isOpNetwork(networkName):
+      let p = opChainParamsForNetwork(networkName).valueOr:
+        raise newException(ProxyError, "Unknown OP network: " & error)
+      some(p)
+    else:
+      none(OpChainParams)
+
+  let
+    l1NetworkName =
+      if opParams.isSome():
+        opParams.get().l1Network
+      else:
+        networkName
+    l1ChainId =
+      if opParams.isSome():
+        opParams.get().l1ChainId
+      else:
+        getConfiguredChainId(config.eth2Network)
+
   let
     engineConf = RpcVerificationEngineConf(
-      chainId: getConfiguredChainId(config.eth2Network),
-      eth2Network: config.eth2Network,
+      chainId: l1ChainId,
+      eth2Network: some(l1NetworkName),
       maxBlockWalk: config.maxBlockWalk,
       headerStoreLen: config.headerStoreLen,
       accountCacheLen: config.accountCacheLen,
@@ -248,6 +285,45 @@ proc run*(
         )
 
   ctx.frontend = engine.getExecutionApiFrontend()
+
+  if opParams.isSome():
+    let l2NetworkId = chainIdToNetworkId(l1ChainId).valueOr:
+      raise newException(
+        ProxyError, "Couldn't derive the L2 network id from the L1 chain id"
+      )
+
+    let l2Engine = RpcVerificationEngine.initCore(
+      chainId = opParams.get().l2ChainId,
+      networkId = l2NetworkId,
+      maxBlockWalk = config.maxBlockWalk,
+      parallelBlockDownloads = config.parallelBlockDownloads,
+      headerStoreLen = config.headerStoreLen,
+      accountCacheLen = config.accountCacheLen,
+      codeCacheLen = config.codeCacheLen,
+      storageCacheLen = config.storageCacheLen,
+    ).valueOr:
+      raise newException(ProxyError, "Couldn't initialize OP verification engine")
+
+    for url in config.opExecutionApiUrls:
+      if executionTransportProc != nil:
+        l2Engine.registerBackend(
+          getExecutionApiBackend(ctx, url, executionTransportProc),
+          fullExecutionCapabilities,
+        )
+      else:
+        let client = JsonRpcClient.init(url).valueOr:
+          error "Error initializing L2 backend client", error = error.errMsg
+          continue
+        let startRes = await client.start()
+        if startRes.isErr():
+          error "Error connecting to L2 backend",
+            url = url, error = startRes.error.errMsg
+          continue
+        l2Engine.registerBackend(
+          client.getExecutionApiBackend(), fullExecutionCapabilities
+        )
+
+    ctx.opFrontend = getExecutionApiFrontend(l2Engine, engine)
 
 proc startVerifProxy(
     configJson: cstring,

--- a/nimbus_verified_proxy/library/verifproxy.nim
+++ b/nimbus_verified_proxy/library/verifproxy.nim
@@ -193,9 +193,9 @@ proc run*(
     if isOpNetwork(networkName):
       let p = opChainParamsForNetwork(networkName).valueOr:
         raise newException(ProxyError, "Unknown OP network: " & error)
-      some(p)
+      Opt.some(p)
     else:
-      none(OpChainParams)
+      Opt.none(OpChainParams)
 
   let
     l1NetworkName =
@@ -286,14 +286,14 @@ proc run*(
 
   ctx.frontend = engine.getExecutionApiFrontend()
 
-  if opParams.isSome():
+  opParams.isErrOr:
     let l2NetworkId = chainIdToNetworkId(l1ChainId).valueOr:
       raise newException(
         ProxyError, "Couldn't derive the L2 network id from the L1 chain id"
       )
 
     let l2Engine = RpcVerificationEngine.initCore(
-      chainId = opParams.get().l2ChainId,
+      chainId = value.l2ChainId,
       networkId = l2NetworkId,
       maxBlockWalk = config.maxBlockWalk,
       parallelBlockDownloads = config.parallelBlockDownloads,

--- a/nimbus_verified_proxy/library/verifproxy.nim
+++ b/nimbus_verified_proxy/library/verifproxy.nim
@@ -189,13 +189,7 @@ proc run*(
 
   let networkName = config.eth2Network.get("mainnet")
 
-  let opParams =
-    if isOpNetwork(networkName):
-      let p = opChainParamsForNetwork(networkName).valueOr:
-        raise newException(ProxyError, "Unknown OP network: " & error)
-      Opt.some(p)
-    else:
-      Opt.none(OpChainParams)
+  let opParams = opChainParamsForNetwork(networkName).optValue()
 
   let
     l1NetworkName =

--- a/nimbus_verified_proxy/nimbus_verified_proxy.nim
+++ b/nimbus_verified_proxy/nimbus_verified_proxy.nim
@@ -30,6 +30,9 @@ import
   ./p2p_lc_backend,
   ./json_rpc_backend,
   ./json_rpc_frontend,
+  ./op/op_anchor,
+  ./op/op_chain_params,
+  ./op/op_frontend,
   ../execution_chain/version_info
 
 # error object to translate results to error
@@ -183,10 +186,33 @@ proc run(
     except Exception:
       notice "commandLineParams() exception"
 
+  let networkName = config.eth2Network.get("mainnet")
+
+  # If an op-stack network is selected we run a secondary engine alongside the primary engine
+  let opParams =
+    if isOpNetwork(networkName):
+      let p = opChainParamsForNetwork(networkName).valueOr:
+        raise newException(ProxyError, "Unknown OP network: " & error)
+      some(p)
+    else:
+      none(OpChainParams)
+
+  let
+    l1NetworkName =
+      if opParams.isSome():
+        opParams.get().l1Network
+      else:
+        networkName
+    l1ChainId =
+      if opParams.isSome():
+        opParams.get().l1ChainId
+      else:
+        getConfiguredChainId(config.eth2Network)
+
   let
     engineConf = RpcVerificationEngineConf(
-      chainId: getConfiguredChainId(config.eth2Network),
-      eth2Network: config.eth2Network,
+      chainId: l1ChainId,
+      eth2Network: some(l1NetworkName),
       maxBlockWalk: config.maxBlockWalk,
       headerStoreLen: config.headerStoreLen,
       accountCacheLen: config.accountCacheLen,
@@ -238,17 +264,65 @@ proc run(
   let frontend = engine.getExecutionApiFrontend()
   let frontendServers = startFrontends(frontend, config.frontendUrls)
 
+  # nil unless an OP network is configured (RpcVerificationEngine is a ref, so nil is the
+  # natural "no L2 engine" state no Option wrapping needed)
+  var
+    l2Engine: RpcVerificationEngine
+    opExecBackendClients: seq[JsonRpcClient] = @[]
+    opFrontendServers: seq[JsonRpcServer] = @[]
+
+  if opParams.isSome():
+    if config.opExecutionApiUrls.len <= 0:
+      raise newException(
+        ProxyError, "Need at least one L2 execution api url (--op-execution-api-url)"
+      )
+
+    # the L2 EVM follows the L1 fork schedule, so it uses the L1 network id
+    let l2NetworkId = chainIdToNetworkId(l1ChainId).valueOr:
+      raise newException(
+        ProxyError, "Couldn't derive the L2 network id from the L1 chain id"
+      )
+
+    l2Engine = RpcVerificationEngine.initCore(
+      chainId = opParams.get().l2ChainId,
+      networkId = l2NetworkId,
+      maxBlockWalk = config.maxBlockWalk,
+      parallelBlockDownloads = config.parallelBlockDownloads,
+      headerStoreLen = config.headerStoreLen,
+      accountCacheLen = config.accountCacheLen,
+      codeCacheLen = config.codeCacheLen,
+      storageCacheLen = config.storageCacheLen,
+    ).valueOr:
+      raise newException(ProxyError, "Couldn't initialize OP verification engine")
+
+    opExecBackendClients = await startExecutionBackends(
+      l2Engine, config.opExecutionApiUrls, fullExecutionCapabilities
+    )
+
+    let opFrontend = getExecutionApiFrontend(l2Engine, engine)
+    opFrontendServers = startFrontends(opFrontend, config.opFrontendUrls)
+
   try:
     while true:
       await sleepAsync(engine.timeParams.SLOT_DURATION)
+
       let syncRes = await engine.syncOnce()
       if syncRes.isErr():
-        debug "LC sync failed", error = syncRes.error.errMsg
+        error "LC sync failed", error = syncRes.error.errMsg
+
+      if opParams.isSome():
+        let opRes = await l2Engine.opSyncOnce(engine)
+        if opRes.isErr():
+          error "OP sync failed", error = opRes.error.errMsg
   except CancelledError as e:
     debug "proxy loop cancelled"
     for s in frontendServers:
       await s.stop()
+    for s in opFrontendServers:
+      await s.stop()
     for c in execBackendClients:
+      await c.stop()
+    for c in opExecBackendClients:
       await c.stop()
     for c in beaconBackendClients:
       await c.stop()

--- a/nimbus_verified_proxy/nimbus_verified_proxy.nim
+++ b/nimbus_verified_proxy/nimbus_verified_proxy.nim
@@ -193,9 +193,9 @@ proc run(
     if isOpNetwork(networkName):
       let p = opChainParamsForNetwork(networkName).valueOr:
         raise newException(ProxyError, "Unknown OP network: " & error)
-      some(p)
+      Opt.some(p)
     else:
-      none(OpChainParams)
+      Opt.none(OpChainParams)
 
   let
     l1NetworkName =
@@ -268,10 +268,10 @@ proc run(
   # natural "no L2 engine" state no Option wrapping needed)
   var
     l2Engine: RpcVerificationEngine
-    opExecBackendClients: seq[JsonRpcClient] = @[]
-    opFrontendServers: seq[JsonRpcServer] = @[]
+    opExecBackendClients: seq[JsonRpcClient]
+    opFrontendServers: seq[JsonRpcServer]
 
-  if opParams.isSome():
+  opParams.isErrOr:
     if config.opExecutionApiUrls.len <= 0:
       raise newException(
         ProxyError, "Need at least one L2 execution api url (--op-execution-api-url)"
@@ -284,7 +284,7 @@ proc run(
       )
 
     l2Engine = RpcVerificationEngine.initCore(
-      chainId = opParams.get().l2ChainId,
+      chainId = value.l2ChainId,
       networkId = l2NetworkId,
       maxBlockWalk = config.maxBlockWalk,
       parallelBlockDownloads = config.parallelBlockDownloads,
@@ -310,7 +310,7 @@ proc run(
       if syncRes.isErr():
         error "LC sync failed", error = syncRes.error.errMsg
 
-      if opParams.isSome():
+      opParams.isErrOr:
         let opRes = await l2Engine.opSyncOnce(engine)
         if opRes.isErr():
           error "OP sync failed", error = opRes.error.errMsg

--- a/nimbus_verified_proxy/nimbus_verified_proxy.nim
+++ b/nimbus_verified_proxy/nimbus_verified_proxy.nim
@@ -189,13 +189,7 @@ proc run(
   let networkName = config.eth2Network.get("mainnet")
 
   # If an op-stack network is selected we run a secondary engine alongside the primary engine
-  let opParams =
-    if isOpNetwork(networkName):
-      let p = opChainParamsForNetwork(networkName).valueOr:
-        raise newException(ProxyError, "Unknown OP network: " & error)
-      Opt.some(p)
-    else:
-      Opt.none(OpChainParams)
+  let opParams = opChainParamsForNetwork(networkName).optValue()
 
   let
     l1NetworkName =

--- a/nimbus_verified_proxy/nimbus_verified_proxy_conf.nim
+++ b/nimbus_verified_proxy/nimbus_verified_proxy_conf.nim
@@ -42,7 +42,8 @@ type VerifiedProxyConf* = object
 
   # Network
   eth2Network* {.
-    desc: "Consensus network to join (mainnet, hoodi, sepolia, custom/path)"
+    desc:
+      "Network to serve. L1: mainnet, hoodi, sepolia. OP Stack L2 (also starts the L2 engine): op-mainnet, base-mainnet, op-sepolia"
     defaultValueDesc: "mainnet"
     name: "network"
   .}: Option[string]
@@ -124,6 +125,13 @@ type VerifiedProxyConf* = object
     name: "execution-api-url"
   .}: UrlList
 
+  # (Untrusted) L2 web3 provider, only used for OP Stack networks
+  opExecutionApiUrls* {.
+    desc: "URL of the L2 (op-geth) execution data provider, used only for OP Stack networks. Multiple URLs can be specified by defining the option again on the command line.",
+    defaultValue: @[],
+    name: "op-execution-api-url"
+  .}: UrlList
+
   # Listening endpoint of the proxy
   # (verified) web3 end
   frontendUrls* {.
@@ -131,6 +139,14 @@ type VerifiedProxyConf* = object
     defaultValue: @["http://127.0.0.1:8545"],
     defaultValueDesc: "http://127.0.0.1:8545",
     name: "listen-url"
+  .}: UrlList
+
+  # Listening endpoint of the secondary L2 (OP Stack) proxy
+  opFrontendUrls* {.
+    desc: "URL for the listening end of the L2 (OP Stack) proxy - [http/ws]://[address]:[port]. Used only for OP Stack networks. Multiple URLs can be specified by defining the option again on the command line",
+    defaultValue: @["http://127.0.0.1:8546"],
+    defaultValueDesc: "http://127.0.0.1:8546",
+    name: "op-listen-url"
   .}: UrlList
 
   # (Untrusted) web3 provider

--- a/nimbus_verified_proxy/op/op_anchor.nim
+++ b/nimbus_verified_proxy/op/op_anchor.nim
@@ -14,6 +14,7 @@ import
   eth/common/[hashes, headers, base, eth_types_rlp],
   web3/eth_api_types,
   ../engine/types,
+  ../engine/engine,
   ../engine/header_store,
   ../engine/accounts,
   ../engine/blocks,

--- a/nimbus_verified_proxy/op/op_anchor.nim
+++ b/nimbus_verified_proxy/op/op_anchor.nim
@@ -1,0 +1,145 @@
+# nimbus_verified_proxy
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
+
+import
+  results,
+  chronos,
+  chronicles,
+  eth/common/[hashes, headers, base, eth_types_rlp],
+  web3/eth_api_types,
+  ../engine/types,
+  ../engine/header_store,
+  ../engine/accounts,
+  ../engine/blocks,
+  ./op_chain_params,
+  ./op_anchor_utils
+
+proc verifyOutputRoot(
+    opEngine: RpcVerificationEngine,
+    proposedOutputRoot: Hash32,
+    blkNum: base.BlockNumber,
+): Future[EngineResult[(Header, Hash32)]] {.async: (raises: [CancelledError]).} =
+  let
+    blkTag = BlockTag(kind: bidNumber, number: Quantity(blkNum))
+    (backend, backendIdx) = ?(opEngine.executionBackendFor(GetBlockByNumber))
+    blk = ?((await backend.eth_getBlockByNumber(blkTag, false)).tagBackend(backendIdx))
+    header = convHeader(blk)
+
+  if header.number != blkNum:
+    let e = (VerificationError, "op-stack block number mismatch", backendIdx)
+    opEngine.applyPenalty(e)
+    return err(e)
+
+  if header.computeBlockHash != blk.hash:
+    let e = (VerificationError, "op-stack header hash mismatch", backendIdx)
+    opEngine.applyPenalty(e)
+    return err(e)
+
+  let messagePasserAccount = ?(
+    await opEngine.getAccount(
+      L2L1_MESSAGE_PASSER_CONTRACT, header.number, header.stateRoot
+    )
+  )
+
+  if not matchesOutputRoot(
+    proposedOutputRoot, header.stateRoot, messagePasserAccount.storageRoot, blk.hash
+  ):
+    let e = (
+      VerificationError,
+      "recomputed op-stack output root does not match the root posted on L1", backendIdx,
+    )
+    opEngine.applyPenalty(e)
+    return err(e)
+
+  ok((header, blk.hash))
+
+proc opSyncOnce*(
+    opEngine: RpcVerificationEngine, l1Engine: RpcVerificationEngine
+): Future[EngineResult[void]] {.async: (raises: [CancelledError]).} =
+  let
+    l1LatestHeader = ?(await l1Engine.getHeader(blockId("latest")))
+    l1FinalizedHeader = ?(await l1Engine.getHeader(blockId("finalized")))
+
+  # the L2 chainId identifies the OP chain whose (trusted) SystemConfig we read from
+  let systemConfig = getSystemConfig(opEngine.chainId).valueOr:
+    return err((InvalidDataError, "no system config for chainId: " & error, UNTAGGED))
+
+  # get latest contracts from system config
+  let contracts = ?(await l1Engine.resolveContracts(systemConfig, l1LatestHeader))
+
+  # get safe block
+  let
+    proposal =
+      ?(await l1Engine.readLatestGame(contracts.disputeGameFactory, l1LatestHeader))
+    (safeHeader, safeHash) =
+      ?(await opEngine.verifyOutputRoot(proposal.outputRoot, proposal.l2BlockNumber))
+
+  let addRes = opEngine.headerStore.add(safeHeader, safeHash)
+  if addRes.isErr():
+    error "op-stack safe header not added to store", error = addRes.error()
+  else:
+    info "op-stack safe header added", number = safeHeader.number, hash = safeHash
+
+  # get finalized block
+  let
+    anchor = (
+      await l1Engine.readAnchorRoot(contracts.anchorStateRegistry, l1FinalizedHeader)
+    ).valueOr:
+      debug "no finalized OP anchor yet", error = error.errMsg
+      return ok()
+    (finalizedHeader, finalizedHash) =
+      ?(await opEngine.verifyOutputRoot(anchor.outputRoot, anchor.l2BlockNumber))
+
+  let finalizedAddRes =
+    opEngine.headerStore.updateFinalized(finalizedHeader, finalizedHash)
+  if finalizedAddRes.isErr():
+    debug "op-stack finalized header update skipped", error = finalizedAddRes.error()
+  else:
+    info "op-stack finalized anchor added to header store",
+      number = finalizedHeader.number, hash = finalizedHash
+
+  ok()
+
+proc resolveUnsafeTip*(
+    opEngine: RpcVerificationEngine
+): Future[EngineResult[Header]] {.async: (raises: [CancelledError]).} =
+  let safe = opEngine.headerStore.latest().valueOr:
+    return err((UnavailableDataError, "no safe anchor yet", UNTAGGED))
+  let safeHash = opEngine.headerStore.latestHash().valueOr:
+    return err((UnavailableDataError, "no safe anchor hash yet", UNTAGGED))
+
+  # NOTE: do not use getHeader here because that will launch a full scale verification of the
+  # latest header. Whereas here we are exactly trying to achieve that for op-stack specific
+  # dynamics
+  let
+    (backend, backendIdx) = ?(opEngine.executionBackendFor(GetBlockByNumber))
+    latestTag = BlockTag(kind: bidAlias, alias: "latest")
+    blk =
+      ?((await backend.eth_getBlockByNumber(latestTag, false)).tagBackend(backendIdx))
+    header = convHeader(blk)
+
+  # loosely check integrity
+  # TODO: can we obtain the sequencer signature somehow?
+  if header.computeBlockHash != blk.hash:
+    let e = (VerificationError, "op-stack header hash mismatch", backendIdx)
+    opEngine.applyPenalty(e)
+    return err(e)
+
+  # if is before safe then latest should be safe
+  if header.number <= safe.number:
+    return ok(safe)
+
+  # verify history anchored at safe
+  ?(
+    (await opEngine.walkBlocks(header.number, safe.number, header.parentHash, safeHash)).tagBackend(
+      backendIdx
+    )
+  )
+
+  ok(header)

--- a/nimbus_verified_proxy/op/op_anchor_utils.nim
+++ b/nimbus_verified_proxy/op/op_anchor_utils.nim
@@ -1,0 +1,171 @@
+# nimbus_verified_proxy
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
+
+import
+  results,
+  chronos,
+  stint,
+  eth/common/[hashes, headers, base, addresses],
+  serialization,
+  web3/eth_api_types,
+  web3/encoding,
+  web3/decoding,
+  ../engine/types,
+  ../engine/evm
+
+type OpContracts* =
+  tuple[
+    disputeGameFactory: Address,
+    optimismPortal: Address,
+    anchorStateRegistry: Address,
+    unsafeBlockSigner: Address,
+  ]
+
+const OUTPUT_ROOT_VERSION_V0* = default(array[32, byte])
+
+func computeOutputRoot*(
+    stateRoot: Hash32, messagePasserStorageRoot: Hash32, blockHash: Hash32
+): Hash32 =
+  let preimage =
+    @OUTPUT_ROOT_VERSION_V0 & @(stateRoot.data) & @(messagePasserStorageRoot.data) &
+    @(blockHash.data)
+  keccak256(preimage)
+
+func matchesOutputRoot*(
+    postedRoot: Hash32,
+    stateRoot: Hash32,
+    messagePasserStorageRoot: Hash32,
+    blockHash: Hash32,
+): bool =
+  computeOutputRoot(stateRoot, messagePasserStorageRoot, blockHash) == postedRoot
+
+type L1OutputProposal* = object
+  outputRoot*: Hash32
+  l2BlockNumber*: base.BlockNumber
+
+func hashFnSig(sig: string): seq[byte] =
+  @(keccak256(sig).data[0 .. 3])
+
+proc abiEncode[T](value: T): EngineResult[seq[byte]] =
+  try:
+    ok(Abi.encode(value))
+  except CatchableError as e:
+    err((InvalidDataError, "calldata ABI encode failed: " & e.msg, UNTAGGED))
+
+proc abiDecode(output: seq[byte], T: typedesc): EngineResult[T] =
+  try:
+    ok(Abi.decode(output, T))
+  except CatchableError as e:
+    err((InvalidDataError, "call return ABI decode failed: " & e.msg, UNTAGGED))
+
+proc makeCall(
+    l1Engine: RpcVerificationEngine, to: Address, calldata: seq[byte], l1Header: Header
+): Future[EngineResult[seq[byte]]] {.async: (raises: [CancelledError]).} =
+  let tx = TransactionArgs(to: Opt.some(to), data: Opt.some(calldata))
+
+  # we don't populate caches because its probably only one getStorageAt/getCode/getAccount per call anyways
+  let callResult = (await l1Engine.evm.call(l1Header, tx, optimisticStateFetch = true)).valueOr:
+    return
+      err((VerificationError, "L1 eth_call for op-stack failed: " & error, UNTAGGED))
+
+  if callResult.error.len() > 0:
+    return err(
+      (
+        VerificationError,
+        "L1 eth_call for op-stack reverted: " & callResult.error,
+        UNTAGGED,
+      )
+    )
+
+  ok(callResult.output)
+
+proc resolveContracts*(
+    l1Engine: RpcVerificationEngine, systemConfigContract: Address, l1Header: Header
+): Future[EngineResult[OpContracts]] {.async: (raises: [CancelledError]).} =
+  let
+    dgfOut = ?(
+      await l1Engine.makeCall(
+        systemConfigContract, hashFnSig("disputeGameFactory()"), l1Header
+      )
+    )
+    disputeGameFactory = ?abiDecode(dgfOut, Address)
+
+    portalOut = ?(
+      await l1Engine.makeCall(
+        systemConfigContract, hashFnSig("optimismPortal()"), l1Header
+      )
+    )
+    optimismPortal = ?abiDecode(portalOut, Address)
+
+    signerOut = ?(
+      await l1Engine.makeCall(
+        systemConfigContract, hashFnSig("unsafeBlockSigner()"), l1Header
+      )
+    )
+    unsafeBlockSigner = ?abiDecode(signerOut, Address)
+
+    asrOut = ?(
+      await l1Engine.makeCall(
+        optimismPortal, hashFnSig("anchorStateRegistry()"), l1Header
+      )
+    )
+    anchorStateRegistry = ?abiDecode(asrOut, Address)
+
+  ok(
+    (
+      disputeGameFactory: disputeGameFactory,
+      optimismPortal: optimismPortal,
+      anchorStateRegistry: anchorStateRegistry,
+      unsafeBlockSigner: unsafeBlockSigner,
+    )
+  )
+
+# this gives us the latest proposed output root
+proc readLatestGame*(
+    l1Engine: RpcVerificationEngine, dgfContract: Address, l1Header: Header
+): Future[EngineResult[L1OutputProposal]] {.async: (raises: [CancelledError]).} =
+  let
+    countOut =
+      ?(await l1Engine.makeCall(dgfContract, hashFnSig("gameCount()"), l1Header))
+    count = ?abiDecode(countOut, UInt256)
+
+  if count == 0.u256:
+    return err((UnavailableDataError, "no dispute games posted yet", UNTAGGED))
+
+  let
+    # get the latest game
+    gameCalldata = hashFnSig("gameAtIndex(uint256)") & ?abiEncode(count - 1.u256)
+    gameOut = ?(await l1Engine.makeCall(dgfContract, gameCalldata, l1Header))
+    proxy = (?abiDecode(gameOut, (uint32, uint64, Address)))[2]
+
+    # get the root claim of the latest game
+    rootOut = ?(await l1Engine.makeCall(proxy, hashFnSig("rootClaim()"), l1Header))
+    outputRoot = (?abiDecode(rootOut, array[32, byte])).to(Hash32)
+
+    # get the block number for the latest game
+    l2nOut = ?(await l1Engine.makeCall(proxy, hashFnSig("l2BlockNumber()"), l1Header))
+    l2Number = base.BlockNumber((?abiDecode(l2nOut, UInt256)).truncate(uint64))
+
+  ok(L1OutputProposal(outputRoot: outputRoot, l2BlockNumber: l2Number))
+
+# this gives us the latest finalized output root
+proc readAnchorRoot*(
+    l1Engine: RpcVerificationEngine, anchorRegistryContract: Address, l1Header: Header
+): Future[EngineResult[L1OutputProposal]] {.async: (raises: [CancelledError]).} =
+  let
+    out0 = ?(
+      await l1Engine.makeCall(
+        anchorRegistryContract, hashFnSig("getAnchorRoot()"), l1Header
+      )
+    )
+    decoded = ?abiDecode(out0, (array[32, byte], UInt256))
+    outputRoot = decoded[0].to(Hash32)
+    l2Number = base.BlockNumber(decoded[1].truncate(uint64))
+
+  ok(L1OutputProposal(outputRoot: outputRoot, l2BlockNumber: l2Number))

--- a/nimbus_verified_proxy/op/op_anchor_utils.nim
+++ b/nimbus_verified_proxy/op/op_anchor_utils.nim
@@ -55,13 +55,13 @@ func hashFnSig(sig: string): seq[byte] =
 proc abiEncode[T](value: T): EngineResult[seq[byte]] =
   try:
     ok(Abi.encode(value))
-  except CatchableError as e:
+  except SerializationError as e:
     err((InvalidDataError, "calldata ABI encode failed: " & e.msg, UNTAGGED))
 
 proc abiDecode(output: seq[byte], T: typedesc): EngineResult[T] =
   try:
     ok(Abi.decode(output, T))
-  except CatchableError as e:
+  except SerializationError as e:
     err((InvalidDataError, "call return ABI decode failed: " & e.msg, UNTAGGED))
 
 proc makeCall(
@@ -135,7 +135,7 @@ proc readLatestGame*(
       ?(await l1Engine.makeCall(dgfContract, hashFnSig("gameCount()"), l1Header))
     count = ?abiDecode(countOut, UInt256)
 
-  if count == 0.u256:
+  if count.isZero:
     return err((UnavailableDataError, "no dispute games posted yet", UNTAGGED))
 
   let

--- a/nimbus_verified_proxy/op/op_anchor_utils.nim
+++ b/nimbus_verified_proxy/op/op_anchor_utils.nim
@@ -32,10 +32,11 @@ const OUTPUT_ROOT_VERSION_V0* = default(array[32, byte])
 func computeOutputRoot*(
     stateRoot: Hash32, messagePasserStorageRoot: Hash32, blockHash: Hash32
 ): Hash32 =
-  let preimage =
-    @OUTPUT_ROOT_VERSION_V0 & @(stateRoot.data) & @(messagePasserStorageRoot.data) &
-    @(blockHash.data)
-  keccak256(preimage)
+  withKeccak256:
+    h.update(OUTPUT_ROOT_VERSION_V0)
+    h.update(stateRoot.data)
+    h.update(messagePasserStorageRoot.data)
+    h.update(blockHash.data)
 
 func matchesOutputRoot*(
     postedRoot: Hash32,

--- a/nimbus_verified_proxy/op/op_chain_params.nim
+++ b/nimbus_verified_proxy/op/op_chain_params.nim
@@ -1,0 +1,70 @@
+# nimbus_verified_proxy
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
+
+import results, stint, eth/common/addresses
+
+const L2L1_MESSAGE_PASSER_CONTRACT* =
+  address("0x4200000000000000000000000000000000000016")
+
+type OpChainParams* = object
+  opNetwork*: string
+  l1Network*: string
+  l1ChainId*: UInt256
+  l2ChainId*: UInt256
+  systemConfig*: Address
+
+const opMainnet = OpChainParams(
+  opNetwork: "op-mainnet",
+  l1Network: "mainnet",
+  l1ChainId: 1.u256,
+  l2ChainId: 10.u256,
+  systemConfig: address("0x229047fed2591dbec1eF1118d64F7aF3dB9EB290"),
+)
+
+const baseMainnet = OpChainParams(
+  opNetwork: "base-mainnet",
+  l1Network: "mainnet",
+  l1ChainId: 1.u256,
+  l2ChainId: 8453.u256,
+  systemConfig: address("0x73a79Fab69143498Ed3712e519A88a918e1f4072"),
+)
+
+const opSepolia = OpChainParams(
+  opNetwork: "op-sepolia",
+  l1Network: "sepolia",
+  l1ChainId: 11155111.u256,
+  l2ChainId: 11155420.u256,
+  systemConfig: address("0x034edD2A225f7f429A63E0f1D2084B9E0A93b538"),
+)
+
+func opChainParamsForNetwork*(name: string): Result[OpChainParams, string] =
+  case name
+  of "op-mainnet":
+    ok(opMainnet)
+  of "base-mainnet":
+    ok(baseMainnet)
+  of "op-sepolia":
+    ok(opSepolia)
+  else:
+    err("unknown op-network preset: " & name)
+
+func isOpNetwork*(name: string): bool =
+  opChainParamsForNetwork(name).isOk()
+
+func getSystemConfig*(chainId: UInt256): Result[Address, string] =
+  for params in [opMainnet, baseMainnet, opSepolia]:
+    if params.l2ChainId == chainId:
+      return ok(params.systemConfig)
+  err("unknown op  chainId: " & $chainId)
+
+func opL1ChainId*(chainId: UInt256): Result[UInt256, string] =
+  for params in [opMainnet, baseMainnet, opSepolia]:
+    if params.l2ChainId == chainId:
+      return ok(params.l1ChainId)
+  err("unknown op  chainId: " & $chainId)

--- a/nimbus_verified_proxy/op/op_chain_params.nim
+++ b/nimbus_verified_proxy/op/op_chain_params.nim
@@ -54,9 +54,6 @@ func opChainParamsForNetwork*(name: string): Result[OpChainParams, string] =
   else:
     err("unknown op-network preset: " & name)
 
-func isOpNetwork*(name: string): bool =
-  opChainParamsForNetwork(name).isOk()
-
 func getSystemConfig*(chainId: UInt256): Result[Address, string] =
   for params in [opMainnet, baseMainnet, opSepolia]:
     if params.l2ChainId == chainId:

--- a/nimbus_verified_proxy/op/op_frontend.nim
+++ b/nimbus_verified_proxy/op/op_frontend.nim
@@ -1,0 +1,563 @@
+# nimbus_verified_proxy
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
+
+import
+  std/strutils,
+  results,
+  stew/byteutils,
+  nimcrypto/sysrand,
+  json_rpc/[rpcserver, rpcclient],
+  eth/common/accounts,
+  web3/[eth_api, eth_api_types],
+  ../../execution_chain/core/eip4844,
+  ../../execution_chain/db/core_db/memory_only,
+  ../../execution_chain/common/common,
+  ../engine/types,
+  ../engine/header_store,
+  ../engine/accounts,
+  ../engine/blocks,
+  ../engine/evm,
+  ../engine/transactions,
+  ../engine/receipts,
+  ../engine/fees,
+  ./op_anchor,
+  ./op_chain_params
+
+template opSync(opEngine: RpcVerificationEngine, l1Engine: RpcVerificationEngine) =
+  block:
+    await opEngine.syncLock.acquire()
+
+    defer:
+      try:
+        opEngine.syncLock.release()
+      except AsyncLockError:
+        # FIXME: is this dangerous?
+        discard
+
+    ?(await opEngine.opSyncOnce(l1Engine))
+
+template penaltyOr[T](engine: RpcVerificationEngine, r: EngineResult[T]): T =
+  let penaltyOrResult: EngineResult[T] = r
+  if penaltyOrResult.isErr():
+    engine.applyPenalty(penaltyOrResult.error)
+    result = err(typeof(result), penaltyOrResult.error)
+    return
+  penaltyOrResult.unsafeGet()
+
+proc resolveOpTag(
+    opEngine: RpcVerificationEngine, blockTag: BlockTag
+): Future[EngineResult[BlockTag]] {.async: (raises: [CancelledError]).} =
+  if blockTag.kind != bidAlias:
+    return ok(blockTag)
+
+  case blockTag.alias.toLowerAscii()
+  of "latest", "pending":
+    let tip = ?(await opEngine.resolveUnsafeTip())
+    ok(BlockTag(kind: bidNumber, number: Quantity(tip.number)))
+  of "safe":
+    let h = opEngine.headerStore.latest().valueOr:
+      return err((UnavailableDataError, "no safe L2 header yet", UNTAGGED))
+    ok(BlockTag(kind: bidNumber, number: Quantity(h.number)))
+  of "finalized":
+    let h = opEngine.headerStore.finalized().valueOr:
+      return err((UnavailableDataError, "no finalized L2 header yet", UNTAGGED))
+    ok(BlockTag(kind: bidNumber, number: Quantity(h.number)))
+  of "earliest":
+    let h = opEngine.headerStore.earliest().valueOr:
+      return err((UnavailableDataError, "no earliest L2 header yet", UNTAGGED))
+    ok(BlockTag(kind: bidNumber, number: Quantity(h.number)))
+  else:
+    err((InvalidDataError, "unsupported block tag " & $blockTag, UNTAGGED))
+
+proc getExecutionApiFrontend*(
+    opEngine: RpcVerificationEngine, l1Engine: RpcVerificationEngine
+): ExecutionApiFrontend =
+  var frontend: ExecutionApiFrontend
+
+  frontend.eth_chainId = proc(): Future[EngineResult[UInt256]] {.
+      async: (raises: [CancelledError])
+  .} =
+    ok(opEngine.chainId)
+
+  frontend.eth_blockNumber = proc(): Future[EngineResult[uint64]] {.
+      async: (raises: [CancelledError])
+  .} =
+    opEngine.opSync(l1Engine)
+
+    let latest = opEngine.penaltyOr(await opEngine.resolveUnsafeTip())
+    ok(latest.number.uint64)
+
+  frontend.eth_getBalance = proc(
+      address: Address, quantityTag: BlockTag
+  ): Future[EngineResult[UInt256]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(quantityTag))
+    let header = opEngine.penaltyOr(await opEngine.getHeader(tag))
+    let account = opEngine.penaltyOr(
+      await opEngine.getAccount(address, header.number, header.stateRoot)
+    )
+    ok(account.balance)
+
+  frontend.eth_getStorageAt = proc(
+      address: Address, slot: UInt256, quantityTag: BlockTag
+  ): Future[EngineResult[FixedBytes[32]]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(quantityTag))
+    let header = opEngine.penaltyOr(await opEngine.getHeader(tag))
+    let storage = opEngine.penaltyOr(
+      await opEngine.getStorageAt(address, slot, header.number, header.stateRoot)
+    )
+    ok(storage.to(Bytes32))
+
+  frontend.eth_getTransactionCount = proc(
+      address: Address, quantityTag: BlockTag
+  ): Future[EngineResult[Quantity]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(quantityTag))
+    let header = opEngine.penaltyOr(await opEngine.getHeader(tag))
+    let account = opEngine.penaltyOr(
+      await opEngine.getAccount(address, header.number, header.stateRoot)
+    )
+    ok(Quantity(account.nonce))
+
+  frontend.eth_getCode = proc(
+      address: Address, quantityTag: BlockTag
+  ): Future[EngineResult[seq[byte]]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(quantityTag))
+    let header = opEngine.penaltyOr(await opEngine.getHeader(tag))
+    let code = opEngine.penaltyOr(
+      await opEngine.getCode(address, header.number, header.stateRoot)
+    )
+    ok(code)
+
+  frontend.eth_getBlockByHash = proc(
+      blockHash: Hash32, fullTransactions: bool
+  ): Future[EngineResult[BlockObject]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let blk = opEngine.penaltyOr(await opEngine.getBlock(blockHash, fullTransactions))
+    ok(blk)
+
+  frontend.eth_getBlockByNumber = proc(
+      blockTag: BlockTag, fullTransactions: bool
+  ): Future[EngineResult[BlockObject]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(blockTag))
+    let blk = opEngine.penaltyOr(await opEngine.getBlock(tag, fullTransactions))
+    ok(blk)
+
+  frontend.eth_getUncleCountByBlockNumber = proc(
+      blockTag: BlockTag
+  ): Future[EngineResult[Quantity]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(blockTag))
+    let blk = opEngine.penaltyOr(await opEngine.getBlock(tag, false))
+    ok(Quantity(blk.uncles.len()))
+
+  frontend.eth_getUncleCountByBlockHash = proc(
+      blockHash: Hash32
+  ): Future[EngineResult[Quantity]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let blk = opEngine.penaltyOr(await opEngine.getBlock(blockHash, false))
+    ok(Quantity(blk.uncles.len()))
+
+  frontend.eth_getBlockTransactionCountByNumber = proc(
+      blockTag: BlockTag
+  ): Future[EngineResult[Quantity]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(blockTag))
+    let blk = opEngine.penaltyOr(await opEngine.getBlock(tag, true))
+    ok(Quantity(blk.transactions.len))
+
+  frontend.eth_getBlockTransactionCountByHash = proc(
+      blockHash: Hash32
+  ): Future[EngineResult[Quantity]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let blk = opEngine.penaltyOr(await opEngine.getBlock(blockHash, true))
+    ok(Quantity(blk.transactions.len))
+
+  frontend.eth_getTransactionByBlockNumberAndIndex = proc(
+      blockTag: BlockTag, index: Quantity
+  ): Future[EngineResult[TransactionObject]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(blockTag))
+    let blk = opEngine.penaltyOr(await opEngine.getBlock(tag, true))
+
+    if distinctBase(index) >= uint64(blk.transactions.len):
+      return
+        err((FrontendError, "provided transaction index is outside bounds", UNTAGGED))
+
+    let x = blk.transactions[distinctBase(index)]
+    ok(x.tx)
+
+  frontend.eth_getTransactionByBlockHashAndIndex = proc(
+      blockHash: Hash32, index: Quantity
+  ): Future[EngineResult[TransactionObject]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let blk = opEngine.penaltyOr(await opEngine.getBlock(blockHash, true))
+
+    if distinctBase(index) >= uint64(blk.transactions.len):
+      return
+        err((FrontendError, "provided transaction index is outside bounds", UNTAGGED))
+
+    let x = blk.transactions[distinctBase(index)]
+    ok(x.tx)
+
+  frontend.eth_call = proc(
+      tx: TransactionArgs, blockTag: BlockTag, optimisticStateFetch: bool = true
+  ): Future[EngineResult[seq[byte]]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    if tx.to.isNone():
+      return err((FrontendError, "to address is required", UNTAGGED))
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(blockTag))
+    let header = opEngine.penaltyOr(await opEngine.getHeader(tag))
+
+    # Start fetching code to get it in the code cache
+    discard opEngine.getCode(tx.to.get(), header.number, header.stateRoot)
+
+    opEngine.penaltyOr(
+      await opEngine.populateCachesUsingAccessList(header.number, header.stateRoot, tx)
+    )
+
+    let callResult = (await opEngine.evm.call(header, tx, optimisticStateFetch)).valueOr:
+      return err((VerificationError, "contract call failed -> " & error, UNTAGGED))
+
+    if callResult.error.len() > 0:
+      return err((VerificationError, callResult.error, UNTAGGED))
+
+    ok(callResult.output)
+
+  frontend.eth_createAccessList = proc(
+      tx: TransactionArgs, blockTag: BlockTag, optimisticStateFetch: bool = true
+  ): Future[EngineResult[AccessListResult]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    if tx.to.isNone():
+      return err((FrontendError, "to address is required", UNTAGGED))
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(blockTag))
+    let header = opEngine.penaltyOr(await opEngine.getHeader(tag))
+
+    discard opEngine.getCode(tx.to.get(), header.number, header.stateRoot)
+
+    opEngine.penaltyOr(
+      await opEngine.populateCachesUsingAccessList(header.number, header.stateRoot, tx)
+    )
+
+    let (accessList, error, gasUsed) = (
+      await opEngine.evm.createAccessList(header, tx, optimisticStateFetch)
+    ).valueOr:
+      return
+        err((VerificationError, "access list calculation failed -> " & error, UNTAGGED))
+
+    ok(
+      AccessListResult(accessList: accessList, error: error, gasUsed: gasUsed.Quantity)
+    )
+
+  frontend.eth_estimateGas = proc(
+      tx: TransactionArgs, blockTag: BlockTag, optimisticStateFetch: bool = true
+  ): Future[EngineResult[Quantity]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    if tx.to.isNone():
+      return err((FrontendError, "to address is required", UNTAGGED))
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(blockTag))
+    let header = opEngine.penaltyOr(await opEngine.getHeader(tag))
+
+    discard opEngine.getCode(tx.to.get(), header.number, header.stateRoot)
+
+    opEngine.penaltyOr(
+      await opEngine.populateCachesUsingAccessList(header.number, header.stateRoot, tx)
+    )
+
+    let gasEstimate = (await opEngine.evm.estimateGas(header, tx, optimisticStateFetch)).valueOr:
+      return err(
+        (VerificationError, "gas estimation calculation failed -> " & error, UNTAGGED)
+      )
+
+    ok(Quantity(gasEstimate))
+
+  frontend.eth_getTransactionByHash = proc(
+      txHash: Hash32
+  ): Future[EngineResult[TransactionObject]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let (backend, backendIdx) = ?(opEngine.executionBackendFor(GetTransactionByHash))
+    let tx = opEngine.penaltyOr(
+      (await backend.eth_getTransactionByHash(txHash)).tagBackend(backendIdx)
+    )
+
+    if tx.hash != txHash:
+      return err(
+        (
+          VerificationError,
+          "the downloaded transaction hash doesn't match the requested transaction hash",
+          backendIdx,
+        )
+      )
+
+    if not checkTxHash(tx, txHash):
+      return err(
+        (
+          VerificationError, "the transaction doesn't hash to the provided hash",
+          backendIdx,
+        )
+      )
+
+    ok(tx)
+
+  frontend.eth_getBlockReceipts = proc(
+      blockTag: BlockTag
+  ): Future[EngineResult[Opt[seq[ReceiptObject]]]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(blockTag))
+    let rxs = opEngine.penaltyOr(await opEngine.getReceipts(tag))
+    ok(Opt.some(rxs))
+
+  frontend.eth_getTransactionReceipt = proc(
+      txHash: Hash32
+  ): Future[EngineResult[ReceiptObject]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let (backend, backendIdx) = ?(opEngine.executionBackendFor(GetTransactionReceipt))
+    let rx = opEngine.penaltyOr(
+      (await backend.eth_getTransactionReceipt(txHash)).tagBackend(backendIdx)
+    )
+    let rxs = opEngine.penaltyOr(await opEngine.getReceipts(rx.blockHash))
+
+    for r in rxs:
+      if r.transactionHash == txHash:
+        return ok(r)
+
+    return err((VerificationError, "receipt couldn't be verified", backendIdx))
+
+  frontend.eth_getLogs = proc(
+      filterOptions: FilterOptions
+  ): Future[EngineResult[seq[LogObject]]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let logObjs = opEngine.penaltyOr(await opEngine.getLogs(filterOptions))
+    ok(logObjs)
+
+  frontend.eth_newFilter = proc(
+      filterOptions: FilterOptions
+  ): Future[EngineResult[string]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    if opEngine.filterStore.len >= MAX_FILTERS:
+      return err((UnavailableDataError, "FilterStore already full", UNTAGGED))
+
+    var
+      id: array[8, byte] # 64bits
+      strId: string
+
+    for i in 0 .. (MAX_ID_TRIES + 1):
+      if randomBytes(id) != len(id):
+        return err(
+          (
+            UnavailableDataError,
+            "Couldn't generate a random identifier for the filter", UNTAGGED,
+          )
+        )
+
+      strId = toHex(id)
+
+      if not opEngine.filterStore.contains(strId):
+        break
+
+      if i >= MAX_ID_TRIES:
+        return err(
+          (
+            UnavailableDataError, "Couldn't create a unique identifier for the filter",
+            UNTAGGED,
+          )
+        )
+
+    opEngine.filterStore[strId] =
+      FilterStoreItem(filter: filterOptions, blockMarker: Opt.none(Quantity))
+
+    ok(strId)
+
+  frontend.eth_uninstallFilter = proc(
+      filterId: string
+  ): Future[EngineResult[bool]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    if filterId in opEngine.filterStore:
+      opEngine.filterStore.del(filterId)
+      return ok(true)
+
+    ok(false)
+
+  frontend.eth_getFilterLogs = proc(
+      filterId: string
+  ): Future[EngineResult[seq[LogObject]]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    try:
+      let logObjs = opEngine.penaltyOr(
+        await opEngine.getLogs(opEngine.filterStore[filterId].filter)
+      )
+      ok(logObjs)
+    except KeyError:
+      err((FrontendError, "Filter doesn't exist", UNTAGGED))
+
+  frontend.eth_getFilterChanges = proc(
+      filterId: string
+  ): Future[EngineResult[seq[LogObject]]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let filterItem =
+      try:
+        opEngine.filterStore[filterId]
+      except KeyError:
+        return err((FrontendError, "Filter doesn't exist", UNTAGGED))
+
+    let
+      filter = ?opEngine.resolveFilterTags(filterItem.filter)
+      toBlock = filter.toBlock.get().number
+
+    if filterItem.blockMarker.isSome() and toBlock <= filterItem.blockMarker.get():
+      return err(
+        (
+          UnavailableDataError, "No changes for the filter since the last query",
+          UNTAGGED,
+        )
+      )
+
+    let
+      fromBlock =
+        if filterItem.blockMarker.isSome():
+          Opt.some(
+            types.BlockTag(kind: bidNumber, number: filterItem.blockMarker.get())
+          )
+        else:
+          filter.fromBlock
+
+      changesFilter = FilterOptions(
+        fromBlock: fromBlock,
+        toBlock: filter.toBlock,
+        address: filter.address,
+        topics: filter.topics,
+        blockHash: filter.blockHash,
+      )
+    let logObjs = opEngine.penaltyOr(await opEngine.getLogs(changesFilter))
+
+    try:
+      opEngine.filterStore[filterId].blockMarker = Opt.some(toBlock)
+    except KeyError:
+      return err((FrontendError, "Filter doesn't exist", UNTAGGED))
+
+    ok(logObjs)
+
+  frontend.eth_blobBaseFee = proc(): Future[EngineResult[UInt256]] {.
+      async: (raises: [CancelledError])
+  .} =
+    opEngine.opSync(l1Engine)
+
+    let db = DefaultDbMemory.newCoreDbRef()
+    defer:
+      db.close()
+
+    # the L2 follows the L1 fork schedule, so configure the common with the L1 chain id
+    let l1ChainId = opL1ChainId(opEngine.chainId).valueOr:
+      return err((InvalidDataError, "unknown op chainId: " & error, UNTAGGED))
+    let com = CommonRef.new(
+      db,
+      config = chainConfigForNetwork(l1ChainId),
+      initializeDb = false,
+      statelessProviderEnabled = true,
+    )
+
+    let header = opEngine.penaltyOr(await opEngine.getHeader(blockId("latest")))
+
+    if header.blobGasUsed.isNone():
+      return
+        err((UnavailableDataError, "blobGasUsed missing from latest header", UNTAGGED))
+    if header.excessBlobGas.isNone():
+      return err(
+        (UnavailableDataError, "excessBlobGas missing from latest header", UNTAGGED)
+      )
+    let blobBaseFee =
+      getBlobBaseFee(header.excessBlobGas.get, com, com.toHardFork(header)) *
+      header.blobGasUsed.get.u256
+
+    ok(blobBaseFee)
+
+  frontend.eth_gasPrice = proc(): Future[EngineResult[Quantity]] {.
+      async: (raises: [CancelledError])
+  .} =
+    opEngine.opSync(l1Engine)
+
+    let suggestedPrice = opEngine.penaltyOr(await opEngine.suggestGasPrice())
+    ok(Quantity(suggestedPrice.uint64))
+
+  frontend.eth_maxPriorityFeePerGas = proc(): Future[EngineResult[Quantity]] {.
+      async: (raises: [CancelledError])
+  .} =
+    opEngine.opSync(l1Engine)
+
+    let suggestedPrice = opEngine.penaltyOr(await opEngine.suggestMaxPriorityGasPrice())
+    ok(Quantity(suggestedPrice.uint64))
+
+  # pass-forward
+  frontend.eth_getProof = proc(
+      address: Address, slots: seq[UInt256], blockId: BlockTag
+  ): Future[EngineResult[ProofResponse]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(blockId))
+    let (backend, backendIdx) = ?(opEngine.executionBackendFor(GetProof))
+    let proof = opEngine.penaltyOr(
+      (await backend.eth_getProof(address, slots, tag)).tagBackend(backendIdx)
+    )
+    ok(proof)
+
+  frontend.eth_feeHistory = proc(
+      blockCount: Quantity, newestBlock: BlockTag, rewardPercentiles: seq[int]
+  ): Future[EngineResult[FeeHistoryResult]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let tag = opEngine.penaltyOr(await opEngine.resolveOpTag(newestBlock))
+    let (backend, backendIdx) = ?(opEngine.executionBackendFor(FeeHistory))
+    let feeHistory = opEngine.penaltyOr(
+      (await backend.eth_feeHistory(blockCount, tag, rewardPercentiles)).tagBackend(
+        backendIdx
+      )
+    )
+    ok(feeHistory)
+
+  frontend.eth_sendRawTransaction = proc(
+      txBytes: seq[byte]
+  ): Future[EngineResult[Hash32]] {.async: (raises: [CancelledError]).} =
+    opEngine.opSync(l1Engine)
+
+    let (backend, backendIdx) = ?(opEngine.executionBackendFor(SendRawTransaction))
+    let txHash = opEngine.penaltyOr(
+      (await backend.eth_sendRawTransaction(txBytes)).tagBackend(backendIdx)
+    )
+    ok(txHash)
+
+  frontend

--- a/nimbus_verified_proxy/op/op_frontend.nim
+++ b/nimbus_verified_proxy/op/op_frontend.nim
@@ -19,6 +19,7 @@ import
   ../../execution_chain/db/core_db/memory_only,
   ../../execution_chain/common/common,
   ../engine/types,
+  ../engine/engine,
   ../engine/header_store,
   ../engine/accounts,
   ../engine/blocks,

--- a/nimbus_verified_proxy/op/op_frontend.nim
+++ b/nimbus_verified_proxy/op/op_frontend.nim
@@ -512,7 +512,7 @@ proc getExecutionApiFrontend*(
     opEngine.opSync(l1Engine)
 
     let suggestedPrice = opEngine.penaltyOr(await opEngine.suggestGasPrice())
-    ok(Quantity(suggestedPrice.uint64))
+    ok(Quantity(suggestedPrice))
 
   frontend.eth_maxPriorityFeePerGas = proc(): Future[EngineResult[Quantity]] {.
       async: (raises: [CancelledError])
@@ -520,7 +520,7 @@ proc getExecutionApiFrontend*(
     opEngine.opSync(l1Engine)
 
     let suggestedPrice = opEngine.penaltyOr(await opEngine.suggestMaxPriorityGasPrice())
-    ok(Quantity(suggestedPrice.uint64))
+    ok(Quantity(suggestedPrice))
 
   # pass-forward
   frontend.eth_getProof = proc(


### PR DESCRIPTION
### Description:

This PR adds support for op-stack L2 chains into verified proxy. Currently the integration supports running the L1 engine and the L2 engine side-by-side so the API for both can be used at the same time. 

### Notes:

1. Organization: All op-stack related code is placed under the subdirectory `op`
2. Semantics: The L2 engine uses the same `RpcVerificationEngine` type since it is an EVM compatible type. Few minor configuration overrides are done when loading/starting the secondary L2 engine. These overrides include passing the L1 network id into the EVM to avoid creating unnecessary code paths
3. Verification: the L2 engine follows a similar pattern of *syncing* anchor points (like light client updates in L1) using the L1 engine. 
     a. Every block on the L2 is added to a batch of blocks which are compressed and posted on L1. A rollup node then derives every block from the "available" data and proposes an output root (hash of state_root and block_hash and other values). This output root is **proposed** via a dispute game through the `DisputeGameFactory` against a block number. Such a proposal itself carries significant monetary capital that can be slashed. Hence, we use this proposal to mark blocks `safe` (safe according op-stack specs means the block can derived not that an output root was proposed, we use it differently in verified proxy for stricter guarantees). 
     b. Note: The output root is posted at an irregular cadence. So `safe` blocks don't come at regular intervals but they do imply through canonical-ness that everything that came before is also "safe". So we read the `DisputeGameFactory` for the latest game, verify the claim and push the "safe" block into the header store of the verified proxy.
     c. After the dispute game resolves and the L1 block at which it resolved is finalized, the L2 block against which the output root was proposed is considered finalized. We use the same semantics for the verified proxy as well. 
     d. Every time a game finalizes, either proposer or any other actor pushes the finalized output root and the block number to the `AnchorStateRegistry`. This registry contract performs a trustless verification of the output root and only then adds it to the registry. We use this registry to read the finalized output root and block number and then store the block in the header store of the proxy.
     e. To achhieve this verified anchor point update a.k.a syncing. The verified proxy first calls the `SystemConfig` contract to get the current addresses of the `OptimismPortal` contract, `DisputeGameFactory` contract and `AnchorStateRegistry` contract (fetched from `OptimismPortal` contract). 
     f. NOTE:  the header store only stores safe blocks as a canonical chain and marks the finalized blocks in the store. If a query is made against the latest block, the proxy first downloads the latest and verifies it comes from the canonical chain by walking through the history to a safe block. This is the only way a latest block can be downloaded with minimized trust.