### PR TITLE
stateless: validate and use StatelessInput in eest blockchain tests

### DIFF
--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -130,8 +130,8 @@ proc processBlock*(
     # Convert the witness to ExecutionWitness format and verify against the pre-stateroot.
     if vmState.com.statelessWitnessValidation:
       doAssert witness.validateKeys(vmState.ledger.getWitnessKeys()).isOk()
-      let executionWitness = ExecutionWitness.build(witness, vmState.ledger)
-      ?executionWitness.statelessProcessBlock(c.com, blk)
+      let executionWitness = ExecutionWitnessWithKeys.build(witness, vmState.ledger)
+      ?executionWitness.toExecutionWitness().statelessProcessBlock(c.com, blk)
 
     ?vmState.ledger.txFrame.persistWitness(blkHash, witness)
 

--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -201,8 +201,8 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
     # Convert the witness to ExecutionWitness format and verify against the pre-stateroot.
     if vmState.com.statelessWitnessValidation:
       doAssert witness.validateKeys(vmState.ledger.getWitnessKeys()).isOk()
-      let executionWitness = ExecutionWitness.build(witness, vmState.ledger)
-      ?executionWitness.statelessProcessBlock(com, blk)
+      let executionWitness = ExecutionWitnessWithKeys.build(witness, vmState.ledger)
+      ?executionWitness.toExecutionWitness().statelessProcessBlock(com, blk)
 
     ?vmState.ledger.txFrame.persistWitness(header.computeBlockHash(), witness)
 

--- a/execution_chain/rpc/debug.nim
+++ b/execution_chain/rpc/debug.nim
@@ -39,7 +39,7 @@ BadBlock.useDefaultSerializationIn EthJson
 
 TestBlockSummary.useDefaultSerializationIn EthJson
 
-ExecutionWitness.useDefaultSerializationIn EthJson
+ExecutionWitnessWithKeys.useDefaultSerializationIn EthJson
 
 #type
 #   TraceOptions = object
@@ -63,7 +63,7 @@ ExecutionWitness.useDefaultSerializationIn EthJson
 #     if opts.disableState.isTrue  : result.incl TracerFlags.DisableState
 #     if opts.disableStateDiff.isTrue: result.incl TracerFlags.DisableStateDiff
 
-proc getExecutionWitness*(chain: ForkedChainRef, blockHash: Hash32): Result[ExecutionWitness, string] =
+proc getExecutionWitness*(chain: ForkedChainRef, blockHash: Hash32): Result[ExecutionWitnessWithKeys, string] =
   let txFrame = chain.txFrame(blockHash).txFrameBegin()
   defer:
     txFrame.dispose()
@@ -71,7 +71,7 @@ proc getExecutionWitness*(chain: ForkedChainRef, blockHash: Hash32): Result[Exec
   let witness = txFrame.getWitness(blockHash).valueOr:
     return err("Witness not found")
 
-  ok(ExecutionWitness.build(witness, txFrame))
+  ok(ExecutionWitnessWithKeys.build(witness, txFrame))
 
 proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
   let
@@ -259,7 +259,7 @@ proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
 
     # Execution Witness endpoints - not specified in the Execution API
 
-    proc debug_executionWitness(quantityTag: BlockTag): ExecutionWitness {.raises: [ValueError].} =
+    proc debug_executionWitness(quantityTag: BlockTag): ExecutionWitnessWithKeys {.raises: [ValueError].} =
       ## Returns an execution witness for the given block number.
       let header = chain.headerFromTag(quantityTag).valueOr:
         raise newException(ValueError, "Header not found")
@@ -267,7 +267,7 @@ proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
       chain.getExecutionWitness(header.computeBlockHash()).valueOr:
         raise newException(ValueError, error)
 
-    proc debug_executionWitnessByBlockHash(blockHash: Hash32): ExecutionWitness {.raises: [ValueError].} =
+    proc debug_executionWitnessByBlockHash(blockHash: Hash32): ExecutionWitnessWithKeys {.raises: [ValueError].} =
       ## Returns an execution witness for the given block hash.
       chain.getExecutionWitness(blockHash).valueOr:
         raise newException(ValueError, error)

--- a/execution_chain/stateless/stateless_execution.nim
+++ b/execution_chain/stateless/stateless_execution.nim
@@ -19,12 +19,22 @@ import
   ../db/core_db/memory_only,
   ../evm/[types, state],
   ../core/executor/process_block,
-  ./[witness_types, witness_verification]
+  ./[witness_types, witness_verification, stateless_types]
 
-export witness_types, common, headers, blocks, results
+export witness_types, stateless_types, common, headers, blocks, results
+
+func toExecutionWitness*(w: ExecutionWitnessWithKeys): ExecutionWitness =
+  var res: ExecutionWitness
+  for node in w.state:
+    discard res.state.add(ByteList[MAX_BYTES_PER_WITNESS_NODE].init(node))
+  for code in w.codes:
+    discard res.codes.add(ByteList[MAX_BYTES_PER_CODE].init(code))
+  for header in w.headers:
+    discard res.headers.add(ByteList[MAX_BYTES_PER_HEADER].init(header))
+  res
 
 proc statelessProcessBlock*(
-    witness: ExecutionWitness, com: CommonRef, blk: Block, verifyState = false
+    witness: ExecutionWitness, com: CommonRef, blk: Block
 ): Result[void, string] =
   let
     verifiedHeaders = ?witness.verifyHeaders(blk.header)
@@ -32,15 +42,10 @@ proc statelessProcessBlock*(
     parent = verifiedHeaders[^1] # The last header is the parent
     preStateRoot = parent.stateRoot
 
-  if verifyState:
-    # Verify the witness against the parent header stateroot.
-    # This validates the state against the keys, the code and headers in the witness.
-    ?witness.verifyState(preStateRoot)
-
   # Convert the list of trie nodes into a table keyed by node hash.
   var nodes: Table[Hash32, seq[byte]]
   for n in witness.state:
-    nodes[keccak256(n)] = n
+    nodes[keccak256(n.asSeq())] = n.asSeq()
 
   # Create an empty in memory database.
   let
@@ -57,7 +62,7 @@ proc statelessProcessBlock*(
 
   # Load the contract code into the database indexed by code hash.
   for c in witness.codes:
-    doAssert memoryTxFrame.persistCodeByHash(keccak256(c), c).isOk()
+    doAssert memoryTxFrame.persistCodeByHash(keccak256(c.asSeq()), c.asSeq()).isOk()
 
   # Load the block hashes into the database indexed by block number.
   for h in verifiedHeaders:

--- a/execution_chain/stateless/stateless_execution_helpers.nim
+++ b/execution_chain/stateless/stateless_execution_helpers.nim
@@ -19,7 +19,7 @@ from ../../hive_integration/engine_client import toBlockHeader, toTransactions
 
 export stateless_execution
 
-ExecutionWitness.useDefaultSerializationIn EthJson
+ExecutionWitnessWithKeys.useDefaultSerializationIn EthJson
 
 proc readFileToStr*(filePath: string): Result[string, string] =
   let fileStr = io2.readAllChars(filePath).valueOr:
@@ -32,7 +32,7 @@ func toBytes*(hexStr: string): Result[seq[byte], string] =
   except ValueError as e:
     err("Error converting hex string to bytes: " & e.msg)
 
-func decodeJson*(T: type ExecutionWitness, jsonStr: string): Result[T, string] =
+func decodeJson*(T: type ExecutionWitnessWithKeys, jsonStr: string): Result[T, string] =
   try:
     ok(EthJson.decode(jsonStr, T))
   except SerializationError as e:
@@ -54,7 +54,7 @@ func toBlock*(blockObject: BlockObject): Block =
   )
 
 func decodeRlp*(
-    T: type ExecutionWitness, rlpBytes: openArray[byte]
+    T: type ExecutionWitnessWithKeys, rlpBytes: openArray[byte]
 ): Result[T, string] =
   try:
     ok(rlp.decode(rlpBytes, T))
@@ -71,9 +71,9 @@ proc statelessProcessBlockRlp*(
     witnessRlpBytes: openArray[byte], com: CommonRef, blkRlpBytes: openArray[byte]
 ): Result[void, string] =
   let
-    witness = ?ExecutionWitness.decodeRlp(witnessRlpBytes)
+    witness = ?ExecutionWitnessWithKeys.decodeRlp(witnessRlpBytes)
     blk = ?Block.decodeRlp(blkRlpBytes)
-  statelessProcessBlock(witness, com, blk)
+  statelessProcessBlock(witness.toExecutionWitness(), com, blk)
 
 proc statelessProcessBlockRlp*(
     witnessRlpStr: string, com: CommonRef, blkRlpStr: string
@@ -87,9 +87,9 @@ proc statelessProcessBlockJson*(
     witnessJson: string, com: CommonRef, blkJson: string
 ): Result[void, string] =
   let
-    witness = ?ExecutionWitness.decodeJson(witnessJson)
+    witness = ?ExecutionWitnessWithKeys.decodeJson(witnessJson)
     blkObject = ?BlockObject.decodeJson(blkJson)
-  statelessProcessBlock(witness, com, blkObject.toBlock())
+  statelessProcessBlock(witness.toExecutionWitness(), com, blkObject.toBlock())
 
 proc statelessProcessBlockJsonFiles*(
     witnessJsonFilePath: string, com: CommonRef, blockJsonFilePath: string

--- a/execution_chain/stateless/stateless_guest.nim
+++ b/execution_chain/stateless/stateless_guest.nim
@@ -1,0 +1,33 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [], gcsafe.}
+
+import stew/[byteutils, endians2], ./stateless_types
+
+export stateless_types
+
+# https://github.com/ethereum/execution-specs/blob/f03c2e0af2df95cd2eed029ba4ea7140acd028c7/src/ethereum/forks/amsterdam/stateless_guest.py#L36
+func deserialize_stateless_input*(
+    data: openArray[byte]
+): Result[StatelessInput, string] =
+  if data.len < STATELESS_INPUT_SCHEMA_ID_SIZE:
+    return err("Stateless input is missing schema id")
+  let schema_id = uint16.fromBytesBE(data.toOpenArray(0, 1))
+  if schema_id != STATELESS_INPUT_SCHEMA_ID:
+    return
+      err("Unsupported stateless input schema id: " & schema_id.toBytesBE().to0xHex())
+  try:
+    ok(
+      SSZ.decode(
+        data.toOpenArray(STATELESS_INPUT_SCHEMA_ID_SIZE, data.high), StatelessInput
+      )
+    )
+  except SerializationError as e:
+    err("Failed to deserialize StatelessInput: " & e.msg)

--- a/execution_chain/stateless/stateless_types.nim
+++ b/execution_chain/stateless/stateless_types.nim
@@ -9,16 +9,85 @@
 
 {.push raises: [], gcsafe.}
 
-import ssz_serialization
+import ssz_serialization, beacon_chain/spec/ssz_codec
 
-export ssz_serialization
+from beacon_chain/spec/datatypes/gloas import ExecutionPayload
+from beacon_chain/spec/datatypes/electra import ExecutionRequests
+from ../common/hardforks import BlobSchedule
+
+export ssz_serialization, ssz_codec
+
+# ---------------------------------------------------------------------------
+# SSZ max-length constants
+# ---------------------------------------------------------------------------
+
+# As per spec:
+# https://github.com/ethereum/execution-specs/blob/f03c2e0af2df95cd2eed029ba4ea7140acd028c7/src/ethereum/forks/amsterdam/stateless_ssz.py#L41
+#
+# Not all consts are defined here as we get some of the types from beacon_chain datatypes
+
+const
+  MAX_BLOB_COMMITMENTS_PER_BLOCK* = 4096
+  MAX_WITNESS_NODES* = 1 shl 22 # 2^22
+  MAX_WITNESS_CODES* = 1 shl 18 # 2^18
+  MAX_WITNESS_HEADERS* = 256
+  # Should be 2^16 but there are test vectors that violate this limit
+  # MAX_BYTES_PER_CODE* = 1 shl 16            # 2^16
+  MAX_BYTES_PER_CODE* = 1 shl 17 # 2^17
+  MAX_BYTES_PER_HEADER* = 1 shl 10 # 2^10
+  MAX_BYTES_PER_WITNESS_NODE* = 1 shl 10 # 2^10
+  MAX_OPTIONAL_FORK_ACTIVATION_VALUES* = 1
+  MAX_BLOB_SCHEDULES_PER_FORK* = 1
+  MAX_PUBLIC_KEYS* = 1 shl 15 # 2^15
+  PUBLIC_KEY_BYTES* = 65
+
+  # Amsterdam SSZ stateless input schema identifier.
+  STATELESS_INPUT_SCHEMA_ID* = 0x0001'u16
+  STATELESS_INPUT_SCHEMA_ID_SIZE* = 2
+
+# ---------------------------------------------------------------------------
+# SSZ container types
+# ---------------------------------------------------------------------------
+
+# As per spec:
+# https://github.com/ethereum/execution-specs/blob/f03c2e0af2df95cd2eed029ba4ea7140acd028c7/src/ethereum/forks/amsterdam/stateless_ssz.py#L96
+#
+# Not all types are defined here as we get some of the types from beacon_chain datatypes
 
 type
-  # https://github.com/ethereum/execution-specs/blob/e2ff4cc00ca94cb5872090e0f813894e231f6be3/src/ethereum/forks/amsterdam/stateless.py#L82
-  StatelessChainConfig = object
-    chain_id*: uint64
+  NewPayloadRequest* = object
+    executionPayload*: ExecutionPayload
+    versionedHashes*: List[Digest, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    parentBeaconBlockRoot*: Digest
+    executionRequests*: ExecutionRequests
 
-  # https://github.com/ethereum/execution-specs/blob/e2ff4cc00ca94cb5872090e0f813894e231f6be3/src/ethereum/forks/amsterdam/stateless.py#L126
+  ExecutionWitness* = object
+    state*: List[ByteList[MAX_BYTES_PER_WITNESS_NODE], MAX_WITNESS_NODES]
+    codes*: List[ByteList[MAX_BYTES_PER_CODE], MAX_WITNESS_CODES]
+    headers*: List[ByteList[MAX_BYTES_PER_HEADER], MAX_WITNESS_HEADERS]
+
+  # Optional uint64 encoded as a List of 0 or 1 elements.
+  ForkActivation* = object
+    block_number*: List[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES]
+    timestamp*: List[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES]
+
+  # Optional BlobSchedule encoded as a List of 0 or 1 elements.
+  ForkConfig* = object
+    fork*: uint64
+    activation*: ForkActivation
+    blob_schedule*: List[BlobSchedule, MAX_BLOB_SCHEDULES_PER_FORK]
+
+  # Note: named `StatelessChainConfig` to avoid name collision with EL `ChainConfig`
+  StatelessChainConfig* = object
+    chain_id*: uint64
+    active_fork*: ForkConfig
+
+  StatelessInput* = object
+    new_payload_request*: NewPayloadRequest
+    witness*: ExecutionWitness
+    chain_config*: StatelessChainConfig
+    public_keys*: List[ByteVector[PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS]
+
   StatelessValidationResult* = object
     new_payload_request_root*: Digest
     successful_validation*: bool

--- a/execution_chain/stateless/witness_generation.nim
+++ b/execution_chain/stateless/witness_generation.nim
@@ -137,8 +137,8 @@ proc build*(
   witness
 
 proc build*(
-    T: type ExecutionWitness, witness: Witness, txFrame: CoreDbTxRef
-): ExecutionWitness =
+    T: type ExecutionWitnessWithKeys, witness: Witness, txFrame: CoreDbTxRef
+): ExecutionWitnessWithKeys =
   var codes: seq[seq[byte]]
   for codeHash in witness.codeHashes:
     let code = txFrame.getCodeByHash(codeHash).valueOr:
@@ -155,7 +155,7 @@ proc build*(
       raiseAssert "Header not found"
     headers.add(rlp.encode(header))
 
-  ExecutionWitness.init(
+  ExecutionWitnessWithKeys.init(
     state = witness.state,
     codes = move(codes),
     keys = witness.keys,
@@ -163,6 +163,6 @@ proc build*(
   )
 
 template build*(
-    T: type ExecutionWitness, witness: Witness, ledger: LedgerRef
-): ExecutionWitness =
+    T: type ExecutionWitnessWithKeys, witness: Witness, ledger: LedgerRef
+): ExecutionWitnessWithKeys =
   T.build(witness, ledger.txFrame)

--- a/execution_chain/stateless/witness_types.nim
+++ b/execution_chain/stateless/witness_types.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2025 Status Research & Development GmbH
+# Copyright (c) 2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -22,7 +22,9 @@ type
     headerHashes*: seq[Hash32]
       # Hashes of block headers which are required by the witness.
 
-  ExecutionWitness* = object
+  # Note: Currently used only for the JSON-RPC debug_executionWitness API.
+  # May be removed if that API gets dropped in the future.
+  ExecutionWitnessWithKeys* = object
     state*: seq[seq[byte]] # MPT trie nodes accessed while executing the block.
     codes*: seq[seq[byte]] # Contract bytecodes read while executing the block.
     keys*: seq[seq[byte]]
@@ -63,31 +65,31 @@ func decode*(T: type Witness, witnessBytes: openArray[byte]): Result[T, string] 
     err(e.msg)
 
 func init*(
-    T: type ExecutionWitness,
+    T: type ExecutionWitnessWithKeys,
     state = newSeq[seq[byte]](),
     codes = newSeq[seq[byte]](),
     keys = newSeq[seq[byte]](),
     headers = newSeq[seq[byte]](),
 ): T =
-  ExecutionWitness(state: state, codes: codes, keys: keys, headers: headers)
+  ExecutionWitnessWithKeys(state: state, codes: codes, keys: keys, headers: headers)
 
-template addState*(witness: var ExecutionWitness, trieNode: seq[byte]) =
+template addState*(witness: var ExecutionWitnessWithKeys, trieNode: seq[byte]) =
   witness.state.add(trieNode)
 
-template addCode*(witness: var ExecutionWitness, code: seq[byte]) =
+template addCode*(witness: var ExecutionWitnessWithKeys, code: seq[byte]) =
   witness.codes.add(code)
 
-template addKey*(witness: var ExecutionWitness, key: seq[byte]) =
+template addKey*(witness: var ExecutionWitnessWithKeys, key: seq[byte]) =
   witness.keys.add(key)
 
-template addHeader*(witness: var ExecutionWitness, header: seq[byte]) =
+template addHeader*(witness: var ExecutionWitnessWithKeys, header: seq[byte]) =
   witness.headers.add(header)
 
-func encode*(witness: ExecutionWitness): seq[byte] =
+func encode*(witness: ExecutionWitnessWithKeys): seq[byte] =
   rlp.encode(witness)
 
 func decode*(
-    T: type ExecutionWitness, witnessBytes: openArray[byte]
+    T: type ExecutionWitnessWithKeys, witnessBytes: openArray[byte]
 ): Result[T, string] =
   try:
     ok(rlp.decode(witnessBytes, T))

--- a/execution_chain/stateless/witness_verification.nim
+++ b/execution_chain/stateless/witness_verification.nim
@@ -14,7 +14,7 @@ import
   eth/common,
   ../db/ledger,
   ../db/aristo/aristo_proof,
-  ./witness_types
+  ./[witness_types, stateless_types]
 
 template isAddress(bytes: openArray[byte]): bool =
   bytes.len() == 20
@@ -84,9 +84,9 @@ func verifyHeaders*(
 
   # Rlp decode the headers in the witness
   var headers: seq[Header]
-  for header in witness.headers:
+  for h in witness.headers:
     try:
-      headers.add(rlp.decode(header, Header))
+      headers.add(rlp.decode(h.asSeq(), Header))
     except RlpError as e:
       return err("Failed to decode header in witness: " & e.msg)
 
@@ -113,7 +113,7 @@ func verifyHeaders*(
   ok(headers)
 
 func verifyState*(
-    witness: ExecutionWitness, preStateRoot: Hash32
+    witness: ExecutionWitnessWithKeys, preStateRoot: Hash32
 ): Result[void, string] =
   # Short path for emptyRoot -> empty trie: no accounts exist in the pre-state,
   # nothing to verify.

--- a/tests/eest/eest_blockchain.nim
+++ b/tests/eest/eest_blockchain.nim
@@ -30,32 +30,35 @@ import
   ../../execution_chain/stateless/witness_types,
   ../../execution_chain/stateless/stateless_types,
   ../../execution_chain/stateless/stateless_execution,
+  ../../execution_chain/stateless/stateless_guest,
   ../../hive_integration/engine_client,
   ./eest_helpers,
   ./bal_parser
 
 from ../../execution_chain/rpc/debug import getExecutionWitness
 
-proc hexListToSeqByteList(n: JsonNode, field: string): seq[seq[byte]] =
-  var res: seq[seq[byte]]
-  for item in n[field]:
-    res.add hexToSeqByte(item.getStr)
-
-  res
-
 proc fromJson(T: type ExecutionWitness, n: JsonNode): ExecutionWitness =
-  ExecutionWitness(
-    state: hexListToSeqByteList(n, "state"),
-    codes: hexListToSeqByteList(n, "codes"),
-    keys: if "keys" in n: hexListToSeqByteList(n, "keys") else: @[],
-    headers: hexListToSeqByteList(n, "headers")
-  )
+  var res: ExecutionWitness
+  for item in n["state"]:
+    discard res.state.add(ByteList[MAX_BYTES_PER_WITNESS_NODE].init(hexToSeqByte(item.getStr)))
+  for item in n["codes"]:
+    discard res.codes.add(ByteList[MAX_BYTES_PER_CODE].init(hexToSeqByte(item.getStr)))
+  if "headers" in n:
+    for item in n["headers"]:
+      discard res.headers.add(ByteList[MAX_BYTES_PER_HEADER].init(hexToSeqByte(item.getStr)))
+  res
 
 proc parseWitness(node: JsonNode): Opt[ExecutionWitness] =
   if "executionWitness" in node:
     Opt.some(ExecutionWitness.fromJson(node["executionWitness"]))
   else:
     Opt.none(ExecutionWitness)
+
+proc parseStatelessInput(node: JsonNode): Opt[StatelessInput] =
+  if "statelessInputBytes" notin node:
+    return Opt.none(StatelessInput)
+
+  deserialize_stateless_input(hexToSeqByte(node["statelessInputBytes"].getStr)).optValue()
 
 proc parseStatelessOutput(node: JsonNode): Opt[StatelessValidationResult] =
   if "statelessOutputBytes" in node:
@@ -101,6 +104,7 @@ proc parseBlocks*(node: JsonNode): seq[BlockDesc] =
         bal: parseBAL(x),
         badBlock: "expectException" in x,
         witness: parseWitness(x),
+        statelessInput: parseStatelessInput(x),
         statelessValidationResult: parseStatelessOutput(x)
       )
     except RlpError:
@@ -116,45 +120,33 @@ proc rootExists(db: CoreDbTxRef; root: Hash32): bool =
 proc shortLog(witness: ExecutionWitness): string =
   var res = "ExecutionWitness:\n"
   res.add "State:\n"
-  for stateNode in witness.state:
-    res.add stateNode.to0xHex() & "\n"
+  for node in witness.state:
+    res.add node.asSeq().to0xHex() & "\n"
   res.add "Codes:\n"
-  for codeNode in witness.codes:
-    res.add codeNode.to0xHex() & "\n"
+  for code in witness.codes:
+    res.add code.asSeq().to0xHex() & "\n"
   res.add "Headers:\n"
-  for headerNode in witness.headers:
-    res.add headerNode.to0xHex() & "\n"
+  for header in witness.headers:
+    res.add header.asSeq().to0xHex() & "\n"
   res
 
 proc compare(
     generated, expected: ExecutionWitness, strict = false
 ): Result[void, string] =
-  ## Compare witness state, nodes and headers, not comparing keys as these
-  ## are not included in the test vectors.
-  ## When strict is false, allow generated witness state, codes and headers to
-  ## be a subset of expected. This is because some test vectors include extra
-  ## unused state nodes, code and headers in the witness to test that stateless
-  ## execution still works. Same counts for the lexicographical order.
+  ## Compare witness state, codes and headers.
+  ## When strict is true the witnesses must be identical.
+  ## When strict is false, allow generated to be a subset of expected.
+  ## This is because some test vectors include extra unused state nodes,
+  ## code and headers in the witness to test that stateless execution
+  ## still works. Same counts for the lexicographical order.
 
   if strict:
-    # when strict enabled, also compare state and codes to be identical
-    if generated.state != expected.state:
+    if generated != expected:
       return err(
-        "Witness state mismatch, got: " & $generated.shortLog & " expected: " &
-          $expected.shortLog
-      )
-    if generated.codes != expected.codes:
-      return err(
-        "Witness codes mismatch, got: " & $generated.shortLog & " expected: " &
-          $expected.shortLog
-      )
-    if generated.headers != expected.headers:
-      return err(
-        "Witness headers mismatch, got: " & $generated.shortLog & " expected: " &
-          $expected.shortLog
+        "Witness mismatch, got: " & $generated.shortLog &
+          " expected: " & $expected.shortLog
       )
   else:
-    # else allow them just to be a subset of expected
     for node in generated.state:
       if node notin expected.state:
         return err(
@@ -192,11 +184,13 @@ proc runTest(env: TestEnv, unit: BlockchainUnitEnv, statelessEnabled = false): F
       else:
         if statelessEnabled:
           # Get witness that should have been generated when importing the block
-          var witness = env.chain.getExecutionWitness(blk.blk.header.computeRlpHash).valueOr:
-            return err("Execution witness was not found in the database")
+          let
+            witness = env.chain.getExecutionWitness(blk.blk.header.computeRlpHash).valueOr:
+              return err("Execution witness was not found in the database")
+            generatedWitness = witness.toExecutionWitness()
 
-          # process block stateless with generated witness
-          ?witness.statelessProcessBlock(env.chain.com, blk.blk, verifyState = true)
+          # Process block stateless with generated witness
+          ?generatedWitness.statelessProcessBlock(env.chain.com, blk.blk)
 
           let successful_validation =
             if blk.statelessValidationResult.isSome():
@@ -204,14 +198,18 @@ proc runTest(env: TestEnv, unit: BlockchainUnitEnv, statelessEnabled = false): F
             else:
               true
 
-          if blk.witness.isSome() and successful_validation:
-            # If block witness in test vector and validation is successful,
-            # process block stateless with test vector witness
-            let expectedWitness = blk.witness.value()
-            ?expectedWitness.statelessProcessBlock(env.chain.com, blk.blk)
+          if blk.statelessInput.isSome() and successful_validation:
+            let statelessInput = blk.statelessInput.get()
 
-            # compare both witnesses
-            ?compare(witness, expectedWitness)
+            # generated witness must be a subset of the statelessInput witness
+            ?compare(generatedWitness, statelessInput.witness)
+
+            # statelessInput witness must exactly match the JSON witness
+            if blk.witness.isSome():
+              ?compare(statelessInput.witness, blk.witness.get(), strict = true)
+
+            # Execute block stateless with the statelessInput witness
+            ?statelessInput.witness.statelessProcessBlock(env.chain.com, blk.blk)
     else:
       if not blk.badBlock:
         return err("Good block was rejected at import: " & res.error)

--- a/tests/eest/eest_helpers.nim
+++ b/tests/eest/eest_helpers.nim
@@ -76,6 +76,7 @@ type
     badBlock*: bool
     bal*: Opt[BlockAccessListRef]
     witness*: Opt[ExecutionWitness]
+    statelessInput*: Opt[StatelessInput]
     statelessValidationResult*: Opt[StatelessValidationResult]
 
   Numero* = distinct uint64

--- a/tests/test_stateless/test_stateless_execution.nim
+++ b/tests/test_stateless/test_stateless_execution.nim
@@ -48,8 +48,8 @@ procSuite "Stateless Execution Tests":
 
       let witness = fc.getExecutionWitness(blk.header.computeBlockHash()).expect("ok")
       check:
-        statelessProcessBlock(witness, com, blk).isOk()
-        statelessProcessBlock(witness, networkId, blk).isOk()
+        statelessProcessBlock(witness.toExecutionWitness(), com, blk).isOk()
+        statelessProcessBlock(witness.toExecutionWitness(), networkId, blk).isOk()
 
       let
         witnessRlpBytes = witness.encode()

--- a/tests/test_stateless/test_stateless_witness_types.nim
+++ b/tests/test_stateless/test_stateless_witness_types.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2025 Status Research & Development GmbH
+# Copyright (c) 2025-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -42,19 +42,19 @@ suite "Stateless: Witness Types":
       decodedWitness.isOk()
       decodedWitness.get() == witness
 
-  test "Encoding/decoding empty ExecutionWitness":
-    var witness: ExecutionWitness
+  test "Encoding/decoding empty ExecutionWitnessWithKeys":
+    var witness: ExecutionWitnessWithKeys
 
     let witnessBytes = witness.encode()
     check witnessBytes.len() > 0
 
-    let decodedWitness = ExecutionWitness.decode(witnessBytes)
+    let decodedWitness = ExecutionWitnessWithKeys.decode(witnessBytes)
     check:
       decodedWitness.isOk()
       decodedWitness.get() == witness
 
-  test "Encoding/decoding ExecutionWitness":
-    var witness = ExecutionWitness.init()
+  test "Encoding/decoding ExecutionWitnessWithKeys":
+    var witness = ExecutionWitnessWithKeys.init()
     witness.addState(@[0x1.byte, 0x2, 0x3])
     witness.addKey(@[0x7.byte, 0x8, 0x9])
     witness.addCode(@[0x4.byte, 0x5, 0x6])
@@ -63,7 +63,7 @@ suite "Stateless: Witness Types":
     let witnessBytes = witness.encode()
     check witnessBytes.len() > 0
 
-    let decodedWitness = ExecutionWitness.decode(witnessBytes)
+    let decodedWitness = ExecutionWitnessWithKeys.decode(witnessBytes)
     check:
       decodedWitness.isOk()
       decodedWitness.get() == witness

--- a/tests/test_stateless/test_stateless_witness_verification.nim
+++ b/tests/test_stateless/test_stateless_witness_verification.nim
@@ -15,7 +15,7 @@ import
   unittest2,
   ../../execution_chain/db/core_db/memory_only,
   ../../execution_chain/common/common,
-  ../../execution_chain/stateless/[witness_generation, witness_verification]
+  ../../execution_chain/stateless/[witness_generation, witness_verification, stateless_execution]
 
 suite "Stateless: Witness Verification":
   setup:
@@ -70,8 +70,8 @@ suite "Stateless: Witness Verification":
     check witness.validateKeys(witnessKeys).isOk()
 
     let
-      executionWitness = ExecutionWitness.build(witness, ledger)
-      headersRes = executionWitness.verifyHeaders(header4)
+      executionWitness = ExecutionWitnessWithKeys.build(witness, ledger)
+      headersRes = executionWitness.toExecutionWitness().verifyHeaders(header4)
 
     check:
       headersRes.isOk()


### PR DESCRIPTION
A first step toward adopting the stateless guest/host execution spec. Adds StatelessInput and underlying types plus its deserialization as is done in the execution specs. And use this to decode and test the StatelessInput in the test vectors.

Also rename ExecutionWitness to ExecutionWitnessWithKeys which is only used in the JSON-RPC debug API. This might be removed if that API gets dropped in the future.