### PR TITLE
Fetch BALs when syncing

### DIFF
--- a/execution_chain/block_access_list/block_access_list_utils.nim
+++ b/execution_chain/block_access_list/block_access_list_utils.nim
@@ -9,7 +9,35 @@
 
 {.push raises: [], gcsafe.}
 
-import std/algorithm, eth/common/[addresses, block_access_lists], stew/byteutils
+import
+  std/algorithm,
+  results,
+  eth/common/[addresses, block_access_lists, headers],
+  stew/byteutils
+
+const
+  SLOTS_PER_EPOCH* = 32'u64
+    ## Consensus layer slots per epoch.
+
+  BAL_RETENTION_EPOCHS* = 3533'u64
+    ## EIP-7928: execution clients are only required to retain block access
+    ## lists for (at least) the last 3533 epochs.
+
+func isWithinBalRetentionPeriod*(header: Header, headSlot: uint64): bool =
+  ## Whether the block access list (EIP-7928) for `header` must still be retained
+  ## by an execution client, i.e. the block falls within the last
+  ## `BAL_RETENTION_EPOCHS` epochs relative to `currentSlot` (typically the slot
+  ## of the chain head).
+  
+  # Blocks before Amsterdam carry no slot number (and no block access list)
+  let blockSlot = header.slotNumber.valueOr:
+    return false
+
+  let
+    blockEpoch = blockSlot div SLOTS_PER_EPOCH
+    headEpoch = headSlot div SLOTS_PER_EPOCH
+
+  blockEpoch + BAL_RETENTION_EPOCHS > headEpoch
 
 func accChangesCmp*(x, y: AccountChanges): int =
   cmp(x.address.data(), y.address.data())

--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -83,10 +83,7 @@ proc processBlock*(
     # Depending on the BAL retention period of clients, finalized blocks might
     # be received without a BAL. In this case we skip checking the BAL against
     # the header bal hash.
-    # For now we allow BALs to be optional even for finalized blocks for bal-devnet-2.
-    # Once clients have implemented the devp2p eth/71 protocol we can require BALs
-    # to be present for finalized blocks.
-    skipPreExecBalCheck = blockAccessList.isNone(), # finalized and blockAccessList.isNone(),
+    skipPreExecBalCheck = blockAccessList.isNone(),
     vmState.parent,
     txFrame
   ).isOkOr:

--- a/execution_chain/sync/beacon/worker/blocks.nim
+++ b/execution_chain/sync/beacon/worker/blocks.nim
@@ -104,15 +104,16 @@ template blocksCollect*(
         if bottom < ctx.subState.topNum:
           discard ctx.blocksUnprocFetch(ctx.subState.topNum-bottom).expect("iv")
 
-        # Fetch blocks and verify result
-        var blocks = buddy.blocksFetch(nFetchBodiesRequest, info).valueOr:
+        # Fetch blocks (with block access lists) and verify result
+        var fetched = buddy.blocksFetch(nFetchBodiesRequest, info).valueOr:
           break fetchBlocksBody                      # done, exit this function
 
         # Set flag that there were some blocks fetched at all
         ctx.pool.seenData = true                     # blocks data exist
 
         # Import blocks (no staging), async/template
-        nImported += buddy.blocksImport(blocks, buddy.peerID, info)
+        nImported += buddy.blocksImport(
+          fetched.blocks, fetched.bals, fetched.peerID, info)
 
         # Sync status logging
         if 0 < nImported:
@@ -132,7 +133,7 @@ template blocksCollect*(
             nImported = 0
 
         # Import may be incomplete, so a partial roll back may be needed
-        let lastBn = blocks[^1].header.number
+        let lastBn = fetched.blocks[^1].header.number
         if ctx.subState.topNum < lastBn:
           ctx.blocksUnprocAppend(ctx.subState.topNum + 1, lastBn)
 
@@ -155,14 +156,13 @@ template blocksCollect*(
 
         let
           # Insert blocks list on the `staged` queue
-          key = rc.value[0].header.number
+          key = rc.value.blocks[0].header.number
           qItem = ctx.blocksStagedQueueInsert(key).valueOr:
             raiseAssert info & ": duplicate key on staged queue iv=" &
-              (key, rc.value[^1].header.number).toStr
+              (key, rc.value.blocks[^1].header.number).toStr
 
-        qItem.data.blocks = rc.value                # store `blocks[]` list
-        qItem.data.peerID = buddy.peerID
-        nQueued += rc.value.len                     # statistics
+        qItem.data = rc.value                       # store blocks + access lists
+        nQueued += rc.value.blocks.len              # statistics
         # End if
 
       # End block: `fetchBlocksBody`
@@ -261,7 +261,8 @@ template blocksUnstage*(
       ctx.blocksStagedQueueDelete qItem.key
 
       # Import blocks list, async/template
-      nImported += buddy.blocksImport(qItem.data.blocks,qItem.data.peerID, info)
+      nImported += buddy.blocksImport(
+        qItem.data.blocks, qItem.data.bals, qItem.data.peerID, info)
       nUnstaged.inc
 
       # Sync status logging

--- a/execution_chain/sync/beacon/worker/blocks/blocks_bal.nim
+++ b/execution_chain/sync/beacon/worker/blocks/blocks_bal.nim
@@ -1,0 +1,76 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at
+#     https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at
+#     https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+{.push raises:[].}
+
+import
+  std/typetraits,
+  pkg/[chronos, results],
+  pkg/eth/common,
+  pkg/eth/common/[block_access_lists, block_access_lists_rlp],
+  ../../../wire_protocol,
+  ../worker_desc
+
+export block_access_lists
+
+# ------------------------------------------------------------------------------
+# Public functions
+# ------------------------------------------------------------------------------
+
+proc fetchRawBlockAccessLists*(
+    buddy: BeaconPeerRef;
+    request: BlockAccessListsRequest;
+      ): Future[Opt[seq[RawBlockAccessList]]]
+      {.async: (raises: []).} =
+  ## Request the raw (RLP-encoded) block access lists (EIP-7928) for the block
+  ## hashes in `request` from the sync peer. 
+
+  if not buddy.peer.supports(eth71):
+    return Opt.none(seq[RawBlockAccessList])
+
+  try:
+    let resp = (await buddy.peer.getBlockAccessLists(
+      request, fetchBalsRlpxTimeout)).valueOr:
+        return Opt.none(seq[RawBlockAccessList])
+    return Opt.some(resp.accessLists)
+  except CancelledError:
+    return Opt.none(seq[RawBlockAccessList])
+  except CatchableError:
+    return Opt.none(seq[RawBlockAccessList])
+
+proc decodeBlockAccessList*(
+    raw: RawBlockAccessList;
+    header: Header;
+      ): Opt[BlockAccessListRef] =
+  ## Decode a single raw (RLP-encoded) block access list received from a peer
+  ## and verify it against the BAL hash committed in the block header.
+  ## Returns `none` when the peer reported the list as unavailable, when it is
+  ## malformed, or when its hash does not match the header. 
+
+  let bytes = distinctBase(raw)
+
+  if bytes.len == 0 or (bytes.len == 1 and bytes[0] == 0x80'u8):
+    return Opt.none(BlockAccessListRef)
+
+  let expectedHash = header.blockAccessListHash.valueOr:
+    return Opt.none(BlockAccessListRef)
+
+  let bal: BlockAccessListRef = new BlockAccessList
+  bal[] = BlockAccessList.decode(bytes).valueOr:
+    return Opt.none(BlockAccessListRef)
+
+  if bal[].computeBlockAccessListHash() != expectedHash:
+    return Opt.none(BlockAccessListRef)
+
+  Opt.some(bal)
+
+# ------------------------------------------------------------------------------
+# End
+# ------------------------------------------------------------------------------

--- a/execution_chain/sync/beacon/worker/blocks/blocks_bal.nim
+++ b/execution_chain/sync/beacon/worker/blocks/blocks_bal.nim
@@ -12,9 +12,9 @@
 
 import
   std/typetraits,
-  pkg/[chronos, results],
-  pkg/eth/common,
-  pkg/eth/common/[block_access_lists, block_access_lists_rlp],
+  chronos, 
+  results,
+  eth/common,
   ../../../wire_protocol,
   ../worker_desc
 
@@ -53,7 +53,6 @@ proc decodeBlockAccessList*(
   ## and verify it against the BAL hash committed in the block header.
   ## Returns `none` when the peer reported the list as unavailable, when it is
   ## malformed, or when its hash does not match the header. 
-
   let bytes = distinctBase(raw)
 
   if bytes.len == 0 or (bytes.len == 1 and bytes[0] == 0x80'u8):
@@ -62,11 +61,11 @@ proc decodeBlockAccessList*(
   let expectedHash = header.blockAccessListHash.valueOr:
     return Opt.none(BlockAccessListRef)
 
-  let bal: BlockAccessListRef = new BlockAccessList
-  bal[] = BlockAccessList.decode(bytes).valueOr:
+  if keccak256(bytes) != expectedHash:
     return Opt.none(BlockAccessListRef)
 
-  if bal[].computeBlockAccessListHash() != expectedHash:
+  let bal: BlockAccessListRef = new BlockAccessList
+  bal[] = BlockAccessList.decode(bytes).valueOr:
     return Opt.none(BlockAccessListRef)
 
   Opt.some(bal)

--- a/execution_chain/sync/beacon/worker/blocks/blocks_bal.nim
+++ b/execution_chain/sync/beacon/worker/blocks/blocks_bal.nim
@@ -30,20 +30,40 @@ proc fetchRawBlockAccessLists*(
       ): Future[Opt[seq[RawBlockAccessList]]]
       {.async: (raises: []).} =
   ## Request the raw (RLP-encoded) block access lists (EIP-7928) for the block
-  ## hashes in `request` from the sync peer. 
+  ## hashes in `request` from the sync peer.
+  ##
+  ## The peer serves the lists in request order but truncates its response at a
+  ## soft size limit (and a maximum count), so a single response may cover only
+  ## a prefix of the requested hashes. Follow-up requests are issued for the
+  ## remaining hashes until all are received (or the peer stops making
+  ## progress), so the returned sequence is aligned by index with
+  ## `request.blockHashes`.
 
   if not buddy.peer.supports(eth71):
     return Opt.none(seq[RawBlockAccessList])
 
+  let nReq = request.blockHashes.len
+  if nReq == 0:
+    return Opt.some(newSeq[RawBlockAccessList](0))
+
+  var accessLists = newSeqOfCap[RawBlockAccessList](nReq)
   try:
-    let resp = (await buddy.peer.getBlockAccessLists(
-      request, fetchBalsRlpxTimeout)).valueOr:
-        return Opt.none(seq[RawBlockAccessList])
-    return Opt.some(resp.accessLists)
+    while accessLists.len < nReq:
+      # Request only the hashes not yet served by previous responses.
+      let remaining = BlockAccessListsRequest(
+        blockHashes: request.blockHashes[accessLists.len ..< nReq])
+      let resp = (await buddy.peer.getBlockAccessLists(
+        remaining, fetchBalsRlpxTimeout)).valueOr:
+          return Opt.none(seq[RawBlockAccessList])
+      if resp.accessLists.len == 0:
+        break               # peer served nothing; avoid looping indefinitely
+      accessLists.add resp.accessLists
   except CancelledError:
     return Opt.none(seq[RawBlockAccessList])
   except CatchableError:
     return Opt.none(seq[RawBlockAccessList])
+
+  Opt.some(accessLists)
 
 proc decodeBlockAccessList*(
     raw: RawBlockAccessList;

--- a/execution_chain/sync/beacon/worker/blocks/blocks_blocks.nim
+++ b/execution_chain/sync/beacon/worker/blocks/blocks_blocks.nim
@@ -125,34 +125,31 @@ template blocksFetchCheckImpl(
         blocks[n].uncles = bodies[n].uncles
         blocks[n].withdrawals = bodies[n].withdrawals
 
-    # Fetch block access lists (EIP-7928) for the post-Amsterdam blocks from the
-    # `eth/71` peer and verify each against the hash committed in its header.
+    # Fetch block access lists (EIP-7928) for the batch from the `eth/71` peer
+    # and verify each against the hash committed in its header.
     var bals = newSeq[Opt[BlockAccessListRef]](blocks.len)
     block balFetch:
-      let
-        com = ctx.chain.com
-        headSlot = ctx.hdrCache.head.slotNumber          # sync target slot
-      var
-        balRequest: BlockAccessListsRequest
-        balPos: seq[int]                                   # bal index -> block index
-      for n in 0 ..< blocks.len:
-        # Only request lists for post-Amsterdam blocks that are still within the
-        # EIP-7928 retention period; peers have pruned anything older.
-        if com.isAmsterdamOrLater(blocks[n].header.timestamp) and
-            blocks[n].header.isWithinBalRetentionPeriod(headSlot.expect("slot number exists"))):
-          balRequest.blockHashes.add request.blockHashes[n]
-          balPos.add n
-      if balRequest.blockHashes.len == 0:
-        break balFetch                                     # no post-Amsterdam blocks
+      if blocks.len == 0:
+        break balFetch
+      
+      let headSlot = ctx.hdrCache.head.slotNumber          # sync target slot
+
+      if not ctx.chain.com.isAmsterdamOrLater(blocks[0].header.timestamp) or 
+          headSlot.isNone() or
+          not blocks[0].header.isWithinBalRetentionPeriod(headSlot.unsafeGet):
+        break balFetch
+
+      let balRequest = BlockAccessListsRequest(
+        blockHashes: request.blockHashes[0 ..< blocks.len])
 
       # The response is served in request order and may be truncated by the
       # peer's soft response size limit.
       let raws = (await buddy.fetchRawBlockAccessLists(balRequest)).valueOr:
         default(seq[RawBlockAccessList])
       var nBals = 0
-      for j in 0 ..< min(raws.len, balPos.len):
-        bals[balPos[j]] = decodeBlockAccessList(raws[j], blocks[balPos[j]].header)
-        if bals[balPos[j]].isSome:
+      for j in 0 ..< min(raws.len, blocks.len):
+        bals[j] = decodeBlockAccessList(raws[j], blocks[j].header)
+        if bals[j].isSome:
           inc nBals
       trace info & ": fetched block access lists", peer, iv=($iv),
         nReq=balRequest.blockHashes.len, nResp=raws.len, nBals

--- a/execution_chain/sync/beacon/worker/blocks/blocks_blocks.nim
+++ b/execution_chain/sync/beacon/worker/blocks/blocks_blocks.nim
@@ -153,7 +153,7 @@ template blocksFetchCheckImpl(
 
     if 0 < blocks.len.uint64:
       bodyRc = Opt[BlocksForImport].ok(BlocksForImport(
-        blocks: move(blocks), move(bals): bals, peerID: buddy.peerID)) # return ok()
+        blocks: move(blocks), bals: move(bals), peerID: buddy.peerID)) # return ok()
 
     buddy.nErrors.apply.blk.inc
     break body                                             # return err()

--- a/execution_chain/sync/beacon/worker/blocks/blocks_blocks.nim
+++ b/execution_chain/sync/beacon/worker/blocks/blocks_blocks.nim
@@ -15,6 +15,7 @@ import
   pkg/eth/common,
   pkg/stew/interval_set,
   ../../../../networking/p2p,
+  ../../../../block_access_list/block_access_list_utils,
   ../../../wire_protocol/types,
   ../[helpers, update, worker_desc],
   ./[blocks_bal, blocks_fetch, blocks_helpers, blocks_unproc]
@@ -128,12 +129,17 @@ template blocksFetchCheckImpl(
     # `eth/71` peer and verify each against the hash committed in its header.
     var bals = newSeq[Opt[BlockAccessListRef]](blocks.len)
     block balFetch:
-      let com = ctx.chain.com
+      let
+        com = ctx.chain.com
+        headSlot = ctx.hdrCache.head.slotNumber          # sync target slot
       var
         balRequest: BlockAccessListsRequest
         balPos: seq[int]                                   # bal index -> block index
       for n in 0 ..< blocks.len:
-        if com.isAmsterdamOrLater(blocks[n].header.timestamp):
+        # Only request lists for post-Amsterdam blocks that are still within the
+        # EIP-7928 retention period; peers have pruned anything older.
+        if com.isAmsterdamOrLater(blocks[n].header.timestamp) and
+            blocks[n].header.isWithinBalRetentionPeriod(headSlot.expect("slot number exists"))):
           balRequest.blockHashes.add request.blockHashes[n]
           balPos.add n
       if balRequest.blockHashes.len == 0:

--- a/execution_chain/sync/beacon/worker/blocks/blocks_blocks.nim
+++ b/execution_chain/sync/beacon/worker/blocks/blocks_blocks.nim
@@ -17,7 +17,7 @@ import
   ../../../../networking/p2p,
   ../../../wire_protocol/types,
   ../[helpers, update, worker_desc],
-  ./[blocks_fetch, blocks_helpers, blocks_unproc]
+  ./[blocks_bal, blocks_fetch, blocks_helpers, blocks_unproc]
 
 # ------------------------------------------------------------------------------
 # Private helpers
@@ -43,16 +43,18 @@ template blocksFetchCheckImpl(
     buddy: BeaconPeerRef;
     iv: BnRange;
     info: static[string];
-      ): Opt[seq[EthBlock]] =
+      ): Opt[BlocksForImport] =
   ## Async/template
   ##
   ## From the ptp/ethXX network fetch the argument range `iv` of block bodies
-  ## and assemble a list of blocks to be returned.
+  ## and assemble a list of blocks to be returned. For post-Amsterdam blocks the
+  ## matching block access lists (EIP-7928) are fetched as well from `eth/71`
+  ## peers.
   ##
   ## The block bodies are heuristically verified, the headers are taken from
   ## the header chain cache.
   ##
-  var bodyRc = Opt[seq[EthBlock]].err()
+  var bodyRc = Opt[BlocksForImport].err()
   block body:
     let
       ctx = buddy.ctx
@@ -122,8 +124,36 @@ template blocksFetchCheckImpl(
         blocks[n].uncles = bodies[n].uncles
         blocks[n].withdrawals = bodies[n].withdrawals
 
+    # Fetch block access lists (EIP-7928) for the post-Amsterdam blocks from the
+    # `eth/71` peer and verify each against the hash committed in its header.
+    var bals = newSeq[Opt[BlockAccessListRef]](blocks.len)
+    block balFetch:
+      let com = ctx.chain.com
+      var
+        balRequest: BlockAccessListsRequest
+        balPos: seq[int]                                   # bal index -> block index
+      for n in 0 ..< blocks.len:
+        if com.isAmsterdamOrLater(blocks[n].header.timestamp):
+          balRequest.blockHashes.add request.blockHashes[n]
+          balPos.add n
+      if balRequest.blockHashes.len == 0:
+        break balFetch                                     # no post-Amsterdam blocks
+
+      # The response is served in request order and may be truncated by the
+      # peer's soft response size limit.
+      let raws = (await buddy.fetchRawBlockAccessLists(balRequest)).valueOr:
+        default(seq[RawBlockAccessList])
+      var nBals = 0
+      for j in 0 ..< min(raws.len, balPos.len):
+        bals[balPos[j]] = decodeBlockAccessList(raws[j], blocks[balPos[j]].header)
+        if bals[balPos[j]].isSome:
+          inc nBals
+      trace info & ": fetched block access lists", peer, iv=($iv),
+        nReq=balRequest.blockHashes.len, nResp=raws.len, nBals
+
     if 0 < blocks.len.uint64:
-      bodyRc = Opt[seq[EthBlock]].ok(blocks)               # return ok()
+      bodyRc = Opt[BlocksForImport].ok(BlocksForImport(
+        blocks: move(blocks), move(bals): bals, peerID: buddy.peerID)) # return ok()
 
     buddy.nErrors.apply.blk.inc
     break body                                             # return err()
@@ -138,14 +168,14 @@ template blocksFetch*(
     buddy: BeaconPeerRef;
     num: uint;
     info: static[string];
-      ): Opt[seq[EthBlock]] =
+      ): Opt[BlocksForImport] =
   ## Async/template
   ##
   ## From the p2p/ethXX network fetch as many blocks as given as argument `num`.
   ##
   let ctx = buddy.ctx
 
-  var bodyRc = Opt[seq[EthBlock]].err()
+  var bodyRc = Opt[BlocksForImport].err()
   block body:
     # Make sure that this sync peer is not banned from block processing,
     # already.
@@ -171,7 +201,7 @@ template blocksFetch*(
     if rc.isErr:
       ctx.blocksUnprocCommit(iv, iv)
     else:
-      ctx.blocksUnprocCommit(iv, iv.minPt + rc.value.len.uint64, iv.maxPt)
+      ctx.blocksUnprocCommit(iv, iv.minPt + rc.value.blocks.len.uint64, iv.maxPt)
 
     bodyRc = rc
 
@@ -181,12 +211,17 @@ template blocksFetch*(
 template blocksImport*(
     buddy: BeaconPeerRef;
     blocks: seq[EthBlock];
+    bals: seq[Opt[BlockAccessListRef]];
     peerID: Hash;
     info: static[string];
       ): uint64 =
   ## Async/template
   ##
-  ## Import/execute a list of argument blocks. The function sets the global
+  ## Import/execute a list of argument blocks. For post-Amsterdam blocks the
+  ## matching block access lists (when available, aligned by index
+  ## with `blocks`) is passed to the importer.
+  ##
+  ## The function sets the global
   ## block number of the last executed block which might preceed the least block
   ## number from the argument list in case of an error.
   ##
@@ -224,7 +259,8 @@ template blocksImport*(
         let importErr: BeaconError =
           try:
             let res = await ctx.chain.queueImportBlock(
-              blocks[n], Opt.none(BlockAccessListRef))
+              blocks[n],
+              if n < bals.len: bals[n] else: Opt.none(BlockAccessListRef))
             if res.isOk:
               default(BeaconError)
             else:

--- a/execution_chain/sync/beacon/worker/worker_const.nim
+++ b/execution_chain/sync/beacon/worker/worker_const.nim
@@ -127,6 +127,9 @@ const
   nFetchBodiesErrThreshold* = 4
     ## Similar to `nFetchHeadersErrThreshold`.
 
+  fetchBalsRlpxTimeout* = chronos.seconds(50)
+    ## Similar to `fetchBodiesRlpxTimeout`.
+
   nProcBlocksErrThreshold* = 2
     ## Similar to `nStashHeadersErrThreshold`.
 

--- a/execution_chain/sync/beacon/worker/worker_desc.nim
+++ b/execution_chain/sync/beacon/worker/worker_desc.nim
@@ -13,6 +13,7 @@
 import
   std/[sets, sequtils],
   pkg/[chronos, eth/common, results],
+  pkg/eth/common/block_access_lists,
   pkg/stew/[interval_set, sorted_set],
   ../../../core/chain,
   ../../[sync_desc, wire_protocol],
@@ -86,6 +87,9 @@ type
   BlocksForImport* = object
     ## Blocks list item indexed by least block number (i.e. by `blocks[0]`.)
     blocks*: seq[EthBlock]           ## List of blocks lineage for import
+    bals*: seq[Opt[BlockAccessListRef]]
+                                     ## Optional block access lists (EIP-7928),
+                                     ## aligned by index with `blocks`.
     peerID*: Hash                    ## For comparing peers
 
   # -------------------

--- a/tests/networking/test_devp2p_eth71.nim
+++ b/tests/networking/test_devp2p_eth71.nim
@@ -15,10 +15,12 @@ import
   testutils,
   chronos,
   eth/[common, rlp],
+  eth/common/block_access_lists_rlp,
   stew/endians2,
   ../../execution_chain/networking/p2p,
   ../../execution_chain/sync/wire_protocol,
   ../../execution_chain/sync/wire_protocol/eth/eth_handler {.all.},
+  ../../execution_chain/sync/beacon/worker/blocks/blocks_bal,
   ../../execution_chain/core/chain/forked_chain,
   ../../execution_chain/db/core_db,
   ../../execution_chain/db/core_db/core_apps,
@@ -396,3 +398,68 @@ procSuite "devp2p eth/71 Tests":
 
     env2.close()
     env1.close()
+
+# Unit tests for the sync-side decoding of block access lists fetched from
+# peers (`blocks_bal.decodeBlockAccessList`). A peer-supplied list is only
+# trusted when it matches the hash committed in the (already validated) header.
+suite "eth/71 sync block access list decoding":
+
+  func balWithAddress(addrHex: string): BlockAccessList =
+    result = newSeq[AccountChanges](1)
+    result[0].address = Address.fromHex(addrHex)
+
+  func headerForBal(bal: BlockAccessList): Header =
+    Header(blockAccessListHash: Opt.some(computeBlockAccessListHash(bal)))
+
+  test "unavailable marker (0x80) decodes to none":
+    let header = headerForBal(default(BlockAccessList))
+    check decodeBlockAccessList(
+      RawBlockAccessList(UNAVAILABLE_BAL_BYTES), header).isNone()
+
+  test "empty raw bytes decode to none":
+    let header = headerForBal(default(BlockAccessList))
+    check decodeBlockAccessList(
+      RawBlockAccessList(newSeq[byte](0)), header).isNone()
+
+  test "header without a bal hash decodes to none":
+    let
+      bal = balWithAddress("0x1234567890123456789012345678901234567890")
+      raw = RawBlockAccessList(rlp.encode(bal))
+      header = Header(blockAccessListHash: Opt.none(Hash32))
+    check decodeBlockAccessList(raw, header).isNone()
+
+  test "valid empty bal (0xC0) decodes to an empty list":
+    let
+      bal = default(BlockAccessList)
+      raw = RawBlockAccessList(rlp.encode(bal))
+      res = decodeBlockAccessList(raw, headerForBal(bal))
+    check:
+      res.isSome()
+      res.get()[] == bal
+
+  test "valid non-empty bal matching the header decodes":
+    let
+      bal = balWithAddress("0x1234567890123456789012345678901234567890")
+      raw = RawBlockAccessList(rlp.encode(bal))
+      res = decodeBlockAccessList(raw, headerForBal(bal))
+    check:
+      res.isSome()
+      res.get()[] == bal
+
+  test "bal not matching the header hash is rejected":
+    let
+      bal = balWithAddress("0x1234567890123456789012345678901234567890")
+      otherBal = balWithAddress("0x2222222222222222222222222222222222222222")
+      raw = RawBlockAccessList(rlp.encode(bal))
+      # The header commits to a different list, so the peer-supplied one must be
+      # discarded - otherwise a bad peer could stall syncing.
+      header = headerForBal(otherBal)
+    check decodeBlockAccessList(raw, header).isNone()
+
+  test "malformed rlp decodes to none":
+    let
+      bal = balWithAddress("0x1234567890123456789012345678901234567890")
+      header = headerForBal(bal)
+      # A valid RLP string item where a list (the access list) is expected.
+      raw = RawBlockAccessList(@[0x82'u8, 0x12, 0x34])
+    check decodeBlockAccessList(raw, header).isNone()

--- a/tests/test_block_access_list/test_block_access_list_utils.nim
+++ b/tests/test_block_access_list/test_block_access_list_utils.nim
@@ -12,7 +12,8 @@
 
 import
   unittest2,
-  eth/common/block_access_lists,
+  results,
+  eth/common/[block_access_lists, headers],
   ../../execution_chain/block_access_list/block_access_list_utils
 
 func accountChanges(address: Address): AccountChanges =
@@ -192,3 +193,63 @@ suite "Block access list utils":
       nonceChanges.findLastWriteBefore(0) == -1
       nonceChanges.findLastWriteBefore(1) == 0
       nonceChanges.findLastWriteBefore(5) == 1
+
+suite "Block access list retention period":
+  # isWithinBalRetentionPeriod is true iff the block falls within the last
+  # BAL_RETENTION_EPOCHS (3533) epochs of the head slot. An epoch is
+  # SLOTS_PER_EPOCH (32) slots, so the retention window is 3533 * 32 = 113056
+  # slots, but the boundary is on the epoch (slot div 32), not the raw slot.
+
+  func headerWithSlot(slot: uint64): Header =
+    Header(slotNumber: Opt.some(slot))
+
+  const retentionSlots = BAL_RETENTION_EPOCHS * SLOTS_PER_EPOCH # 113056
+
+  test "a pre-Amsterdam header (no slot number) is never within retention":
+    let header = Header(slotNumber: Opt.none(uint64))
+    check:
+      not header.isWithinBalRetentionPeriod(0)
+      not header.isWithinBalRetentionPeriod(1_000_000)
+
+  test "current and future blocks are within the retention period":
+    const headSlot = 1_000_000'u64
+    check:
+      headerWithSlot(headSlot).isWithinBalRetentionPeriod(headSlot)       # head itself
+      headerWithSlot(headSlot - 1).isWithinBalRetentionPeriod(headSlot)   # just behind
+      headerWithSlot(headSlot + 1).isWithinBalRetentionPeriod(headSlot)   # ahead, no underflow
+      headerWithSlot(headSlot + retentionSlots).isWithinBalRetentionPeriod(headSlot)
+
+  test "the oldest in-window epoch is retained, the next one out is pruned":
+    # Epoch-aligned head so the boundary is exact: head epoch is 4000, so the
+    # oldest retained epoch is 4000 - (3533 - 1) = 468 and epoch 467 is pruned.
+    const headSlot = 4000'u64 * SLOTS_PER_EPOCH
+    check:
+      # First and last slot of the oldest retained epoch (468).
+      headerWithSlot(468'u64 * SLOTS_PER_EPOCH).isWithinBalRetentionPeriod(headSlot)
+      headerWithSlot(468'u64 * SLOTS_PER_EPOCH + (SLOTS_PER_EPOCH - 1))
+        .isWithinBalRetentionPeriod(headSlot)
+      # First and last slot of the first pruned epoch (467), and the genesis slot.
+      not headerWithSlot(467'u64 * SLOTS_PER_EPOCH).isWithinBalRetentionPeriod(headSlot)
+      not headerWithSlot(467'u64 * SLOTS_PER_EPOCH + (SLOTS_PER_EPOCH - 1))
+        .isWithinBalRetentionPeriod(headSlot)
+      not headerWithSlot(0).isWithinBalRetentionPeriod(headSlot)
+
+  test "a block exactly the retention window back is pruned":
+    const headSlot = 1_000_000'u64 # head epoch 31250
+    let blockSlot = headSlot - retentionSlots # 886944, epoch 27717
+    check:
+      not headerWithSlot(blockSlot).isWithinBalRetentionPeriod(headSlot)
+      # One epoch newer is retained.
+      headerWithSlot(blockSlot + SLOTS_PER_EPOCH).isWithinBalRetentionPeriod(headSlot)
+
+  test "the boundary is by epoch, not raw slot distance":
+    # Mid-epoch head (epoch 5000). A block in epoch 1467 is exactly 3533 epochs
+    # back and pruned even though it is fewer than `retentionSlots` slots behind.
+    const headSlot = 5000'u64 * SLOTS_PER_EPOCH + 5
+    let
+      prunedSlot = 1467'u64 * SLOTS_PER_EPOCH + (SLOTS_PER_EPOCH - 1) # epoch 1467
+      retainedSlot = 1468'u64 * SLOTS_PER_EPOCH                       # epoch 1468
+    check:
+      headSlot - prunedSlot < retentionSlots # closer than the window, yet ...
+      not headerWithSlot(prunedSlot).isWithinBalRetentionPeriod(headSlot) # ... pruned
+      headerWithSlot(retainedSlot).isWithinBalRetentionPeriod(headSlot)


### PR DESCRIPTION
This updates the sync code to fetch BALs for Amsterdam blocks via devp2p eth/71. It makes sense to support this since we now support state prefetching using BALs.

Only BALs within the BAL retention period (which is defined in EIP-7928 as 3533 epochs from head) are fetched.