### PR TITLE
evm: error on missing in-range BLOCKHASH instead of returning zero

### DIFF
--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -169,6 +169,11 @@ proc processTransaction*(
   var callResult = tx.txCallEvm(sender, vmState, intrinsic)
   vmState.captureTxEnd(tx.gasLimit - callResult.gasUsed)
 
+  # A fatal condition is recorded on the ledger during execution, abort the
+  # block immediately.
+  if vmState.ledger.fatalError.isSome:
+    return err(vmState.ledger.fatalError.get())
+
   let
     tmp = commitOrRollbackDependingOnGasUsed(
       vmState, savePoint, tx, callResult, blobGasUsed, rollbackReads)

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -102,6 +102,13 @@ type
       ## Also used when building the execution witness to determine the
       ## block numbers fetched by the BLOCKHASH opcode for any given block.
 
+    fatalError*: Opt[string]
+      ## Set when a fatal block-aborting condition is detected during
+      ## execution that cannot travel the EVM's transaction-level error channel
+      ## (which is absorbed by the calling frame as a reverted CALL). Checked in
+      ## processTransaction to abort the whole block immediately rather than
+      ## letting it fail later at the state-root check.
+
     balOverlay*: Opt[BlockAccessListOverlay]
       ## For Parallel execution using BALs, when executing each transaction
       ## we need to read from the writes in the BAL in order to have the
@@ -741,7 +748,11 @@ proc getBlockHash*(ledger: LedgerRef, blockNumber: BlockNumber): Result[Hash32, 
       # reading this cache, then fetches them and re-runs. This makes this whole thing
       # even uglier. But it is still better than continuing with just default hashes.
       ledger.blockHashes.put(blockNumber, default(Hash32))
-      return err("Block hash not available for block " & $blockNumber)
+      # Record the miss as a fatal error so processTransaction aborts the whole
+      # block, since the EVM only reverts the current transaction from here.
+      let errorMsg = "Block hash not available for block " & $blockNumber
+      ledger.fatalError = Opt.some(errorMsg)
+      return err(errorMsg)
 
     ledger.blockHashes.put(blockNumber, hash)
     hash

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -735,9 +735,14 @@ template clearCollapsedSiblings*(ledger: LedgerRef) =
 proc getBlockHash*(ledger: LedgerRef, blockNumber: BlockNumber): Result[Hash32, string] =
   # Range checks must be done earlier, any miss here treated as an error
   let blockHash = ledger.blockHashes.get(blockNumber).valueOr:
-
     let hash = ledger.txFrame.getBlockHash(blockNumber).valueOr:
+      # Still record the requested number in the cache on a miss: the async EVM
+      # used by the verified proxy discovers which block hashes to fetch by
+      # reading this cache, then fetches them and re-runs. This makes this whole thing
+      # even uglier. But it is still better than continuing with just default hashes.
+      ledger.blockHashes.put(blockNumber, default(Hash32))
       return err("Block hash not available for block " & $blockNumber)
+
     ledger.blockHashes.put(blockNumber, hash)
     hash
   ok(blockHash)

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -732,13 +732,15 @@ template clearWitnessKeys*(ledger: LedgerRef) =
 template clearCollapsedSiblings*(ledger: LedgerRef) =
   ledger.txFrame.aTx.collapsedSiblings.setLen(0)
 
-proc getBlockHash*(ledger: LedgerRef, blockNumber: BlockNumber): Hash32 =
-  ledger.blockHashes.get(blockNumber).valueOr:
-    let blockHash = ledger.txFrame.getBlockHash(blockNumber).valueOr:
-      default(Hash32)
+proc getBlockHash*(ledger: LedgerRef, blockNumber: BlockNumber): Result[Hash32, string] =
+  # Range checks must be done earlier, any miss here treated as an error
+  let blockHash = ledger.blockHashes.get(blockNumber).valueOr:
 
-    ledger.blockHashes.put(blockNumber, blockHash)
-    blockHash
+    let hash = ledger.txFrame.getBlockHash(blockNumber).valueOr:
+      return err("Block hash not available for block " & $blockNumber)
+    ledger.blockHashes.put(blockNumber, hash)
+    hash
+  ok(blockHash)
 
 template getBlockHashesCache*(ledger: LedgerRef): BlockHashesCache =
   ledger.blockHashes

--- a/execution_chain/evm/computation.nim
+++ b/execution_chain/evm/computation.nim
@@ -77,14 +77,17 @@ template getVersionedHashesLen*(c: Computation): int =
 template getBlobBaseFee*(c: Computation): UInt256 =
   c.vmState.txCtx.blobBaseFee
 
-proc getBlockHash*(c: Computation, number: BlockNumber): Hash32 =
+proc getBlockHash*(c: Computation, number: BlockNumber): Result[Hash32, string] =
   let
     blockNumber = c.vmState.blockNumber
     ancestorDepth = blockNumber - number - 1
+  # Outside the accessible range (older than 256 blocks or not a past block) is
+  # not an error: BLOCKHASH returns the default zero hash. Inside the range the
+  # hash must be available, so a miss there propagates as an error.
   if ancestorDepth >= constants.MAX_PREV_HEADER_DEPTH:
-    return default(Hash32)
+    return ok(default(Hash32))
   if number >= blockNumber:
-    return default(Hash32)
+    return ok(default(Hash32))
   c.vmState.getAncestorHash(number)
 
 template accountExists*(c: Computation, address: Address): bool =

--- a/execution_chain/evm/interpreter/op_handlers/oph_blockdata.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_blockdata.nim
@@ -33,7 +33,10 @@ proc blockhashOp(cpt: VmCpt): EvmResultVoid =
     if number > high(BlockNumber).u256:
       conv(zero(UInt256), top)
     else:
-      conv(cpt.getBlockHash(number.truncate(BlockNumber)), top)
+      let h = cpt.getBlockHash(number.truncate(BlockNumber))
+      if h.isErr:
+        return EvmResultVoid.err(evmErr(EvmBug))
+      conv(h.get(), top)
 
   cpt.stack.unaryWithTop(block256)
 

--- a/execution_chain/evm/state.nim
+++ b/execution_chain/evm/state.nim
@@ -250,7 +250,8 @@ proc difficultyOrPrevRandao*(vmState: BaseVMState): UInt256 =
     vmState.blockCtx.difficulty
 
 method getAncestorHash*(
-    vmState: BaseVMState, blockNumber: BlockNumber): Hash32 {.gcsafe, base.} =
+    vmState: BaseVMState, blockNumber: BlockNumber
+): Result[Hash32, string] {.gcsafe, base.} =
   vmState.ledger.getBlockHash(blockNumber)
 
 proc readOnlyLedger*(vmState: BaseVMState): ReadOnlyLedger {.inline.} =

--- a/execution_chain/stateless/witness_generation.nim
+++ b/execution_chain/stateless/witness_generation.nim
@@ -13,6 +13,7 @@ import
   std/[tables, sets, algorithm],
   stew/byteutils,
   minilru,
+  results,
   eth/common,
   ../db/[ledger, core_db],
   ./witness_types
@@ -128,8 +129,8 @@ proc build*(
     # Add headers in ascending block number order:
     # https://github.com/ethereum/execution-specs/blob/33aa038697162a3ba0aedbadf177c4c59ee5b007/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L175-L176
     for n in earliestBlockNumber.get() ..< parent.number:
-      let blockHash = ledger.getBlockHash(BlockNumber(n))
-      doAssert(blockHash != default(Hash32))
+      let blockHash = ledger.getBlockHash(BlockNumber(n)).valueOr:
+        raiseAssert "Missing block hash for witness at block " & $n
       witness.addHeaderHash(blockHash)
 
   witness.addHeaderHash(header.parentHash)

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -47,9 +47,6 @@ const skipFiles = [
   "validation_codes_missing_sender_delegation_marker.json",
   "validation_codes_missing_redelegation_old_marker.json",
   "validation_codes_missing_external_code_read_target.json",
-
-  # cases of missing headers in witness, which we currently don't check for
-  "validation_headers_missing_oldest_blockhash_ancestor.json"
 ]
 
 runEESTSuite(

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -789,8 +789,10 @@ proc runLedgerBasicOperationsTests() =
 
       let ledger = LedgerRef.init(db, false)
       check:
-        ledger.getBlockHash(BlockNumber(1)) == blockHash
-        ledger.getBlockHash(BlockNumber(2)) == default(Hash32)
+        # A present block hash is returned; a missing one is an error rather
+        # than a zero hash (range checks happen earlier, in the EVM).
+        ledger.getBlockHash(BlockNumber(1)).get == blockHash
+        ledger.getBlockHash(BlockNumber(2)).isErr
 
     test "Get earliest cached block number":
       let

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -65,15 +65,17 @@ proc toBytes(x: string): seq[byte] =
   result = newSeq[byte](x.len)
   for i in 0..<x.len: result[i] = x[i].byte
 
-method getAncestorHash(vmState: TestVMState; blockNumber: BlockNumber): Hash32 =
+method getAncestorHash(
+    vmState: TestVMState; blockNumber: BlockNumber
+): Result[Hash32, string] =
   if blockNumber >= vmState.blockNumber:
-    default(Hash32)
+    ok(default(Hash32))
   elif blockNumber < 0:
-    default(Hash32)
+    ok(default(Hash32))
   elif (vmState.blockNumber > 256) and (blockNumber < vmState.blockNumber - 256):
-    default(Hash32)
+    ok(default(Hash32))
   else:
-    keccak256(toBytes($blockNumber))
+    ok(keccak256(toBytes($blockNumber)))
 
 proc verifyResult(ctx: var StateContext,
                   vmState: BaseVMState,

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -423,14 +423,16 @@ proc setupAlloc(ledger: LedgerRef, alloc: GenesisAlloc) =
     for slot, value in acc.storage:
       ledger.setStorage(accAddr, slot, value)
 
-method getAncestorHash(vmState: TestVMState; blockNumber: BlockNumber): Hash32 =
+method getAncestorHash(
+    vmState: TestVMState; blockNumber: BlockNumber
+): Result[Hash32, string] =
   # we can't raise exception here, it'll mess with EVM exception handler.
   # so, store the exception for later using `hashError`
   var h = default(Hash32)
   if vmState.blockHashes.len == 0:
     vmState.hashError = "getAncestorHash(" &
       $blockNumber & ") invoked, no blockhashes provided"
-    return h
+    return ok(h)
 
   vmState.blockHashes.withValue(blockNumber, val) do:
     h = val[]
@@ -438,7 +440,7 @@ method getAncestorHash(vmState: TestVMState; blockNumber: BlockNumber): Hash32 =
     vmState.hashError = "getAncestorHash(" &
       $blockNumber & ") invoked, blockhash for that block not provided"
 
-  return h
+  return ok(h)
 
 proc parseChainConfig(network: string): ChainConfig =
   try:


### PR DESCRIPTION
getBlockHash now returns Result[Hash32, string] and propagates the error up through getAncestorHash -> computation.getBlockHash -> blockhashOp. A block hash that is missing while within the accessible 256-block range should be considered an error for stateless (an incomplete witness in stateless execution), so the BLOCKHASH opcode now reverts the transaction rather than silently pushing a zero hash. The block then fails at the state-root check.
For stateful execution this should never occur as those block headers and/or hashes should be available. So perhaps an assert would have been better here.

Out-of-range requests (older than 256 blocks or not a past block) are unchanged and still return the default zero hash. This matches the execution-specs, where an in-range miss raises rather than returning 0.

The error causes an transaction-level revert and not full block exec stop, which is not ideal. But it is not evident to propogate errors all the way up outside of the opcodes handling.