### PR TITLE
ConcurrentLruCache withGet/withPeek templates and other improvements

### DIFF
--- a/execution_chain/concurrency/lru.nim
+++ b/execution_chain/concurrency/lru.nim
@@ -872,34 +872,44 @@ template withValueImpl[K, V](
     let
       sh = keyHash.subhash
       s = addr lru.shards[keyHash.shardIdx]
-    var found = false
-
-    s.lock.withReadLock:
-      let valuePtr = s.cache.peekPtr(sh, key)
-      if valuePtr != nil:
-        found = true
-        template value(): untyped {.inject.} = toLent(valuePtr)
-        foundBody
-
-    if found:
-      when not peek:
-        inc tlsLruGetCounter
-        if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
-          s.lock.withWriteLock:
-            s.cache.moveToFront(sh, key)
+    
+    var valuePtr: ptr V
+    when peek:
+      s.lock.withReadLock:
+        valuePtr = s.cache.peekPtr(sh, key)
+        if not valuePtr.isNil():
+          template value(): untyped {.inject.} = toLent(valuePtr)
+          foundBody
     else:
+      try:
+        s.lock.withReadLock:
+          valuePtr = s.cache.peekPtr(sh, key)
+          if not valuePtr.isNil():
+            template value(): untyped {.inject.} = toLent(valuePtr)
+            foundBody
+      finally:
+        # Promote in a `finally` so it still runs if `foundBody` exits early via
+        # `return`/`break`. The read lock is released before the `finally` runs, so
+        # taking the write lock here cannot deadlock against it.
+        if not valuePtr.isNil():
+          inc tlsLruGetCounter
+          if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
+            s.lock.withWriteLock:
+              s.cache.moveToFront(sh, key)
+    if valuePtr.isNil():
       notFoundBody
+
   else:
     let valuePtr =
       when peek:
         lru.cache.peekPtr(keyHash.subhash, key)
       else:
         lru.cache.getPtr(keyHash.subhash, key)
-    if valuePtr != nil:
+    if valuePtr.isNil():
+      notFoundBody
+    else:
       template value(): untyped {.inject.} = toLent(valuePtr)
       foundBody
-    else:
-      notFoundBody
 
 template withGetByHash*[K, V](
     lru: var ConcurrentLruCache[K, V], keyHash: KeyHash, key: auto, value, body: untyped

--- a/execution_chain/concurrency/lru.nim
+++ b/execution_chain/concurrency/lru.nim
@@ -446,6 +446,30 @@ template peek[K, V](s: var LruCache[K, V], key: auto): Opt[V] =
   ## Retrieve item without moving it to the front
   s.peek(subhash(key), key)
 
+proc getPtr[K, V](s: var LruCache[K, V], subhash: uint32, key: auto): ptr V =
+  ## Pointer to the value, moving the item to the front - nil if not found
+  let index = s.tableGet(subhash, key).valueOr:
+    return nil
+  s.moveToFront(index)
+  addr s.nodes[index].value
+
+template getPtr[K, V](s: var LruCache[K, V], key: auto): ptr V =
+  ## Pointer to the value, moving the item to the front - nil if not found
+  s.getPtr(subhash(key), key)
+
+func peekPtr[K, V](s: var LruCache[K, V], subhash: uint32, key: auto): ptr V =
+  ## Pointer to the value without moving the item - nil if not found
+  let index = s.tableGet(subhash, key).valueOr:
+    return nil
+  addr s.nodes[index].value
+
+proc moveToFront(s: var LruCache, subhash: uint32, key: auto) =
+  ## Look up the item by key and move it to the front of the LRU cache - does
+  ## nothing if the key is not present. Unlike `get`, no value is copied out.
+  let index = s.tableGet(subhash, key).valueOr:
+    return
+  s.moveToFront(index)
+
 proc update(s: var LruCache, subhash: uint32, key: auto, value: auto): bool =
   let index = s.tableGet(subhash, key).valueOr:
     return false
@@ -802,18 +826,88 @@ proc get*[K, V](lru: var ConcurrentLruCache[K, V], key: K): Opt[V] =
       inc tlsLruGetCounter
       if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
         s.lock.withWriteLock:
-          discard s.cache.get(sh, key)
+          s.cache.moveToFront(sh, key)
     value
   else:
     lru.cache.get(key)
 
-proc put*[K, V](lru: var ConcurrentLruCache[K, V], key: K, val: V) =
+
+type
+  KeyHash* = object
+    subhash: uint32
+    shardIdx: int
+
+func toKeyHash*[K, V](lru: ConcurrentLruCache[K, V], key: auto): KeyHash =
+  ## Hash `key` for `lru` once, returning a token to pass to
+  ## `withReadValueByHash` / `putByHash` - reuse it for a lookup followed by a
+  ## `put` so the key is hashed (and the subhash derived) only once.
+  ##
+  ## `key` may be a borrowed view rather than a `K` (e.g. an `openArray` aliasing
+  ## the bytes of the key) as long as it hashes identically to - and
+  ## compares equal to - the corresponding `K`. This lets a lookup avoid
+  ## materializing the key, copying it only when a miss requires a `put`.
+  mixin hash
+  let h = hash(key)
   if lru.threadSafe:
-    withShardWrite(lru, key):
+    KeyHash(subhash: h.toSubhash(), shardIdx: h.toShardIdx(lru.shardBits))
+  else:
+    KeyHash(subhash: h.toSubhash())
+
+func toLent[T](p: ptr T): lent T =
+  # Borrow the pointee as a read-only view (no copy). Used to hand `withReadValue`
+  # bodies access to the cached value without letting them mutate it - assigning
+  # to a `lent` is a compile error.
+  p[]
+
+template withReadValueByHash*[K, V](
+    lru: var ConcurrentLruCache[K, V], keyHash: KeyHash, key: auto, value, body: untyped
+) =
+  ## `key` may be a borrowed view that hashes and compares equal to a `K` (see
+  ## `toKeyHash`); `keyHash` must have been derived from the same key.
+  if lru.threadSafe:
+    let
+      sh = keyHash.subhash
+      s = addr lru.shards[keyHash.shardIdx]
+    var found = false
+
+    s.lock.withReadLock:
+      let valuePtr = s.cache.peekPtr(sh, key)
+      if valuePtr != nil:
+        found = true
+        template value(): untyped {.inject.} = toLent(valuePtr)
+        body
+
+    if found:
+      inc tlsLruGetCounter
+      if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
+        s.lock.withWriteLock:
+          s.cache.moveToFront(sh, key)
+  else:
+    let valuePtr = lru.cache.getPtr(keyHash.subhash, key)
+    if valuePtr != nil:
+      template value(): untyped {.inject.} = toLent(valuePtr)
+      body
+
+proc putByHash*[K, V](
+    lru: var ConcurrentLruCache[K, V], keyHash: KeyHash, key: K, val: V
+) =
+  if lru.threadSafe:
+    let
+      sh = keyHash.subhash
+      s = addr lru.shards[keyHash.shardIdx]
+    s.lock.withWriteLock:
       if s.cache.put(sh, key, val):
         s.usedCount.store(s.cache.len, moRelaxed)
   else:
-    lru.cache.put(key, val)
+    lru.cache.put(keyHash.subhash, key, val)
+
+template withReadValue*[K, V](
+    lru: var ConcurrentLruCache[K, V], key: K, value, body: untyped
+) =
+  lru.withReadValueByHash(lru.toKeyHash(key), key, value, body)
+
+proc put*[K, V](lru: var ConcurrentLruCache[K, V], key: K, val: V) =
+  lru.putByHash(lru.toKeyHash(key), key, val)
 
 proc pop*[K, V](lru: var ConcurrentLruCache[K, V], key: K): Opt[V] =
   if lru.threadSafe:

--- a/execution_chain/concurrency/lru.nim
+++ b/execution_chain/concurrency/lru.nim
@@ -839,7 +839,7 @@ type
 
 func toKeyHash*[K, V](lru: ConcurrentLruCache[K, V], key: auto): KeyHash =
   ## Hash `key` for `lru` once, returning a token to pass to
-  ## `withReadValueByHash` / `putByHash` - reuse it for a lookup followed by a
+  ## `withGetByHash` / `putByHash` - reuse it for a lookup followed by a
   ## `put` so the key is hashed (and the subhash derived) only once.
   ##
   ## `key` may be a borrowed view rather than a `K` (e.g. an `openArray` aliasing
@@ -854,16 +854,20 @@ func toKeyHash*[K, V](lru: ConcurrentLruCache[K, V], key: auto): KeyHash =
     KeyHash(subhash: h.toSubhash())
 
 func toLent[T](p: ptr T): lent T =
-  # Borrow the pointee as a read-only view (no copy). Used to hand `withReadValue`
+  # Borrow the pointee as a read-only view (no copy). Used to hand `withGet`
   # bodies access to the cached value without letting them mutate it - assigning
   # to a `lent` is a compile error.
   p[]
 
-template withReadValueByHash*[K, V](
-    lru: var ConcurrentLruCache[K, V], keyHash: KeyHash, key: auto, value, body: untyped
+template withValueImpl[K, V](
+    lru: var ConcurrentLruCache[K, V],
+    keyHash: KeyHash,
+    key: auto,
+    value: untyped,
+    peek: static bool,
+    foundBody: untyped,
+    notFoundBody: untyped,
 ) =
-  ## `key` may be a borrowed view that hashes and compares equal to a `K` (see
-  ## `toKeyHash`); `keyHash` must have been derived from the same key.
   if lru.threadSafe:
     let
       sh = keyHash.subhash
@@ -875,18 +879,66 @@ template withReadValueByHash*[K, V](
       if valuePtr != nil:
         found = true
         template value(): untyped {.inject.} = toLent(valuePtr)
-        body
+        foundBody
 
     if found:
-      inc tlsLruGetCounter
-      if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
-        s.lock.withWriteLock:
-          s.cache.moveToFront(sh, key)
+      when not peek:
+        inc tlsLruGetCounter
+        if (tlsLruGetCounter and SAMPLE_MASK) == 0'u32:
+          s.lock.withWriteLock:
+            s.cache.moveToFront(sh, key)
+    else:
+      notFoundBody
   else:
-    let valuePtr = lru.cache.getPtr(keyHash.subhash, key)
+    let valuePtr =
+      when peek:
+        lru.cache.peekPtr(keyHash.subhash, key)
+      else:
+        lru.cache.getPtr(keyHash.subhash, key)
     if valuePtr != nil:
       template value(): untyped {.inject.} = toLent(valuePtr)
-      body
+      foundBody
+    else:
+      notFoundBody
+
+template withGetByHash*[K, V](
+    lru: var ConcurrentLruCache[K, V], keyHash: KeyHash, key: auto, value, body: untyped
+) =
+  ## Run `body` with `value` bound to a read-only, zero-copy view of the cached
+  ## value if `key` is present, promoting the item towards the
+  ## most-recently-used end (sampled, like `get`). `body` does not run on a miss.
+  ##
+  ## `key` may be a borrowed view that hashes and compares equal to a `K` (see
+  ## `toKeyHash`); `keyHash` must have been derived from the same key.
+  withValueImpl(lru, keyHash, key, value, false, body, (discard))
+
+template withGetByHash*[K, V](
+    lru: var ConcurrentLruCache[K, V],
+    keyHash: KeyHash,
+    key: auto,
+    value, foundBody, notFoundBody: untyped,
+) =
+  ## Variant taking an optional second block (introduced with `do:`) that runs
+  ## when `key` is missing - similar to `Tables.withValue`. The miss block runs
+  ## after the read lock is released, so it may `put` the value.
+  withValueImpl(lru, keyHash, key, value, false, foundBody, notFoundBody)
+
+template withPeekByHash*[K, V](
+    lru: var ConcurrentLruCache[K, V], keyHash: KeyHash, key: auto, value, body: untyped
+) =
+  ## Like `withGetByHash` but leaves the item's position unchanged (like
+  ## `peek`) rather than promoting it.
+  withValueImpl(lru, keyHash, key, value, true, body, (discard))
+
+template withPeekByHash*[K, V](
+    lru: var ConcurrentLruCache[K, V],
+    keyHash: KeyHash,
+    key: auto,
+    value, foundBody, notFoundBody: untyped,
+) =
+  ## Like `withGetByHash` (with a `do:` miss block) but leaves the item's
+  ## position unchanged (like `peek`) rather than promoting it.
+  withValueImpl(lru, keyHash, key, value, true, foundBody, notFoundBody)
 
 proc putByHash*[K, V](
     lru: var ConcurrentLruCache[K, V], keyHash: KeyHash, key: K, val: V
@@ -901,10 +953,35 @@ proc putByHash*[K, V](
   else:
     lru.cache.put(keyHash.subhash, key, val)
 
-template withReadValue*[K, V](
+template withGet*[K, V](
     lru: var ConcurrentLruCache[K, V], key: K, value, body: untyped
 ) =
-  lru.withReadValueByHash(lru.toKeyHash(key), key, value, body)
+  ## Run `body` with `value` bound to a read-only, zero-copy view of the cached
+  ## value if `key` is present, promoting the item towards the
+  ## most-recently-used end (sampled, like `get`). `body` does not run on a miss.
+  withValueImpl(lru, lru.toKeyHash(key), key, value, false, body, (discard))
+
+template withGet*[K, V](
+    lru: var ConcurrentLruCache[K, V], key: K, value, foundBody, notFoundBody: untyped
+) =
+  ## Variant taking an optional second block (introduced with `do:`) that runs
+  ## when `key` is missing - similar to `Tables.withValue`. The miss block runs
+  ## after the read lock is released, so it may `put` the value.
+  withValueImpl(lru, lru.toKeyHash(key), key, value, false, foundBody, notFoundBody)
+
+template withPeek*[K, V](
+    lru: var ConcurrentLruCache[K, V], key: K, value, body: untyped
+) =
+  ## Like `withGet` but leaves the item's position unchanged (like `peek`)
+  ## rather than promoting it.
+  withValueImpl(lru, lru.toKeyHash(key), key, value, true, body, (discard))
+
+template withPeek*[K, V](
+    lru: var ConcurrentLruCache[K, V], key: K, value, foundBody, notFoundBody: untyped
+) =
+  ## Like `withGet` (with a `do:` miss block) but leaves the item's position
+  ## unchanged (like `peek`) rather than promoting it.
+  withValueImpl(lru, lru.toKeyHash(key), key, value, true, foundBody, notFoundBody)
 
 proc put*[K, V](lru: var ConcurrentLruCache[K, V], key: K, val: V) =
   lru.putByHash(lru.toKeyHash(key), key, val)

--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -840,6 +840,10 @@ proc ereDir*(config: ExecutionClientConf): string =
 func udpPort*(config: ExecutionClientConf): Port =
   config.udpPortFlag.get(config.tcpPort)
 
+func threadSafeCaches*(config: ExecutionClientConf): bool =
+  config.optimisticStatePrefetch or config.balStatePrefetch or
+    config.parallelStateRootComputation
+
 func dbOptions*(config: ExecutionClientConf, noKeyCache = false): DbOptions =
   DbOptions.init(
     maxOpenFiles = config.rocksdbMaxOpenFiles,
@@ -856,8 +860,7 @@ func dbOptions*(config: ExecutionClientConf, noKeyCache = false): DbOptions =
     rdbPrintStats = config.rdbPrintStats,
     maxSnapshots = config.aristoDbMaxSnapshots,
     parallelStateRootComputation = config.parallelStateRootComputation,
-    threadSafeCaches = config.optimisticStatePrefetch or config.balStatePrefetch or
-      config.parallelStateRootComputation,
+    threadSafeCaches = config.threadSafeCaches,
     blockCacheType = config.rocksdbBlockCacheType,
   )
 

--- a/execution_chain/db/aristo/aristo_fetch.nim
+++ b/execution_chain/db/aristo/aristo_fetch.nim
@@ -43,12 +43,24 @@ proc retrieveLeaf(
 proc cachedAccLeaf*(db: AristoTxRef; accPath: Hash32): Opt[AccLeafRef] =
   # Return vertex from layers or cache, `nil` if it's known to not exist and
   # none otherwise
-  db.layersGetAccLeaf(accPath) or db.db.accLeaves.get(accPath).map(toLeaf)
+  db.layersGetAccLeaf(accPath).isErrOr:
+    return Opt.some(value)
+
+  db.db.accLeaves.withGet(accPath, cached):
+    return Opt.some(cached.toLeaf())
+  do:
+    return Opt.none(AccLeafRef)
 
 proc cachedStoLeaf*(db: AristoTxRef; mixPath: Hash32): Opt[StoLeafRef] =
   # Return vertex from layers or cache, `nil` if it's known to not exist and
   # none otherwise
-  db.layersGetStoLeaf(mixPath) or db.db.stoLeaves.get(mixPath).map(toLeaf)
+  db.layersGetStoLeaf(mixPath).isErrOr:
+    return Opt.some(value)
+
+  db.db.stoLeaves.withGet(mixPath, cached):
+    return Opt.some(cached.toLeaf())
+  do:
+    return Opt.none(StoLeafRef)
 
 proc retrieveAccStatic(
     db: AristoTxRef;
@@ -280,30 +292,29 @@ proc fetchSlot*(
   ## from the database indexed by `path`. Returns err(FetchPathNotFound) if the
   ## account does not exist and 0'u256 if the account has not stored anything
   ## at the given slot
-  let 
-    mixPath = mixUp(accPath, stoPath)
-    leafVtx = db.layersGetStoLeaf(mixPath)
+  let mixPath = mixUp(accPath, stoPath)
   
-  if leafVtx.isSome():
+  db.layersGetStoLeaf(mixPath).isErrOr:
     # Found in the layers so we don't need to copy into the cache 
     # because the value will be updated from the layers during persist
-    ok leafVtx[].toStoData()
-  else:
-    let cached = db.db.stoLeaves.get(mixPath)
-    if cached.isSome():
-      ok cached[].toStoData()
-    else:
-      # Updated payloads are stored in the layers so if we didn't find them there,
-      # it must have been in the database
-      let stoID = ?db.fetchStorageID(accPath)
+    return ok value.toStoData()
+  
+  db.db.stoLeaves.withGet(mixPath, cached):
+    return ok cached.toStoData()
+  do:
+    # Updated payloads are stored in the layers so if we didn't find them there,
+    # it must have been in the database
 
-      if stoID.isValid():
-        let leaf = StoLeafRef(db.retrieveLeaf(stoID, NibblesBuf.fromBytes(stoPath.data)).valueOr(nil))
-        db.db.stoLeaves.put(mixPath, if leaf.isValid(): CachedStoLeaf.init(leaf.pfx, leaf.stoData) else: emptyCachedStoLeaf)
-        ok leaf.toStoData()
-      else:
-        db.db.stoLeaves.put(mixPath, emptyCachedStoLeaf)
-        ok 0'u256
+    let stoID = ?db.fetchStorageID(accPath)
+    if not stoID.isValid():
+      db.db.stoLeaves.put(mixPath, emptyCachedStoLeaf)
+      return ok 0'u256
+
+    let leaf = StoLeafRef(db.retrieveLeaf(stoID, 
+        NibblesBuf.fromBytes(stoPath.data)).valueOr(nil))
+    db.db.stoLeaves.put(mixPath, if leaf.isValid(): 
+        CachedStoLeaf.init(leaf.pfx, leaf.stoData) else: emptyCachedStoLeaf)
+    return ok leaf.toStoData()
 
 proc fetchStorageRoot*(
     db: AristoTxRef;

--- a/execution_chain/db/aristo/aristo_init/rocks_db/rdb_get.nim
+++ b/execution_chain/db/aristo/aristo_init/rocks_db/rdb_get.nim
@@ -137,9 +137,8 @@ proc getKey*(
 
   block:
     # We don't store keys for leaves, no need to hit the database
-    let rc = rdb.rdVtxLru.peek(rvid.vid)
-    if rc.isOk():
-      let vtx = rc[].data().deblobify(VertexRef).expect("valid data in db")
+    rdb.rdVtxLru.withPeek(rvid.vid, cached):
+      let vtx = cached.data().deblobify(VertexRef).expect("valid data in db")
       if vtx.vType in Leaves:
         return ok((VOID_HASH_KEY, vtx))
 
@@ -194,14 +193,15 @@ proc getVtx*(
       return ok(BranchRef.init(rc[][0], rc[][1]))
 
   block:
-    var rc =
-      if GetVtxFlag.PeekCache in flags:
-        rdb.rdVtxLru.peek(rvid.vid)
-      else:
-        rdb.rdVtxLru.get(rvid.vid)
+    var vtx: VertexRef
+    if GetVtxFlag.PeekCache in flags:
+      rdb.rdVtxLru.withPeek(rvid.vid, cached):
+        vtx = cached.data().deblobify(VertexRef).expect("valid data in db")
+    else:
+      rdb.rdVtxLru.withGet(rvid.vid, cached):
+        vtx = cached.data().deblobify(VertexRef).expect("valid data in db")
 
-    if rc.isOk:
-      let vtx = rc[].data().deblobify(VertexRef).expect("valid data in db")
+    if vtx != nil:
       rdbVtxLruStats[rvid.to(RdbStateType)][vtx.vType.to(RdbVertexType)].inc(
         true
       )

--- a/tests/eest/eest_helpers.nim
+++ b/tests/eest/eest_helpers.nim
@@ -266,6 +266,8 @@ proc prepareEnv*(
         optimisticStatePrefetch = parallelEnabled,
         balStatePrefetch = parallelEnabled)
 
+    com.db.mpt.parallelStateRootComputation = parallelEnabled
+
     if parallelEnabled:
       let taskpool =
         try:

--- a/tests/test_aristo/bench_aristo_fetch.nim
+++ b/tests/test_aristo/bench_aristo_fetch.nim
@@ -1,0 +1,156 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+## Benchmark for the leaf-cache read path in `aristo_fetch` (`fetchAccount` /
+## `fetchSlot`). Accounts and one storage slot each are merged and persisted to
+## an in-memory backend, the leaf caches (`accLeaves`/`stoLeaves`) are warmed,
+## and then the fetches are timed - so the measured loop is dominated by the
+## `withGet`/`get` cache-hit path that `cachedAccLeaf`/`cachedStoLeaf`/`fetchSlot`
+## use.
+
+{.used.}
+
+import
+  std/[strformat, strutils, times],
+  unittest2,
+  stew/endians2,
+  results,
+  eth/common/hashes,
+  ../../execution_chain/db/aristo/[
+    aristo_desc,
+    aristo_fetch,
+    aristo_merge,
+    aristo_tx_frame,
+    aristo_init/init_common,
+    aristo_init/memory_only,
+  ]
+
+const
+  benchmarkNameWidth = 28
+  accountCount = 20_000
+  readCount = 5_000_000
+
+type BenchmarkStats = object
+  elapsed: float
+  operations: int
+  checksum: uint64
+
+proc benchmarkHeader(): string =
+  "  " & alignLeft("benchmark", benchmarkNameWidth) & " " & align("elapsed(s)", 10) &
+    " " & align("reads/s", 14) & " " & align("us/read", 10)
+
+proc benchmarkLine(name: string, stats: BenchmarkStats): string =
+  let
+    readsPerSecond = stats.operations.float / stats.elapsed
+    microsecondsPerRead = (stats.elapsed * 1_000_000.0) / stats.operations.float
+  "  " & alignLeft(name, benchmarkNameWidth) & " " & align(fmt"{stats.elapsed:.4f}", 10) &
+    " " & align(fmt"{readsPerSecond:.2f}", 14) & " " &
+    align(fmt"{microsecondsPerRead:.4f}", 10)
+
+proc makeAccPath(i: uint64): Hash32 =
+  var path: Hash32
+  path.data()[0 .. 7] = i.toBytesBE()
+  path
+
+const stoPath =
+  hash32"2000000000000000000000000000000000000000000000000000000000000001"
+
+proc makeReadOrder(sampleCount: int): seq[int] =
+  result = newSeq[int](readCount)
+  for i in 0 ..< readCount:
+    result[i] = ((i.int64 * 2654435761'i64) mod sampleCount.int64).int
+
+proc runFetchAccountBenchmark(
+    tx: AristoTxRef, accPaths: openArray[Hash32], readOrder: openArray[int]
+): BenchmarkStats =
+  var checksum = 0'u64
+  let started = epochTime()
+  for index in readOrder:
+    let acc = tx.fetchAccount(accPaths[index]).expect("benchmark fetchAccount")
+    checksum += acc.balance.truncate(uint64)
+  BenchmarkStats(
+    elapsed: epochTime() - started, operations: readOrder.len, checksum: checksum
+  )
+
+proc runFetchSlotBenchmark(
+    tx: AristoTxRef, accPaths: openArray[Hash32], readOrder: openArray[int]
+): BenchmarkStats =
+  var checksum = 0'u64
+  let started = epochTime()
+  for index in readOrder:
+    let slot = tx.fetchSlot(accPaths[index], stoPath).expect("benchmark fetchSlot")
+    checksum += slot.truncate(uint64)
+  BenchmarkStats(
+    elapsed: epochTime() - started, operations: readOrder.len, checksum: checksum
+  )
+
+suite "Aristo fetch leaf-cache benchmark":
+  test "Benchmark fetchAccount and fetchSlot (warm leaf caches)":
+    # Serial state-root computation so no taskpool is required for `persist`.
+    let db = AristoDbRef.init()
+    db.parallelStateRootComputation = false
+
+    var accPaths = newSeq[Hash32](accountCount)
+
+    # Populate accounts + one storage slot each and persist to the backend
+    let wtx = db.txFrameBegin(db.baseTxFrame())
+    for i in 0 ..< accountCount:
+      let accPath = makeAccPath((i + 1).uint64)
+      accPaths[i] = accPath
+      check wtx.mergeAccount(
+        accPath, AristoAccount(balance: (i + 1).u256, codeHash: EMPTY_CODE_HASH)
+      ).isOk()
+      check wtx.mergeSlot(accPath, stoPath, (i + 1).u256).isOk()
+
+    wtx.checkpoint(1, skipSnapshot = true)
+    let batch = db.putBegFn().expect("working batch")
+    db.persist(batch, wtx)
+    check db.putEndFn(batch).isOk()
+
+    # Re-open with fresh, cache-enabled instance so reads fall through the empty
+    # layers into the leaf caches (backed by the persisted data).
+    db.close()
+    db.initInstance(
+      accLeavesLruSize = ACC_LRU_SIZE,
+      stoLeavesLruSize = ACC_LRU_SIZE,
+      parallelStateRootComputation = false,
+    ).expect("re-init instance")
+    let tx = db.baseTxFrame()
+
+    # Warm the leaf caches with one fetch per account/slot
+    for accPath in accPaths:
+      check tx.fetchAccount(accPath).isOk()
+      check tx.fetchSlot(accPath, stoPath).isOk()
+
+    # Sanity check that the reads are actually served by the leaf caches
+    check:
+      db.accLeaves.len == accountCount
+      db.stoLeaves.len == accountCount
+
+    let readOrder = makeReadOrder(accountCount)
+
+    let
+      fetchAccount = runFetchAccountBenchmark(tx, accPaths, readOrder)
+      fetchSlot = runFetchSlotBenchmark(tx, accPaths, readOrder)
+
+    debugEcho ""
+    debugEcho "Aristo fetch leaf-cache benchmark"
+    debugEcho "  accounts seeded: ", accountCount
+    debugEcho "  accLeaves cached: ", db.accLeaves.len
+    debugEcho "  stoLeaves cached: ", db.stoLeaves.len
+    debugEcho benchmarkHeader()
+    debugEcho benchmarkLine("fetchAccount warm cache", fetchAccount)
+    debugEcho benchmarkLine("fetchSlot warm cache", fetchSlot)
+    debugEcho "  checksum(fetchAccount): ", fetchAccount.checksum
+    debugEcho "  checksum(fetchSlot): ", fetchSlot.checksum
+
+    check:
+      fetchAccount.checksum != 0
+      fetchSlot.checksum != 0

--- a/tests/test_concurrency/bench_lru.nim
+++ b/tests/test_concurrency/bench_lru.nim
@@ -16,7 +16,7 @@ import
   ../../execution_chain/concurrency/lru {.all.}
 
 const
-  benchNameWidth = 36
+  benchNameWidth = 44
   cacheCapacity = 100_000
   singleThreadOps = 8_000_000
   opsPerThread = 2_000_000
@@ -110,6 +110,18 @@ proc runSingleThreadedPeek(
       checksum += uint64(v.unsafeGet()) + 1
   BenchmarkStats(elapsed: epochTime() - started, operations: count, checksum: checksum)
 
+proc runSingleThreadedWithReadValue(
+    cache: ptr ConcurrentLruCache[int, int], count: int
+): BenchmarkStats =
+  # Like get, but reads the value in place through a read-only view rather than
+  # copying it out. The body only runs on a hit.
+  var checksum: uint64
+  let started = epochTime()
+  for i in 0 ..< count:
+    cache[].withReadValue(i mod cacheCapacity, v):
+      checksum += uint64(v) + 1
+  BenchmarkStats(elapsed: epochTime() - started, operations: count, checksum: checksum)
+
 proc runLruPut(cache: ptr lru.LruCache[int, int], count: int): BenchmarkStats =
   let started = epochTime()
   for i in 0 ..< count:
@@ -194,9 +206,12 @@ suite "LruCache vs ConcurrentLruCache single-threaded comparison":
       concPut = runSingleThreadedPut(concPtr, singleThreadOps)
       concGet = runSingleThreadedGet(concPtr, singleThreadOps)
       concPeek = runSingleThreadedPeek(concPtr, singleThreadOps)
+      concWithReadValue = runSingleThreadedWithReadValue(concPtr, singleThreadOps)
       concNoLockPut = runSingleThreadedPut(concNoLockPtr, singleThreadOps)
       concNoLockGet = runSingleThreadedGet(concNoLockPtr, singleThreadOps)
       concNoLockPeek = runSingleThreadedPeek(concNoLockPtr, singleThreadOps)
+      concNoLockWithReadValue =
+        runSingleThreadedWithReadValue(concNoLockPtr, singleThreadOps)
 
     debugEcho ""
     debugEcho "  capacity=", cacheCapacity, ", ops=", singleThreadOps
@@ -207,6 +222,9 @@ suite "LruCache vs ConcurrentLruCache single-threaded comparison":
     debugEcho benchmarkLine("LruCache get", lruGet)
     debugEcho benchmarkLine("ConcurrentLruCache get (no lock)", concNoLockGet)
     debugEcho benchmarkLine("ConcurrentLruCache get", concGet)
+    debugEcho benchmarkLine(
+      "ConcurrentLruCache withReadValue (no lock)", concNoLockWithReadValue)
+    debugEcho benchmarkLine("ConcurrentLruCache withReadValue", concWithReadValue)
     debugEcho benchmarkLine("LruCache peek", lruPeek)
     debugEcho benchmarkLine("ConcurrentLruCache peek (no lock)", concNoLockPeek)
     debugEcho benchmarkLine("ConcurrentLruCache peek", concPeek)
@@ -221,6 +239,9 @@ suite "LruCache vs ConcurrentLruCache single-threaded comparison":
       concNoLockPut.elapsed > 0
       concNoLockGet.checksum != 0
       concNoLockPeek.checksum != 0
+      # withReadValue reads the same values as get on the same cache
+      concWithReadValue.checksum == concGet.checksum
+      concNoLockWithReadValue.checksum == concNoLockGet.checksum
 
 suite "ConcurrentLruCache Benchmark":
   test "Single and multi-threaded throughput":

--- a/tests/test_concurrency/bench_lru.nim
+++ b/tests/test_concurrency/bench_lru.nim
@@ -110,7 +110,7 @@ proc runSingleThreadedPeek(
       checksum += uint64(v.unsafeGet()) + 1
   BenchmarkStats(elapsed: epochTime() - started, operations: count, checksum: checksum)
 
-proc runSingleThreadedWithReadValue(
+proc runSingleThreadedWithGet(
     cache: ptr ConcurrentLruCache[int, int], count: int
 ): BenchmarkStats =
   # Like get, but reads the value in place through a read-only view rather than
@@ -118,7 +118,19 @@ proc runSingleThreadedWithReadValue(
   var checksum: uint64
   let started = epochTime()
   for i in 0 ..< count:
-    cache[].withReadValue(i mod cacheCapacity, v):
+    cache[].withGet(i mod cacheCapacity, v):
+      checksum += uint64(v) + 1
+  BenchmarkStats(elapsed: epochTime() - started, operations: count, checksum: checksum)
+
+proc runSingleThreadedWithPeek(
+    cache: ptr ConcurrentLruCache[int, int], count: int
+): BenchmarkStats =
+  # Like peek, but reads the value in place through a read-only view rather than
+  # copying it out. The body only runs on a hit and the item is not promoted.
+  var checksum: uint64
+  let started = epochTime()
+  for i in 0 ..< count:
+    cache[].withPeek(i mod cacheCapacity, v):
       checksum += uint64(v) + 1
   BenchmarkStats(elapsed: epochTime() - started, operations: count, checksum: checksum)
 
@@ -206,12 +218,15 @@ suite "LruCache vs ConcurrentLruCache single-threaded comparison":
       concPut = runSingleThreadedPut(concPtr, singleThreadOps)
       concGet = runSingleThreadedGet(concPtr, singleThreadOps)
       concPeek = runSingleThreadedPeek(concPtr, singleThreadOps)
-      concWithReadValue = runSingleThreadedWithReadValue(concPtr, singleThreadOps)
+      concWithGet = runSingleThreadedWithGet(concPtr, singleThreadOps)
+      concWithPeek = runSingleThreadedWithPeek(concPtr, singleThreadOps)
       concNoLockPut = runSingleThreadedPut(concNoLockPtr, singleThreadOps)
       concNoLockGet = runSingleThreadedGet(concNoLockPtr, singleThreadOps)
       concNoLockPeek = runSingleThreadedPeek(concNoLockPtr, singleThreadOps)
-      concNoLockWithReadValue =
-        runSingleThreadedWithReadValue(concNoLockPtr, singleThreadOps)
+      concNoLockWithGet =
+        runSingleThreadedWithGet(concNoLockPtr, singleThreadOps)
+      concNoLockWithPeek =
+        runSingleThreadedWithPeek(concNoLockPtr, singleThreadOps)
 
     debugEcho ""
     debugEcho "  capacity=", cacheCapacity, ", ops=", singleThreadOps
@@ -223,11 +238,14 @@ suite "LruCache vs ConcurrentLruCache single-threaded comparison":
     debugEcho benchmarkLine("ConcurrentLruCache get (no lock)", concNoLockGet)
     debugEcho benchmarkLine("ConcurrentLruCache get", concGet)
     debugEcho benchmarkLine(
-      "ConcurrentLruCache withReadValue (no lock)", concNoLockWithReadValue)
-    debugEcho benchmarkLine("ConcurrentLruCache withReadValue", concWithReadValue)
+      "ConcurrentLruCache withGet (no lock)", concNoLockWithGet)
+    debugEcho benchmarkLine("ConcurrentLruCache withGet", concWithGet)
     debugEcho benchmarkLine("LruCache peek", lruPeek)
     debugEcho benchmarkLine("ConcurrentLruCache peek (no lock)", concNoLockPeek)
     debugEcho benchmarkLine("ConcurrentLruCache peek", concPeek)
+    debugEcho benchmarkLine(
+      "ConcurrentLruCache withPeek (no lock)", concNoLockWithPeek)
+    debugEcho benchmarkLine("ConcurrentLruCache withPeek", concWithPeek)
 
     check:
       lruPut.elapsed > 0
@@ -239,9 +257,12 @@ suite "LruCache vs ConcurrentLruCache single-threaded comparison":
       concNoLockPut.elapsed > 0
       concNoLockGet.checksum != 0
       concNoLockPeek.checksum != 0
-      # withReadValue reads the same values as get on the same cache
-      concWithReadValue.checksum == concGet.checksum
-      concNoLockWithReadValue.checksum == concNoLockGet.checksum
+      # withGet reads the same values as get on the same cache
+      concWithGet.checksum == concGet.checksum
+      concNoLockWithGet.checksum == concNoLockGet.checksum
+      # withPeek reads the same values as peek on the same cache
+      concWithPeek.checksum == concPeek.checksum
+      concNoLockWithPeek.checksum == concNoLockPeek.checksum
 
 suite "ConcurrentLruCache Benchmark":
   test "Single and multi-threaded throughput":

--- a/tests/test_concurrency/test_lru.nim
+++ b/tests/test_concurrency/test_lru.nim
@@ -373,6 +373,25 @@ suite "LruCache Tests":
     check:
       toSeq(lru.keys()) == @[5, 4, 3, 2, 1]
 
+  test "moveToFront by key":
+    var lru = LruCache[int, int].init(5)
+
+    for i in 0 ..< 5:
+      lru.put(i, i)
+    check toSeq(lru.keys()) == @[4, 3, 2, 1, 0]
+
+    # promote a key to the front (without copying its value out)
+    lru.moveToFront(subhash(0), 0)
+    check toSeq(lru.keys()) == @[0, 4, 3, 2, 1]
+
+    # promoting the existing front is a no-op
+    lru.moveToFront(subhash(0), 0)
+    check toSeq(lru.keys()) == @[0, 4, 3, 2, 1]
+
+    # a missing key leaves the order untouched
+    lru.moveToFront(subhash(99), 99)
+    check toSeq(lru.keys()) == @[0, 4, 3, 2, 1]
+
   test "dispose":
     block:
       var lru = LruCache[int, int].init(2)
@@ -489,6 +508,57 @@ suite "ConcurrentLruCache Tests":
     check:
       lru.peek(1) == Opt.some(10)
       lru.peek(99) == Opt.none(int)
+
+  test "withReadValue":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(1000)
+    defer:
+      lru.dispose()
+
+    lru.put(1, 10)
+
+    var ran = false
+    var seen = 0
+    lru.withReadValue(1, v):
+      ran = true
+      seen = v # v is a read-only, zero-copy view of the stored value
+    check:
+      ran
+      seen == 10
+
+    # absent key: body must not run and no pointer is exposed
+    ran = false
+    lru.withReadValue(99, v):
+      ran = true
+    check not ran
+
+  test "withReadValue and put with a precomputed hash":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(1000)
+    defer:
+      lru.dispose()
+
+    let
+      key = 7
+      keyHash = lru.toKeyHash(key)
+
+    lru.putByHash(keyHash, key, 70) # insert using the precomputed hash
+
+    var ran = false
+    var seen = 0
+    lru.withReadValueByHash(keyHash, key, v): # look up using the same hash
+      ran = true
+      seen = v
+    check:
+      ran
+      seen == 70
+      lru.peek(key) == Opt.some(70) # agrees with the hash-computing overloads
+
+    # absent key: the body must not run
+    ran = false
+    lru.withReadValueByHash(lru.toKeyHash(8), 8, v):
+      ran = true
+    check not ran
 
   test "del":
     var lru: ConcurrentLruCache[int, int]
@@ -1022,3 +1092,59 @@ suite "ConcurrentLruCache Tests (threadSafe = false)":
       not lru.contains(2)
       lru.contains(3)
       lru.contains(4)
+
+  test "withReadValue promotes and exposes a read-only view":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(3, shardBits = 0, threadSafe = false)
+    defer:
+      lru.dispose()
+
+    lru.put(1, 10)
+    lru.put(2, 20)
+    lru.put(3, 30)
+
+    # withReadValue promotes to MRU like get; inserting a new key must evict 2
+    # (the actual LRU), not 1
+    for _ in 0 ..< 5:
+      var seen = 0
+      lru.withReadValue(1, v):
+        seen = v
+      check seen == 10
+
+    lru.put(4, 40)
+    check:
+      lru.contains(1)
+      not lru.contains(2)
+      lru.contains(3)
+      lru.contains(4)
+
+    # the view is read-only: assigning through it must not compile
+    check not compiles(
+      (block:
+        lru.withReadValue(1, v):
+          v = 111))
+
+    # absent key: body must not run
+    var ran = false
+    lru.withReadValue(123, v):
+      ran = true
+    check not ran
+
+  test "withReadValue and put with a precomputed hash":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(1000, shardBits = 0, threadSafe = false)
+    defer:
+      lru.dispose()
+
+    let
+      key = 7
+      keyHash = lru.toKeyHash(key)
+
+    lru.putByHash(keyHash, key, 70)
+
+    var seen = 0
+    lru.withReadValueByHash(keyHash, key, v):
+      seen = v
+    check:
+      seen == 70
+      lru.peek(key) == Opt.some(70)

--- a/tests/test_concurrency/test_lru.nim
+++ b/tests/test_concurrency/test_lru.nim
@@ -509,7 +509,7 @@ suite "ConcurrentLruCache Tests":
       lru.peek(1) == Opt.some(10)
       lru.peek(99) == Opt.none(int)
 
-  test "withReadValue":
+  test "withGet":
     var lru: ConcurrentLruCache[int, int]
     lru.init(1000)
     defer:
@@ -519,7 +519,7 @@ suite "ConcurrentLruCache Tests":
 
     var ran = false
     var seen = 0
-    lru.withReadValue(1, v):
+    lru.withGet(1, v):
       ran = true
       seen = v # v is a read-only, zero-copy view of the stored value
     check:
@@ -528,11 +528,104 @@ suite "ConcurrentLruCache Tests":
 
     # absent key: body must not run and no pointer is exposed
     ran = false
-    lru.withReadValue(99, v):
+    lru.withGet(99, v):
       ran = true
     check not ran
 
-  test "withReadValue and put with a precomputed hash":
+  test "withGet with a do: miss block":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(1000)
+    defer:
+      lru.dispose()
+
+    lru.put(1, 10)
+
+    # hit: found block runs, miss block does not
+    var seen = 0
+    var missed = false
+    lru.withGet(1, v):
+      seen = v
+    do:
+      missed = true
+    check:
+      seen == 10
+      not missed
+
+    # miss: found block does not run, miss block does - and it may `put` the
+    # value since it runs after the read lock is released
+    var found = false
+    missed = false
+    lru.withGet(2, v):
+      found = true
+    do:
+      missed = true
+      lru.put(2, 20)
+    check:
+      not found
+      missed
+      lru.peek(2) == Opt.some(20)
+
+  test "withGetByHash with a do: miss block":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(1000)
+    defer:
+      lru.dispose()
+
+    let
+      key = 7
+      keyHash = lru.toKeyHash(key)
+
+    # miss populates via the precomputed hash, then a second lookup hits
+    var seen = 0
+    var missed = false
+    lru.withGetByHash(keyHash, key, v):
+      seen = v
+    do:
+      missed = true
+      lru.putByHash(keyHash, key, 70)
+    check:
+      missed
+      seen == 0
+
+    missed = false
+    lru.withGetByHash(keyHash, key, v):
+      seen = v
+    do:
+      missed = true
+    check:
+      not missed
+      seen == 70
+
+  test "withPeek with a do: miss block does not promote":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(3, shardBits = 0, threadSafe = false)
+    defer:
+      lru.dispose()
+
+    lru.put(1, 10)
+    lru.put(2, 20)
+    lru.put(3, 30)
+
+    # peeking the LRU item with a miss block present must not promote it
+    for _ in 0 ..< 5:
+      var seen = 0
+      var missed = false
+      lru.withPeek(1, v):
+        seen = v
+      do:
+        missed = true
+      check:
+        seen == 10
+        not missed
+
+    lru.put(4, 40)
+    check:
+      not lru.contains(1) # 1 stayed the LRU and was evicted
+      lru.contains(2)
+      lru.contains(3)
+      lru.contains(4)
+
+  test "withGet and put with a precomputed hash":
     var lru: ConcurrentLruCache[int, int]
     lru.init(1000)
     defer:
@@ -546,7 +639,7 @@ suite "ConcurrentLruCache Tests":
 
     var ran = false
     var seen = 0
-    lru.withReadValueByHash(keyHash, key, v): # look up using the same hash
+    lru.withGetByHash(keyHash, key, v): # look up using the same hash
       ran = true
       seen = v
     check:
@@ -556,7 +649,7 @@ suite "ConcurrentLruCache Tests":
 
     # absent key: the body must not run
     ran = false
-    lru.withReadValueByHash(lru.toKeyHash(8), 8, v):
+    lru.withGetByHash(lru.toKeyHash(8), 8, v):
       ran = true
     check not ran
 
@@ -1093,7 +1186,7 @@ suite "ConcurrentLruCache Tests (threadSafe = false)":
       lru.contains(3)
       lru.contains(4)
 
-  test "withReadValue promotes and exposes a read-only view":
+  test "withGet promotes and exposes a read-only view":
     var lru: ConcurrentLruCache[int, int]
     lru.init(3, shardBits = 0, threadSafe = false)
     defer:
@@ -1103,11 +1196,11 @@ suite "ConcurrentLruCache Tests (threadSafe = false)":
     lru.put(2, 20)
     lru.put(3, 30)
 
-    # withReadValue promotes to MRU like get; inserting a new key must evict 2
+    # withGet promotes to MRU like get; inserting a new key must evict 2
     # (the actual LRU), not 1
     for _ in 0 ..< 5:
       var seen = 0
-      lru.withReadValue(1, v):
+      lru.withGet(1, v):
         seen = v
       check seen == 10
 
@@ -1121,16 +1214,65 @@ suite "ConcurrentLruCache Tests (threadSafe = false)":
     # the view is read-only: assigning through it must not compile
     check not compiles(
       (block:
-        lru.withReadValue(1, v):
+        lru.withGet(1, v):
           v = 111))
 
     # absent key: body must not run
     var ran = false
-    lru.withReadValue(123, v):
+    lru.withGet(123, v):
       ran = true
     check not ran
 
-  test "withReadValue and put with a precomputed hash":
+  test "withPeek does not promote":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(3, shardBits = 0, threadSafe = false)
+    defer:
+      lru.dispose()
+
+    lru.put(1, 10)
+    lru.put(2, 20)
+    lru.put(3, 30)
+
+    # withPeek reads the value without promoting it, so 1 stays the LRU and
+    # is the one evicted when a fourth key is inserted
+    for _ in 0 ..< 5:
+      var seen = 0
+      lru.withPeek(1, v):
+        seen = v
+      check seen == 10
+
+    lru.put(4, 40)
+    check:
+      not lru.contains(1)
+      lru.contains(2)
+      lru.contains(3)
+      lru.contains(4)
+
+  test "withPeekByHash does not promote":
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(3, shardBits = 0, threadSafe = false)
+    defer:
+      lru.dispose()
+
+    lru.put(1, 10)
+    lru.put(2, 20)
+    lru.put(3, 30)
+
+    let keyHash = lru.toKeyHash(1)
+    for _ in 0 ..< 5:
+      var seen = 0
+      lru.withPeekByHash(keyHash, 1, v):
+        seen = v
+      check seen == 10
+
+    lru.put(4, 40)
+    check:
+      not lru.contains(1) # 1 was never promoted, so it is evicted
+      lru.contains(2)
+      lru.contains(3)
+      lru.contains(4)
+
+  test "withGet and put with a precomputed hash":
     var lru: ConcurrentLruCache[int, int]
     lru.init(1000, shardBits = 0, threadSafe = false)
     defer:
@@ -1143,7 +1285,7 @@ suite "ConcurrentLruCache Tests (threadSafe = false)":
     lru.putByHash(keyHash, key, 70)
 
     var seen = 0
-    lru.withReadValueByHash(keyHash, key, v):
+    lru.withGetByHash(keyHash, key, v):
       seen = v
     check:
       seen == 70

--- a/tests/test_concurrency/test_lru.nim
+++ b/tests/test_concurrency/test_lru.nim
@@ -403,6 +403,13 @@ suite "LruCache Tests":
       lru.put(20, 20)
       lru.dispose()
 
+proc getOrReturn(lru: var ConcurrentLruCache[int, int], key: int): int =
+  ## Reads via `withGet` but exits the `foundBody` early via `return`. Used to
+  ## verify that the sampled MRU promotion still runs when the body returns.
+  lru.withGet(key, v):
+    return v
+  -1
+
 suite "ConcurrentLruCache Tests":
   test "defaultShardBits":
     # Smallest shardBits b such that (1 shl b) >= cpuCount * 4
@@ -417,6 +424,33 @@ suite "ConcurrentLruCache Tests":
       defaultShardBits(16) == 6 # 64 shards
       defaultShardBits(16) == 6 # 64 shards
       defaultShardBits(32) == 6 # 64 shards
+
+  test "withGet promotion runs even if foundBody returns":
+    # Single-shard, thread-safe cache so the promotion goes through the locked
+    # path (the one that promotes in a `finally`).
+    var lru: ConcurrentLruCache[int, int]
+    lru.init(3, shardBits = 0)
+    defer:
+      lru.dispose()
+
+    lru.put(1, 10)
+    lru.put(2, 20)
+    lru.put(3, 30)
+
+    # Access key 1 (the current LRU item) via reads that `return` out of the
+    # foundBody. Promotion is sampled (one hit per 16 reads), so 16 consecutive
+    # reads guarantee at least one promotion - and it must fire despite the
+    # early `return`.
+    for _ in 0 ..< 16:
+      check lru.getOrReturn(1) == 10
+
+    # 1 was promoted, so inserting a 4th key evicts 2 (now the LRU), not 1
+    lru.put(4, 40)
+    check:
+      lru.contains(1)
+      not lru.contains(2)
+      lru.contains(3)
+      lru.contains(4)
 
   test "init and dispose":
     block:


### PR DESCRIPTION
Changes in this PR:
- New templates added to the `ConcurrentLruCache` to reduce number of copies and hashes computed.
- `withGet` and `withPeek` templates give the caller access to a pointer to the data without copying into an Opt for the return value. Supports cases where larger types are cached and reducing the number of copies is useful.
- `toKeyHash`, `withGetByHash`, `withPeekByHash` and `putByHash` can be used together to avoid rehashing the key and computing the shard (when threadsafe = true) for each call. Instead just do it once when calling `toKeyHash`.
- Each of the with* templates also supports a do block for handling the case when the value doesn't exist.
- Aristo fetch code is now updated to use the new `withGet` functions.
- Rdb get `VertexBuf` cache lookups are updated to use `withGet`/`withPeek`.