### PR TITLE
stateless: fail block on missing in-range BLOCKHASH

### DIFF
--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -155,7 +155,7 @@ proc processTransaction*(
     rollbackReads: bool = false;
       ): Result[LogResult, string] =
   ## Modelled after `https://eips.ethereum.org/EIPS/eip-1559#specification`_
-  ## which provides a backward compatible framwork for EIP1559.
+  ## which provides a backward compatible framework for EIP1559.
 
   validateForInclusion(vmState, tx, sender, false, true, intrinsic, blobGasUsed)
 
@@ -168,6 +168,13 @@ proc processTransaction*(
 
   var callResult = tx.txCallEvm(sender, vmState, intrinsic)
   vmState.captureTxEnd(tx.gasLimit - callResult.gasUsed)
+
+  # A fatal condition recorded during execution aborts the block immediately
+  if vmState.ledger.fatalError.isSome:
+    if vmState.ledger.stateless:
+      return err(vmState.ledger.fatalError.get())
+    else:
+      raiseAssert vmState.ledger.fatalError.get()
 
   let
     tmp = commitOrRollbackDependingOnGasUsed(

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -97,6 +97,19 @@ type
       ## Used to collect the keys of all read accounts, code and storage slots.
       ## Maps a tuple of address and slot (optional) to the codeTouched flag.
 
+    stateless*: bool
+      ## Selects how a fatal condition detected during execution (see fatalError)
+      ## is handled. Under stateless execution the used witness is untrusted, so
+      ## it may be invalid or incomplete. A fatal condition then must stop the
+      ## block execution with a validation error. On a full node the state is
+      ## complete, so it is instead a defect (assert).
+
+    fatalError*: Opt[string]
+      ## Set when a fatal block-aborting condition is detected during execution
+      ## that cannot travel the EVM's transaction-level error channel (which is
+      ## absorbed by the calling frame as a reverted CALL). Checked and acted on
+      ## in processTransaction (see the stateless flag).
+
     blockHashes: BlockHashesCache
       ## Caches the block hashes fetched by the BLOCKHASH opcode in the EVM.
       ## Also used when building the execution witness to determine the
@@ -444,7 +457,7 @@ proc dispose*(ledger: LedgerRef, savePoint: LedgerSpRef) =
   if savePoint.parentSavePoint != nil:
     ledger.rollback(savePoint)
 
-proc init*(x: typedesc[LedgerRef], db: CoreDbTxRef, storeSlotHash: bool, collectWitness = false): LedgerRef =
+proc init*(x: typedesc[LedgerRef], db: CoreDbTxRef, storeSlotHash: bool, collectWitness = false, stateless = false): LedgerRef =
   new result
   result.txFrame = db
   result.storeSlotHash = storeSlotHash
@@ -452,6 +465,7 @@ proc init*(x: typedesc[LedgerRef], db: CoreDbTxRef, storeSlotHash: bool, collect
   result.slots = typeof(result.slots).init(slotsLruSize)
   result.collectWitness = collectWitness
   result.txFrame.aTx.collectWitness = collectWitness
+  result.stateless = stateless
   result.blockHashes = typeof(result.blockHashes).init(MAX_PREV_HEADER_DEPTH.int)
   discard result.beginSavePoint
 
@@ -733,8 +747,14 @@ template clearCollapsedSiblings*(ledger: LedgerRef) =
   ledger.txFrame.aTx.collapsedSiblings.setLen(0)
 
 proc getBlockHash*(ledger: LedgerRef, blockNumber: BlockNumber): Hash32 =
+  # Range checks must be done earlier, any miss here treated as an error:
+  # we record it as a fatalError.
+  # The zero hash is still returned so behaviour is otherwise unchanged,
+  # in particular the verified proxy's async EVM continues, discovers the
+  # number from the cache, fetches it and re-runs.
   ledger.blockHashes.get(blockNumber).valueOr:
     let blockHash = ledger.txFrame.getBlockHash(blockNumber).valueOr:
+      ledger.fatalError = Opt.some("Block hash not available for block " & $blockNumber)
       default(Hash32)
 
     ledger.blockHashes.put(blockNumber, blockHash)

--- a/execution_chain/evm/state.nim
+++ b/execution_chain/evm/state.nim
@@ -178,7 +178,8 @@ proc init*(
       txFrame: CoreDbTxRef;
       tracer: TracerRef = nil,
       storeSlotHash = false,
-      enableBalTracker = false) =
+      enableBalTracker = false,
+      stateless = false) =
   ## Variant of `new()` constructor above for in-place initalisation. The
   ## `parent` argument is used to sync the accounts cache and the `header`
   ## is used as a container to pass the `timestamp`, `gasLimit`, and `fee`
@@ -187,7 +188,8 @@ proc init*(
   ## It requires the `header` argument properly initalised so that for PoA
   ## networks, the miner address is retrievable via `ecRecover()`.
   let
-    ledger = LedgerRef.init(txFrame, storeSlotHash, com.statelessProviderEnabled)
+    ledger = LedgerRef.init(
+      txFrame, storeSlotHash, com.statelessProviderEnabled, stateless)
     tracker =
       if enableBalTracker:
         BlockAccessListTrackerRef.init(ledger.ReadOnlyLedger)

--- a/execution_chain/stateless/stateless_execution.nim
+++ b/execution_chain/stateless/stateless_execution.nim
@@ -84,7 +84,8 @@ proc statelessProcessBlock*(
   let memoryVmState = BaseVMState()
   memoryVmState.init(
     parent, blk.header, com, memoryTxFrame, storeSlotHash = false,
-    enableBalTracker = com.isAmsterdamOrLater(blk.header.timestamp))
+    enableBalTracker = com.isAmsterdamOrLater(blk.header.timestamp),
+    stateless = true)
 
   defer:
     memoryVmState.dispose()

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -47,9 +47,6 @@ const skipFiles = [
   "validation_codes_missing_sender_delegation_marker.json",
   "validation_codes_missing_redelegation_old_marker.json",
   "validation_codes_missing_external_code_read_target.json",
-
-  # cases of missing headers in witness, which we currently don't check for
-  "validation_headers_missing_oldest_blockhash_ancestor.json"
 ]
 
 runEESTSuite(


### PR DESCRIPTION
An in-range BLOCKHASH whose hash is absent used to silently return the zero hash. During stateless execution that hides an incomplete witness. getBlockHash now records a fatalError on such a miss, which processTransaction turns into a block validation error under stateless execution and an assert (corrupt database) on a full node. The zero hash is still returned so the async EVM path is unaffected (i.e. the verified proxy).