### PR TITLE
EIP-7997: don't reset factory nonce when it already exists

### DIFF
--- a/execution_chain/core/eip7997.nim
+++ b/execution_chain/core/eip7997.nim
@@ -20,9 +20,11 @@ const
   FactoryCode = hexToSeqByte"0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"
 
 proc applyEip7997*(ledger: LedgerRef) =
-  # Although this code only called once during fork transition,
-  # if using the constant above, sometimes it will crash
-  # when interacting with CodeBytesRef sink in test environment.
-  let factoryCode = FactoryCode
-  ledger.setCode(FactoryAddress, factoryCode)
-  ledger.setNonce(FactoryAddress, 1)
+  # EIP-7997: seed the factory with nonce 1 and its runtime code, but only when
+  # it isn't already present. Per the EIP this is a no-op on chains that already
+  # have the factory; resetting an existing (possibly already-used) factory's
+  # nonce would corrupt the state root at the transition block.
+  if ledger.getCodeSize(FactoryAddress) == 0:
+    let factoryCode = FactoryCode
+    ledger.setCode(FactoryAddress, factoryCode)
+    ledger.setNonce(FactoryAddress, 1)


### PR DESCRIPTION
## Problem

`applyEip7997()` unconditionally sets the deterministic-deployment factory (`0x4e59b44847b379578588920cA78FbF26c0B4956C`) to **nonce 1** and its runtime code at the Amsterdam fork-transition block.

When the factory already exists — seeded in genesis, or deployed earlier and used for CREATE2 so its nonce has grown past 1 — this resets the nonce back to 1, diverging the post-state root from every other client and halting sync at the transition block.

On `glamsterdam-devnet-6` the factory is in genesis (nonce 1) and reaches **nonce 32** by block 956 (31 CREATE2 deployments). Block 957 is the Amsterdam transition, where Nimbus resets it to 1:

| block 957 | geth / canonical | nimbus (before fix) |
|---|---|---|
| factory nonce | 32 | 1 |
| state root | `0x90c64cda…` | `0x15583024…` |

This is the only difference in the entire state — receipts, gas, logs and all other accounts match — so it surfaces only when the post-state root is re-derived, crashing the node with `State root sanity check failed`.

## Fix

EIP-7997's Backwards Compatibility section: *"On chains that already have the factory at `FACTORY_ADDRESS` … satisfying this requirement is a no-op."*

Guard the injection on the factory's code being absent, so an existing (possibly already-used) factory is left untouched, while a not-yet-deployed factory is still created with nonce 1 (preserving any pre-existing balance).

## Reproduction

`--debug-persist-batch-size=1` makes the node crash at the first base advance (956→957). Verified against `ethpandaops/geth:glamsterdam-devnet-6` archive: the divergent account is exactly the EIP-7997 factory, nonce 32 (geth) vs 1 (nimbus).

A matching EEST fork-transition test is being added under `tests/amsterdam/`.