### PR TITLE
Only allow skipping pre-execution BAL check for finalized blocks

### DIFF
--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -83,10 +83,7 @@ proc processBlock*(
     # Depending on the BAL retention period of clients, finalized blocks might
     # be received without a BAL. In this case we skip checking the BAL against
     # the header bal hash.
-    # For now we allow BALs to be optional even for finalized blocks for bal-devnet-2.
-    # Once clients have implemented the devp2p eth/71 protocol we can require BALs
-    # to be present for finalized blocks.
-    skipPreExecBalCheck = blockAccessList.isNone(), # finalized and blockAccessList.isNone(),
+    skipPreExecBalCheck = finalized and blockAccessList.isNone(),
     vmState.parent,
     txFrame
   ).isOkOr:

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -279,7 +279,7 @@ proc generateBlock(env: var TestEnv) =
   doAssert(blk.transactions.len == 2)
 
   # import block
-  (waitFor chain.importBlock(blk)).isOkOr:
+  (waitFor chain.importBlock(blk, finalized = true)).isOkOr:
     debugEcho error
     quit(QuitFailure)
 

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -151,7 +151,7 @@ template checkAssembleBlock(xp, expCount): auto =
   rc.get
 
 template checkImportBlock(xp: TxPoolRef, bundle: AssembledBlock) =
-  let rc = waitFor xp.chain.importBlock(bundle.blk)
+  let rc = waitFor xp.chain.importBlock(bundle.blk, finalized = true)
   check rc.isOk == true
   if rc.isErr:
     debugEcho "IMPORT BLOCK: ", rc.error
@@ -402,7 +402,7 @@ suite "TxPool test suite":
 
       numTxsPacked += bundle.blk.transactions.len
 
-      (waitFor chain.importBlock(bundle.blk)).isOkOr:
+      (waitFor chain.importBlock(bundle.blk, finalized = true)).isOkOr:
         check false
         debugEcho error
         return


### PR DESCRIPTION
Reverts the temporary change for bal devnets which didn't require having eth/71 implemented so non finalized blocks could be received without a valid BAL. 

eth/71 is now required so this workaround is no longer required.