### PR TITLE
t8n: support EIP-7843 currentSlotNumber in env

### DIFF
--- a/tools/t8n/helpers.nim
+++ b/tools/t8n/helpers.nim
@@ -169,6 +169,7 @@ proc readValue*(r: var JsonReader[T8Conv], val: var EnvStruct)
     of "currentTimestamp":
       r.readValue(val.currentTimestamp)
       currentTimestampParsed = true
+    of "currentSlotNumber": r.readValue(val.currentSlotNumber)
     of "currentDifficulty": r.readValue(val.currentDifficulty)
     of "currentRandom": r.readValue(val.currentRandom)
     of "parentDifficulty": r.readValue(val.parentDifficulty)

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -95,6 +95,7 @@ proc envToHeader(env: EnvStruct): Header =
     difficulty : env.currentDifficulty.get(0.u256),
     mixHash    : env.currentRandom.get(default(Bytes32)),
     number     : env.currentNumber,
+    slotNumber : env.currentSlotNumber,
     gasLimit   : env.currentGasLimit,
     timestamp  : env.currentTimestamp,
     stateRoot  : emptyRlpHash,

--- a/tools/t8n/types.nim
+++ b/tools/t8n/types.nim
@@ -37,6 +37,7 @@ type
     parentDifficulty*: Opt[UInt256]
     currentGasLimit*: GasInt
     currentNumber*: BlockNumber
+    currentSlotNumber*: Opt[uint64]  # EIP-7843: consensus slot number, read by SLOTNUM
     currentTimestamp*: EthTime
     parentTimestamp*: EthTime
     blockHashes*: Table[uint64, Hash32]


### PR DESCRIPTION
## Problem

t8n's `EnvStruct` has no field for the EIP-7843 slot number, and its custom env `readValue` discards unknown keys, so `blockCtx.slotNumber` is always `0`. The `SLOTNUM` opcode therefore always reads `0`, and t8n cannot faithfully replay any block whose transactions use `SLOTNUM` — storing the slot becomes a no-op.

## Fix

- `tools/t8n/types.nim` — add `currentSlotNumber*: Opt[uint64]` to `EnvStruct`
- `tools/t8n/helpers.nim` — parse `"currentSlotNumber"` in the custom env `readValue`
- `tools/t8n/transition.nim` — thread it through `envToHeader` into the header (→ `blockCtx.slotNumber`)

## Verification

On a glamsterdam-devnet block that uses `SLOTNUM`: with `currentSlotNumber` set in the env, `SLOTNUM` returns the slot and a contract storing it persists the correct value (`0x…03c0`), matching the canonical chain. Previously the store was a no-op (value `0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)