### PR TITLE
Stateless: Fix verifyHeaders to check for contiguous chain

### DIFF
--- a/execution_chain/stateless/stateless_execution.nim
+++ b/execution_chain/stateless/stateless_execution.nim
@@ -47,7 +47,6 @@ proc statelessProcessBlock*(
 ): Result[void, string] =
   let
     verifiedHeaders = ?witness.verifyHeaders(blk.header)
-      # Returns headers sorted by block number
     parent = verifiedHeaders[^1] # The last header is the parent
     preStateRoot = parent.stateRoot
 
@@ -67,7 +66,8 @@ proc statelessProcessBlock*(
   # in memory database.
   memoryTxFrame.putSubtrie(preStateRoot, nodes).isOkOr:
     return err("Unable to load subtrie: " & $error)
-  doAssert memoryTxFrame.getStateRoot().get() == preStateRoot
+  if memoryTxFrame.getStateRoot().get() != preStateRoot:
+    return err("Witness subtrie state root mismatch")
 
   # Load the contract code into the database indexed by code hash.
   for c in witness.codes:

--- a/execution_chain/stateless/witness_verification.nim
+++ b/execution_chain/stateless/witness_verification.nim
@@ -10,7 +10,7 @@
 {.push raises: [], gcsafe.}
 
 import
-  std/[tables, sets, algorithm],
+  std/[tables, sets],
   eth/common,
   ../db/ledger,
   ../db/aristo/aristo_proof,
@@ -74,6 +74,7 @@ func validateKeys*(witness: Witness, expectedKeys: WitnessTable): Result[void, s
 
   ok()
 
+# https://github.com/ethereum/execution-specs/blob/b6b764ff21bb754b79e11ef5dc7ad1f79996e923/src/ethereum/forks/amsterdam/stateless.py#L257
 func verifyHeaders*(
     witness: ExecutionWitness, header: Header
 ): Result[seq[Header], string] =
@@ -90,25 +91,22 @@ func verifyHeaders*(
     except RlpError as e:
       return err("Failed to decode header in witness: " & e.msg)
 
-  # Sort the headers in ascending order by block number
-  func compareByNumber(a, b: Header): int =
-    if a.number == b.number:
-      0
-    elif a.number > b.number:
-      1
-    else: # a.number < b.number
-      -1
-  headers.sort(compareByNumber)
+  # Validate that a sequence of encoded headers forms a contiguous chain
+  for i in 1..<headers.len:
+    if headers[i].parentHash != keccak256(witness.headers[i - 1].asSeq()):
+      return err("Witness headers are not contiguous")
 
-  # Check that the last header in the list (after sorting) is the parent header
-  if headers[headers.high].computeRlpHash() != header.parentHash:
+  # The last provided header must be the parent of the block being validated.
+  # This anchors preStateRoot (taken from the last witness header) to the block's
+  # parentHash: without it an attacker could supply a fabricated last header with
+  # an arbitrary stateRoot, paired with matching fake trie nodes, and pass the
+  # preStateRoot check in statelessProcessBlock() while executing on a bogus
+  # pre-state.
+  #
+  # Note that execution-specs does the same check inside execute_block via
+  # validate_header().
+  if keccak256(witness.headers[^1].asSeq()) != header.parentHash:
     return err("Parent header is required in the witness")
-
-  var i = headers.high
-  while i > 0:
-    if headers[i - 1].computeRlpHash() != headers[i].parentHash:
-      return err("Header chain verification failed")
-    dec i
 
   ok(headers)
 

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -49,8 +49,7 @@ const skipFiles = [
   "validation_codes_missing_external_code_read_target.json",
 
   # cases of missing headers in witness, which we currently don't check for
-  "validation_headers_missing_oldest_blockhash_ancestor.json",
-  "validation_headers_non_contiguous_chain.json"
+  "validation_headers_missing_oldest_blockhash_ancestor.json"
 ]
 
 runEESTSuite(


### PR DESCRIPTION
Need to actually check if the chain of headers is correct.

Not fix it by sorting in case it is not. See specs.

Also fix current assert on preStateRoot to error, as this can actually occur by invalid witnesses.