### PR TITLE
proxy: EIP-2935 speedup

### DIFF
--- a/nimbus_verified_proxy/engine/blocks.nim
+++ b/nimbus_verified_proxy/engine/blocks.nim
@@ -9,6 +9,7 @@
 
 import
   std/[strutils, sequtils],
+  stint,
   results,
   chronicles,
   web3/[eth_api_types, eth_api],
@@ -17,13 +18,76 @@ import
   eth/rlp,
   eth/trie/[ordered_trie, trie_defs],
   ../../execution_chain/beacon/web3_eth_conv,
+  ../../execution_chain/constants,
   ./types,
   ./header_store,
+  ./accounts,
   ./transactions
+
+# EIP-2935 windows size 
+const HISTORY_SERVE_WINDOW = 8191'u64
+
+func isInEIP2935VerifiableRange(
+    finalized: base.BlockNumber, latest: base.BlockNumber, target: base.BlockNumber
+): bool =
+  # relax the timing by one block
+  if target > finalized or target < latest - HISTORY_SERVE_WINDOW + 1: false else: true
+
+proc verifyEIP2935Membership(
+    engine: RpcVerificationEngine,
+    finalized: Header,
+    latest: Header,
+    targetNum: base.BlockNumber,
+    targetHash: Hash32,
+): Future[EngineResult[bool]] {.async: (raises: [CancelledError]).} =
+  if not isInEIP2935VerifiableRange(finalized.number, latest.number, targetNum):
+    return ok(false)
+
+  let slot = (targetNum mod HISTORY_SERVE_WINDOW).u256
+
+  let storedValue = (
+    await engine.getStorageAt(
+      HISTORY_STORAGE_ADDRESS, slot, finalized.number, finalized.stateRoot
+    )
+  ).valueOr:
+    return ok(false) # unservable/invalid proof -> fall back to the walk
+
+  # storage value is zero only when the fork activated less than 8191 blocks before
+  if storedValue.isZero():
+    return ok(false) # cannot be verified using EIP 2935
+
+  if storedValue == UInt256.fromBytesBE(targetHash.data):
+    return ok(true)
+
+  err(
+    (
+      VerificationError, "the requested block is not part of the canonical chain",
+      UNTAGGED,
+    )
+  )
+
+proc isEIP2935Full(
+    engine: RpcVerificationEngine, latest: Header
+): Future[bool] {.async: (raises: [CancelledError]).} =
+  # realx the timing by 1 block
+  let slot = ((latest.number - HISTORY_SERVE_WINDOW + 1) mod HISTORY_SERVE_WINDOW).u256
+
+  let storedValue = (
+    await engine.getStorageAt(
+      HISTORY_STORAGE_ADDRESS, slot, latest.number, latest.stateRoot
+    )
+  ).valueOr:
+    return false
+
+  # storage value is zero only when the fork activated less than 8191 blocks before
+  if storedValue.isZero():
+    return false
+
+  return true
 
 proc resolveBlockTag*(
     engine: RpcVerificationEngine, blockTag: BlockTag
-): EngineResult[BlockTag] =
+): Future[EngineResult[BlockTag]] {.async: (raises: [CancelledError]).} =
   if blockTag.kind == bidAlias:
     let tag = blockTag.alias.toLowerAscii()
     case tag
@@ -48,6 +112,22 @@ proc resolveBlockTag*(
         )
       ok(BlockTag(kind: bidNumber, number: Quantity(hFinalized.number)))
     of "earliest":
+      let hLatest = engine.headerStore.latest.valueOr:
+        # untagged(-1) so the relevant backend can be tagged
+        return err(
+          (
+            UnavailableDataError,
+            "Couldn't get the earliest block number from header store", UNTAGGED,
+          )
+        )
+
+      if await engine.isEIP2935Full(hLatest):
+        return ok(
+          BlockTag(
+            kind: bidNumber, number: Quantity(hLatest.number - HISTORY_SERVE_WINDOW + 1)
+          )
+        )
+
       let hEarliest = engine.headerStore.earliest.valueOr:
         # untagged(-1) so the relevant backend can be tagged
         return err(
@@ -56,6 +136,7 @@ proc resolveBlockTag*(
             "Couldn't get the earliest block number from header store", UNTAGGED,
           )
         )
+
       ok(BlockTag(kind: bidNumber, number: Quantity(hEarliest.number)))
     else:
       # untagged(-1) so the relevant backend can be tagged
@@ -206,14 +287,6 @@ proc verifyHeader(
             UNTAGGED,
           )
         )
-      finalized = engine.headerStore.finalized.valueOr:
-        # untagged(-1) because this doesn't link to any backend
-        return err(
-          (
-            UnavailableDataError,
-            "finalized block is not available yet. Still syncing?", UNTAGGED,
-          )
-        )
       latest = engine.headerStore.latest.valueOr:
         # untagged(-1) because this doesn't link to any backend
         return err(
@@ -222,28 +295,24 @@ proc verifyHeader(
             UNTAGGED,
           )
         )
+      finalized = engine.headerStore.finalized.valueOr:
+        # untagged(-1) because this doesn't link to any backend
+        return err(
+          (
+            UnavailableDataError, "latest block is not available yet. Still syncing?",
+            UNTAGGED,
+          )
+        )
 
-    # header is older than earliest
-    if header.number < earliest.number:
-      # earliest is finalized
-      if earliest.number < finalized.number:
-        ?await engine.walkBlocks(
+    let eipVerified =
+      ?(await engine.verifyEIP2935Membership(finalized, latest, header.number, hash))
+
+    if not eipVerified:
+      ?(
+        await engine.walkBlocks(
           earliest.number, header.number, earliest.parentHash, hash
         )
-      # earliest is not finalized (headerstore is smaller than 2 epochs or chain hasn't finalized for long)
-      else:
-        ?await engine.walkBlocks(
-          finalized.number, header.number, finalized.parentHash, hash
-        )
-    # is within the boundaries of header store but not found in cache
-    else:
-      if header.number < finalized.number:
-        ?await engine.walkBlocks(
-          finalized.number, header.number, finalized.parentHash, hash
-        )
-      else:
-        # optimistic walk
-        ?await engine.walkBlocks(latest.number, header.number, latest.parentHash, hash)
+      )
 
   ok()
 
@@ -300,7 +369,7 @@ proc getBlock*(
 proc getBlock*(
     engine: RpcVerificationEngine, blockTag: BlockTag, fullTransactions: bool
 ): Future[EngineResult[BlockObject]] {.async: (raises: [CancelledError]).} =
-  let numberTag = ?engine.resolveBlockTag(blockTag)
+  let numberTag = ?(await engine.resolveBlockTag(blockTag))
 
   # get the target block
   let
@@ -358,7 +427,7 @@ proc getHeader*(
     engine: RpcVerificationEngine, blockTag: BlockTag
 ): Future[EngineResult[Header]] {.async: (raises: [CancelledError]).} =
   let
-    numberTag = ?engine.resolveBlockTag(blockTag)
+    numberTag = ?(await engine.resolveBlockTag(blockTag))
     n = distinctBase(numberTag.number)
     cachedHeader = engine.headerStore.get(n)
 

--- a/nimbus_verified_proxy/engine/blocks.nim
+++ b/nimbus_verified_proxy/engine/blocks.nim
@@ -287,15 +287,15 @@ proc verifyHeader(
             UNTAGGED,
           )
         )
-      latest = engine.headerStore.latest.valueOr:
+      finalized = engine.headerStore.finalized.valueOr:
         # untagged(-1) because this doesn't link to any backend
         return err(
           (
-            UnavailableDataError, "latest block is not available yet. Still syncing?",
-            UNTAGGED,
+            UnavailableDataError,
+            "finalized block is not available yet. Still syncing?", UNTAGGED,
           )
         )
-      finalized = engine.headerStore.finalized.valueOr:
+      latest = engine.headerStore.latest.valueOr:
         # untagged(-1) because this doesn't link to any backend
         return err(
           (

--- a/nimbus_verified_proxy/engine/blocks.nim
+++ b/nimbus_verified_proxy/engine/blocks.nim
@@ -28,26 +28,26 @@ import
 const HISTORY_SERVE_WINDOW = 8191'u64
 
 func isInEIP2935VerifiableRange(
-    finalized: base.BlockNumber, latest: base.BlockNumber, target: base.BlockNumber
+    anchor: base.BlockNumber, latest: base.BlockNumber, target: base.BlockNumber
 ): bool =
   # relax the timing by one block
-  if target > finalized or target < latest - HISTORY_SERVE_WINDOW + 1: false else: true
+  if target > anchor or target < latest - HISTORY_SERVE_WINDOW + 1: false else: true
 
 proc verifyEIP2935Membership(
     engine: RpcVerificationEngine,
-    finalized: Header,
+    anchor: Header,
     latest: Header,
     targetNum: base.BlockNumber,
     targetHash: Hash32,
 ): Future[EngineResult[bool]] {.async: (raises: [CancelledError]).} =
-  if not isInEIP2935VerifiableRange(finalized.number, latest.number, targetNum):
+  if not isInEIP2935VerifiableRange(anchor.number, latest.number, targetNum):
     return ok(false)
 
   let slot = (targetNum mod HISTORY_SERVE_WINDOW).u256
 
   let storedValue = (
     await engine.getStorageAt(
-      HISTORY_STORAGE_ADDRESS, slot, finalized.number, finalized.stateRoot
+      HISTORY_STORAGE_ADDRESS, slot, anchor.number, anchor.stateRoot
     )
   ).valueOr:
     return ok(false) # unservable/invalid proof -> fall back to the walk
@@ -287,14 +287,24 @@ proc verifyHeader(
             UNTAGGED,
           )
         )
-      finalized = engine.headerStore.finalized.valueOr:
-        # untagged(-1) because this doesn't link to any backend
-        return err(
-          (
-            UnavailableDataError,
-            "finalized block is not available yet. Still syncing?", UNTAGGED,
-          )
-        )
+      anchorOrFinalized =
+        if engine.anchor.kind == bidAlias and
+            engine.anchor.alias.toLowerAscii() == "safe":
+          engine.headerStore.latest.valueOr:
+            return err(
+              (
+                UnavailableDataError, "safe block is not available yet. Still syncing?",
+                UNTAGGED,
+              )
+            )
+        else:
+          engine.headerStore.finalized.valueOr:
+            return err(
+              (
+                UnavailableDataError,
+                "finalized block is not available yet. Still syncing?", UNTAGGED,
+              )
+            )
       latest = engine.headerStore.latest.valueOr:
         # untagged(-1) because this doesn't link to any backend
         return err(
@@ -304,8 +314,11 @@ proc verifyHeader(
           )
         )
 
-    let eipVerified =
-      ?(await engine.verifyEIP2935Membership(finalized, latest, header.number, hash))
+    let eipVerified = ?(
+      await engine.verifyEIP2935Membership(
+        anchorOrFinalized, latest, header.number, hash
+      )
+    )
 
     if not eipVerified:
       ?(

--- a/nimbus_verified_proxy/engine/engine.nim
+++ b/nimbus_verified_proxy/engine/engine.nim
@@ -12,6 +12,7 @@ import
   chronicles,
   chronos,
   eth/common/[hashes, headers, addresses, eth_types_rlp],
+  web3/eth_api_types,
   beacon_chain/spec/forks,
   beacon_chain/gossip_processing/light_client_processor,
   beacon_chain/beacon_clock,
@@ -144,7 +145,7 @@ func convLCHeader*(lcHeader: ForkyLightClientHeader): Result[Header, string] =
         receiptsRoot: p.receipts_root.asBlockHash,
         logsBloom: FixedBytes[BYTES_PER_LOGS_BLOOM](p.logs_bloom.data),
         difficulty: DifficultyInt(0.u256),
-        number: BlockNumber(p.block_number),
+        number: base.BlockNumber(p.block_number),
         gasLimit: GasInt(p.gas_limit),
         gasUsed: GasInt(p.gas_used),
         timestamp: EthTime(p.timestamp),
@@ -170,11 +171,13 @@ proc initCore*(
     accountCacheLen: int,
     codeCacheLen: int,
     storageCacheLen: int,
+    anchor: BlockTag = blockId("finalized"),
 ): EngineResult[T] =
   randomize()
 
   let engine = RpcVerificationEngine(
     chainId: chainId,
+    anchor: anchor,
     maxBlockWalk: maxBlockWalk,
     headerStore: HeaderStore.new(headerStoreLen),
     accountsCache: AccountsCache.init(accountCacheLen),

--- a/nimbus_verified_proxy/engine/receipts.nim
+++ b/nimbus_verified_proxy/engine/receipts.nim
@@ -88,14 +88,14 @@ proc getReceipts*(
 
 proc resolveFilterTags*(
     engine: RpcVerificationEngine, filter: FilterOptions
-): EngineResult[FilterOptions] =
+): Future[EngineResult[FilterOptions]] {.async: (raises: [CancelledError]).} =
   if filter.blockHash.isSome():
     return ok(filter)
   let
     fromBlock = filter.fromBlock.get(types.BlockTag(kind: bidAlias, alias: "latest"))
     toBlock = filter.toBlock.get(types.BlockTag(kind: bidAlias, alias: "latest"))
-    fromBlockNumberTag = ?engine.resolveBlockTag(fromBlock)
-    toBlockNumberTag = ?engine.resolveBlockTag(toBlock)
+    fromBlockNumberTag = ?(await engine.resolveBlockTag(fromBlock))
+    toBlockNumberTag = ?(await engine.resolveBlockTag(toBlock))
 
   return ok(
     FilterOptions(
@@ -144,7 +144,7 @@ proc getLogs*(
     engine: RpcVerificationEngine, filter: FilterOptions
 ): Future[EngineResult[seq[LogObject]]] {.async: (raises: [CancelledError]).} =
   let
-    resolvedFilter = ?engine.resolveFilterTags(filter)
+    resolvedFilter = ?(await engine.resolveFilterTags(filter))
     (backend, backendIdx) = ?(engine.executionBackendFor(GetLogs))
     logObjs = ?((await backend.eth_getLogs(resolvedFilter)).tagBackend(backendIdx))
 

--- a/nimbus_verified_proxy/engine/rpc_frontend.nim
+++ b/nimbus_verified_proxy/engine/rpc_frontend.nim
@@ -433,7 +433,7 @@ proc getExecutionApiFrontend*(engine: RpcVerificationEngine): ExecutionApiFronte
         return err((FrontendError, "Filter doesn't exist", UNTAGGED))
 
     let
-      filter = ?engine.resolveFilterTags(filterItem.filter)
+      filter = ?(await engine.resolveFilterTags(filterItem.filter))
       # after resolving toBlock is always some and a number tag
       toBlock = filter.toBlock.get().number
 

--- a/nimbus_verified_proxy/engine/types.nim
+++ b/nimbus_verified_proxy/engine/types.nim
@@ -306,6 +306,7 @@ type
 
     # config items
     chainId*: UInt256
+    anchor*: BlockTag
     maxBlockWalk*: uint64
     parallelBlockDownloads*: uint64
     maxLightClientUpdates*: uint64

--- a/nimbus_verified_proxy/library/verifproxy.nim
+++ b/nimbus_verified_proxy/library/verifproxy.nim
@@ -9,6 +9,7 @@ import
   chronos,
   std/[json, options, strutils],
   stint,
+  web3/eth_api_types,
   beacon_chain/spec/digest,
   beacon_chain/spec/beaconstate,
   beacon_chain/spec/forks,
@@ -295,6 +296,7 @@ proc run*(
       accountCacheLen = config.accountCacheLen,
       codeCacheLen = config.codeCacheLen,
       storageCacheLen = config.storageCacheLen,
+      anchor = blockId("safe"),
     ).valueOr:
       raise newException(ProxyError, "Couldn't initialize OP verification engine")
 

--- a/nimbus_verified_proxy/nimbus_verified_proxy.nim
+++ b/nimbus_verified_proxy/nimbus_verified_proxy.nim
@@ -13,6 +13,7 @@ import
   chronos,
   confutils,
   eth/common/[keys, eth_types_rlp],
+  web3/eth_api_types,
   json_rpc/rpcproxy,
   beacon_chain/gossip_processing/light_client_processor,
   beacon_chain/networking/network_metadata,
@@ -286,6 +287,7 @@ proc run(
       accountCacheLen = config.accountCacheLen,
       codeCacheLen = config.codeCacheLen,
       storageCacheLen = config.storageCacheLen,
+      anchor = blockId("safe"),
     ).valueOr:
       raise newException(ProxyError, "Couldn't initialize OP verification engine")
 

--- a/nimbus_verified_proxy/op/op_frontend.nim
+++ b/nimbus_verified_proxy/op/op_frontend.nim
@@ -437,7 +437,7 @@ proc getExecutionApiFrontend*(
         return err((FrontendError, "Filter doesn't exist", UNTAGGED))
 
     let
-      filter = ?opEngine.resolveFilterTags(filterItem.filter)
+      filter = ?(await opEngine.resolveFilterTags(filterItem.filter))
       toBlock = filter.toBlock.get().number
 
     if filterItem.blockMarker.isSome() and toBlock <= filterItem.blockMarker.get():


### PR DESCRIPTION
EIP-2935 introduces a history contract that stores the last 8191 block hashes in a ring buffer in the first 8191 slots of the contract storage. We use the contract to jump to a point in a history rather than walking the chain. On the verification path, the state root against which the storage proofs are verified is hardcoded to "finalized". This is in light of the fact that a block walk from latest head is more secure than a storage proof verified against latest (multiple providers, execution and beacon, would facilitate a block walk but only one provider would provide the storage proof)