### PR TITLE
Add precompile result caching / memoization

### DIFF
--- a/execution_chain/concurrency/lru.nim
+++ b/execution_chain/concurrency/lru.nim
@@ -446,6 +446,30 @@ template peek[K, V](s: var LruCache[K, V], key: auto): Opt[V] =
   ## Retrieve item without moving it to the front
   s.peek(subhash(key), key)
 
+proc getPtr[K, V](s: var LruCache[K, V], subhash: uint32, key: auto): ptr V =
+  ## Pointer to the value, moving the item to the front - nil if not found
+  let index = s.tableGet(subhash, key).valueOr:
+    return nil
+  s.moveToFront(index)
+  addr s.nodes[index].value
+
+template getPtr[K, V](s: var LruCache[K, V], key: auto): ptr V =
+  ## Pointer to the value, moving the item to the front - nil if not found
+  s.getPtr(subhash(key), key)
+
+func peekPtr[K, V](s: var LruCache[K, V], subhash: uint32, key: auto): ptr V =
+  ## Pointer to the value without moving the item - nil if not found
+  let index = s.tableGet(subhash, key).valueOr:
+    return nil
+  addr s.nodes[index].value
+
+proc moveToFront(s: var LruCache, subhash: uint32, key: auto) =
+  ## Look up the item by key and move it to the front of the LRU cache - does
+  ## nothing if the key is not present. Unlike `get`, no value is copied out.
+  let index = s.tableGet(subhash, key).valueOr:
+    return
+  s.moveToFront(index)
+
 proc update(s: var LruCache, subhash: uint32, key: auto, value: auto): bool =
   let index = s.tableGet(subhash, key).valueOr:
     return false
@@ -802,10 +826,42 @@ proc get*[K, V](lru: var ConcurrentLruCache[K, V], key: K): Opt[V] =
       inc tlsLruGetCounter
       if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
         s.lock.withWriteLock:
-          discard s.cache.get(sh, key)
+          s.cache.moveToFront(sh, key)
     value
   else:
     lru.cache.get(key)
+
+template withValue*[K, V](
+    lru: var ConcurrentLruCache[K, V], key: K, value, body: untyped
+) =
+  mixin hash
+
+  if lru.threadSafe:
+    let
+      h = hash(key)
+      sh = h.toSubhash()
+      s = addr lru.shards[h.toShardIdx(lru.shardBits)]
+    var promote = false
+
+    # s.lock.lockRead()
+    # try:
+    s.lock.withReadLock:
+      let value {.inject.} = s.cache.peekPtr(sh, key)
+      if value != nil:
+        promote = true
+        body
+    # finally:
+    #   s.lock.unlockRead()
+
+    if promote:
+      inc tlsLruGetCounter
+      if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
+        s.lock.withWriteLock:
+          s.cache.moveToFront(sh, key)
+  else:
+    let value {.inject.} = lru.cache.getPtr(key)
+    if value != nil:
+      body
 
 proc put*[K, V](lru: var ConcurrentLruCache[K, V], key: K, val: V) =
   if lru.threadSafe:

--- a/execution_chain/concurrency/lru.nim
+++ b/execution_chain/concurrency/lru.nim
@@ -837,10 +837,15 @@ type
     subhash: uint32
     shardIdx: int
 
-func toKeyHash*[K, V](lru: ConcurrentLruCache[K, V], key: K): KeyHash =
+func toKeyHash*[K, V](lru: ConcurrentLruCache[K, V], key: auto): KeyHash =
   ## Hash `key` for `lru` once, returning a token to pass to
   ## `withReadValueByHash` / `putByHash` - reuse it for a lookup followed by a
   ## `put` so the key is hashed (and the subhash derived) only once.
+  ##
+  ## `key` may be a borrowed view rather than a `K` (e.g. an `openArray` aliasing
+  ## the bytes of an `ArrayBuf` key) as long as it hashes identically to - and
+  ## compares equal to - the corresponding `K`. This lets a lookup avoid
+  ## materializing the key, copying it only when a miss requires a `put`.
   mixin hash
   let h = hash(key)
   if lru.threadSafe:
@@ -855,8 +860,10 @@ func toLent[T](p: ptr T): lent T =
   p[]
 
 template withReadValueByHash*[K, V](
-    lru: var ConcurrentLruCache[K, V], keyHash: KeyHash, key: K, value, body: untyped
+    lru: var ConcurrentLruCache[K, V], keyHash: KeyHash, key: auto, value, body: untyped
 ) =
+  ## `key` may be a borrowed view that hashes and compares equal to a `K` (see
+  ## `toKeyHash`); `keyHash` must have been derived from the same key.
   if lru.threadSafe:
     let
       sh = keyHash.subhash

--- a/execution_chain/concurrency/lru.nim
+++ b/execution_chain/concurrency/lru.nim
@@ -837,16 +837,13 @@ func toLent[T](p: ptr T): lent T =
   # to a `lent` is a compile error.
   p[]
 
-template withReadValue*[K, V](
-    lru: var ConcurrentLruCache[K, V], key: K, value, body: untyped
+template withReadValueByHash*[K, V](
+    lru: var ConcurrentLruCache[K, V], keyHash: Hash, key: K, value, body: untyped
 ) =
-  mixin hash
-
   if lru.threadSafe:
     let
-      h = hash(key)
-      sh = h.toSubhash()
-      s = addr lru.shards[h.toShardIdx(lru.shardBits)]
+      sh = keyHash.toSubhash()
+      s = addr lru.shards[keyHash.toShardIdx(lru.shardBits)]
     var found = false
 
     s.lock.withReadLock:
@@ -862,21 +859,20 @@ template withReadValue*[K, V](
         s.lock.withWriteLock:
           s.cache.moveToFront(sh, key)
   else:
-    let valuePtr = lru.cache.getPtr(key)
+    let valuePtr = lru.cache.getPtr(keyHash.toSubhash(), key)
     if valuePtr != nil:
       template value(): untyped {.inject.} = toLent(valuePtr)
       body
 
 template withReadValue*[K, V](
-    lru: var ConcurrentLruCache[K, V], key: K, value, body1, body2: untyped
+    lru: var ConcurrentLruCache[K, V], key: K, value, body: untyped
 ) =
   mixin hash
-
+  let keyHash = hash(key)
   if lru.threadSafe:
     let
-      h = hash(key)
-      sh = h.toSubhash()
-      s = addr lru.shards[h.toShardIdx(lru.shardBits)]
+      sh = keyHash.toSubhash()
+      s = addr lru.shards[keyHash.toShardIdx(lru.shardBits)]
     var found = false
 
     s.lock.withReadLock:
@@ -884,30 +880,34 @@ template withReadValue*[K, V](
       if valuePtr != nil:
         found = true
         template value(): untyped {.inject.} = toLent(valuePtr)
-        body1
+        body
 
     if found:
       inc tlsLruGetCounter
       if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
         s.lock.withWriteLock:
           s.cache.moveToFront(sh, key)
-    else:
-      body2
   else:
-    let valuePtr = lru.cache.getPtr(key)
+    let valuePtr = lru.cache.getPtr(keyHash.toSubhash(), key)
     if valuePtr != nil:
       template value(): untyped {.inject.} = toLent(valuePtr)
-      body1
-    else:
-      body2
+      body
 
-proc put*[K, V](lru: var ConcurrentLruCache[K, V], key: K, val: V) =
+proc putByHash*[K, V](
+    lru: var ConcurrentLruCache[K, V], keyHash: Hash, key: K, val: V
+) =
   if lru.threadSafe:
-    withShardWrite(lru, key):
+    let
+      sh = keyHash.toSubhash()
+      s = addr lru.shards[keyHash.toShardIdx(lru.shardBits)]
+    s.lock.withWriteLock:
       if s.cache.put(sh, key, val):
         s.usedCount.store(s.cache.len, moRelaxed)
   else:
-    lru.cache.put(key, val)
+    lru.cache.put(keyHash.toSubhash(), key, val)
+
+proc put*[K, V](lru: var ConcurrentLruCache[K, V], key: K, val: V) =
+  lru.putByHash(hash(key), key, val)
 
 proc pop*[K, V](lru: var ConcurrentLruCache[K, V], key: K): Opt[V] =
   if lru.threadSafe:

--- a/execution_chain/concurrency/lru.nim
+++ b/execution_chain/concurrency/lru.nim
@@ -831,6 +831,23 @@ proc get*[K, V](lru: var ConcurrentLruCache[K, V], key: K): Opt[V] =
   else:
     lru.cache.get(key)
 
+
+type
+  KeyHash* = object
+    subhash: uint32
+    shardIdx: int
+
+func toKeyHash*[K, V](lru: ConcurrentLruCache[K, V], key: K): KeyHash =
+  ## Hash `key` for `lru` once, returning a token to pass to
+  ## `withReadValueByHash` / `putByHash` - reuse it for a lookup followed by a
+  ## `put` so the key is hashed (and the subhash derived) only once.
+  mixin hash
+  let h = hash(key)
+  if lru.threadSafe:
+    KeyHash(subhash: h.toSubhash(), shardIdx: h.toShardIdx(lru.shardBits))
+  else:
+    KeyHash(subhash: h.toSubhash())
+
 func toLent[T](p: ptr T): lent T =
   # Borrow the pointee as a read-only view (no copy). Used to hand `withReadValue`
   # bodies access to the cached value without letting them mutate it - assigning
@@ -838,12 +855,12 @@ func toLent[T](p: ptr T): lent T =
   p[]
 
 template withReadValueByHash*[K, V](
-    lru: var ConcurrentLruCache[K, V], keyHash: Hash, key: K, value, body: untyped
+    lru: var ConcurrentLruCache[K, V], keyHash: KeyHash, key: K, value, body: untyped
 ) =
   if lru.threadSafe:
     let
-      sh = keyHash.toSubhash()
-      s = addr lru.shards[keyHash.toShardIdx(lru.shardBits)]
+      sh = keyHash.subhash
+      s = addr lru.shards[keyHash.shardIdx]
     var found = false
 
     s.lock.withReadLock:
@@ -859,55 +876,54 @@ template withReadValueByHash*[K, V](
         s.lock.withWriteLock:
           s.cache.moveToFront(sh, key)
   else:
-    let valuePtr = lru.cache.getPtr(keyHash.toSubhash(), key)
-    if valuePtr != nil:
-      template value(): untyped {.inject.} = toLent(valuePtr)
-      body
-
-template withReadValue*[K, V](
-    lru: var ConcurrentLruCache[K, V], key: K, value, body: untyped
-) =
-  mixin hash
-  let keyHash = hash(key)
-  if lru.threadSafe:
-    let
-      sh = keyHash.toSubhash()
-      s = addr lru.shards[keyHash.toShardIdx(lru.shardBits)]
-    var found = false
-
-    s.lock.withReadLock:
-      let valuePtr = s.cache.peekPtr(sh, key)
-      if valuePtr != nil:
-        found = true
-        template value(): untyped {.inject.} = toLent(valuePtr)
-        body
-
-    if found:
-      inc tlsLruGetCounter
-      if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
-        s.lock.withWriteLock:
-          s.cache.moveToFront(sh, key)
-  else:
-    let valuePtr = lru.cache.getPtr(keyHash.toSubhash(), key)
+    let valuePtr = lru.cache.getPtr(keyHash.subhash, key)
     if valuePtr != nil:
       template value(): untyped {.inject.} = toLent(valuePtr)
       body
 
 proc putByHash*[K, V](
-    lru: var ConcurrentLruCache[K, V], keyHash: Hash, key: K, val: V
+    lru: var ConcurrentLruCache[K, V], keyHash: KeyHash, key: K, val: V
 ) =
   if lru.threadSafe:
     let
-      sh = keyHash.toSubhash()
-      s = addr lru.shards[keyHash.toShardIdx(lru.shardBits)]
+      sh = keyHash.subhash
+      s = addr lru.shards[keyHash.shardIdx]
     s.lock.withWriteLock:
       if s.cache.put(sh, key, val):
         s.usedCount.store(s.cache.len, moRelaxed)
   else:
-    lru.cache.put(keyHash.toSubhash(), key, val)
+    lru.cache.put(keyHash.subhash, key, val)
+
+template withReadValue*[K, V](
+    lru: var ConcurrentLruCache[K, V], key: K, value, body: untyped
+) =
+  let keyHash = lru.toKeyHash(key)
+  if lru.threadSafe:
+    let
+      sh = keyHash.subhash
+      s = addr lru.shards[keyHash.shardIdx]
+    var found = false
+
+    s.lock.withReadLock:
+      let valuePtr = s.cache.peekPtr(sh, key)
+      if valuePtr != nil:
+        found = true
+        template value(): untyped {.inject.} = toLent(valuePtr)
+        body
+
+    if found:
+      inc tlsLruGetCounter
+      if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
+        s.lock.withWriteLock:
+          s.cache.moveToFront(sh, key)
+  else:
+    let valuePtr = lru.cache.getPtr(keyHash.subhash, key)
+    if valuePtr != nil:
+      template value(): untyped {.inject.} = toLent(valuePtr)
+      body
 
 proc put*[K, V](lru: var ConcurrentLruCache[K, V], key: K, val: V) =
-  lru.putByHash(hash(key), key, val)
+  lru.putByHash(lru.toKeyHash(key), key, val)
 
 proc pop*[K, V](lru: var ConcurrentLruCache[K, V], key: K): Opt[V] =
   if lru.threadSafe:

--- a/execution_chain/concurrency/lru.nim
+++ b/execution_chain/concurrency/lru.nim
@@ -831,7 +831,13 @@ proc get*[K, V](lru: var ConcurrentLruCache[K, V], key: K): Opt[V] =
   else:
     lru.cache.get(key)
 
-template withValue*[K, V](
+func toLent[T](p: ptr T): lent T =
+  # Borrow the pointee as a read-only view (no copy). Used to hand `withReadValue`
+  # bodies access to the cached value without letting them mutate it - assigning
+  # to a `lent` is a compile error.
+  p[]
+
+template withReadValue*[K, V](
     lru: var ConcurrentLruCache[K, V], key: K, value, body: untyped
 ) =
   mixin hash
@@ -841,27 +847,59 @@ template withValue*[K, V](
       h = hash(key)
       sh = h.toSubhash()
       s = addr lru.shards[h.toShardIdx(lru.shardBits)]
-    var promote = false
+    var found = false
 
-    # s.lock.lockRead()
-    # try:
     s.lock.withReadLock:
-      let value {.inject.} = s.cache.peekPtr(sh, key)
-      if value != nil:
-        promote = true
+      let valuePtr = s.cache.peekPtr(sh, key)
+      if valuePtr != nil:
+        found = true
+        template value(): untyped {.inject.} = toLent(valuePtr)
         body
-    # finally:
-    #   s.lock.unlockRead()
 
-    if promote:
+    if found:
       inc tlsLruGetCounter
       if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
         s.lock.withWriteLock:
           s.cache.moveToFront(sh, key)
   else:
-    let value {.inject.} = lru.cache.getPtr(key)
-    if value != nil:
+    let valuePtr = lru.cache.getPtr(key)
+    if valuePtr != nil:
+      template value(): untyped {.inject.} = toLent(valuePtr)
       body
+
+template withReadValue*[K, V](
+    lru: var ConcurrentLruCache[K, V], key: K, value, body1, body2: untyped
+) =
+  mixin hash
+
+  if lru.threadSafe:
+    let
+      h = hash(key)
+      sh = h.toSubhash()
+      s = addr lru.shards[h.toShardIdx(lru.shardBits)]
+    var found = false
+
+    s.lock.withReadLock:
+      let valuePtr = s.cache.peekPtr(sh, key)
+      if valuePtr != nil:
+        found = true
+        template value(): untyped {.inject.} = toLent(valuePtr)
+        body1
+
+    if found:
+      inc tlsLruGetCounter
+      if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
+        s.lock.withWriteLock:
+          s.cache.moveToFront(sh, key)
+    else:
+      body2
+  else:
+    let valuePtr = lru.cache.getPtr(key)
+    if valuePtr != nil:
+      template value(): untyped {.inject.} = toLent(valuePtr)
+      body1
+    else:
+      body2
 
 proc put*[K, V](lru: var ConcurrentLruCache[K, V], key: K, val: V) =
   if lru.threadSafe:

--- a/execution_chain/concurrency/lru.nim
+++ b/execution_chain/concurrency/lru.nim
@@ -843,7 +843,7 @@ func toKeyHash*[K, V](lru: ConcurrentLruCache[K, V], key: auto): KeyHash =
   ## `put` so the key is hashed (and the subhash derived) only once.
   ##
   ## `key` may be a borrowed view rather than a `K` (e.g. an `openArray` aliasing
-  ## the bytes of an `ArrayBuf` key) as long as it hashes identically to - and
+  ## the bytes of the key) as long as it hashes identically to - and
   ## compares equal to - the corresponding `K`. This lets a lookup avoid
   ## materializing the key, copying it only when a miss requires a `put`.
   mixin hash
@@ -904,30 +904,7 @@ proc putByHash*[K, V](
 template withReadValue*[K, V](
     lru: var ConcurrentLruCache[K, V], key: K, value, body: untyped
 ) =
-  let keyHash = lru.toKeyHash(key)
-  if lru.threadSafe:
-    let
-      sh = keyHash.subhash
-      s = addr lru.shards[keyHash.shardIdx]
-    var found = false
-
-    s.lock.withReadLock:
-      let valuePtr = s.cache.peekPtr(sh, key)
-      if valuePtr != nil:
-        found = true
-        template value(): untyped {.inject.} = toLent(valuePtr)
-        body
-
-    if found:
-      inc tlsLruGetCounter
-      if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
-        s.lock.withWriteLock:
-          s.cache.moveToFront(sh, key)
-  else:
-    let valuePtr = lru.cache.getPtr(keyHash.subhash, key)
-    if valuePtr != nil:
-      template value(): untyped {.inject.} = toLent(valuePtr)
-      body
+  lru.withReadValueByHash(lru.toKeyHash(key), key, value, body)
 
 proc put*[K, V](lru: var ConcurrentLruCache[K, V], key: K, val: V) =
   lru.putByHash(lru.toKeyHash(key), key, val)

--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -392,6 +392,12 @@ type
       desc: "Eagerly check state roots when syncing finalized blocks"
       name: "debug-eager-state-root".}: bool
 
+    precompileCache* {.
+      hidden
+      defaultValue: false
+      desc: "Enable precompile caching"
+      name: "debug-precompile-cache".}: bool
+
     deserializeFcState* {.
       hidden
       defaultValue: true

--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -394,7 +394,7 @@ type
 
     precompileCache* {.
       hidden
-      defaultValue: false
+      defaultValue: true
       desc: "Enable precompile caching"
       name: "debug-precompile-cache".}: bool
 

--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -394,7 +394,7 @@ type
 
     precompileCache* {.
       hidden
-      defaultValue: true
+      defaultValue: false
       desc: "Enable precompile caching"
       name: "debug-precompile-cache".}: bool
 
@@ -846,6 +846,10 @@ proc ereDir*(config: ExecutionClientConf): string =
 func udpPort*(config: ExecutionClientConf): Port =
   config.udpPortFlag.get(config.tcpPort)
 
+func threadSafeCaches*(config: ExecutionClientConf): bool =
+  config.optimisticStatePrefetch or config.balStatePrefetch or
+    config.parallelStateRootComputation
+
 func dbOptions*(config: ExecutionClientConf, noKeyCache = false): DbOptions =
   DbOptions.init(
     maxOpenFiles = config.rocksdbMaxOpenFiles,
@@ -862,8 +866,7 @@ func dbOptions*(config: ExecutionClientConf, noKeyCache = false): DbOptions =
     rdbPrintStats = config.rdbPrintStats,
     maxSnapshots = config.aristoDbMaxSnapshots,
     parallelStateRootComputation = config.parallelStateRootComputation,
-    threadSafeCaches = config.optimisticStatePrefetch or config.balStatePrefetch or
-      config.parallelStateRootComputation,
+    threadSafeCaches = config.threadSafeCaches,
     blockCacheType = config.rocksdbBlockCacheType,
   )
 

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -808,9 +808,11 @@ template isPrecompile*(fork: EVMFork, codeAddress: Address): bool =
 # bytes fit in a fixed-capacity buffer and can be used directly as the cache
 # key. Using the raw bytes as the key means lookups are exact (the cache
 # compares the full key with `==`), so there is no collision/correctness risk -
-# the internal hash only affects bucket placement. Precompiles whose input is
-# variable/large (modExp, the pairings and multi-exponentiations) are not
-# cached, nor are the cheap identity/sha256/ripemd160 precompiles.
+# the internal hash only affects bucket placement. A call is only cached when
+# its input fits the fixed-capacity key buffer (and, on store, its output fits
+# the value buffer), so variable/large-input precompiles are transparently
+# cached for their small inputs and fall through to normal computation for big
+# ones. Only the trivial identity precompile is never cached.
 
 const
   # Compile with `-d:disablePrecompileCache` to bypass the cache entirely (for
@@ -820,9 +822,14 @@ const
   MaxCachedPrecompileInput = 512    # BLS G2 add - the largest cached input
   MaxCachedPrecompileOutput = 256   # BLS G2 add / mapG2 - the largest cached output
 
+  # Every precompile except the trivial identity (a plain memcpy) is cached;
+  # variable-input precompiles are only actually cached when their input fits
+  # the key buffer (see the `cacheable` guard in execPrecompile).
   cachedPrecompiles = {
-    paEcRecover, paEcAdd, paEcMul, paBlake2bf, paPointEvaluation,
-    paBlsG1Add, paBlsG2Add, paBlsMapG1, paBlsMapG2, paP256Verify}
+    paEcRecover, paSha256, paRipeMd160, paModExp, paEcAdd, paEcMul,
+    paPairing, paBlake2bf, paPointEvaluation, paBlsG1Add, paBlsG1MultiExp,
+    paBlsG2Add, paBlsG2MultiExp, paBlsPairing, paBlsMapG1, paBlsMapG2,
+    paP256Verify}
 
 type
   PrecompileCacheKey = ArrayBuf[MaxCachedPrecompileInput, byte]

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -11,14 +11,16 @@
 {.push raises: [].}
 
 import
+  std/hashes,
   results,
   ./[types, blake2b_f, blscurve],
   ./interpreter/[gas_meter, gas_costs, utils/utils_numeric],
   eth/common/keys,
   chronicles,
   nimcrypto/[ripemd, sha2, utils],
-  stew/assign2,
+  stew/[assign2, arraybuf],
   ../common/evmforks,
+  ../concurrency/lru,
   ../core/eip4844,
   ../compile_info,
   ./modexp,
@@ -794,10 +796,101 @@ func getPrecompile*(fork: EVMFork, codeAddress: Address): Opt[Precompiles] =
 template isPrecompile*(fork: EVMFork, codeAddress: Address): bool =
   getPrecompile(fork, codeAddress).isSome
 
+# ------------------------------------------------------------------------------
+# Precompile result cache
+# ------------------------------------------------------------------------------
+#
+# Precompiles are pure functions of (input bytes, fork), so their results can be
+# cached and replayed - skipping the (often expensive) computation - as long as
+# the exact same gas and output bytes are reproduced.
+#
+# Only precompiles with a bounded input length are cached, so the raw input
+# bytes fit in a fixed-capacity buffer and can be used directly as the cache
+# key. Using the raw bytes as the key means lookups are exact (the cache
+# compares the full key with `==`), so there is no collision/correctness risk -
+# the internal hash only affects bucket placement. Precompiles whose input is
+# variable/large (modExp, the pairings and multi-exponentiations) are not
+# cached, nor are the cheap identity/sha256/ripemd160 precompiles.
+
+const
+  # Compile with `-d:disablePrecompileCache` to bypass the cache entirely (for
+  # differential testing / benchmarking against the uncached behaviour).
+  enablePrecompileCache = not defined(disablePrecompileCache)
+
+  MaxCachedPrecompileInput = 512    # BLS G2 add - the largest cached input
+  MaxCachedPrecompileOutput = 256   # BLS G2 add / mapG2 - the largest cached output
+
+  cachedPrecompiles = {
+    paEcRecover, paEcAdd, paEcMul, paBlake2bf, paPointEvaluation,
+    paBlsG1Add, paBlsG2Add, paBlsMapG1, paBlsMapG2, paP256Verify}
+
+type
+  PrecompileCacheKey = ArrayBuf[MaxCachedPrecompileInput, byte]
+
+  PrecompileCacheEntry = object
+    fork: EVMFork
+    gasUsed: GasInt
+    output: ArrayBuf[MaxCachedPrecompileOutput, byte]
+
+func hash(k: PrecompileCacheKey): Hash =
+  # Fast (non-cryptographic) bucket hash over the raw input bytes. Key identity
+  # is still the full byte comparison via ArrayBuf's `==`, so this never affects
+  # correctness, only bucket distribution.
+  hash(k.data())
+
+var precompileCaches: array[Precompiles, ConcurrentLruCache[PrecompileCacheKey, PrecompileCacheEntry]]
+
+const
+  precompileCacheBytes = 1_000_000  # ~1MB per cached precompile
+  lruOverhead = 20                  # approximate per-entry LRU overhead
+  precompileCacheCapacity =
+    precompileCacheBytes div
+    (sizeof(PrecompileCacheKey) + sizeof(PrecompileCacheEntry) + lruOverhead)
+
+proc initPrecompileCaches() =
+  for p in cachedPrecompiles:
+    precompileCaches[p].init(precompileCacheCapacity)
+
+when enablePrecompileCache:
+  initPrecompileCaches()
+
+proc handlePrecompileResult(
+    c: Computation, precompile: Precompiles, fork: EVMFork, res: EvmResultVoid) =
+  if res.isErr:
+    if res.error.code == EvmErrorCode.OutOfGas:
+      c.setError(StatusCode.OutOfGas, $res.error.code, true)
+    else:
+      if fork >= FkByzantium and precompile > paIdentity:
+        c.setError(StatusCode.PrecompileFailure, $res.error.code, true)
+      else:
+        # swallow any other precompiles errors
+        debug "execPrecompiles validation error",
+          errCode = $res.error.code,
+          precompile = precompile
+
 proc execPrecompile*(c: Computation, precompile: Precompiles) =
   if c.balTrackerEnabled:
     c.vmState.balTracker.trackAddressAccess(precompileAddrs[precompile])
   let fork = c.fork
+
+  # A cacheable call only when the input fits the fixed-capacity key buffer.
+  let cacheable = enablePrecompileCache and
+                  precompile in cachedPrecompiles and
+                  c.msg.data.len <= MaxCachedPrecompileInput
+
+  var key: PrecompileCacheKey
+  if cacheable:
+    key = PrecompileCacheKey.initCopyFrom(c.msg.data)
+    let cached = precompileCaches[precompile].get(key)
+    if cached.isSome and cached[].fork == fork:
+      # Cache hit: reproduce the exact gas and output of the original call.
+      let res = c.gasMeter.consumeGas(cached[].gasUsed, reason = "Precompile cache hit")
+      if res.isOk:
+        assign(c.output, cached[].output.data())
+      handlePrecompileResult(c, precompile, fork, res)
+      return
+
+  let gasBefore = c.gasMeter.gasRemaining
   let res = case precompile
     of paEcRecover: ecRecover(c)
     of paSha256: sha256(c)
@@ -818,14 +911,11 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
     of paBlsMapG2: blsMapG2(c)
     of paP256Verify: p256verify(c)
 
-  if res.isErr:
-    if res.error.code == EvmErrorCode.OutOfGas:
-      c.setError(StatusCode.OutOfGas, $res.error.code, true)
-    else:
-      if fork >= FkByzantium and precompile > paIdentity:
-        c.setError(StatusCode.PrecompileFailure, $res.error.code, true)
-      else:
-        # swallow any other precompiles errors
-        debug "execPrecompiles validation error",
-          errCode = $res.error.code,
-          precompile = precompile
+  # Cache successful results whose output fits the fixed-capacity buffer.
+  if cacheable and res.isOk and c.output.len <= MaxCachedPrecompileOutput:
+    precompileCaches[precompile].put(key, PrecompileCacheEntry(
+      fork: fork,
+      gasUsed: gasBefore - c.gasMeter.gasRemaining,
+      output: ArrayBuf[MaxCachedPrecompileOutput, byte].initCopyFrom(c.output)))
+
+  handlePrecompileResult(c, precompile, fork, res)

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -796,67 +796,77 @@ func getPrecompile*(fork: EVMFork, codeAddress: Address): Opt[Precompiles] =
 template isPrecompile*(fork: EVMFork, codeAddress: Address): bool =
   getPrecompile(fork, codeAddress).isSome
 
+var
+  precompileCacheActive = false
+  precompileCachesInitialized = false
+
+proc precompileCacheEnabled*(): bool =
+  precompileCacheActive
+
+type
+  PrecompileCacheKey[I: static int] = ArrayBuf[I, byte]
+
+  PrecompileCacheValue[O: static int] = object
+    fork: EVMFork
+    gasUsed: GasInt
+    output: ArrayBuf[O, byte]
+
+func hash[I: static int](k: PrecompileCacheKey[I]): Hash =
+  hash(k.data())
 
 const
-  enablePrecompileCache = true
+  precompileCacheBytes = 1_000_000 # ~1MB budget per cached precompile
+  lruOverhead = 20
 
-when enablePrecompileCache:
-  type
-    PrecompileCacheKey[I: static int] = ArrayBuf[I, byte]
+var
+  ecRecoverCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[32]]
+  modExpCache: ConcurrentLruCache[PrecompileCacheKey[1024], PrecompileCacheValue[512]]
+  ecAddCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[64]]
+  ecMulCache: ConcurrentLruCache[PrecompileCacheKey[96], PrecompileCacheValue[64]]
+  pairingCache: ConcurrentLruCache[PrecompileCacheKey[768], PrecompileCacheValue[32]]
+  blake2bfCache: ConcurrentLruCache[PrecompileCacheKey[213], PrecompileCacheValue[64]]
+  pointEvaluationCache: ConcurrentLruCache[PrecompileCacheKey[192], PrecompileCacheValue[64]]
+  blsG1AddCache: ConcurrentLruCache[PrecompileCacheKey[256], PrecompileCacheValue[128]]
+  blsG1MultiExpCache: ConcurrentLruCache[PrecompileCacheKey[640], PrecompileCacheValue[128]]
+  blsG2AddCache: ConcurrentLruCache[PrecompileCacheKey[512], PrecompileCacheValue[256]]
+  blsG2MultiExpCache: ConcurrentLruCache[PrecompileCacheKey[1152], PrecompileCacheValue[256]]
+  blsPairingCache: ConcurrentLruCache[PrecompileCacheKey[1536], PrecompileCacheValue[32]]
+  blsMapG1Cache: ConcurrentLruCache[PrecompileCacheKey[64], PrecompileCacheValue[128]]
+  blsMapG2Cache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[256]]
+  p256VerifyCache: ConcurrentLruCache[PrecompileCacheKey[160], PrecompileCacheValue[32]]
 
-    PrecompileCacheValue[O: static int] = object
-      fork: EVMFork
-      gasUsed: GasInt
-      output: ArrayBuf[O, byte]
+proc initCache[I, O: static int](
+    cache: var ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]],
+    threadSafe: bool) =
+  let capacity = precompileCacheBytes div
+    (sizeof(PrecompileCacheKey[I]) + sizeof(PrecompileCacheValue[O]) + lruOverhead)
+  if threadSafe:
+    cache.init(capacity, initialSize = capacity, threadSafe = true)
+  else:
+    cache.init(capacity, initialSize = capacity, shardBits = 0, threadSafe = false)
 
-  func hash[I: static int](k: PrecompileCacheKey[I]): Hash =
-    hash(k.data())
+proc initPrecompileCaches(threadSafe: bool) =
+  initCache(ecRecoverCache, threadSafe)
+  initCache(modExpCache, threadSafe)
+  initCache(ecAddCache, threadSafe)
+  initCache(ecMulCache, threadSafe)
+  initCache(pairingCache, threadSafe)
+  initCache(blake2bfCache, threadSafe)
+  initCache(pointEvaluationCache, threadSafe)
+  initCache(blsG1AddCache, threadSafe)
+  initCache(blsG1MultiExpCache, threadSafe)
+  initCache(blsG2AddCache, threadSafe)
+  initCache(blsG2MultiExpCache, threadSafe)
+  initCache(blsPairingCache, threadSafe)
+  initCache(blsMapG1Cache, threadSafe)
+  initCache(blsMapG2Cache, threadSafe)
+  initCache(p256VerifyCache, threadSafe)
 
-  const
-    precompileCacheBytes = 1_000_000 # ~1MB budget per cached precompile
-    lruOverhead = 20
-
-  var
-    ecRecoverCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[32]]
-    modExpCache: ConcurrentLruCache[PrecompileCacheKey[1024], PrecompileCacheValue[512]]
-    ecAddCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[64]]
-    ecMulCache: ConcurrentLruCache[PrecompileCacheKey[96], PrecompileCacheValue[64]]
-    pairingCache: ConcurrentLruCache[PrecompileCacheKey[768], PrecompileCacheValue[32]]
-    blake2bfCache: ConcurrentLruCache[PrecompileCacheKey[213], PrecompileCacheValue[64]]
-    pointEvaluationCache: ConcurrentLruCache[PrecompileCacheKey[192], PrecompileCacheValue[64]]
-    blsG1AddCache: ConcurrentLruCache[PrecompileCacheKey[256], PrecompileCacheValue[128]]
-    blsG1MultiExpCache: ConcurrentLruCache[PrecompileCacheKey[640], PrecompileCacheValue[128]]
-    blsG2AddCache: ConcurrentLruCache[PrecompileCacheKey[512], PrecompileCacheValue[256]]
-    blsG2MultiExpCache: ConcurrentLruCache[PrecompileCacheKey[1152], PrecompileCacheValue[256]]
-    blsPairingCache: ConcurrentLruCache[PrecompileCacheKey[1536], PrecompileCacheValue[32]]
-    blsMapG1Cache: ConcurrentLruCache[PrecompileCacheKey[64], PrecompileCacheValue[128]]
-    blsMapG2Cache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[256]]
-    p256VerifyCache: ConcurrentLruCache[PrecompileCacheKey[160], PrecompileCacheValue[32]]
-
-  proc initCache[I, O: static int](
-      cache: var ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]]) =
-    let capacity = precompileCacheBytes div
-      (sizeof(PrecompileCacheKey[I]) + sizeof(PrecompileCacheValue[O]) + lruOverhead)
-    cache.init(capacity, initialSize = capacity)
-
-  proc initPrecompileCaches() =
-    initCache(ecRecoverCache)
-    initCache(modExpCache)
-    initCache(ecAddCache)
-    initCache(ecMulCache)
-    initCache(pairingCache)
-    initCache(blake2bfCache)
-    initCache(pointEvaluationCache)
-    initCache(blsG1AddCache)
-    initCache(blsG1MultiExpCache)
-    initCache(blsG2AddCache)
-    initCache(blsG2MultiExpCache)
-    initCache(blsPairingCache)
-    initCache(blsMapG1Cache)
-    initCache(blsMapG2Cache)
-    initCache(p256VerifyCache)
-
-  initPrecompileCaches()
+proc setPrecompileCacheEnabled*(enabled: bool, threadSafe = true) =
+  if enabled and not precompileCachesInitialized:
+    initPrecompileCaches(threadSafe)
+    precompileCachesInitialized = true
+  precompileCacheActive = enabled
 
 template handlePrecompileResult(c: Computation, precompile: Precompiles, fork: EVMFork, res: EvmResultVoid) =
   if res.isErr:
@@ -892,79 +902,80 @@ template dispatchPrecompile(c: Computation, precompile: Precompiles, fork: EVMFo
   of paBlsMapG2: blsMapG2(c)
   of paP256Verify: p256verify(c)
 
-when enablePrecompileCache:
-  proc execCachedPrecompile[I, O: static int](
-      c: Computation, precompile: Precompiles, fork: EVMFork,
-      cache: var ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]],
-      checkInputLen: static bool = false, checkOutputLen: static bool = false
-  ): EvmResultVoid =
-    when checkInputLen:
-      if c.msg.data.len > I:
-        # Larger than this precompile's cache key can hold - run uncached.
-        return dispatchPrecompile(c, precompile, fork)
+proc execCachedPrecompile[I, O: static int](
+    c: Computation, precompile: Precompiles, fork: EVMFork,
+    cache: var ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]],
+    checkInputLen: static bool = false, checkOutputLen: static bool = false
+): EvmResultVoid =
+  when checkInputLen:
+    if c.msg.data.len > I:
+      # Larger than this precompile's cache key can hold - run uncached.
+      return dispatchPrecompile(c, precompile, fork)
 
-    let
-      key = PrecompileCacheKey[I].initCopyFrom(c.msg.data)
-      keyHash = cache.toKeyHash(key) # hash once, reuse for the lookup and the put
+  let
+    key = PrecompileCacheKey[I].initCopyFrom(c.msg.data)
+    keyHash = cache.toKeyHash(key) # hash once, reuse for the lookup and the put
 
-    var hit = false
-    cache.withReadValueByHash(keyHash, key, cached):
-      if cached.fork == fork:
-        result = c.gasMeter.consumeGas(cached.gasUsed, reason = "Precompile cache hit")
-        if result.isOk():
-          assign(c.output, cached.output.data())
-        hit = true
-
-    if not hit:
-      let gasBefore = c.gasMeter.gasRemaining
-      result = dispatchPrecompile(c, precompile, fork)
+  var hit = false
+  cache.withReadValueByHash(keyHash, key, cached):
+    if cached.fork == fork:
+      result = c.gasMeter.consumeGas(cached.gasUsed, reason = "Precompile cache hit")
       if result.isOk():
-        when checkOutputLen:
-          if c.output.len > O:
-            return
-        cache.putByHash(keyHash, key, PrecompileCacheValue[O](
-          fork: fork,
-          gasUsed: gasBefore - c.gasMeter.gasRemaining,
-          output: ArrayBuf[O, byte].initCopyFrom(c.output)))
+        assign(c.output, cached.output.data())
+      hit = true
+
+  if not hit:
+    let gasBefore = c.gasMeter.gasRemaining
+    result = dispatchPrecompile(c, precompile, fork)
+    if result.isOk():
+      when checkOutputLen:
+        if c.output.len > O:
+          return
+      cache.putByHash(keyHash, key, PrecompileCacheValue[O](
+        fork: fork,
+        gasUsed: gasBefore - c.gasMeter.gasRemaining,
+        output: ArrayBuf[O, byte].initCopyFrom(c.output)))
 
 proc execPrecompile*(c: Computation, precompile: Precompiles) =
   if c.balTrackerEnabled:
     c.vmState.balTracker.trackAddressAccess(precompileAddrs[precompile])
 
+  if not precompileCacheActive:
+    let res = dispatchPrecompile(c, precompile, c.fork)
+    handlePrecompileResult(c, precompile, c.fork, res)
+    return
+
   let res =
-    when enablePrecompileCache:
-      # Dispatch to the precompile's exactly-sized cache; the sizes are carried
-      # by each cache's type. Uncached precompiles fall through to `else`.
-      # Fixed-size precompiles skip the length guards (the precompile errors on a
-      # wrong-length input, so it is never cached). Variable-length ones enable
-      # checkInputLen so over-cap inputs run uncached instead of truncating the
-      # key; modExp also has variable output so it enables checkOutputLen. p256
-      # verify is fixed-length but returns ok (not err) for a wrong length, so it
-      # needs checkInputLen too to avoid a truncated >160B input colliding keys.
-      case precompile
-      of paEcRecover: execCachedPrecompile(c, precompile, c.fork, ecRecoverCache)
-      of paModExp: execCachedPrecompile(c, precompile, c.fork, modExpCache, 
-                                        checkInputLen = true, checkOutputLen = true)
-      of paEcAdd: execCachedPrecompile(c, precompile, c.fork, ecAddCache)
-      of paEcMul: execCachedPrecompile(c, precompile, c.fork, ecMulCache)
-      of paPairing: execCachedPrecompile(c, precompile, c.fork, pairingCache, 
-                                         checkInputLen = true)
-      of paBlake2bf: execCachedPrecompile(c, precompile, c.fork, blake2bfCache)
-      of paPointEvaluation: execCachedPrecompile(c, precompile, c.fork, pointEvaluationCache)
-      of paBlsG1Add: execCachedPrecompile(c, precompile, c.fork, blsG1AddCache)
-      of paBlsG1MultiExp: execCachedPrecompile(c, precompile, c.fork, blsG1MultiExpCache, 
-                                               checkInputLen = true)
-      of paBlsG2Add: execCachedPrecompile(c, precompile, c.fork, blsG2AddCache)
-      of paBlsG2MultiExp: execCachedPrecompile(c, precompile, c.fork, blsG2MultiExpCache, 
-                                               checkInputLen = true)
-      of paBlsPairing: execCachedPrecompile(c, precompile, c.fork, blsPairingCache, 
-                                            checkInputLen = true)
-      of paBlsMapG1: execCachedPrecompile(c, precompile, c.fork, blsMapG1Cache)
-      of paBlsMapG2: execCachedPrecompile(c, precompile, c.fork, blsMapG2Cache)
-      of paP256Verify: execCachedPrecompile(c, precompile, c.fork, p256VerifyCache, 
-                                            checkInputLen = true)
-      else: dispatchPrecompile(c, precompile, c.fork)
-    else:
-      dispatchPrecompile(c, precompile, c.fork)
+    # Dispatch to the precompile's exactly-sized cache; the sizes are carried by
+    # each cache's type. Uncached precompiles fall through to `else`.
+    # Fixed-size precompiles skip the length guards (the precompile errors on a
+    # wrong-length input, so it is never cached). Variable-length ones enable
+    # checkInputLen so over-cap inputs run uncached instead of truncating the
+    # key; modExp also has variable output so it enables checkOutputLen. p256
+    # verify is fixed-length but returns ok (not err) for a wrong length, so it
+    # needs checkInputLen too to avoid a truncated >160B input colliding keys.
+    case precompile
+    of paEcRecover: execCachedPrecompile(c, precompile, c.fork, ecRecoverCache)
+    of paModExp: execCachedPrecompile(c, precompile, c.fork, modExpCache,
+                                      checkInputLen = true, checkOutputLen = true)
+    of paEcAdd: execCachedPrecompile(c, precompile, c.fork, ecAddCache)
+    of paEcMul: execCachedPrecompile(c, precompile, c.fork, ecMulCache)
+    of paPairing: execCachedPrecompile(c, precompile, c.fork, pairingCache,
+                                       checkInputLen = true)
+    of paBlake2bf: execCachedPrecompile(c, precompile, c.fork, blake2bfCache)
+    of paPointEvaluation: execCachedPrecompile(c, precompile, c.fork, pointEvaluationCache)
+    of paBlsG1Add: execCachedPrecompile(c, precompile, c.fork, blsG1AddCache)
+    of paBlsG1MultiExp: execCachedPrecompile(c, precompile, c.fork, blsG1MultiExpCache,
+                                             checkInputLen = true)
+    of paBlsG2Add: execCachedPrecompile(c, precompile, c.fork, blsG2AddCache)
+    of paBlsG2MultiExp: execCachedPrecompile(c, precompile, c.fork, blsG2MultiExpCache,
+                                             checkInputLen = true)
+    of paBlsPairing: execCachedPrecompile(c, precompile, c.fork, blsPairingCache,
+                                          checkInputLen = true)
+    of paBlsMapG1: execCachedPrecompile(c, precompile, c.fork, blsMapG1Cache)
+    of paBlsMapG2: execCachedPrecompile(c, precompile, c.fork, blsMapG2Cache)
+    of paP256Verify: execCachedPrecompile(c, precompile, c.fork, p256VerifyCache,
+                                          checkInputLen = true)
+    else: dispatchPrecompile(c, precompile, c.fork)
 
   handlePrecompileResult(c, precompile, c.fork, res)

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -796,73 +796,71 @@ func getPrecompile*(fork: EVMFork, codeAddress: Address): Opt[Precompiles] =
 template isPrecompile*(fork: EVMFork, codeAddress: Address): bool =
   getPrecompile(fork, codeAddress).isSome
 
-# ------------------------------------------------------------------------------
-# Precompile result cache
-# ------------------------------------------------------------------------------
-#
-# Precompiles are pure functions of (input bytes, fork), so their results can be
-# cached and replayed - skipping the (often expensive) computation - as long as
-# the exact same gas and output bytes are reproduced.
-#
-# Only precompiles with a bounded input length are cached, so the raw input
-# bytes fit in a fixed-capacity buffer and can be used directly as the cache
-# key. Using the raw bytes as the key means lookups are exact (the cache
-# compares the full key with `==`), so there is no collision/correctness risk -
-# the internal hash only affects bucket placement. A call is only cached when
-# its input fits the fixed-capacity key buffer (and, on store, its output fits
-# the value buffer), so variable/large-input precompiles are transparently
-# cached for their small inputs and fall through to normal computation for big
-# ones. Only the trivial identity precompile is never cached.
 
 const
-  # Compile with `-d:disablePrecompileCache` to bypass the cache entirely (for
-  # differential testing / benchmarking against the uncached behaviour).
-  enablePrecompileCache = not defined(disablePrecompileCache)
+  enablePrecompileCache = true
 
-  MaxCachedPrecompileInput = 512    # BLS G2 add - the largest cached input
-  MaxCachedPrecompileOutput = 256   # BLS G2 add / mapG2 - the largest cached output
+  MaxCachedPrecompileInput = 192
+  MaxCachedPrecompileOutput = 128
 
-  # Every precompile except the trivial identity (a plain memcpy) is cached;
-  # variable-input precompiles are only actually cached when their input fits
-  # the key buffer (see the `cacheable` guard in execPrecompile).
+  # Only precompiles that have input and outputs less than these limits above
+  # are cached. We also don't cache precompiles which are generally fast such as
+  # the hash functions.
   cachedPrecompiles = {
-    paEcRecover, paSha256, paRipeMd160, paModExp, paEcAdd, paEcMul,
-    paPairing, paBlake2bf, paPointEvaluation, paBlsG1Add, paBlsG1MultiExp,
-    paBlsG2Add, paBlsG2MultiExp, paBlsPairing, paBlsMapG1, paBlsMapG2,
-    paP256Verify}
+    # Frontier to Spurious Dragron
+    paEcRecover,
+    #paSha256,
+    #paRipeMd160,
+    #paIdentity,
+    # Byzantium and Constantinople
+    #paModExp,
+    paEcAdd,
+    paEcMul,
+    paPairing,
+    # Istanbul
+    #paBlake2bf,
+    # Cancun
+    paPointEvaluation,
+    # Prague (EIP-2537)
+    #paBlsG1Add,
+    paBlsG1MultiExp,
+    #paBlsG2Add,
+    #paBlsG2MultiExp,
+    #paBlsPairing,
+    paBlsMapG1,
+    #paBlsMapG2,
+    # Osaka
+    paP256Verify,
+  }
 
 type
   PrecompileCacheKey = ArrayBuf[MaxCachedPrecompileInput, byte]
 
-  PrecompileCacheEntry = object
+  PrecompileCacheValue = object
     fork: EVMFork
     gasUsed: GasInt
     output: ArrayBuf[MaxCachedPrecompileOutput, byte]
 
 func hash(k: PrecompileCacheKey): Hash =
-  # Fast (non-cryptographic) bucket hash over the raw input bytes. Key identity
-  # is still the full byte comparison via ArrayBuf's `==`, so this never affects
-  # correctness, only bucket distribution.
   hash(k.data())
-
-var precompileCaches: array[Precompiles, ConcurrentLruCache[PrecompileCacheKey, PrecompileCacheEntry]]
 
 const
   precompileCacheBytes = 1_000_000  # ~1MB per cached precompile
-  lruOverhead = 20                  # approximate per-entry LRU overhead
+  lruOverhead = 20
   precompileCacheCapacity =
     precompileCacheBytes div
-    (sizeof(PrecompileCacheKey) + sizeof(PrecompileCacheEntry) + lruOverhead)
+    (sizeof(PrecompileCacheKey) + sizeof(PrecompileCacheValue) + lruOverhead)
+
+var precompileCaches: array[Precompiles, ConcurrentLruCache[PrecompileCacheKey, PrecompileCacheValue]]
 
 proc initPrecompileCaches() =
   for p in cachedPrecompiles:
-    precompileCaches[p].init(precompileCacheCapacity)
+    precompileCaches[p].init(precompileCacheCapacity, initialSize = precompileCacheCapacity)
 
 when enablePrecompileCache:
   initPrecompileCaches()
 
-proc handlePrecompileResult(
-    c: Computation, precompile: Precompiles, fork: EVMFork, res: EvmResultVoid) =
+template handlePrecompileResult(c: Computation, precompile: Precompiles, fork: EVMFork, res: EvmResultVoid) =
   if res.isErr:
     if res.error.code == EvmErrorCode.OutOfGas:
       c.setError(StatusCode.OutOfGas, $res.error.code, true)
@@ -875,54 +873,60 @@ proc handlePrecompileResult(
           errCode = $res.error.code,
           precompile = precompile
 
+template dispatchPrecompile(c: Computation, precompile: Precompiles, fork: EVMFork): EvmResultVoid =
+  case precompile
+  of paEcRecover: ecRecover(c)
+  of paSha256: sha256(c)
+  of paRipeMd160: ripemd160(c)
+  of paIdentity: identity(c)
+  of paModExp: modExp(c, fork)
+  of paEcAdd: bn256ecAdd(c, fork)
+  of paEcMul: bn256ecMul(c, fork)
+  of paPairing: bn256ecPairing(c, fork)
+  of paBlake2bf: blake2bf(c)
+  of paPointEvaluation: pointEvaluation(c)
+  of paBlsG1Add: blsG1Add(c)
+  of paBlsG1MultiExp: blsG1MultiExp(c)
+  of paBlsG2Add: blsG2Add(c)
+  of paBlsG2MultiExp: blsG2MultiExp(c)
+  of paBlsPairing: blsPairing(c)
+  of paBlsMapG1: blsMapG1(c)
+  of paBlsMapG2: blsMapG2(c)
+  of paP256Verify: p256verify(c)
+
 proc execPrecompile*(c: Computation, precompile: Precompiles) =
   if c.balTrackerEnabled:
     c.vmState.balTracker.trackAddressAccess(precompileAddrs[precompile])
-  let fork = c.fork
 
-  # A cacheable call only when the input fits the fixed-capacity key buffer.
-  let cacheable = enablePrecompileCache and
-                  precompile in cachedPrecompiles and
-                  c.msg.data.len <= MaxCachedPrecompileInput
+  let
+    fork = c.fork
+    cacheable = 
+      when enablePrecompileCache:
+        precompile in cachedPrecompiles and c.msg.data.len <= MaxCachedPrecompileInput
+      else: 
+        false
+    res = 
+      if cacheable:
+        let
+          key = PrecompileCacheKey.initCopyFrom(c.msg.data)
+          cached = precompileCaches[precompile].get(key)
 
-  var key: PrecompileCacheKey
-  if cacheable:
-    key = PrecompileCacheKey.initCopyFrom(c.msg.data)
-    let cached = precompileCaches[precompile].get(key)
-    if cached.isSome and cached[].fork == fork:
-      # Cache hit: reproduce the exact gas and output of the original call.
-      let res = c.gasMeter.consumeGas(cached[].gasUsed, reason = "Precompile cache hit")
-      if res.isOk:
-        assign(c.output, cached[].output.data())
-      handlePrecompileResult(c, precompile, fork, res)
-      return
-
-  let gasBefore = c.gasMeter.gasRemaining
-  let res = case precompile
-    of paEcRecover: ecRecover(c)
-    of paSha256: sha256(c)
-    of paRipeMd160: ripemd160(c)
-    of paIdentity: identity(c)
-    of paModExp: modExp(c, fork)
-    of paEcAdd: bn256ecAdd(c, fork)
-    of paEcMul: bn256ecMul(c, fork)
-    of paPairing: bn256ecPairing(c, fork)
-    of paBlake2bf: blake2bf(c)
-    of paPointEvaluation: pointEvaluation(c)
-    of paBlsG1Add: blsG1Add(c)
-    of paBlsG1MultiExp: blsG1MultiExp(c)
-    of paBlsG2Add: blsG2Add(c)
-    of paBlsG2MultiExp: blsG2MultiExp(c)
-    of paBlsPairing: blsPairing(c)
-    of paBlsMapG1: blsMapG1(c)
-    of paBlsMapG2: blsMapG2(c)
-    of paP256Verify: p256verify(c)
-
-  # Cache successful results whose output fits the fixed-capacity buffer.
-  if cacheable and res.isOk and c.output.len <= MaxCachedPrecompileOutput:
-    precompileCaches[precompile].put(key, PrecompileCacheEntry(
-      fork: fork,
-      gasUsed: gasBefore - c.gasMeter.gasRemaining,
-      output: ArrayBuf[MaxCachedPrecompileOutput, byte].initCopyFrom(c.output)))
+        if cached.isSome() and cached[].fork == fork:
+          let r = c.gasMeter.consumeGas(cached[].gasUsed, reason = "Precompile cache hit")
+          if r.isOk():
+            assign(c.output, cached[].output.data())
+          r
+        else:
+          let
+            gasBefore = c.gasMeter.gasRemaining
+            r = dispatchPrecompile(c, precompile, fork)
+          if r.isOk() and c.output.len <= MaxCachedPrecompileOutput:
+            precompileCaches[precompile].put(key, PrecompileCacheValue(
+              fork: fork,
+              gasUsed: gasBefore - c.gasMeter.gasRemaining,
+              output: ArrayBuf[MaxCachedPrecompileOutput, byte].initCopyFrom(c.output)))
+          r
+      else:
+        dispatchPrecompile(c, precompile, fork)
 
   handlePrecompileResult(c, precompile, fork, res)

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -815,7 +815,7 @@ func hash[I: static int](k: PrecompileCacheKey[I]): Hash =
   hash(k.data())
 
 const
-  precompileCacheBytes = 1_000_000 # ~1MB budget per cached precompile
+  precompileCacheBytes = 10_000_000 # ~10MB budget per cached precompile
   lruOverhead = 20
 
 var

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -808,10 +808,10 @@ const
   # the hash functions.
   cachedPrecompiles = {
     # Frontier to Spurious Dragron
-    paEcRecover,
-    #paSha256,
-    #paRipeMd160,
-    #paIdentity,
+    paEcRecover, # IN=128 OUT=32
+    #paSha256, # IN=variable OUT=32
+    #paRipeMd160, # IN=variable OUT=32
+    #paIdentity, # IN=variable OUT=variable
     # Byzantium and Constantinople
     #paModExp,
     paEcAdd,
@@ -900,33 +900,34 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
 
   let
     fork = c.fork
-    cacheable = 
+    cacheable =
       when enablePrecompileCache:
         precompile in cachedPrecompiles and c.msg.data.len <= MAX_CACHED_PRECOMPILE_INPUT
-      else: 
-        false
-    res = 
-      if cacheable:
-        let
-          key = PrecompileCacheKey.initCopyFrom(c.msg.data)
-          cached = precompileCaches[precompile].get(key)
-
-        if cached.isSome() and cached[].fork == fork:
-          let r = c.gasMeter.consumeGas(cached[].gasUsed, reason = "Precompile cache hit")
-          if r.isOk():
-            assign(c.output, cached[].output.data())
-          r
-        else:
-          let
-            gasBefore = c.gasMeter.gasRemaining
-            r = dispatchPrecompile(c, precompile, fork)
-          if r.isOk() and c.output.len <= MAX_CACHED_PRECOMPILE_OUTPUT:
-            precompileCaches[precompile].put(key, PrecompileCacheValue(
-              fork: fork,
-              gasUsed: gasBefore - c.gasMeter.gasRemaining,
-              output: ArrayBuf[MAX_CACHED_PRECOMPILE_OUTPUT, byte].initCopyFrom(c.output)))
-          r
       else:
-        dispatchPrecompile(c, precompile, fork)
+        false
+
+  var res: EvmResultVoid
+  if cacheable:
+    let key = PrecompileCacheKey.initCopyFrom(c.msg.data)
+
+    var hit = false
+    precompileCaches[precompile].withReadValue(key, cached):
+
+      if cached.fork == fork:
+        res = c.gasMeter.consumeGas(cached.gasUsed, reason = "Precompile cache hit")
+        if res.isOk():
+          assign(c.output, cached.output.data())
+        hit = true
+
+    if not hit:
+      let gasBefore = c.gasMeter.gasRemaining
+      res = dispatchPrecompile(c, precompile, fork)
+      if res.isOk() and c.output.len <= MAX_CACHED_PRECOMPILE_OUTPUT:
+        precompileCaches[precompile].put(key, PrecompileCacheValue(
+          fork: fork,
+          gasUsed: gasBefore - c.gasMeter.gasRemaining,
+          output: ArrayBuf[MAX_CACHED_PRECOMPILE_OUTPUT, byte].initCopyFrom(c.output)))
+  else:
+    res = dispatchPrecompile(c, precompile, fork)
 
   handlePrecompileResult(c, precompile, fork, res)

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -908,11 +908,12 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
 
   var res: EvmResultVoid
   if cacheable:
-    let key = PrecompileCacheKey.initCopyFrom(c.msg.data)
+    let
+      key = PrecompileCacheKey.initCopyFrom(c.msg.data)
+      keyHash = hash(key) # hash once and reuse for both the lookup and the put
 
     var hit = false
-    precompileCaches[precompile].withReadValue(key, cached):
-
+    precompileCaches[precompile].withReadValueByHash(keyHash, key, cached):
       if cached.fork == fork:
         res = c.gasMeter.consumeGas(cached.gasUsed, reason = "Precompile cache hit")
         if res.isOk():
@@ -923,7 +924,7 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
       let gasBefore = c.gasMeter.gasRemaining
       res = dispatchPrecompile(c, precompile, fork)
       if res.isOk() and c.output.len <= MAX_CACHED_PRECOMPILE_OUTPUT:
-        precompileCaches[precompile].put(key, PrecompileCacheValue(
+        precompileCaches[precompile].putByHash(keyHash, key, PrecompileCacheValue(
           fork: fork,
           gasUsed: gasBefore - c.gasMeter.gasRemaining,
           output: ArrayBuf[MAX_CACHED_PRECOMPILE_OUTPUT, byte].initCopyFrom(c.output)))

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -802,14 +802,8 @@ const
 
 when enablePrecompileCache:
   type
-    # Input bytes for a precompile, sized to its maximum cacheable input `I`.
-    # `ArrayBuf` tracks the actual length, so inputs shorter than `I` are
-    # distinguished from each other and from a full-length input.
     PrecompileCacheKey[I: static int] = ArrayBuf[I, byte]
 
-    # A cached precompile result: the fork it was produced under (a hit is only
-    # valid within the same fork), the gas it consumed and its output (up to `O`
-    # bytes; `ArrayBuf` tracks the actual length).
     PrecompileCacheValue[O: static int] = object
       fork: EVMFork
       gasUsed: GasInt
@@ -822,40 +816,42 @@ when enablePrecompileCache:
     precompileCacheBytes = 1_000_000 # ~1MB budget per cached precompile
     lruOverhead = 20
 
-  # One cache per cached precompile, with the key and value buffers sized to
-  # exactly that precompile's input and output byte counts (see IN/OUT). Sizing
-  # each cache individually keeps entries compact so the byte budget holds more
-  # of them. Only precompiles with small, fixed-size input and output are cached;
-  # the generally-fast hash precompiles (sha256, ripemd160, identity) and the
-  # variable-length ones (modExp, pairings, multi-exp) are not.
   var
-    ecRecoverCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[32]]  # IN=128 OUT=32
-    ecAddCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[64]]  # IN=128 OUT=64
-    ecMulCache: ConcurrentLruCache[PrecompileCacheKey[96], PrecompileCacheValue[64]]   # IN=96  OUT=64
-    blake2bfCache: ConcurrentLruCache[PrecompileCacheKey[213], PrecompileCacheValue[64]]  # IN=213 OUT=64
-    pointEvaluationCache: ConcurrentLruCache[PrecompileCacheKey[192], PrecompileCacheValue[64]]  # IN=192 OUT=64
-    blsG1AddCache: ConcurrentLruCache[PrecompileCacheKey[256], PrecompileCacheValue[128]] # IN=256 OUT=128
-    blsG2AddCache: ConcurrentLruCache[PrecompileCacheKey[512], PrecompileCacheValue[256]] # IN=512 OUT=256
-    blsMapG1Cache: ConcurrentLruCache[PrecompileCacheKey[64], PrecompileCacheValue[128]]  # IN=64  OUT=128
-    blsMapG2Cache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[256]] # IN=128 OUT=256
-    p256VerifyCache: ConcurrentLruCache[PrecompileCacheKey[160], PrecompileCacheValue[32]]  # IN=160 OUT=32
+    ecRecoverCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[32]]
+    modExpCache: ConcurrentLruCache[PrecompileCacheKey[1024], PrecompileCacheValue[512]]
+    ecAddCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[64]]
+    ecMulCache: ConcurrentLruCache[PrecompileCacheKey[96], PrecompileCacheValue[64]]
+    pairingCache: ConcurrentLruCache[PrecompileCacheKey[768], PrecompileCacheValue[32]]
+    blake2bfCache: ConcurrentLruCache[PrecompileCacheKey[213], PrecompileCacheValue[64]]
+    pointEvaluationCache: ConcurrentLruCache[PrecompileCacheKey[192], PrecompileCacheValue[64]]
+    blsG1AddCache: ConcurrentLruCache[PrecompileCacheKey[256], PrecompileCacheValue[128]]
+    blsG1MultiExpCache: ConcurrentLruCache[PrecompileCacheKey[640], PrecompileCacheValue[128]]
+    blsG2AddCache: ConcurrentLruCache[PrecompileCacheKey[512], PrecompileCacheValue[256]]
+    blsG2MultiExpCache: ConcurrentLruCache[PrecompileCacheKey[1152], PrecompileCacheValue[256]]
+    blsPairingCache: ConcurrentLruCache[PrecompileCacheKey[1536], PrecompileCacheValue[32]]
+    blsMapG1Cache: ConcurrentLruCache[PrecompileCacheKey[64], PrecompileCacheValue[128]]
+    blsMapG2Cache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[256]]
+    p256VerifyCache: ConcurrentLruCache[PrecompileCacheKey[160], PrecompileCacheValue[32]]
 
   proc initCache[I, O: static int](
       cache: var ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]]) =
-    # Give every cache the same byte budget; smaller entries get proportionally
-    # more slots. `I`/`O` are inferred from the cache's type.
     let capacity = precompileCacheBytes div
       (sizeof(PrecompileCacheKey[I]) + sizeof(PrecompileCacheValue[O]) + lruOverhead)
     cache.init(capacity, initialSize = capacity)
 
   proc initPrecompileCaches() =
     initCache(ecRecoverCache)
+    initCache(modExpCache)
     initCache(ecAddCache)
     initCache(ecMulCache)
+    initCache(pairingCache)
     initCache(blake2bfCache)
     initCache(pointEvaluationCache)
     initCache(blsG1AddCache)
+    initCache(blsG1MultiExpCache)
     initCache(blsG2AddCache)
+    initCache(blsG2MultiExpCache)
+    initCache(blsPairingCache)
     initCache(blsMapG1Cache)
     initCache(blsMapG2Cache)
     initCache(p256VerifyCache)
@@ -899,13 +895,13 @@ template dispatchPrecompile(c: Computation, precompile: Precompiles, fork: EVMFo
 when enablePrecompileCache:
   proc execCachedPrecompile[I, O: static int](
       c: Computation, precompile: Precompiles, fork: EVMFork,
-      cache: var ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]]
+      cache: var ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]],
+      checkInputLen: static bool = false, checkOutputLen: static bool = false
   ): EvmResultVoid =
-    ## Run `precompile` through its dedicated result cache. The key/value sizes
-    ## `I`/`O` are inferred from `cache`, so each call site only names the cache.
-    if c.msg.data.len > I:
-      # Larger than this precompile's cache key can hold - run uncached.
-      return dispatchPrecompile(c, precompile, fork)
+    when checkInputLen:
+      if c.msg.data.len > I:
+        # Larger than this precompile's cache key can hold - run uncached.
+        return dispatchPrecompile(c, precompile, fork)
 
     let
       key = PrecompileCacheKey[I].initCopyFrom(c.msg.data)
@@ -922,7 +918,10 @@ when enablePrecompileCache:
     if not hit:
       let gasBefore = c.gasMeter.gasRemaining
       result = dispatchPrecompile(c, precompile, fork)
-      if result.isOk() and c.output.len <= O:
+      if result.isOk():
+        when checkOutputLen:
+          if c.output.len > O:
+            return
         cache.putByHash(keyHash, key, PrecompileCacheValue[O](
           fork: fork,
           gasUsed: gasBefore - c.gasMeter.gasRemaining,
@@ -936,18 +935,35 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
     when enablePrecompileCache:
       # Dispatch to the precompile's exactly-sized cache; the sizes are carried
       # by each cache's type. Uncached precompiles fall through to `else`.
+      # Fixed-size precompiles skip the length guards (the precompile errors on a
+      # wrong-length input, so it is never cached). Variable-length ones enable
+      # checkInputLen so over-cap inputs run uncached instead of truncating the
+      # key; modExp also has variable output so it enables checkOutputLen. p256
+      # verify is fixed-length but returns ok (not err) for a wrong length, so it
+      # needs checkInputLen too to avoid a truncated >160B input colliding keys.
       case precompile
-      of paEcRecover:       execCachedPrecompile(c, precompile, c.fork, ecRecoverCache)
-      of paEcAdd:           execCachedPrecompile(c, precompile, c.fork, ecAddCache)
-      of paEcMul:           execCachedPrecompile(c, precompile, c.fork, ecMulCache)
-      of paBlake2bf:        execCachedPrecompile(c, precompile, c.fork, blake2bfCache)
+      of paEcRecover: execCachedPrecompile(c, precompile, c.fork, ecRecoverCache)
+      of paModExp: execCachedPrecompile(c, precompile, c.fork, modExpCache, 
+                                        checkInputLen = true, checkOutputLen = true)
+      of paEcAdd: execCachedPrecompile(c, precompile, c.fork, ecAddCache)
+      of paEcMul: execCachedPrecompile(c, precompile, c.fork, ecMulCache)
+      of paPairing: execCachedPrecompile(c, precompile, c.fork, pairingCache, 
+                                         checkInputLen = true)
+      of paBlake2bf: execCachedPrecompile(c, precompile, c.fork, blake2bfCache)
       of paPointEvaluation: execCachedPrecompile(c, precompile, c.fork, pointEvaluationCache)
-      of paBlsG1Add:        execCachedPrecompile(c, precompile, c.fork, blsG1AddCache)
-      of paBlsG2Add:        execCachedPrecompile(c, precompile, c.fork, blsG2AddCache)
-      of paBlsMapG1:        execCachedPrecompile(c, precompile, c.fork, blsMapG1Cache)
-      of paBlsMapG2:        execCachedPrecompile(c, precompile, c.fork, blsMapG2Cache)
-      of paP256Verify:      execCachedPrecompile(c, precompile, c.fork, p256VerifyCache)
-      else:                 dispatchPrecompile(c, precompile, c.fork)
+      of paBlsG1Add: execCachedPrecompile(c, precompile, c.fork, blsG1AddCache)
+      of paBlsG1MultiExp: execCachedPrecompile(c, precompile, c.fork, blsG1MultiExpCache, 
+                                               checkInputLen = true)
+      of paBlsG2Add: execCachedPrecompile(c, precompile, c.fork, blsG2AddCache)
+      of paBlsG2MultiExp: execCachedPrecompile(c, precompile, c.fork, blsG2MultiExpCache, 
+                                               checkInputLen = true)
+      of paBlsPairing: execCachedPrecompile(c, precompile, c.fork, blsPairingCache, 
+                                            checkInputLen = true)
+      of paBlsMapG1: execCachedPrecompile(c, precompile, c.fork, blsMapG1Cache)
+      of paBlsMapG2: execCachedPrecompile(c, precompile, c.fork, blsMapG2Cache)
+      of paP256Verify: execCachedPrecompile(c, precompile, c.fork, p256VerifyCache, 
+                                            checkInputLen = true)
+      else: dispatchPrecompile(c, precompile, c.fork)
     else:
       dispatchPrecompile(c, precompile, c.fork)
 

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -905,7 +905,7 @@ when enablePrecompileCache:
 
     let
       key = PrecompileCacheKey[I].initCopyFrom(c.msg.data)
-      keyHash = hash(key) # hash once and reuse for both the lookup and the put
+      keyHash = cache.toKeyHash(key) # hash once, reuse for the lookup and the put
 
     var hit = false
     cache.withReadValueByHash(keyHash, key, cached):

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -902,80 +902,107 @@ template dispatchPrecompile(c: Computation, precompile: Precompiles, fork: EVMFo
   of paBlsMapG2: blsMapG2(c)
   of paP256Verify: p256verify(c)
 
-proc execCachedPrecompile[I, O: static int](
-    c: Computation, precompile: Precompiles, fork: EVMFork,
-    cache: var ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]],
+# Helpers that let `execCachedPrecompile` recover a cache's key/value byte sizes
+# (`I`/`O`) and build its key/value without the caller spelling the sizes out.
+template keyCapacity[I, O: static int](
+    cache: ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]]): int =
+  I
+
+template valueCapacity[I, O: static int](
+    cache: ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]]): int =
+  O
+
+func toCacheKey[I, O: static int](
+    cache: ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]],
+    data: openArray[byte]): PrecompileCacheKey[I] =
+  PrecompileCacheKey[I].initCopyFrom(data)
+
+func toCacheValue[I, O: static int](
+    cache: ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]],
+    fork: EVMFork, gasUsed: GasInt, output: openArray[byte]): PrecompileCacheValue[O] =
+  PrecompileCacheValue[O](
+    fork: fork, gasUsed: gasUsed, output: ArrayBuf[O, byte].initCopyFrom(output))
+
+template execCachedPrecompile(
+    c: Computation, fork: EVMFork, cache: untyped, compute: untyped,
     checkInputLen: static bool = false, checkOutputLen: static bool = false
 ): EvmResultVoid =
-  when checkInputLen:
-    if c.msg.data.len > I:
-      # Larger than this precompile's cache key can hold - run uncached.
-      return dispatchPrecompile(c, precompile, fork)
+  block:
+    var res: EvmResultVoid
+    block body:
+      when checkInputLen:
+        if c.msg.data.len > cache.keyCapacity:
+          # Larger than this precompile's cache key can hold - run uncached.
+          res = compute
+          break body
 
-  let
-    key = PrecompileCacheKey[I].initCopyFrom(c.msg.data)
-    keyHash = cache.toKeyHash(key) # hash once, reuse for the lookup and the put
+      let
+        key = cache.toCacheKey(c.msg.data)
+        keyHash = cache.toKeyHash(key) # hash once, reuse for the lookup and put
 
-  var hit = false
-  cache.withReadValueByHash(keyHash, key, cached):
-    if cached.fork == fork:
-      result = c.gasMeter.consumeGas(cached.gasUsed, reason = "Precompile cache hit")
-      if result.isOk():
-        assign(c.output, cached.output.data())
-      hit = true
+      var hit = false
+      cache.withReadValueByHash(keyHash, key, cached):
+        if cached.fork == fork:
+          res = c.gasMeter.consumeGas(cached.gasUsed, reason = "Precompile cache hit")
+          if res.isOk():
+            assign(c.output, cached.output.data())
+          hit = true
 
-  if not hit:
-    let gasBefore = c.gasMeter.gasRemaining
-    result = dispatchPrecompile(c, precompile, fork)
-    if result.isOk():
-      when checkOutputLen:
-        if c.output.len > O:
-          return
-      cache.putByHash(keyHash, key, PrecompileCacheValue[O](
-        fork: fork,
-        gasUsed: gasBefore - c.gasMeter.gasRemaining,
-        output: ArrayBuf[O, byte].initCopyFrom(c.output)))
+      if not hit:
+        let gasBefore = c.gasMeter.gasRemaining
+        res = compute
+        if res.isOk():
+          when checkOutputLen:
+            if c.output.len > cache.valueCapacity:
+              break body
+          cache.putByHash(keyHash, key,
+            cache.toCacheValue(fork, gasBefore - c.gasMeter.gasRemaining, c.output))
+    res
 
 proc execPrecompile*(c: Computation, precompile: Precompiles) =
   if c.balTrackerEnabled:
     c.vmState.balTracker.trackAddressAccess(precompileAddrs[precompile])
 
+  let fork = c.fork
+
   if not precompileCacheActive:
-    let res = dispatchPrecompile(c, precompile, c.fork)
-    handlePrecompileResult(c, precompile, c.fork, res)
+    let res = dispatchPrecompile(c, precompile, fork)
+    handlePrecompileResult(c, precompile, fork, res)
     return
 
   let res =
-    # Dispatch to the precompile's exactly-sized cache; the sizes are carried by
-    # each cache's type. Uncached precompiles fall through to `else`.
     # Fixed-size precompiles skip the length guards (the precompile errors on a
     # wrong-length input, so it is never cached). Variable-length ones enable
     # checkInputLen so over-cap inputs run uncached instead of truncating the
     # key; modExp also has variable output so it enables checkOutputLen. p256
     # verify is fixed-length but returns ok (not err) for a wrong length, so it
     # needs checkInputLen too to avoid a truncated >160B input colliding keys.
+    # sha256, ripemd160 and identity are not cached (cheap, variable length).
     case precompile
-    of paEcRecover: execCachedPrecompile(c, precompile, c.fork, ecRecoverCache)
-    of paModExp: execCachedPrecompile(c, precompile, c.fork, modExpCache,
+    of paEcRecover: execCachedPrecompile(c, fork, ecRecoverCache, ecRecover(c))
+    of paSha256: sha256(c)
+    of paRipeMd160: ripemd160(c)
+    of paIdentity: identity(c)
+    of paModExp: execCachedPrecompile(c, fork, modExpCache, modExp(c, fork),
                                       checkInputLen = true, checkOutputLen = true)
-    of paEcAdd: execCachedPrecompile(c, precompile, c.fork, ecAddCache)
-    of paEcMul: execCachedPrecompile(c, precompile, c.fork, ecMulCache)
-    of paPairing: execCachedPrecompile(c, precompile, c.fork, pairingCache,
+    of paEcAdd: execCachedPrecompile(c, fork, ecAddCache, bn256ecAdd(c, fork))
+    of paEcMul: execCachedPrecompile(c, fork, ecMulCache, bn256ecMul(c, fork))
+    of paPairing: execCachedPrecompile(c, fork, pairingCache, bn256ecPairing(c, fork),
                                        checkInputLen = true)
-    of paBlake2bf: execCachedPrecompile(c, precompile, c.fork, blake2bfCache)
-    of paPointEvaluation: execCachedPrecompile(c, precompile, c.fork, pointEvaluationCache)
-    of paBlsG1Add: execCachedPrecompile(c, precompile, c.fork, blsG1AddCache)
-    of paBlsG1MultiExp: execCachedPrecompile(c, precompile, c.fork, blsG1MultiExpCache,
+    of paBlake2bf: execCachedPrecompile(c, fork, blake2bfCache, blake2bf(c))
+    of paPointEvaluation:
+      execCachedPrecompile(c, fork, pointEvaluationCache, pointEvaluation(c))
+    of paBlsG1Add: execCachedPrecompile(c, fork, blsG1AddCache, blsG1Add(c))
+    of paBlsG1MultiExp: execCachedPrecompile(c, fork, blsG1MultiExpCache, blsG1MultiExp(c),
                                              checkInputLen = true)
-    of paBlsG2Add: execCachedPrecompile(c, precompile, c.fork, blsG2AddCache)
-    of paBlsG2MultiExp: execCachedPrecompile(c, precompile, c.fork, blsG2MultiExpCache,
+    of paBlsG2Add: execCachedPrecompile(c, fork, blsG2AddCache, blsG2Add(c))
+    of paBlsG2MultiExp: execCachedPrecompile(c, fork, blsG2MultiExpCache, blsG2MultiExp(c),
                                              checkInputLen = true)
-    of paBlsPairing: execCachedPrecompile(c, precompile, c.fork, blsPairingCache,
+    of paBlsPairing: execCachedPrecompile(c, fork, blsPairingCache, blsPairing(c),
                                           checkInputLen = true)
-    of paBlsMapG1: execCachedPrecompile(c, precompile, c.fork, blsMapG1Cache)
-    of paBlsMapG2: execCachedPrecompile(c, precompile, c.fork, blsMapG2Cache)
-    of paP256Verify: execCachedPrecompile(c, precompile, c.fork, p256VerifyCache,
+    of paBlsMapG1: execCachedPrecompile(c, fork, blsMapG1Cache, blsMapG1(c))
+    of paBlsMapG2: execCachedPrecompile(c, fork, blsMapG2Cache, blsMapG2(c))
+    of paP256Verify: execCachedPrecompile(c, fork, p256VerifyCache, p256verify(c),
                                           checkInputLen = true)
-    else: dispatchPrecompile(c, precompile, c.fork)
 
-  handlePrecompileResult(c, precompile, c.fork, res)
+  handlePrecompileResult(c, precompile, fork, res)

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -814,6 +814,11 @@ type
 func hash[I: static int](k: PrecompileCacheKey[I]): Hash =
   hash(k.data())
 
+func `==`[I: static int](k: PrecompileCacheKey[I], data: openArray[byte]): bool =
+  ## Compare a stored key against raw input bytes, so a cache lookup can borrow
+  ## `c.msg.data` directly instead of first copying it into a key.
+  k.data() == data
+
 const
   precompileCacheBytes = 10_000_000 # ~10MB budget per cached precompile
   lruOverhead = 20
@@ -914,34 +919,35 @@ template valueCapacity[I, O: static int](
 
 func toCacheKey[I, O: static int](
     cache: ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]],
-    data: openArray[byte]): PrecompileCacheKey[I] =
+    data: openArray[byte]): PrecompileCacheKey[I] {.inline.} =
   PrecompileCacheKey[I].initCopyFrom(data)
 
 func toCacheValue[I, O: static int](
     cache: ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]],
-    fork: EVMFork, gasUsed: GasInt, output: openArray[byte]): PrecompileCacheValue[O] =
+    fork: EVMFork, gasUsed: GasInt, output: openArray[byte]): PrecompileCacheValue[O] {.inline.} =
   PrecompileCacheValue[O](
     fork: fork, gasUsed: gasUsed, output: ArrayBuf[O, byte].initCopyFrom(output))
 
 template execCachedPrecompile(
     c: Computation, fork: EVMFork, cache: untyped, compute: untyped,
-    checkInputLen: static bool = false, checkOutputLen: static bool = false
+    checkOutputLen: static bool = false
 ): EvmResultVoid =
   block:
     var res: EvmResultVoid
     block body:
-      when checkInputLen:
-        if c.msg.data.len > cache.keyCapacity:
-          # Larger than this precompile's cache key can hold - run uncached.
-          res = compute
-          break body
+      if c.msg.data.len > cache.keyCapacity:
+        # Input doesn't fit this cache's key buffer - run uncached. Caching would
+        # store a truncated key (initCopyFrom silently truncates)
+        res = compute
+        break body
 
-      let
-        key = cache.toCacheKey(c.msg.data)
-        keyHash = cache.toKeyHash(key) # hash once, reuse for the lookup and put
+      # Hash and look up using the raw input bytes (a borrowed view, no copy).
+      # The key is only copied into an ArrayBuf on a miss, when it must be stored.
+      let keyHash = cache.toKeyHash(c.msg.data.toOpenArray(0, c.msg.data.high))
 
       var hit = false
-      cache.withReadValueByHash(keyHash, key, cached):
+      cache.withReadValueByHash(
+          keyHash, c.msg.data.toOpenArray(0, c.msg.data.high), cached):
         if cached.fork == fork:
           res = c.gasMeter.consumeGas(cached.gasUsed, reason = "Precompile cache hit")
           if res.isOk():
@@ -955,7 +961,7 @@ template execCachedPrecompile(
           when checkOutputLen:
             if c.output.len > cache.valueCapacity:
               break body
-          cache.putByHash(keyHash, key,
+          cache.putByHash(keyHash, cache.toCacheKey(c.msg.data),
             cache.toCacheValue(fork, gasBefore - c.gasMeter.gasRemaining, c.output))
     res
 
@@ -971,12 +977,10 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
     return
 
   let res =
-    # Fixed-size precompiles skip the length guards (the precompile errors on a
-    # wrong-length input, so it is never cached). Variable-length ones enable
-    # checkInputLen so over-cap inputs run uncached instead of truncating the
-    # key; modExp also has variable output so it enables checkOutputLen. p256
-    # verify is fixed-length but returns ok (not err) for a wrong length, so it
-    # needs checkInputLen too to avoid a truncated >160B input colliding keys.
+    # Every cached precompile runs uncached when the input exceeds its cache key
+    # capacity (the guard inside execCachedPrecompile), so an over-length input is
+    # never stored as a truncated key. modExp additionally has variable output,
+    # so it enables checkOutputLen to skip caching outputs that don't fit.
     # sha256, ripemd160 and identity are not cached (cheap, variable length).
     case precompile
     of paEcRecover: execCachedPrecompile(c, fork, ecRecoverCache, ecRecover(c))
@@ -984,25 +988,22 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
     of paRipeMd160: ripemd160(c)
     of paIdentity: identity(c)
     of paModExp: execCachedPrecompile(c, fork, modExpCache, modExp(c, fork),
-                                      checkInputLen = true, checkOutputLen = true)
+                                      checkOutputLen = true)
     of paEcAdd: execCachedPrecompile(c, fork, ecAddCache, bn256ecAdd(c, fork))
     of paEcMul: execCachedPrecompile(c, fork, ecMulCache, bn256ecMul(c, fork))
-    of paPairing: execCachedPrecompile(c, fork, pairingCache, bn256ecPairing(c, fork),
-                                       checkInputLen = true)
+    of paPairing: execCachedPrecompile(c, fork, pairingCache, bn256ecPairing(c, fork))
     of paBlake2bf: execCachedPrecompile(c, fork, blake2bfCache, blake2bf(c))
     of paPointEvaluation:
       execCachedPrecompile(c, fork, pointEvaluationCache, pointEvaluation(c))
     of paBlsG1Add: execCachedPrecompile(c, fork, blsG1AddCache, blsG1Add(c))
-    of paBlsG1MultiExp: execCachedPrecompile(c, fork, blsG1MultiExpCache, blsG1MultiExp(c),
-                                             checkInputLen = true)
+    of paBlsG1MultiExp:
+      execCachedPrecompile(c, fork, blsG1MultiExpCache, blsG1MultiExp(c))
     of paBlsG2Add: execCachedPrecompile(c, fork, blsG2AddCache, blsG2Add(c))
-    of paBlsG2MultiExp: execCachedPrecompile(c, fork, blsG2MultiExpCache, blsG2MultiExp(c),
-                                             checkInputLen = true)
-    of paBlsPairing: execCachedPrecompile(c, fork, blsPairingCache, blsPairing(c),
-                                          checkInputLen = true)
+    of paBlsG2MultiExp:
+      execCachedPrecompile(c, fork, blsG2MultiExpCache, blsG2MultiExp(c))
+    of paBlsPairing: execCachedPrecompile(c, fork, blsPairingCache, blsPairing(c))
     of paBlsMapG1: execCachedPrecompile(c, fork, blsMapG1Cache, blsMapG1(c))
     of paBlsMapG2: execCachedPrecompile(c, fork, blsMapG2Cache, blsMapG2(c))
-    of paP256Verify: execCachedPrecompile(c, fork, p256VerifyCache, p256verify(c),
-                                          checkInputLen = true)
+    of paP256Verify: execCachedPrecompile(c, fork, p256VerifyCache, p256verify(c))
 
   handlePrecompileResult(c, precompile, fork, res)

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -800,64 +800,66 @@ template isPrecompile*(fork: EVMFork, codeAddress: Address): bool =
 const
   enablePrecompileCache = true
 
-  MAX_CACHED_PRECOMPILE_INPUT = 192
-  MAX_CACHED_PRECOMPILE_OUTPUT = 128
-
-  # Only precompiles that have input and outputs less than these limits above
-  # are cached. We also don't cache precompiles which are generally fast such as
-  # the hash functions.
-  cachedPrecompiles = {
-    # Frontier to Spurious Dragron
-    paEcRecover, # IN=128 OUT=32
-    #paSha256, # IN=variable OUT=32
-    #paRipeMd160, # IN=variable OUT=32
-    #paIdentity, # IN=variable OUT=variable
-    # Byzantium and Constantinople
-    #paModExp,
-    paEcAdd,
-    paEcMul,
-    paPairing,
-    # Istanbul
-    #paBlake2bf,
-    # Cancun
-    paPointEvaluation,
-    # Prague (EIP-2537)
-    #paBlsG1Add,
-    paBlsG1MultiExp,
-    #paBlsG2Add,
-    #paBlsG2MultiExp,
-    #paBlsPairing,
-    paBlsMapG1,
-    #paBlsMapG2,
-    # Osaka
-    paP256Verify,
-  }
-
-type
-  PrecompileCacheKey = ArrayBuf[MAX_CACHED_PRECOMPILE_INPUT, byte]
-
-  PrecompileCacheValue = object
-    fork: EVMFork
-    gasUsed: GasInt
-    output: ArrayBuf[MAX_CACHED_PRECOMPILE_OUTPUT, byte]
-
-func hash(k: PrecompileCacheKey): Hash =
-  hash(k.data())
-
-const
-  precompileCacheBytes = 1_000_000  # ~1MB per cached precompile
-  lruOverhead = 20
-  precompileCacheCapacity =
-    precompileCacheBytes div
-    (sizeof(PrecompileCacheKey) + sizeof(PrecompileCacheValue) + lruOverhead)
-
-var precompileCaches: array[Precompiles, ConcurrentLruCache[PrecompileCacheKey, PrecompileCacheValue]]
-
-proc initPrecompileCaches() =
-  for p in cachedPrecompiles:
-    precompileCaches[p].init(precompileCacheCapacity, initialSize = precompileCacheCapacity)
-
 when enablePrecompileCache:
+  type
+    # Input bytes for a precompile, sized to its maximum cacheable input `I`.
+    # `ArrayBuf` tracks the actual length, so inputs shorter than `I` are
+    # distinguished from each other and from a full-length input.
+    PrecompileCacheKey[I: static int] = ArrayBuf[I, byte]
+
+    # A cached precompile result: the fork it was produced under (a hit is only
+    # valid within the same fork), the gas it consumed and its output (up to `O`
+    # bytes; `ArrayBuf` tracks the actual length).
+    PrecompileCacheValue[O: static int] = object
+      fork: EVMFork
+      gasUsed: GasInt
+      output: ArrayBuf[O, byte]
+
+  func hash[I: static int](k: PrecompileCacheKey[I]): Hash =
+    hash(k.data())
+
+  const
+    precompileCacheBytes = 1_000_000 # ~1MB budget per cached precompile
+    lruOverhead = 20
+
+  # One cache per cached precompile, with the key and value buffers sized to
+  # exactly that precompile's input and output byte counts (see IN/OUT). Sizing
+  # each cache individually keeps entries compact so the byte budget holds more
+  # of them. Only precompiles with small, fixed-size input and output are cached;
+  # the generally-fast hash precompiles (sha256, ripemd160, identity) and the
+  # variable-length ones (modExp, pairings, multi-exp) are not.
+  var
+    ecRecoverCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[32]]  # IN=128 OUT=32
+    ecAddCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[64]]  # IN=128 OUT=64
+    ecMulCache: ConcurrentLruCache[PrecompileCacheKey[96], PrecompileCacheValue[64]]   # IN=96  OUT=64
+    blake2bfCache: ConcurrentLruCache[PrecompileCacheKey[213], PrecompileCacheValue[64]]  # IN=213 OUT=64
+    pointEvaluationCache: ConcurrentLruCache[PrecompileCacheKey[192], PrecompileCacheValue[64]]  # IN=192 OUT=64
+    blsG1AddCache: ConcurrentLruCache[PrecompileCacheKey[256], PrecompileCacheValue[128]] # IN=256 OUT=128
+    blsG2AddCache: ConcurrentLruCache[PrecompileCacheKey[512], PrecompileCacheValue[256]] # IN=512 OUT=256
+    blsMapG1Cache: ConcurrentLruCache[PrecompileCacheKey[64], PrecompileCacheValue[128]]  # IN=64  OUT=128
+    blsMapG2Cache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[256]] # IN=128 OUT=256
+    p256VerifyCache: ConcurrentLruCache[PrecompileCacheKey[160], PrecompileCacheValue[32]]  # IN=160 OUT=32
+
+  proc initCache[I, O: static int](
+      cache: var ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]]) =
+    # Give every cache the same byte budget; smaller entries get proportionally
+    # more slots. `I`/`O` are inferred from the cache's type.
+    let capacity = precompileCacheBytes div
+      (sizeof(PrecompileCacheKey[I]) + sizeof(PrecompileCacheValue[O]) + lruOverhead)
+    cache.init(capacity, initialSize = capacity)
+
+  proc initPrecompileCaches() =
+    initCache(ecRecoverCache)
+    initCache(ecAddCache)
+    initCache(ecMulCache)
+    initCache(blake2bfCache)
+    initCache(pointEvaluationCache)
+    initCache(blsG1AddCache)
+    initCache(blsG2AddCache)
+    initCache(blsMapG1Cache)
+    initCache(blsMapG2Cache)
+    initCache(p256VerifyCache)
+
   initPrecompileCaches()
 
 template handlePrecompileResult(c: Computation, precompile: Precompiles, fork: EVMFork, res: EvmResultVoid) =
@@ -894,41 +896,59 @@ template dispatchPrecompile(c: Computation, precompile: Precompiles, fork: EVMFo
   of paBlsMapG2: blsMapG2(c)
   of paP256Verify: p256verify(c)
 
-proc execPrecompile*(c: Computation, precompile: Precompiles) =
-  if c.balTrackerEnabled:
-    c.vmState.balTracker.trackAddressAccess(precompileAddrs[precompile])
+when enablePrecompileCache:
+  proc execCachedPrecompile[I, O: static int](
+      c: Computation, precompile: Precompiles, fork: EVMFork,
+      cache: var ConcurrentLruCache[PrecompileCacheKey[I], PrecompileCacheValue[O]]
+  ): EvmResultVoid =
+    ## Run `precompile` through its dedicated result cache. The key/value sizes
+    ## `I`/`O` are inferred from `cache`, so each call site only names the cache.
+    if c.msg.data.len > I:
+      # Larger than this precompile's cache key can hold - run uncached.
+      return dispatchPrecompile(c, precompile, fork)
 
-  let
-    fork = c.fork
-    cacheable =
-      when enablePrecompileCache:
-        precompile in cachedPrecompiles and c.msg.data.len <= MAX_CACHED_PRECOMPILE_INPUT
-      else:
-        false
-
-  var res: EvmResultVoid
-  if cacheable:
     let
-      key = PrecompileCacheKey.initCopyFrom(c.msg.data)
+      key = PrecompileCacheKey[I].initCopyFrom(c.msg.data)
       keyHash = hash(key) # hash once and reuse for both the lookup and the put
 
     var hit = false
-    precompileCaches[precompile].withReadValueByHash(keyHash, key, cached):
+    cache.withReadValueByHash(keyHash, key, cached):
       if cached.fork == fork:
-        res = c.gasMeter.consumeGas(cached.gasUsed, reason = "Precompile cache hit")
-        if res.isOk():
+        result = c.gasMeter.consumeGas(cached.gasUsed, reason = "Precompile cache hit")
+        if result.isOk():
           assign(c.output, cached.output.data())
         hit = true
 
     if not hit:
       let gasBefore = c.gasMeter.gasRemaining
-      res = dispatchPrecompile(c, precompile, fork)
-      if res.isOk() and c.output.len <= MAX_CACHED_PRECOMPILE_OUTPUT:
-        precompileCaches[precompile].putByHash(keyHash, key, PrecompileCacheValue(
+      result = dispatchPrecompile(c, precompile, fork)
+      if result.isOk() and c.output.len <= O:
+        cache.putByHash(keyHash, key, PrecompileCacheValue[O](
           fork: fork,
           gasUsed: gasBefore - c.gasMeter.gasRemaining,
-          output: ArrayBuf[MAX_CACHED_PRECOMPILE_OUTPUT, byte].initCopyFrom(c.output)))
-  else:
-    res = dispatchPrecompile(c, precompile, fork)
+          output: ArrayBuf[O, byte].initCopyFrom(c.output)))
 
-  handlePrecompileResult(c, precompile, fork, res)
+proc execPrecompile*(c: Computation, precompile: Precompiles) =
+  if c.balTrackerEnabled:
+    c.vmState.balTracker.trackAddressAccess(precompileAddrs[precompile])
+
+  let res =
+    when enablePrecompileCache:
+      # Dispatch to the precompile's exactly-sized cache; the sizes are carried
+      # by each cache's type. Uncached precompiles fall through to `else`.
+      case precompile
+      of paEcRecover:       execCachedPrecompile(c, precompile, c.fork, ecRecoverCache)
+      of paEcAdd:           execCachedPrecompile(c, precompile, c.fork, ecAddCache)
+      of paEcMul:           execCachedPrecompile(c, precompile, c.fork, ecMulCache)
+      of paBlake2bf:        execCachedPrecompile(c, precompile, c.fork, blake2bfCache)
+      of paPointEvaluation: execCachedPrecompile(c, precompile, c.fork, pointEvaluationCache)
+      of paBlsG1Add:        execCachedPrecompile(c, precompile, c.fork, blsG1AddCache)
+      of paBlsG2Add:        execCachedPrecompile(c, precompile, c.fork, blsG2AddCache)
+      of paBlsMapG1:        execCachedPrecompile(c, precompile, c.fork, blsMapG1Cache)
+      of paBlsMapG2:        execCachedPrecompile(c, precompile, c.fork, blsMapG2Cache)
+      of paP256Verify:      execCachedPrecompile(c, precompile, c.fork, p256VerifyCache)
+      else:                 dispatchPrecompile(c, precompile, c.fork)
+    else:
+      dispatchPrecompile(c, precompile, c.fork)
+
+  handlePrecompileResult(c, precompile, c.fork, res)

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -800,8 +800,8 @@ template isPrecompile*(fork: EVMFork, codeAddress: Address): bool =
 const
   enablePrecompileCache = true
 
-  MaxCachedPrecompileInput = 192
-  MaxCachedPrecompileOutput = 128
+  MAX_CACHED_PRECOMPILE_INPUT = 192
+  MAX_CACHED_PRECOMPILE_OUTPUT = 128
 
   # Only precompiles that have input and outputs less than these limits above
   # are cached. We also don't cache precompiles which are generally fast such as
@@ -834,12 +834,12 @@ const
   }
 
 type
-  PrecompileCacheKey = ArrayBuf[MaxCachedPrecompileInput, byte]
+  PrecompileCacheKey = ArrayBuf[MAX_CACHED_PRECOMPILE_INPUT, byte]
 
   PrecompileCacheValue = object
     fork: EVMFork
     gasUsed: GasInt
-    output: ArrayBuf[MaxCachedPrecompileOutput, byte]
+    output: ArrayBuf[MAX_CACHED_PRECOMPILE_OUTPUT, byte]
 
 func hash(k: PrecompileCacheKey): Hash =
   hash(k.data())
@@ -902,7 +902,7 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
     fork = c.fork
     cacheable = 
       when enablePrecompileCache:
-        precompile in cachedPrecompiles and c.msg.data.len <= MaxCachedPrecompileInput
+        precompile in cachedPrecompiles and c.msg.data.len <= MAX_CACHED_PRECOMPILE_INPUT
       else: 
         false
     res = 
@@ -920,11 +920,11 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
           let
             gasBefore = c.gasMeter.gasRemaining
             r = dispatchPrecompile(c, precompile, fork)
-          if r.isOk() and c.output.len <= MaxCachedPrecompileOutput:
+          if r.isOk() and c.output.len <= MAX_CACHED_PRECOMPILE_OUTPUT:
             precompileCaches[precompile].put(key, PrecompileCacheValue(
               fork: fork,
               gasUsed: gasBefore - c.gasMeter.gasRemaining,
-              output: ArrayBuf[MaxCachedPrecompileOutput, byte].initCopyFrom(c.output)))
+              output: ArrayBuf[MAX_CACHED_PRECOMPILE_OUTPUT, byte].initCopyFrom(c.output)))
           r
       else:
         dispatchPrecompile(c, precompile, fork)

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -817,6 +817,9 @@ func `==`[I: static int](a: PrecompileCacheKey[I], b: openArray[byte]): bool =
 func `==`[I: static int](a: PrecompileCacheKey[I], b: PrecompileCacheKey[I]): bool =
   a.len() == b.len() and a.buf.toOpenArray(0, a.len() - 1) == b.buf.toOpenArray(0, b.len() - 1)
 
+func hash[I: static int](k: PrecompileCacheKey[I]): Hash =
+  hash(k.data())
+
 const
   precompileCacheBytes = 10_000_000 # ~10MB budget per cached precompile
   lruOverhead = 20
@@ -824,10 +827,8 @@ const
 var
   ecRecoverCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[32]]
   modExpCache: ConcurrentLruCache[PrecompileCacheKey[1024], PrecompileCacheValue[512]]
-  ecAddCache: ConcurrentLruCache[PrecompileCacheKey[128], PrecompileCacheValue[64]]
   ecMulCache: ConcurrentLruCache[PrecompileCacheKey[96], PrecompileCacheValue[64]]
   pairingCache: ConcurrentLruCache[PrecompileCacheKey[768], PrecompileCacheValue[32]]
-  blake2bfCache: ConcurrentLruCache[PrecompileCacheKey[213], PrecompileCacheValue[64]]
   pointEvaluationCache: ConcurrentLruCache[PrecompileCacheKey[192], PrecompileCacheValue[64]]
   blsG1AddCache: ConcurrentLruCache[PrecompileCacheKey[256], PrecompileCacheValue[128]]
   blsG1MultiExpCache: ConcurrentLruCache[PrecompileCacheKey[640], PrecompileCacheValue[128]]
@@ -844,17 +845,15 @@ proc initCache[I, O: static int](
   let capacity = precompileCacheBytes div
     (sizeof(PrecompileCacheKey[I]) + sizeof(PrecompileCacheValue[O]) + lruOverhead)
   if threadSafe:
-    cache.init(capacity, initialSize = capacity, threadSafe = true)
+    cache.init(capacity, threadSafe = true)
   else:
-    cache.init(capacity, initialSize = capacity, shardBits = 0, threadSafe = false)
+    cache.init(capacity, shardBits = 0, threadSafe = false)
 
 proc initPrecompileCaches(threadSafe: bool) =
   initCache(ecRecoverCache, threadSafe)
   initCache(modExpCache, threadSafe)
-  initCache(ecAddCache, threadSafe)
   initCache(ecMulCache, threadSafe)
   initCache(pairingCache, threadSafe)
-  initCache(blake2bfCache, threadSafe)
   initCache(pointEvaluationCache, threadSafe)
   initCache(blsG1AddCache, threadSafe)
   initCache(blsG1MultiExpCache, threadSafe)
@@ -979,18 +978,19 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
     # capacity (the guard inside execCachedPrecompile), so an over-length input is
     # never stored as a truncated key. modExp additionally has variable output,
     # so it enables checkOutputLen to skip caching outputs that don't fit.
-    # sha256, ripemd160 and identity are not cached (cheap, variable length).
+    # sha256 is cached with a 256-byte key (longer inputs run uncached) and a
+    # fixed 32-byte output. ripemd160 and identity are not cached.
     case precompile
     of paEcRecover: execCachedPrecompile(c, fork, ecRecoverCache, ecRecover(c))
-    of paSha256: sha256(c)
+    of paSha256: sha256(c) 
     of paRipeMd160: ripemd160(c)
     of paIdentity: identity(c)
     of paModExp: execCachedPrecompile(c, fork, modExpCache, modExp(c, fork),
                                       checkOutputLen = true)
-    of paEcAdd: execCachedPrecompile(c, fork, ecAddCache, bn256ecAdd(c, fork))
+    of paEcAdd: bn256ecAdd(c, fork)
     of paEcMul: execCachedPrecompile(c, fork, ecMulCache, bn256ecMul(c, fork))
     of paPairing: execCachedPrecompile(c, fork, pairingCache, bn256ecPairing(c, fork))
-    of paBlake2bf: execCachedPrecompile(c, fork, blake2bfCache, blake2bf(c))
+    of paBlake2bf: blake2bf(c)
     of paPointEvaluation:
       execCachedPrecompile(c, fork, pointEvaluationCache, pointEvaluation(c))
     of paBlsG1Add: execCachedPrecompile(c, fork, blsG1AddCache, blsG1Add(c))

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -978,8 +978,6 @@ proc execPrecompile*(c: Computation, precompile: Precompiles) =
     # capacity (the guard inside execCachedPrecompile), so an over-length input is
     # never stored as a truncated key. modExp additionally has variable output,
     # so it enables checkOutputLen to skip caching outputs that don't fit.
-    # sha256 is cached with a 256-byte key (longer inputs run uncached) and a
-    # fixed 32-byte output. ripemd160 and identity are not cached.
     case precompile
     of paEcRecover: execCachedPrecompile(c, fork, ecRecoverCache, ecRecover(c))
     of paSha256: sha256(c) 

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -811,13 +811,11 @@ type
     gasUsed: GasInt
     output: ArrayBuf[O, byte]
 
-func hash[I: static int](k: PrecompileCacheKey[I]): Hash =
-  hash(k.data())
+func `==`[I: static int](a: PrecompileCacheKey[I], b: openArray[byte]): bool =
+  a.len() == b.len() and a.buf.toOpenArray(0, a.len() - 1) == b
 
-func `==`[I: static int](k: PrecompileCacheKey[I], data: openArray[byte]): bool =
-  ## Compare a stored key against raw input bytes, so a cache lookup can borrow
-  ## `c.msg.data` directly instead of first copying it into a key.
-  k.data() == data
+func `==`[I: static int](a: PrecompileCacheKey[I], b: PrecompileCacheKey[I]): bool =
+  a.len() == b.len() and a.buf.toOpenArray(0, a.len() - 1) == b.buf.toOpenArray(0, b.len() - 1)
 
 const
   precompileCacheBytes = 10_000_000 # ~10MB budget per cached precompile

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -19,6 +19,7 @@ import
   stew/byteutils,
   kzg4844/kzg,
   ./[conf, constants, nimbus_desc, nimbus_import, rpc, version_info],
+  ./evm/precompiles,
   ./core/block_import,
   ./core/chain/forked_chain/chain_serialize,
   ./db/aristo/aristo_compute,
@@ -397,6 +398,12 @@ proc main*(config = makeConfig(), nimbus = NimbusNode(nil)) {.noinline.} =
     loadTrustedSetupFromString(kzg.trustedSetup, 8).expect(
       "Baked-in KZG setup is correct"
     )
+
+  # Configure the precompile caches
+  setPrecompileCacheEnabled(
+    config.precompileCache,
+    threadSafe = config.optimisticStatePrefetch or config.balStatePrefetch or
+      config.parallelStateRootComputation)
 
   # Metrics are useful not just when running node but also during import
   let metricsServer =

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -401,9 +401,7 @@ proc main*(config = makeConfig(), nimbus = NimbusNode(nil)) {.noinline.} =
 
   # Configure the precompile caches
   setPrecompileCacheEnabled(
-    config.precompileCache,
-    threadSafe = config.optimisticStatePrefetch or config.balStatePrefetch or
-      config.parallelStateRootComputation)
+    config.precompileCache, threadSafe = config.threadSafeCaches)
 
   # Metrics are useful not just when running node but also during import
   let metricsServer =

--- a/tests/bench_precompiles.nim
+++ b/tests/bench_precompiles.nim
@@ -40,36 +40,67 @@ const
 
 # precompile -> fixture file holding a valid (non-error) input
 const cases = [
-  (paEcRecover,  "ecrecover.json"),
-  (paEcAdd,      "bn256Add_istanbul.json"),
-  (paEcMul,      "bn256mul_istanbul.json"),
-  (paBlake2bf,   "blake2F.json"),
-  (paBlsG1Add,   "blsG1Add.json"),
-  (paBlsG2Add,   "blsG2Add.json"),
-  (paBlsMapG1,   "blsMapG1.json"),
-  (paBlsMapG2,   "blsMapG2.json"),
-  (paP256Verify, "P256Verify.json"),
+  (paEcRecover,      "ecrecover.json"),
+  (paSha256,         "sha256.json"),
+  (paRipeMd160,      "ripemd160.json"),
+  (paModExp,         "modexp_eip7883.json"),
+  (paEcAdd,          "bn256Add_istanbul.json"),
+  (paEcMul,          "bn256mul_istanbul.json"),
+  (paPairing,        "pairing_istanbul.json"),
+  (paBlake2bf,       "blake2F.json"),
+  (paBlsG1Add,       "blsG1Add.json"),
+  (paBlsG1MultiExp,  "blsG1MultiExp.json"),
+  (paBlsG2Add,       "blsG2Add.json"),
+  (paBlsG2MultiExp,  "blsG2MultiExp.json"),
+  (paBlsPairing,     "blsPairing.json"),
+  (paBlsMapG1,       "blsMapG1.json"),
+  (paBlsMapG2,       "blsMapG2.json"),
+  (paP256Verify,     "P256Verify.json"),
 ]
 
-proc firstValidInput(file: string): seq[byte] =
+# Variable-input precompiles: time the smallest vs largest cacheable (<=512B)
+# fixture input rather than a constructed fast/slow pair.
+const sizeVarying = {
+  paModExp, paPairing, paBlsG1MultiExp, paBlsG2MultiExp, paBlsPairing}
+
+proc validInputs(file: string): seq[seq[byte]] =
+  ## All valid (non-error) fixture inputs that fit the cache key buffer,
+  ## sorted ascending by length.
   let fixture = json.parseFile(fixtureDir / file)
   for test in fixture["data"]:
     if not test.hasKey("ExpectedError") and
        test.hasKey("Input") and test["Input"].getStr.len > 0:
       let input = test["Input"].getStr.hexToSeqByte
       if input.len <= 512:
-        return input
-  raiseAssert "no valid bounded input in " & file
+        result.add input
+  doAssert result.len > 0, "no valid bounded input in " & file
+  # simple insertion sort by length (input lists are tiny)
+  for i in 1 ..< result.len:
+    var j = i
+    while j > 0 and result[j-1].len > result[j].len:
+      swap(result[j-1], result[j]); dec j
 
 proc padded(input: openArray[byte], n: int): seq[byte] =
   result = newSeq[byte](n)
   for i in 0 ..< min(n, input.len):
     result[i] = input[i]
 
-# Construct (fastInput, slowInput) for a precompile from its valid fixture input.
-proc scenarios(precompile: Precompiles, fixture: seq[byte]):
+# Construct (fastInput, slowInput) for a precompile from its valid fixture inputs
+# (sorted ascending by length).
+proc scenarios(precompile: Precompiles, inputs: seq[seq[byte]]):
     tuple[fast, slow: seq[byte], note: string] =
+  if precompile in sizeVarying:
+    # smallest vs largest cacheable fixture input
+    let fast = inputs[0]
+    let slow = inputs[^1]
+    return (fast, slow, $fast.len & "B vs " & $slow.len & "B input")
+
+  let fixture = inputs[0]
   case precompile
+  of paSha256, paRipeMd160:
+    # Cost scales with input length; cache only stores inputs <= 512 bytes.
+    # FAST: empty input. SLOW: largest cacheable input (512 bytes).
+    (newSeq[byte](0), newSeq[byte](512), "0B vs 512B input (max cacheable)")
   of paEcAdd:
     # FAST: infinity + infinity (all zeros). SLOW: two real curve points.
     (newSeq[byte](128), padded(fixture, 128), "0+0 vs P+Q")
@@ -158,8 +189,7 @@ proc main() =
   echo align("precompile", 14), align("fast ns/op", 13), align("slow ns/op", 13),
        "  scenario (fast vs slow)"
   for (precompile, file) in cases:
-    let fixture = firstValidInput(file)
-    let (fast, slow, note) = scenarios(precompile, fixture)
+    let (fast, slow, note) = scenarios(precompile, validInputs(file))
     let fastNs = bench(vmState, precompile, fast)
     let slowNs = bench(vmState, precompile, slow)
     echo align($precompile, 14),

--- a/tests/bench_precompiles.nim
+++ b/tests/bench_precompiles.nim
@@ -1,0 +1,170 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# Micro-benchmark for the precompile result cache (see precompiles.nim).
+#
+# For each cached precompile we time two scenarios:
+#   * FAST  - parameters that trigger the cheapest possible computation
+#   * SLOW  - parameters that trigger the most expensive computation
+# both repeated with a fixed input (a 100% cache-hit workload).
+#
+# Build the cached and uncached variants and compare:
+#   nim c -d:release -o:build/bench_precompiles tests/bench_precompiles.nim
+#   nim c -d:release -d:disablePrecompileCache -o:build/bench_precompiles_nocache tests/bench_precompiles.nim
+#   ./build/bench_precompiles_nocache    # "before"
+#   ./build/bench_precompiles            # "after"
+
+import
+  std/[json, os, strutils, monotimes, times],
+  stew/byteutils,
+  ../execution_chain/db/core_db/memory_only,
+  ../execution_chain/common/common,
+  ../tools/common/helpers as chp,
+  ../execution_chain/[
+    evm/computation,
+    evm/state,
+    evm/types,
+    constants,
+    evm/precompiles {.all.}],
+  eth/common/base
+
+const
+  fixtureDir = "tests/fixtures/PrecompileTests"
+  warmupIters = 100
+  budgetNs = 400_000_000'i64   # ~0.4s of timed work per scenario
+  blakeSlowRounds = 50_000'u32
+
+# precompile -> fixture file holding a valid (non-error) input
+const cases = [
+  (paEcRecover,  "ecrecover.json"),
+  (paEcAdd,      "bn256Add_istanbul.json"),
+  (paEcMul,      "bn256mul_istanbul.json"),
+  (paBlake2bf,   "blake2F.json"),
+  (paBlsG1Add,   "blsG1Add.json"),
+  (paBlsG2Add,   "blsG2Add.json"),
+  (paBlsMapG1,   "blsMapG1.json"),
+  (paBlsMapG2,   "blsMapG2.json"),
+  (paP256Verify, "P256Verify.json"),
+]
+
+proc firstValidInput(file: string): seq[byte] =
+  let fixture = json.parseFile(fixtureDir / file)
+  for test in fixture["data"]:
+    if not test.hasKey("ExpectedError") and
+       test.hasKey("Input") and test["Input"].getStr.len > 0:
+      let input = test["Input"].getStr.hexToSeqByte
+      if input.len <= 512:
+        return input
+  raiseAssert "no valid bounded input in " & file
+
+proc padded(input: openArray[byte], n: int): seq[byte] =
+  result = newSeq[byte](n)
+  for i in 0 ..< min(n, input.len):
+    result[i] = input[i]
+
+# Construct (fastInput, slowInput) for a precompile from its valid fixture input.
+proc scenarios(precompile: Precompiles, fixture: seq[byte]):
+    tuple[fast, slow: seq[byte], note: string] =
+  case precompile
+  of paEcAdd:
+    # FAST: infinity + infinity (all zeros). SLOW: two real curve points.
+    (newSeq[byte](128), padded(fixture, 128), "0+0 vs P+Q")
+  of paEcMul:
+    # Same point; FAST scalar = 0 (-> infinity), SLOW scalar = 2^256-1.
+    var fast = padded(fixture, 96)
+    var slow = padded(fixture, 96)
+    for i in 64 ..< 96:
+      fast[i] = 0x00
+      slow[i] = 0xFF
+    (fast, slow, "scalar 0 vs 2^256-1")
+  of paBlake2bf:
+    # FAST: 0 rounds. SLOW: many rounds (first 4 big-endian bytes).
+    var fast = padded(fixture, 213)
+    var slow = padded(fixture, 213)
+    fast[0] = 0; fast[1] = 0; fast[2] = 0; fast[3] = 0
+    slow[0] = byte(blakeSlowRounds shr 24)
+    slow[1] = byte(blakeSlowRounds shr 16)
+    slow[2] = byte(blakeSlowRounds shr 8)
+    slow[3] = byte(blakeSlowRounds)
+    (fast, slow, "0 vs " & $blakeSlowRounds & " rounds")
+  of paBlsG1Add:
+    (newSeq[byte](256), padded(fixture, 256), "0+0 vs P+Q")
+  of paBlsG2Add:
+    (newSeq[byte](512), padded(fixture, 512), "0+0 vs P+Q")
+  of paBlsMapG1:
+    (newSeq[byte](64), padded(fixture, 64), "fe=0 vs fe (~constant)")
+  of paBlsMapG2:
+    (newSeq[byte](128), padded(fixture, 128), "fe=0 vs fe (~constant)")
+  of paP256Verify:
+    # FAST: zeroed public key -> bound check fails fast (still returns ok).
+    # SLOW: valid signature -> full verification.
+    var fast = padded(fixture, 160)
+    for i in 96 ..< 160: fast[i] = 0
+    (fast, padded(fixture, 160), "invalid pk vs full verify")
+  else:
+    # ecRecover: only the full-recovery path is cacheable (constant cost).
+    (fixture, fixture, "constant (no cheap cacheable path)")
+
+proc newVmState(): BaseVMState =
+  let
+    conf = getChainConfig("Osaka")
+    com = CommonRef.new(newCoreDbRef DefaultDbMemory, config = conf)
+  BaseVMState.new(
+    Header(number: 1'u64, stateRoot: EMPTY_ROOT_HASH),
+    Header(),
+    com,
+    com.db.baseTxFrame())
+
+proc run(c: Computation, precompile: Precompiles) {.inline.} =
+  c.gasMeter.gasRemaining = 1_000_000_000
+  c.output.setLen(0)
+  c.error = nil
+  c.execPrecompile(precompile)
+
+proc bench(vmState: BaseVMState, precompile: Precompiles, input: seq[byte]):
+    float =
+  let msg = Message(
+    kind: CallKind.Call,
+    gas: 1_000_000_000,
+    contractAddress: precompileAddrs[precompile],
+    codeAddress: precompileAddrs[precompile],
+    data: input,
+    flags: {MsgFlags.Precompile})
+  let c = newComputation(vmState, false, msg)
+
+  for _ in 0 ..< warmupIters:
+    run(c, precompile)
+
+  var iters = 0
+  let start = getMonoTime()
+  while true:
+    run(c, precompile)
+    inc iters
+    if (iters and 0x3FF) == 0 and
+       (getMonoTime() - start).inNanoseconds >= budgetNs:
+      break
+  (getMonoTime() - start).inNanoseconds.float / iters.float
+
+proc main() =
+  let vmState = newVmState()
+  when enablePrecompileCache:
+    echo "precompile cache: ENABLED  (fork=", vmState.fork, ")"
+  else:
+    echo "precompile cache: DISABLED (fork=", vmState.fork, ")"
+  echo align("precompile", 14), align("fast ns/op", 13), align("slow ns/op", 13),
+       "  scenario (fast vs slow)"
+  for (precompile, file) in cases:
+    let fixture = firstValidInput(file)
+    let (fast, slow, note) = scenarios(precompile, fixture)
+    let fastNs = bench(vmState, precompile, fast)
+    let slowNs = bench(vmState, precompile, slow)
+    echo align($precompile, 14),
+         align(formatFloat(fastNs, ffDecimal, 1), 13),
+         align(formatFloat(slowNs, ffDecimal, 1), 13),
+         "  ", note
+
+main()

--- a/tests/bench_precompiles.nim
+++ b/tests/bench_precompiles.nim
@@ -7,16 +7,12 @@
 
 # Micro-benchmark for the precompile result cache (see precompiles.nim).
 #
-# For each cached precompile we time two scenarios:
-#   * FAST  - parameters that trigger the cheapest possible computation
-#   * SLOW  - parameters that trigger the most expensive computation
-# both repeated with a fixed input (a 100% cache-hit workload).
+# Each precompile's most expensive ("slow") input is timed twice - once with the
+# cache enabled (a 100% cache-hit workload) and once disabled - and the results
+# are printed side by side with the speedup.
 #
-# Build the cached and uncached variants and compare:
 #   nim c -d:release -o:build/bench_precompiles tests/bench_precompiles.nim
-#   nim c -d:release -d:disablePrecompileCache -o:build/bench_precompiles_nocache tests/bench_precompiles.nim
-#   ./build/bench_precompiles_nocache    # "before"
-#   ./build/bench_precompiles            # "after"
+#   ./build/bench_precompiles
 
 import
   std/[json, os, strutils, monotimes, times],
@@ -182,19 +178,36 @@ proc bench(vmState: BaseVMState, precompile: Precompiles, input: seq[byte]):
 
 proc main() =
   let vmState = newVmState()
-  when enablePrecompileCache:
-    echo "precompile cache: ENABLED  (fork=", vmState.fork, ")"
-  else:
-    echo "precompile cache: DISABLED (fork=", vmState.fork, ")"
-  echo align("precompile", 14), align("fast ns/op", 13), align("slow ns/op", 13),
-       "  scenario (fast vs slow)"
+
+  # Build the work list once so both runs use identical inputs.
+  var work: seq[tuple[precompile: Precompiles, fast, slow: seq[byte], note: string]]
   for (precompile, file) in cases:
     let (fast, slow, note) = scenarios(precompile, validInputs(file))
-    let fastNs = bench(vmState, precompile, fast)
-    let slowNs = bench(vmState, precompile, slow)
-    echo align($precompile, 14),
-         align(formatFloat(fastNs, ffDecimal, 1), 13),
-         align(formatFloat(slowNs, ffDecimal, 1), 13),
-         "  ", note
+    work.add (precompile, fast, slow, note)
+
+  proc runAll(): seq[tuple[fast, slow: float]] =
+    for w in work:
+      result.add (bench(vmState, w.precompile, w.fast),
+                  bench(vmState, w.precompile, w.slow))
+
+  setPrecompileCacheEnabled(true)
+  let cached = runAll()
+  setPrecompileCacheEnabled(false)
+  let uncached = runAll()
+
+  echo "precompile cache: cached vs uncached (fork=", vmState.fork,
+    ", timing the slow scenario)"
+  echo align("precompile", 18), align("cached ns", 13), align("uncached ns", 13),
+       align("speedup", 11), "  scenario"
+  for i in 0 ..< work.len:
+    let
+      c = cached[i].slow
+      u = uncached[i].slow
+      speedup = if c > 0: u / c else: 0.0
+    echo align($work[i].precompile, 18),
+         align(formatFloat(c, ffDecimal, 1), 13),
+         align(formatFloat(u, ffDecimal, 1), 13),
+         align(formatFloat(speedup, ffDecimal, 1) & "x", 11),
+         "  ", work[i].note
 
 main()

--- a/tests/bench_precompiles.nim
+++ b/tests/bench_precompiles.nim
@@ -7,9 +7,13 @@
 
 # Micro-benchmark for the precompile result cache (see precompiles.nim).
 #
-# Each precompile's most expensive ("slow") input is timed twice - once with the
-# cache enabled (a 100% cache-hit workload) and once disabled - and the results
-# are printed side by side with the speedup.
+# Each precompile's most expensive ("slow") input is timed three ways and the
+# results are printed side by side:
+#   - hit:      cache enabled, same input repeated (steady-state cache hit)
+#   - miss:     cache enabled, entry evicted before every call (lookup miss +
+#               compute + put). This includes the forced eviction, so it slightly
+#               overstates a true single miss - most visible on cheap precompiles.
+#   - disabled: cache disabled (the raw precompile cost)
 #
 #   nim c -d:release -o:build/bench_precompiles tests/bench_precompiles.nim
 #   ./build/bench_precompiles
@@ -25,6 +29,7 @@ import
     evm/state,
     evm/types,
     constants,
+    concurrency/lru,
     evm/precompiles {.all.}],
   eth/common/base
 
@@ -98,8 +103,17 @@ proc scenarios(precompile: Precompiles, inputs: seq[seq[byte]]):
     # FAST: empty input. SLOW: largest cacheable input (512 bytes).
     (newSeq[byte](0), newSeq[byte](512), "0B vs 512B input (max cacheable)")
   of paEcAdd:
-    # FAST: infinity + infinity (all zeros). SLOW: two real curve points.
-    (newSeq[byte](128), padded(fixture, 128), "0+0 vs P+Q")
+    # FAST: infinity + infinity (all zeros, the cheap early-out).
+    # SLOW: two real curve points (a genuine field-arithmetic addition).
+    # inputs[0] is the shortest fixture, which is all-zeros (infinity) and would
+    # measure the same trivial path as FAST; pick a full 128-byte input whose
+    # first point is non-zero instead.
+    var slow = padded(fixture, 128)
+    for inp in inputs:
+      if inp.len >= 128 and inp[0] != 0:
+        slow = padded(inp, 128)
+        break
+    (newSeq[byte](128), slow, "0+0 vs P+Q")
   of paEcMul:
     # Same point; FAST scalar = 0 (-> infinity), SLOW scalar = 2^256-1.
     var fast = padded(fixture, 96)
@@ -152,8 +166,31 @@ proc run(c: Computation, precompile: Precompiles) {.inline.} =
   c.error = nil
   c.execPrecompile(precompile)
 
-proc bench(vmState: BaseVMState, precompile: Precompiles, input: seq[byte]):
-    float =
+proc evict(precompile: Precompiles, input: openArray[byte]) =
+  ## Remove this precompile's cached entry (using the same key the cache builds
+  ## for `input`) so the next call is a cache miss. The cache must be enabled.
+  template d(cache: untyped) =
+    cache.del(cache.toCacheKey(input))
+  case precompile
+  of paEcRecover: d(ecRecoverCache)
+  of paSha256, paRipeMd160, paIdentity: discard # not cached
+  of paModExp: d(modExpCache)
+  of paEcAdd: d(ecAddCache)
+  of paEcMul: d(ecMulCache)
+  of paPairing: d(pairingCache)
+  of paBlake2bf: d(blake2bfCache)
+  of paPointEvaluation: d(pointEvaluationCache)
+  of paBlsG1Add: d(blsG1AddCache)
+  of paBlsG1MultiExp: d(blsG1MultiExpCache)
+  of paBlsG2Add: d(blsG2AddCache)
+  of paBlsG2MultiExp: d(blsG2MultiExpCache)
+  of paBlsPairing: d(blsPairingCache)
+  of paBlsMapG1: d(blsMapG1Cache)
+  of paBlsMapG2: d(blsMapG2Cache)
+  of paP256Verify: d(p256VerifyCache)
+
+proc bench(vmState: BaseVMState, precompile: Precompiles, input: seq[byte],
+           forceMiss: bool): float =
   let msg = Message(
     kind: CallKind.Call,
     gas: 1_000_000_000,
@@ -163,51 +200,100 @@ proc bench(vmState: BaseVMState, precompile: Precompiles, input: seq[byte]):
     flags: {MsgFlags.Precompile})
   let c = newComputation(vmState, false, msg)
 
-  for _ in 0 ..< warmupIters:
+  template once() =
+    if forceMiss:
+      evict(precompile, input)
     run(c, precompile)
+
+  for _ in 0 ..< warmupIters:
+    once()
 
   var iters = 0
   let start = getMonoTime()
   while true:
-    run(c, precompile)
+    once()
     inc iters
     if (iters and 0x3FF) == 0 and
        (getMonoTime() - start).inNanoseconds >= budgetNs:
       break
   (getMonoTime() - start).inNanoseconds.float / iters.float
 
+proc disposeAllCaches() =
+  ## Free and reset every cache back to the UNINITIALIZED state so it can be
+  ## re-initialized in a different mode (`init` asserts UNINITIALIZED, and
+  ## `dispose` alone leaves it DISPOSED). A no-op on a fresh cache.
+  template z(cache: untyped) =
+    cache.dispose()
+    reset(cache)
+  z ecRecoverCache
+  z modExpCache
+  z ecAddCache
+  z ecMulCache
+  z pairingCache
+  z blake2bfCache
+  z pointEvaluationCache
+  z blsG1AddCache
+  z blsG1MultiExpCache
+  z blsG2AddCache
+  z blsG2MultiExpCache
+  z blsPairingCache
+  z blsMapG1Cache
+  z blsMapG2Cache
+  z p256VerifyCache
+
+proc runComparison(
+    vmState: BaseVMState, threadSafe: bool,
+    work: seq[tuple[precompile: Precompiles, input: seq[byte], note: string]]) =
+  # Hit (same input repeated) and miss (entry evicted before every call) both
+  # need the cache enabled; disabled measures the raw precompile cost. Re-init
+  # the caches in the requested mode (dispose any previous run's caches first).
+  disposeAllCaches()
+  initPrecompileCaches(threadSafe)
+  precompileCacheActive = true
+  var hit, miss: seq[float]
+  for w in work:
+    hit.add bench(vmState, w.precompile, w.input, forceMiss = false)
+    miss.add bench(vmState, w.precompile, w.input, forceMiss = true)
+
+  precompileCacheActive = false
+  var disabled: seq[float]
+  for w in work:
+    disabled.add bench(vmState, w.precompile, w.input, forceMiss = false)
+
+  echo "precompile cache: hit vs miss vs disabled (fork=", vmState.fork,
+    ", threadSafe=", threadSafe,
+    ", slow input; miss includes the eviction used to force it)"
+  echo align("precompile", 18), align("hit ns", 12), align("miss ns", 12),
+       align("disabled ns", 13), align("hit speedup", 13), align("miss ovh", 11),
+       "  scenario"
+  for i in 0 ..< work.len:
+    let
+      h = hit[i]
+      m = miss[i]
+      d = disabled[i]
+      hitSpeedup = if h > 0: d / h else: 0.0
+      missOverhead = if d > 0: m / d else: 0.0
+    echo align($work[i].precompile, 18),
+         align(formatFloat(h, ffDecimal, 1), 12),
+         align(formatFloat(m, ffDecimal, 1), 12),
+         align(formatFloat(d, ffDecimal, 1), 13),
+         align(formatFloat(hitSpeedup, ffDecimal, 1) & "x", 13),
+         align(formatFloat(missOverhead, ffDecimal, 2) & "x", 11),
+         "  ", work[i].note
+
 proc main() =
   let vmState = newVmState()
 
-  # Build the work list once so both runs use identical inputs.
-  var work: seq[tuple[precompile: Precompiles, fast, slow: seq[byte], note: string]]
+  # Build the work list once so every run uses identical inputs. Each precompile
+  # is timed on its most expensive ("slow") cacheable input.
+  var work: seq[tuple[precompile: Precompiles, input: seq[byte], note: string]]
   for (precompile, file) in cases:
-    let (fast, slow, note) = scenarios(precompile, validInputs(file))
-    work.add (precompile, fast, slow, note)
+    let (_, slow, note) = scenarios(precompile, validInputs(file))
+    work.add (precompile, slow, note)
 
-  proc runAll(): seq[tuple[fast, slow: float]] =
-    for w in work:
-      result.add (bench(vmState, w.precompile, w.fast),
-                  bench(vmState, w.precompile, w.slow))
-
-  setPrecompileCacheEnabled(true)
-  let cached = runAll()
-  setPrecompileCacheEnabled(false)
-  let uncached = runAll()
-
-  echo "precompile cache: cached vs uncached (fork=", vmState.fork,
-    ", timing the slow scenario)"
-  echo align("precompile", 18), align("cached ns", 13), align("uncached ns", 13),
-       align("speedup", 11), "  scenario"
-  for i in 0 ..< work.len:
-    let
-      c = cached[i].slow
-      u = uncached[i].slow
-      speedup = if c > 0: u / c else: 0.0
-    echo align($work[i].precompile, 18),
-         align(formatFloat(c, ffDecimal, 1), 13),
-         align(formatFloat(u, ffDecimal, 1), 13),
-         align(formatFloat(speedup, ffDecimal, 1) & "x", 11),
-         "  ", work[i].note
+  # Single-threaded caches (shardBits = 0, no locking) then thread-safe caches.
+  runComparison(vmState, threadSafe = false, work)
+  echo ""
+  runComparison(vmState, threadSafe = true, work)
 
 main()

--- a/tests/bench_precompiles.nim
+++ b/tests/bench_precompiles.nim
@@ -5,21 +5,31 @@
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-# Micro-benchmark for the precompile result cache (see precompiles.nim).
+# Benchmark: precompile cache speedup vs. disabled, across cache hit rates.
 #
-# Each precompile's most expensive ("slow") input is timed three ways and the
-# results are printed side by side:
-#   - hit:      cache enabled, same input repeated (steady-state cache hit)
-#   - miss:     cache enabled, entry evicted before every call (lookup miss +
-#               compute + put). This includes the forced eviction, so it slightly
-#               overstates a true single miss - most visible on cheap precompiles.
-#   - disabled: cache disabled (the raw precompile cost)
+# bench_precompiles.nim times each precompile's single worst-case input repeated
+# - i.e. a 100%-hit steady state, which flatters the cache enormously. This
+# benchmark asks the practical question instead: for a realistic mix where only
+# a fraction of lookups hit, is the cache a net win for the run overall?
 #
-#   nim c -d:release -o:build/bench_precompiles tests/bench_precompiles.nim
-#   ./build/bench_precompiles
+# For each cached precompile we pick an *average* input - the median-compute-cost
+# valid fixture input, not the worst case (pathological inputs above a cost cap,
+# e.g. blake2f with millions of rounds, are excluded from the median) - and time
+# a sequence of calls at several hit rates with the cache enabled vs disabled.
+#
+#   speedup = (disabled compute ns) / (enabled ns at that hit rate)
+#   > 1  cache is faster;  < 1  cache is a net loss
+#
+# A miss is forced by evicting the entry just before the call (a small, documented
+# overhead). The cache holds a single entry, so probe lengths are best-case - this
+# slightly understates real overhead, so treat low-hit-rate speedups as optimistic.
+#
+#   nim c -d:release -o:build/bench_precompile_cache_hitrate \
+#     tests/bench_precompile_cache_hitrate.nim
+#   ./build/bench_precompile_cache_hitrate
 
 import
-  std/[json, os, strutils, monotimes, times],
+  std/[json, os, strutils, monotimes, times, algorithm, math],
   stew/byteutils,
   ../execution_chain/db/core_db/memory_only,
   ../execution_chain/common/common,
@@ -35,120 +45,43 @@ import
 
 const
   fixtureDir = "tests/fixtures/PrecompileTests"
-  warmupIters = 100
-  budgetNs = 400_000_000'i64   # ~0.4s of timed work per scenario
-  blakeSlowRounds = 50_000'u32
+  warmupIters = 20
+  budgetNs = 150_000_000'i64       # ~0.15s of timed work per (precompile, scenario)
+  calibIters = 5                   # cost samples per fixture input when picking the median
+  costCapNs = 5_000_000.0          # exclude inputs slower than this from the "average"
+  hitRates = [5, 25, 50, 75, 95, 100]
 
-# precompile -> fixture file holding a valid (non-error) input
+# precompile -> (fixture file, cache key capacity in bytes). Only the cached
+# precompiles are listed; pointEvaluation needs a trusted setup and is omitted
+# (matching bench_precompiles.nim).
 const cases = [
-  (paEcRecover,      "ecrecover.json"),
-  (paSha256,         "sha256.json"),
-  (paRipeMd160,      "ripemd160.json"),
-  (paModExp,         "modexp_eip7883.json"),
-  (paEcAdd,          "bn256Add_istanbul.json"),
-  (paEcMul,          "bn256mul_istanbul.json"),
-  (paPairing,        "pairing_istanbul.json"),
-  (paBlake2bf,       "blake2F.json"),
-  (paBlsG1Add,       "blsG1Add.json"),
-  (paBlsG1MultiExp,  "blsG1MultiExp.json"),
-  (paBlsG2Add,       "blsG2Add.json"),
-  (paBlsG2MultiExp,  "blsG2MultiExp.json"),
-  (paBlsPairing,     "blsPairing.json"),
-  (paBlsMapG1,       "blsMapG1.json"),
-  (paBlsMapG2,       "blsMapG2.json"),
-  (paP256Verify,     "P256Verify.json"),
+  (paEcRecover,     "ecrecover.json",          128),
+  (paSha256,        "sha256.json",             256),
+  (paModExp,        "modexp_eip7883.json",    1024),
+  (paEcAdd,         "bn256Add_istanbul.json",  128),
+  (paEcMul,         "bn256mul_istanbul.json",   96),
+  (paPairing,       "pairing_istanbul.json",   768),
+  (paBlake2bf,      "blake2F.json",            213),
+  (paBlsG1Add,      "blsG1Add.json",           256),
+  (paBlsG1MultiExp, "blsG1MultiExp.json",      640),
+  (paBlsG2Add,      "blsG2Add.json",           512),
+  (paBlsG2MultiExp, "blsG2MultiExp.json",     1152),
+  (paBlsPairing,    "blsPairing.json",        1536),
+  (paBlsMapG1,      "blsMapG1.json",            64),
+  (paBlsMapG2,      "blsMapG2.json",            128),
+  (paP256Verify,    "P256Verify.json",         160),
 ]
 
-# Variable-input precompiles: time the smallest vs largest cacheable (<=512B)
-# fixture input rather than a constructed fast/slow pair.
-const sizeVarying = {
-  paModExp, paPairing, paBlsG1MultiExp, paBlsG2MultiExp, paBlsPairing}
-
-proc validInputs(file: string): seq[seq[byte]] =
-  ## All valid (non-error) fixture inputs that fit the cache key buffer,
-  ## sorted ascending by length.
+proc validInputs(file: string, keyCap: int): seq[seq[byte]] =
+  ## All valid (non-error) fixture inputs that fit this precompile's cache key.
   let fixture = json.parseFile(fixtureDir / file)
   for test in fixture["data"]:
     if not test.hasKey("ExpectedError") and
        test.hasKey("Input") and test["Input"].getStr.len > 0:
       let input = test["Input"].getStr.hexToSeqByte
-      if input.len <= 512:
+      if input.len <= keyCap:
         result.add input
-  doAssert result.len > 0, "no valid bounded input in " & file
-  # simple insertion sort by length (input lists are tiny)
-  for i in 1 ..< result.len:
-    var j = i
-    while j > 0 and result[j-1].len > result[j].len:
-      swap(result[j-1], result[j]); dec j
-
-proc padded(input: openArray[byte], n: int): seq[byte] =
-  result = newSeq[byte](n)
-  for i in 0 ..< min(n, input.len):
-    result[i] = input[i]
-
-# Construct (fastInput, slowInput) for a precompile from its valid fixture inputs
-# (sorted ascending by length).
-proc scenarios(precompile: Precompiles, inputs: seq[seq[byte]]):
-    tuple[fast, slow: seq[byte], note: string] =
-  if precompile in sizeVarying:
-    # smallest vs largest cacheable fixture input
-    let fast = inputs[0]
-    let slow = inputs[^1]
-    return (fast, slow, $fast.len & "B vs " & $slow.len & "B input")
-
-  let fixture = inputs[0]
-  case precompile
-  of paSha256, paRipeMd160:
-    # Cost scales with input length; cache only stores inputs <= 512 bytes.
-    # FAST: empty input. SLOW: largest cacheable input (512 bytes).
-    (newSeq[byte](0), newSeq[byte](512), "0B vs 512B input (max cacheable)")
-  of paEcAdd:
-    # FAST: infinity + infinity (all zeros, the cheap early-out).
-    # SLOW: two real curve points (a genuine field-arithmetic addition).
-    # inputs[0] is the shortest fixture, which is all-zeros (infinity) and would
-    # measure the same trivial path as FAST; pick a full 128-byte input whose
-    # first point is non-zero instead.
-    var slow = padded(fixture, 128)
-    for inp in inputs:
-      if inp.len >= 128 and inp[0] != 0:
-        slow = padded(inp, 128)
-        break
-    (newSeq[byte](128), slow, "0+0 vs P+Q")
-  of paEcMul:
-    # Same point; FAST scalar = 0 (-> infinity), SLOW scalar = 2^256-1.
-    var fast = padded(fixture, 96)
-    var slow = padded(fixture, 96)
-    for i in 64 ..< 96:
-      fast[i] = 0x00
-      slow[i] = 0xFF
-    (fast, slow, "scalar 0 vs 2^256-1")
-  of paBlake2bf:
-    # FAST: 0 rounds. SLOW: many rounds (first 4 big-endian bytes).
-    var fast = padded(fixture, 213)
-    var slow = padded(fixture, 213)
-    fast[0] = 0; fast[1] = 0; fast[2] = 0; fast[3] = 0
-    slow[0] = byte(blakeSlowRounds shr 24)
-    slow[1] = byte(blakeSlowRounds shr 16)
-    slow[2] = byte(blakeSlowRounds shr 8)
-    slow[3] = byte(blakeSlowRounds)
-    (fast, slow, "0 vs " & $blakeSlowRounds & " rounds")
-  of paBlsG1Add:
-    (newSeq[byte](256), padded(fixture, 256), "0+0 vs P+Q")
-  of paBlsG2Add:
-    (newSeq[byte](512), padded(fixture, 512), "0+0 vs P+Q")
-  of paBlsMapG1:
-    (newSeq[byte](64), padded(fixture, 64), "fe=0 vs fe (~constant)")
-  of paBlsMapG2:
-    (newSeq[byte](128), padded(fixture, 128), "fe=0 vs fe (~constant)")
-  of paP256Verify:
-    # FAST: zeroed public key -> bound check fails fast (still returns ok).
-    # SLOW: valid signature -> full verification.
-    var fast = padded(fixture, 160)
-    for i in 96 ..< 160: fast[i] = 0
-    (fast, padded(fixture, 160), "invalid pk vs full verify")
-  else:
-    # ecRecover: only the full-recovery path is cacheable (constant cost).
-    (fixture, fixture, "constant (no cheap cacheable path)")
+  doAssert result.len > 0, "no valid cacheable input in " & file
 
 proc newVmState(): BaseVMState =
   let
@@ -156,9 +89,18 @@ proc newVmState(): BaseVMState =
     com = CommonRef.new(newCoreDbRef DefaultDbMemory, config = conf)
   BaseVMState.new(
     Header(number: 1'u64, stateRoot: EMPTY_ROOT_HASH),
-    Header(),
-    com,
-    com.db.baseTxFrame())
+    Header(), com, com.db.baseTxFrame())
+
+proc newComp(vmState: BaseVMState, precompile: Precompiles,
+             input: seq[byte]): Computation =
+  let msg = Message(
+    kind: CallKind.Call,
+    gas: 1_000_000_000,
+    contractAddress: precompileAddrs[precompile],
+    codeAddress: precompileAddrs[precompile],
+    data: input,
+    flags: {MsgFlags.Precompile})
+  newComputation(vmState, false, msg)
 
 proc run(c: Computation, precompile: Precompiles) {.inline.} =
   c.gasMeter.gasRemaining = 1_000_000_000
@@ -167,13 +109,14 @@ proc run(c: Computation, precompile: Precompiles) {.inline.} =
   c.execPrecompile(precompile)
 
 proc evict(precompile: Precompiles, input: openArray[byte]) =
-  ## Remove this precompile's cached entry (using the same key the cache builds
-  ## for `input`) so the next call is a cache miss. The cache must be enabled.
+  ## Drop this precompile's cached entry (same key the cache builds for `input`)
+  ## so the next call is a miss. The cache must be enabled.
   template d(cache: untyped) =
     cache.del(cache.toCacheKey(input))
   case precompile
   of paEcRecover: d(ecRecoverCache)
-  of paSha256, paRipeMd160, paIdentity: discard # not cached
+  of paSha256: d(sha256Cache)
+  of paRipeMd160, paIdentity: discard # not cached
   of paModExp: d(modExpCache)
   of paEcAdd: d(ecAddCache)
   of paEcMul: d(ecMulCache)
@@ -189,43 +132,12 @@ proc evict(precompile: Precompiles, input: openArray[byte]) =
   of paBlsMapG2: d(blsMapG2Cache)
   of paP256Verify: d(p256VerifyCache)
 
-proc bench(vmState: BaseVMState, precompile: Precompiles, input: seq[byte],
-           forceMiss: bool): float =
-  let msg = Message(
-    kind: CallKind.Call,
-    gas: 1_000_000_000,
-    contractAddress: precompileAddrs[precompile],
-    codeAddress: precompileAddrs[precompile],
-    data: input,
-    flags: {MsgFlags.Precompile})
-  let c = newComputation(vmState, false, msg)
-
-  template once() =
-    if forceMiss:
-      evict(precompile, input)
-    run(c, precompile)
-
-  for _ in 0 ..< warmupIters:
-    once()
-
-  var iters = 0
-  let start = getMonoTime()
-  while true:
-    once()
-    inc iters
-    if (iters and 0x3FF) == 0 and
-       (getMonoTime() - start).inNanoseconds >= budgetNs:
-      break
-  (getMonoTime() - start).inNanoseconds.float / iters.float
-
 proc disposeAllCaches() =
-  ## Free and reset every cache back to the UNINITIALIZED state so it can be
-  ## re-initialized in a different mode (`init` asserts UNINITIALIZED, and
-  ## `dispose` alone leaves it DISPOSED). A no-op on a fresh cache.
   template z(cache: untyped) =
     cache.dispose()
     reset(cache)
   z ecRecoverCache
+  z sha256Cache
   z modExpCache
   z ecAddCache
   z ecMulCache
@@ -241,59 +153,148 @@ proc disposeAllCaches() =
   z blsMapG2Cache
   z p256VerifyCache
 
-proc runComparison(
-    vmState: BaseVMState, threadSafe: bool,
-    work: seq[tuple[precompile: Precompiles, input: seq[byte], note: string]]) =
-  # Hit (same input repeated) and miss (entry evicted before every call) both
-  # need the cache enabled; disabled measures the raw precompile cost. Re-init
-  # the caches in the requested mode (dispose any previous run's caches first).
+# ----------------------------------------------------------------------------
+# Timing
+# ----------------------------------------------------------------------------
+
+proc timeCompute(vmState: BaseVMState, precompile: Precompiles,
+                 input: seq[byte]): float =
+  ## ns/call, cache disabled (raw compute). Caller sets precompileCacheActive = false.
+  let c = newComp(vmState, precompile, input)
+  for _ in 0 ..< warmupIters:
+    run(c, precompile)
+  var iters = 0
+  let start = getMonoTime()
+  while true:
+    run(c, precompile)
+    inc iters
+    if (iters and 0x3F) == 0 and (getMonoTime() - start).inNanoseconds >= budgetNs:
+      break
+  (getMonoTime() - start).inNanoseconds.float / iters.float
+
+proc timeEnabled(vmState: BaseVMState, precompile: Precompiles,
+                 input: seq[byte], hitRatePct: int): float =
+  ## ns/call, cache enabled, with hitRatePct% of calls hitting and the rest
+  ## forced to miss by eviction. Caller has the caches initialized & active.
+  let c = newComp(vmState, precompile, input)
+  run(c, precompile) # warm: ensure the entry is present
+  for _ in 0 ..< warmupIters:
+    run(c, precompile)
+  var acc = 0
+  template once() =
+    acc += hitRatePct
+    if acc >= 100:
+      acc -= 100 # hit: leave the entry in place
+    else:
+      evict(precompile, input) # miss: drop it -> miss + compute + put
+    run(c, precompile)
+  var iters = 0
+  let start = getMonoTime()
+  while true:
+    once()
+    inc iters
+    if (iters and 0x3F) == 0 and (getMonoTime() - start).inNanoseconds >= budgetNs:
+      break
+  (getMonoTime() - start).inNanoseconds.float / iters.float
+
+proc avgInput(vmState: BaseVMState, precompile: Precompiles, file: string,
+              keyCap: int): seq[byte] =
+  ## The median-compute-cost valid fixture input - a representative "average"
+  ## call. Inputs slower than costCapNs (pathological worst cases) are excluded.
+  let inputs = validInputs(file, keyCap)
+  if inputs.len == 1:
+    return inputs[0]
+  var
+    ranked: seq[(float, seq[byte])]
+    cheapest = (float.high, inputs[0])
+  for inp in inputs:
+    let c = newComp(vmState, precompile, inp)
+    run(c, precompile) # warmup
+    var best = float.high
+    for _ in 0 ..< calibIters:
+      let s = getMonoTime()
+      run(c, precompile)
+      best = min(best, (getMonoTime() - s).inNanoseconds.float)
+    if best < cheapest[0]:
+      cheapest = (best, inp)
+    if best <= costCapNs:
+      ranked.add (best, inp)
+  if ranked.len == 0: # everything was pathologically slow - fall back to cheapest
+    return cheapest[1]
+  ranked.sort(proc(x, y: (float, seq[byte])): int = cmp(x[0], y[0]))
+  ranked[ranked.len div 2][1]
+
+proc runSweep(vmState: BaseVMState, threadSafe: bool,
+              work: seq[tuple[precompile: Precompiles, input: seq[byte]]]) =
   disposeAllCaches()
   initPrecompileCaches(threadSafe)
-  precompileCacheActive = true
-  var hit, miss: seq[float]
-  for w in work:
-    hit.add bench(vmState, w.precompile, w.input, forceMiss = false)
-    miss.add bench(vmState, w.precompile, w.input, forceMiss = true)
 
+  # disabled compute cost per precompile
   precompileCacheActive = false
-  var disabled: seq[float]
+  var compute: seq[float]
   for w in work:
-    disabled.add bench(vmState, w.precompile, w.input, forceMiss = false)
+    compute.add timeCompute(vmState, w.precompile, w.input)
 
-  echo "precompile cache: hit vs miss vs disabled (fork=", vmState.fork,
-    ", threadSafe=", threadSafe,
-    ", slow input; miss includes the eviction used to force it)"
-  echo align("precompile", 18), align("hit ns", 12), align("miss ns", 12),
-       align("disabled ns", 13), align("hit speedup", 13), align("miss ovh", 11),
-       "  scenario"
-  for i in 0 ..< work.len:
-    let
-      h = hit[i]
-      m = miss[i]
-      d = disabled[i]
-      hitSpeedup = if h > 0: d / h else: 0.0
-      missOverhead = if d > 0: m / d else: 0.0
-    echo align($work[i].precompile, 18),
-         align(formatFloat(h, ffDecimal, 1), 12),
-         align(formatFloat(m, ffDecimal, 1), 12),
-         align(formatFloat(d, ffDecimal, 1), 13),
-         align(formatFloat(hitSpeedup, ffDecimal, 1) & "x", 13),
-         align(formatFloat(missOverhead, ffDecimal, 2) & "x", 11),
-         "  ", work[i].note
+  # enabled cost at each hit rate
+  precompileCacheActive = true
+  var enabled: seq[array[hitRates.len, float]]
+  for w in work:
+    var row: array[hitRates.len, float]
+    for hi, hr in hitRates:
+      row[hi] = timeEnabled(vmState, w.precompile, w.input, hr)
+    enabled.add row
+
+  # ----- report -----
+  echo "precompile cache speedup vs disabled, by hit rate (fork=", vmState.fork,
+       ", threadSafe=", threadSafe, ")"
+  echo "speedup = compute / enabled;  >1.0 cache faster, <1.0 net loss;  ",
+       "miss forced by eviction"
+  stdout.write align("precompile", 18), align("compute ns", 13), "  "
+  for hr in hitRates:
+    stdout.write align($hr & "%", 9)
+  echo align("input B", 9)
+
+  var
+    sumCompute = 0.0
+    sumEnabled: array[hitRates.len, float]
+    logSpeedup: array[hitRates.len, float]
+  for wi, w in work:
+    stdout.write align($w.precompile, 18),
+      align(formatFloat(compute[wi], ffDecimal, 1), 13), "  "
+    for hi in 0 ..< hitRates.len:
+      let sp = compute[wi] / enabled[wi][hi]
+      stdout.write align(formatFloat(sp, ffDecimal, 2) & "x", 9)
+      sumEnabled[hi] += enabled[wi][hi]
+      logSpeedup[hi] += ln(sp)
+    echo align($w.input.len, 9)
+    sumCompute += compute[wi]
+
+  # overall: a run calling each precompile once (cost-weighted -> dominated by
+  # the expensive precompiles)
+  stdout.write align("OVERALL sum", 18),
+    align(formatFloat(sumCompute, ffDecimal, 1), 13), "  "
+  for hi in 0 ..< hitRates.len:
+    stdout.write align(formatFloat(sumCompute / sumEnabled[hi], ffDecimal, 2) & "x", 9)
+  echo align("each x1", 9)
+
+  # overall: geometric mean of per-precompile speedups (equal weight, cost-independent)
+  stdout.write align("OVERALL geomean", 18), align("-", 13), "  "
+  for hi in 0 ..< hitRates.len:
+    let g = exp(logSpeedup[hi] / work.len.float)
+    stdout.write align(formatFloat(g, ffDecimal, 2) & "x", 9)
+  echo align("equal wt", 9)
 
 proc main() =
   let vmState = newVmState()
 
-  # Build the work list once so every run uses identical inputs. Each precompile
-  # is timed on its most expensive ("slow") cacheable input.
-  var work: seq[tuple[precompile: Precompiles, input: seq[byte], note: string]]
-  for (precompile, file) in cases:
-    let (_, slow, note) = scenarios(precompile, validInputs(file))
-    work.add (precompile, slow, note)
+  # Calibrate the average input per precompile with the cache off.
+  precompileCacheActive = false
+  var work: seq[tuple[precompile: Precompiles, input: seq[byte]]]
+  for (precompile, file, keyCap) in cases:
+    work.add (precompile, avgInput(vmState, precompile, file, keyCap))
 
-  # Single-threaded caches (shardBits = 0, no locking) then thread-safe caches.
-  runComparison(vmState, threadSafe = false, work)
+  runSweep(vmState, threadSafe = false, work)
   echo ""
-  runComparison(vmState, threadSafe = true, work)
+  runSweep(vmState, threadSafe = true, work)
 
 main()

--- a/tests/eest/eest_helpers.nim
+++ b/tests/eest/eest_helpers.nim
@@ -265,6 +265,8 @@ proc prepareEnv*(
         optimisticStatePrefetch = parallelEnabled,
         balStatePrefetch = parallelEnabled)
 
+    com.db.mpt.parallelStateRootComputation = parallelEnabled
+
     if parallelEnabled:
       let taskpool =
         try:

--- a/tests/eest/eest_helpers.nim
+++ b/tests/eest/eest_helpers.nim
@@ -35,6 +35,7 @@ import
   ../../execution_chain/conf,
   ../../execution_chain/stateless/witness_types,
   ../../execution_chain/stateless/stateless_types,
+  ../../execution_chain/evm/precompiles,
   ../../hive_integration/engine_client
 
 import ../../tools/common/helpers as chp except HardFork
@@ -266,6 +267,8 @@ proc prepareEnv*(
         balStatePrefetch = parallelEnabled)
 
     com.db.mpt.parallelStateRootComputation = parallelEnabled
+
+    setPrecompileCacheEnabled(true, threadSafe = true)
 
     if parallelEnabled:
       let taskpool =

--- a/tests/eest/eest_helpers.nim
+++ b/tests/eest/eest_helpers.nim
@@ -268,7 +268,7 @@ proc prepareEnv*(
 
     com.db.mpt.parallelStateRootComputation = parallelEnabled
 
-    setPrecompileCacheEnabled(true, threadSafe = true)
+    setPrecompileCacheEnabled(false)
 
     if parallelEnabled:
       let taskpool =

--- a/tests/test_concurrency/bench_lru.nim
+++ b/tests/test_concurrency/bench_lru.nim
@@ -16,7 +16,7 @@ import
   ../../execution_chain/concurrency/lru {.all.}
 
 const
-  benchNameWidth = 36
+  benchNameWidth = 44
   cacheCapacity = 100_000
   singleThreadOps = 8_000_000
   opsPerThread = 2_000_000
@@ -110,6 +110,18 @@ proc runSingleThreadedPeek(
       checksum += uint64(v.unsafeGet()) + 1
   BenchmarkStats(elapsed: epochTime() - started, operations: count, checksum: checksum)
 
+proc runSingleThreadedWithReadValue(
+    cache: ptr ConcurrentLruCache[int, int], count: int
+): BenchmarkStats =
+  # Like get, but reads the value in place through a read-only view rather than
+  # copying it out. The body only runs on a hit.
+  var checksum: uint64
+  let started = epochTime()
+  for i in 0 ..< count:
+    cache[].withReadValue(i mod cacheCapacity, v):
+      checksum += uint64(v) + 1
+  BenchmarkStats(elapsed: epochTime() - started, operations: count, checksum: checksum)
+
 proc runLruPut(cache: ptr lru.LruCache[int, int], count: int): BenchmarkStats =
   let started = epochTime()
   for i in 0 ..< count:
@@ -194,9 +206,12 @@ suite "LruCache vs ConcurrentLruCache single-threaded comparison":
       concPut = runSingleThreadedPut(concPtr, singleThreadOps)
       concGet = runSingleThreadedGet(concPtr, singleThreadOps)
       concPeek = runSingleThreadedPeek(concPtr, singleThreadOps)
+      concWithReadValue = runSingleThreadedWithReadValue(concPtr, singleThreadOps)
       concNoLockPut = runSingleThreadedPut(concNoLockPtr, singleThreadOps)
       concNoLockGet = runSingleThreadedGet(concNoLockPtr, singleThreadOps)
       concNoLockPeek = runSingleThreadedPeek(concNoLockPtr, singleThreadOps)
+      concNoLockWithReadValue =
+        runSingleThreadedWithReadValue(concNoLockPtr, singleThreadOps)
 
     debugEcho ""
     debugEcho "  capacity=", cacheCapacity, ", ops=", singleThreadOps
@@ -207,6 +222,9 @@ suite "LruCache vs ConcurrentLruCache single-threaded comparison":
     debugEcho benchmarkLine("LruCache get", lruGet)
     debugEcho benchmarkLine("ConcurrentLruCache get (no lock)", concNoLockGet)
     debugEcho benchmarkLine("ConcurrentLruCache get", concGet)
+    debugEcho benchmarkLine(
+      "ConcurrentLruCache withReadValue (no lock)", concNoLockWithReadValue)
+    debugEcho benchmarkLine("ConcurrentLruCache withReadValue", concWithReadValue)
     debugEcho benchmarkLine("LruCache peek", lruPeek)
     debugEcho benchmarkLine("ConcurrentLruCache peek (no lock)", concNoLockPeek)
     debugEcho benchmarkLine("ConcurrentLruCache peek", concPeek)
@@ -221,6 +239,9 @@ suite "LruCache vs ConcurrentLruCache single-threaded comparison":
       concNoLockPut.elapsed > 0
       concNoLockGet.checksum != 0
       concNoLockPeek.checksum != 0
+      # withReadValue reads the same values as get on the same cache
+      concWithReadValue.checksum == concGet.checksum
+      concNoLockWithReadValue.checksum == concNoLockGet.checksum
 
 suite "ConcurrentLruCache Benchmark":
   test "Single and multi-threaded throughput":

--- a/tests/test_concurrency/test_lru.nim
+++ b/tests/test_concurrency/test_lru.nim
@@ -533,16 +533,14 @@ suite "ConcurrentLruCache Tests":
     check not ran
 
   test "withReadValue and put with a precomputed hash":
-    # Uses an object key (not int) because Hash is an alias of int, which would
-    # make the precomputed-hash withReadValue overload ambiguous for int keys.
-    var lru: ConcurrentLruCache[A, int]
+    var lru: ConcurrentLruCache[int, int]
     lru.init(1000)
     defer:
       lru.dispose()
 
     let
-      key = A(v: 7)
-      keyHash = hash(key)
+      key = 7
+      keyHash = lru.toKeyHash(key)
 
     lru.putByHash(keyHash, key, 70) # insert using the precomputed hash
 
@@ -557,9 +555,8 @@ suite "ConcurrentLruCache Tests":
       lru.peek(key) == Opt.some(70) # agrees with the hash-computing overloads
 
     # absent key: the body must not run
-    let missKey = A(v: 8)
     ran = false
-    lru.withReadValueByHash(hash(missKey), missKey, v):
+    lru.withReadValueByHash(lru.toKeyHash(8), 8, v):
       ran = true
     check not ran
 
@@ -1134,14 +1131,14 @@ suite "ConcurrentLruCache Tests (threadSafe = false)":
     check not ran
 
   test "withReadValue and put with a precomputed hash":
-    var lru: ConcurrentLruCache[A, int]
+    var lru: ConcurrentLruCache[int, int]
     lru.init(1000, shardBits = 0, threadSafe = false)
     defer:
       lru.dispose()
 
     let
-      key = A(v: 7)
-      keyHash = hash(key)
+      key = 7
+      keyHash = lru.toKeyHash(key)
 
     lru.putByHash(keyHash, key, 70)
 

--- a/tests/test_concurrency/test_lru.nim
+++ b/tests/test_concurrency/test_lru.nim
@@ -509,7 +509,7 @@ suite "ConcurrentLruCache Tests":
       lru.peek(1) == Opt.some(10)
       lru.peek(99) == Opt.none(int)
 
-  test "withValue":
+  test "withReadValue":
     var lru: ConcurrentLruCache[int, int]
     lru.init(1000)
     defer:
@@ -519,18 +519,77 @@ suite "ConcurrentLruCache Tests":
 
     var ran = false
     var seen = 0
-    lru.withValue(1, v):
+    lru.withReadValue(1, v):
       ran = true
-      seen = v[] # v is a `ptr int` pointing straight at the stored value
+      seen = v # v is a read-only, zero-copy view of the stored value
     check:
       ran
       seen == 10
 
     # absent key: body must not run and no pointer is exposed
     ran = false
-    lru.withValue(99, v):
+    lru.withReadValue(99, v):
       ran = true
     check not ran
+
+  test "withReadValue with do block":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(1000)
+    defer:
+      lru.dispose()
+
+    lru.put(1, 10)
+
+    # present key: the found body runs, the do block does not
+    var seen = 0
+    var missRan = false
+    lru.withReadValue(1, v):
+      seen = v
+    do:
+      missRan = true
+    check:
+      seen == 10
+      not missRan
+
+    # absent key: the do block runs, the found body does not
+    var foundRan = false
+    missRan = false
+    lru.withReadValue(99, v):
+      foundRan = true
+    do:
+      missRan = true
+    check:
+      not foundRan
+      missRan
+
+  test "withReadValue do block can populate on miss":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(1000)
+    defer:
+      lru.dispose()
+
+    # miss: the do block computes and inserts the value. It runs outside the
+    # read lock, so calling back into the cache (put) does not deadlock.
+    var computed = 0
+    lru.withReadValue(7, v):
+      computed = v
+    do:
+      lru.put(7, 70)
+      computed = 70
+    check:
+      computed == 70
+      lru.peek(7) == Opt.some(70)
+
+    # the freshly inserted value is now a hit
+    var hitVal = 0
+    var missRan = false
+    lru.withReadValue(7, v):
+      hitVal = v
+    do:
+      missRan = true
+    check:
+      hitVal == 70
+      not missRan
 
   test "del":
     var lru: ConcurrentLruCache[int, int]
@@ -1065,7 +1124,7 @@ suite "ConcurrentLruCache Tests (threadSafe = false)":
       lru.contains(3)
       lru.contains(4)
 
-  test "withValue promotes and allows mutation":
+  test "withReadValue promotes and exposes a read-only view":
     var lru: ConcurrentLruCache[int, int]
     lru.init(3, shardBits = 0, threadSafe = false)
     defer:
@@ -1075,12 +1134,12 @@ suite "ConcurrentLruCache Tests (threadSafe = false)":
     lru.put(2, 20)
     lru.put(3, 30)
 
-    # withValue promotes to MRU like get; inserting a new key must evict 2
+    # withReadValue promotes to MRU like get; inserting a new key must evict 2
     # (the actual LRU), not 1
     for _ in 0 ..< 5:
       var seen = 0
-      lru.withValue(1, v):
-        seen = v[]
+      lru.withReadValue(1, v):
+        seen = v
       check seen == 10
 
     lru.put(4, 40)
@@ -1090,13 +1149,43 @@ suite "ConcurrentLruCache Tests (threadSafe = false)":
       lru.contains(3)
       lru.contains(4)
 
-    # single-threaded mode: the value can be mutated through the pointer
-    lru.withValue(1, v):
-      v[] = 111
-    check lru.peek(1) == Opt.some(111)
+    # the view is read-only: assigning through it must not compile
+    check not compiles(
+      (block:
+        lru.withReadValue(1, v):
+          v = 111))
 
     # absent key: body must not run
     var ran = false
-    lru.withValue(123, v):
+    lru.withReadValue(123, v):
       ran = true
     check not ran
+
+  test "withReadValue with do block":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(1000, shardBits = 0, threadSafe = false)
+    defer:
+      lru.dispose()
+
+    lru.put(1, 10)
+
+    # present key: the found body runs, the do block does not
+    var seen = 0
+    var missRan = false
+    lru.withReadValue(1, v):
+      seen = v
+    do:
+      missRan = true
+    check:
+      seen == 10
+      not missRan
+
+    # absent key: the do block runs and can populate the cache
+    var foundRan = false
+    lru.withReadValue(2, v):
+      foundRan = true
+    do:
+      lru.put(2, 20)
+    check:
+      not foundRan
+      lru.peek(2) == Opt.some(20)

--- a/tests/test_concurrency/test_lru.nim
+++ b/tests/test_concurrency/test_lru.nim
@@ -532,64 +532,36 @@ suite "ConcurrentLruCache Tests":
       ran = true
     check not ran
 
-  test "withReadValue with do block":
-    var lru: ConcurrentLruCache[int, int]
+  test "withReadValue and put with a precomputed hash":
+    # Uses an object key (not int) because Hash is an alias of int, which would
+    # make the precomputed-hash withReadValue overload ambiguous for int keys.
+    var lru: ConcurrentLruCache[A, int]
     lru.init(1000)
     defer:
       lru.dispose()
 
-    lru.put(1, 10)
+    let
+      key = A(v: 7)
+      keyHash = hash(key)
 
-    # present key: the found body runs, the do block does not
+    lru.putByHash(keyHash, key, 70) # insert using the precomputed hash
+
+    var ran = false
     var seen = 0
-    var missRan = false
-    lru.withReadValue(1, v):
+    lru.withReadValueByHash(keyHash, key, v): # look up using the same hash
+      ran = true
       seen = v
-    do:
-      missRan = true
     check:
-      seen == 10
-      not missRan
+      ran
+      seen == 70
+      lru.peek(key) == Opt.some(70) # agrees with the hash-computing overloads
 
-    # absent key: the do block runs, the found body does not
-    var foundRan = false
-    missRan = false
-    lru.withReadValue(99, v):
-      foundRan = true
-    do:
-      missRan = true
-    check:
-      not foundRan
-      missRan
-
-  test "withReadValue do block can populate on miss":
-    var lru: ConcurrentLruCache[int, int]
-    lru.init(1000)
-    defer:
-      lru.dispose()
-
-    # miss: the do block computes and inserts the value. It runs outside the
-    # read lock, so calling back into the cache (put) does not deadlock.
-    var computed = 0
-    lru.withReadValue(7, v):
-      computed = v
-    do:
-      lru.put(7, 70)
-      computed = 70
-    check:
-      computed == 70
-      lru.peek(7) == Opt.some(70)
-
-    # the freshly inserted value is now a hit
-    var hitVal = 0
-    var missRan = false
-    lru.withReadValue(7, v):
-      hitVal = v
-    do:
-      missRan = true
-    check:
-      hitVal == 70
-      not missRan
+    # absent key: the body must not run
+    let missKey = A(v: 8)
+    ran = false
+    lru.withReadValueByHash(hash(missKey), missKey, v):
+      ran = true
+    check not ran
 
   test "del":
     var lru: ConcurrentLruCache[int, int]
@@ -1161,31 +1133,21 @@ suite "ConcurrentLruCache Tests (threadSafe = false)":
       ran = true
     check not ran
 
-  test "withReadValue with do block":
-    var lru: ConcurrentLruCache[int, int]
+  test "withReadValue and put with a precomputed hash":
+    var lru: ConcurrentLruCache[A, int]
     lru.init(1000, shardBits = 0, threadSafe = false)
     defer:
       lru.dispose()
 
-    lru.put(1, 10)
+    let
+      key = A(v: 7)
+      keyHash = hash(key)
 
-    # present key: the found body runs, the do block does not
+    lru.putByHash(keyHash, key, 70)
+
     var seen = 0
-    var missRan = false
-    lru.withReadValue(1, v):
+    lru.withReadValueByHash(keyHash, key, v):
       seen = v
-    do:
-      missRan = true
     check:
-      seen == 10
-      not missRan
-
-    # absent key: the do block runs and can populate the cache
-    var foundRan = false
-    lru.withReadValue(2, v):
-      foundRan = true
-    do:
-      lru.put(2, 20)
-    check:
-      not foundRan
-      lru.peek(2) == Opt.some(20)
+      seen == 70
+      lru.peek(key) == Opt.some(70)

--- a/tests/test_concurrency/test_lru.nim
+++ b/tests/test_concurrency/test_lru.nim
@@ -373,6 +373,25 @@ suite "LruCache Tests":
     check:
       toSeq(lru.keys()) == @[5, 4, 3, 2, 1]
 
+  test "moveToFront by key":
+    var lru = LruCache[int, int].init(5)
+
+    for i in 0 ..< 5:
+      lru.put(i, i)
+    check toSeq(lru.keys()) == @[4, 3, 2, 1, 0]
+
+    # promote a key to the front (without copying its value out)
+    lru.moveToFront(subhash(0), 0)
+    check toSeq(lru.keys()) == @[0, 4, 3, 2, 1]
+
+    # promoting the existing front is a no-op
+    lru.moveToFront(subhash(0), 0)
+    check toSeq(lru.keys()) == @[0, 4, 3, 2, 1]
+
+    # a missing key leaves the order untouched
+    lru.moveToFront(subhash(99), 99)
+    check toSeq(lru.keys()) == @[0, 4, 3, 2, 1]
+
   test "dispose":
     block:
       var lru = LruCache[int, int].init(2)
@@ -489,6 +508,29 @@ suite "ConcurrentLruCache Tests":
     check:
       lru.peek(1) == Opt.some(10)
       lru.peek(99) == Opt.none(int)
+
+  test "withValue":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(1000)
+    defer:
+      lru.dispose()
+
+    lru.put(1, 10)
+
+    var ran = false
+    var seen = 0
+    lru.withValue(1, v):
+      ran = true
+      seen = v[] # v is a `ptr int` pointing straight at the stored value
+    check:
+      ran
+      seen == 10
+
+    # absent key: body must not run and no pointer is exposed
+    ran = false
+    lru.withValue(99, v):
+      ran = true
+    check not ran
 
   test "del":
     var lru: ConcurrentLruCache[int, int]
@@ -1022,3 +1064,39 @@ suite "ConcurrentLruCache Tests (threadSafe = false)":
       not lru.contains(2)
       lru.contains(3)
       lru.contains(4)
+
+  test "withValue promotes and allows mutation":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(3, shardBits = 0, threadSafe = false)
+    defer:
+      lru.dispose()
+
+    lru.put(1, 10)
+    lru.put(2, 20)
+    lru.put(3, 30)
+
+    # withValue promotes to MRU like get; inserting a new key must evict 2
+    # (the actual LRU), not 1
+    for _ in 0 ..< 5:
+      var seen = 0
+      lru.withValue(1, v):
+        seen = v[]
+      check seen == 10
+
+    lru.put(4, 40)
+    check:
+      lru.contains(1)
+      not lru.contains(2)
+      lru.contains(3)
+      lru.contains(4)
+
+    # single-threaded mode: the value can be mutated through the pointer
+    lru.withValue(1, v):
+      v[] = 111
+    check lru.peek(1) == Opt.some(111)
+
+    # absent key: body must not run
+    var ran = false
+    lru.withValue(123, v):
+      ran = true
+    check not ran

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -24,7 +24,6 @@ import
 
   ./test_helpers
 
-
 template doTest(fixture: JsonNode; vmState: BaseVMState; precompile: Precompiles): untyped =
   for test in fixture:
     let
@@ -101,5 +100,7 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
     echo "Unknown test vector '" & $label & "'"
     testStatusIMPL = SKIPPED
 
-suite "Precompiles":
-  jsonTest("PrecompileTests", testFixture)
+for cacheEnabled in [true, false]:
+  setPrecompileCacheEnabled(cacheEnabled)
+  suite "Precompiles (cache " & (if cacheEnabled: "enabled" else: "disabled") & ")":
+    jsonTest("PrecompileTests", testFixture)


### PR DESCRIPTION


**Performance testing results**

Running bench_precompiles.nim:

```
precompile cache speedup vs disabled, by hit rate (fork=FkOsaka, threadSafe=false)
speedup = compute / enabled;  >1.0 cache faster, <1.0 net loss;  miss forced by eviction
        precompile   compute ns         5%      25%      50%      75%      95%     100%  input B
       paEcRecover      25952.3      1.05x    1.34x    2.01x    4.01x   18.87x  303.11x      128
          paSha256        519.7      0.82x    0.99x    1.39x    2.27x    4.68x    6.17x      128
          paModExp      20069.0      1.10x    1.39x    2.05x    4.00x   18.36x  196.70x      160
           paEcAdd        275.8      0.78x    0.91x    1.24x    1.91x    3.51x    4.18x       64
           paEcMul      51537.7      1.29x    1.59x    2.41x    4.82x   23.11x  649.92x       96
         paPairing    1625728.8      1.05x    1.32x    1.98x    3.97x   19.56x 9781.49x      384
        paBlake2bf        156.9      0.47x    0.53x    0.66x    0.86x    1.21x    1.33x      213
        paBlsG1Add       3421.3      1.00x    1.25x    1.80x    3.32x   10.73x   24.62x      256
   paBlsG1MultiExp     119986.8      1.05x    1.34x    2.00x    3.94x   19.19x  567.86x      480
        paBlsG2Add       5258.1      0.98x    1.23x    1.80x    3.31x   10.67x   25.00x      512
   paBlsG2MultiExp      51902.4      1.05x    1.33x    1.99x    3.64x   18.87x  361.64x      288
      paBlsPairing     759850.5      1.05x    1.33x    2.01x    4.05x   19.93x 2703.88x      768
        paBlsMapG1      35100.3      1.04x    1.31x    1.96x    3.93x   18.97x  517.99x       64
        paBlsMapG2     114290.0      1.04x    1.32x    1.97x    3.98x   19.71x 1275.61x      128
      paP256Verify     234862.7      1.05x    1.32x    1.98x    3.98x   19.68x 2361.41x      160
       OVERALL sum    3048912.1      1.05x    1.33x    1.99x    3.99x   19.59x 1569.19x  each x1
   OVERALL geomean            -      0.97x    1.20x    1.75x    3.24x   12.17x  180.36x equal wt
```

Imported 10K blocks starting at block 24 million with optimistic state prefetching disabled:
master - elapsed=17m3s84ms
precompiles - elapsed=16m59s570ms

Imported 10K blocks starting at block 24 million with optimistic state prefetching enabled:
master - elapsed=16m9s598ms
precompiles - elapsed=14m9s902ms

