### PR TITLE
fix(txpool): reset vmState before every assembleBlock

### DIFF
--- a/execution_chain/core/tx_pool.nim
+++ b/execution_chain/core/tx_pool.nim
@@ -158,8 +158,17 @@ proc assembleBlock*(
     someBaseFee: bool = false,
     gasLimit: Opt[GasInt] = Opt.none(GasInt)
 ): Result[AssembledBlock, string] =
-  if xp.timestamp != xp.vmState.blockCtx.timestamp:
-    xp.updateVmState()
+  # Packing mutates the ledger (tx nonces/balances are persisted) and the
+  # per-block accumulators (blobGasUsed, gas counters, receipts), and
+  # vmExecInit does not reset them. forkchoiceUpdated rebuilds the payload
+  # for the same slot (same timestamp) arbitrarily many times, so guarding
+  # the reset on a timestamp change let a rebuild reuse the previous pack's
+  # dirtied state: every pooled tx then failed the nonce check, the body
+  # ended up empty, yet the header still committed to the stale blobGasUsed
+  # (and gasUsed/stateRoot) of the first pack — producing a block other
+  # clients reject as a blob-gas mismatch. Always start each build from a
+  # fresh transaction environment.
+  xp.updateVmState()
 
   let com = xp.vmState.com
 

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -1090,3 +1090,56 @@ suite "TxPool EIP-7934 block RLP size limit":
     check ic.isOk
     if ic.isErr:
       debugEcho "IMPORT BLOCK: ", ic.error.msg
+
+suite "TxPool payload rebuild consistency":
+  # Regression: forkchoiceUpdated rebuilds the payload for the same slot
+  # (same timestamp) arbitrarily many times. assembleBlock only reset the
+  # packing vmState when the timestamp changed, so a second build at the same
+  # timestamp reused the first pack's persisted ledger (tx nonces bumped) and
+  # its stale blobGasUsed accumulator. Every pooled tx then failed the nonce
+  # check, leaving an empty body while the header still committed to the first
+  # pack's blobGasUsed -- a block every peer rejects as
+  # "blob gas used mismatch (header N, calculated 0)".
+  let
+    env = initEnv(Cancun)
+    xp = env.xp
+    mx = env.sender
+
+  xp.prevRandao = prevRandao
+  xp.feeRecipient = feeRecipient
+  xp.timestamp = EthTime.now()
+
+  test "repeated build at same timestamp keeps header consistent with body":
+    let
+      acc = mx.getAccount(0)
+      tx1 = mx.createPooledTransactionWithBlob(acc, recipient, amount, 0)
+      tx2 = mx.createPooledTransactionWithBlob(acc, recipient, amount, 1)
+    xp.checkAddTx(tx1)
+    xp.checkAddTx(tx2)
+
+    let expectedBlobGas = tx1.tx.getTotalBlobGas + tx2.tx.getTotalBlobGas
+
+    # advance to a new slot timestamp: first payload build
+    xp.timestamp = xp.timestamp + 1
+    let rc1 = xp.assembleBlock()
+    require rc1.isOk
+    let b1 = rc1.get
+    check b1.blk.transactions.len == 2
+    check b1.blk.header.blobGasUsed.get(0'u64) == expectedBlobGas
+
+    # rebuild for the SAME slot/timestamp (mimics a repeated forkchoiceUpdated).
+    # It must not collapse to an empty body with a stale header.
+    let rc2 = xp.assembleBlock()
+    require rc2.isOk
+    let b2 = rc2.get
+    check b2.blk.transactions.len == 2
+    check b2.blk.header.blobGasUsed.get(0'u64) == expectedBlobGas
+
+    # header blobGasUsed must equal the blob gas actually present in the body
+    var bodyBlobGas = 0'u64
+    for tx in b2.blk.transactions:
+      bodyBlobGas += tx.getTotalBlobGas
+    check b2.blk.header.blobGasUsed.get(0'u64) == bodyBlobGas
+
+    # the rebuilt block must survive re-execution (what every peer does)
+    xp.checkImportBlock(b2)


### PR DESCRIPTION
## Problem

On `glamsterdam-devnet-6`, nimbus-el proposers repeatedly produce execution payloads that **every other EL** (geth, reth, nethermind, ethrex, besu) rejects as:

```
blob gas used mismatch (header 917504, calculated 0)
```

The header declares N blobs' worth of `blobGasUsed` while the body contains **zero** blob transactions. These payloads are orphaned network-wide, which shows up as a high missed-slot rate on the devnet. The builder's own `Created payload for block proposal` logs show the smoking gun — the same slot rebuilt several times, with the body collapsing while `blobGasUsed` stays frozen:

```
number=43375 txs=167 blobGasUsed=655360   <- fresh pack
number=43375 txs=0   blobGasUsed=655360   <- rebuild: empty body, stale header  (shipped, rejected by all peers)
number=43375 txs=22  blobGasUsed=655360
```

## Root cause

`assembleBlock` only refreshes the packing `vmState` when the **slot timestamp changes**:

```nim
if xp.timestamp != xp.vmState.blockCtx.timestamp:
  xp.updateVmState()
```

But `forkchoiceUpdated` builds the payload for the same slot **arbitrarily many times** (see the comment in `api_forkchoice.nim`: *"The payload will be requested later, and we might replace it arbitrarily many times in between."*). Every rebuild after the first happens at the **same timestamp**, so `updateVmState()` is skipped and the reused `vmState` still carries:

- the previous pack's **persisted ledger** (`ledger.persist` in `tx_packer`, so tx nonces are already bumped), and
- stale per-block accumulators (`blobGasUsed`, `cumulativeGasUsed`, `blockRegularGasUsed`, receipts), which `vmExecInit` does **not** reset.

On the rebuild every pooled tx fails the nonce check against the dirtied ledger, so `packedTxs` ends up (near-)empty — but `assembleHeader` still emits the **first pack's** `blobGasUsed`. Result: a block whose header commits to blob gas that the body doesn't contain. `blobGasUsed` is simply the first consistency check peers run (a cheap pre-execution check), so it's the error that surfaces; `gasUsed`/`stateRoot` are equally stale.

## Fix

Always reset the transaction environment at the start of `assembleBlock` — which is exactly what `updateVmState`'s own doc-comment says it is for (*"Reset transaction environment, e.g. before packing a new block"*). Packing mutates the ledger, so a rebuild must always start clean, regardless of whether the timestamp changed.

A regression test is added: two `assembleBlock` calls at the same timestamp must produce a block whose header `blobGasUsed` matches the body and that survives re-execution, instead of an empty body with a stale header.

## Verification (live `glamsterdam-devnet-6`)

Synced a local node to head, then drove the Engine API exactly like a proposer's CL — two `forkchoiceUpdatedV4` builds at the **same timestamp** (distinct fee recipients), then `getPayloadV6` — on the **same synced datadir** with both images:

**Stock `v0.3.1-9a49f9fd` (this branch's HEAD, unfixed):** the 2nd build collapses.
```
build A (fresh pack)        : txs=33  gasUsed=24735675
build B (rebuild @ same ts) : txs=0   gasUsed=24735675   <- empty body, stale header  (BUG)
build A (fresh pack)        : txs=78 ; build B: txs=5                                   (BUG)
```

**Fixed (`9a49f9fd` + this change):** every rebuild is a full, self-consistent block, across many runs (never drops below the fresh pack; `blobGasUsed` matches the body, incl. a run that preserved 2 blobs = `blobGasUsed 262144`).
```
build A: txs=173 blobGasUsed=262144 ; build B: txs=173 blobGasUsed=262144  [OK]
build A: txs=110                     ; build B: txs=119                    [OK]
build A: txs=32                      ; build B: txs=43                     [OK]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
