### PR TITLE
stateless: fail block on incomplete witness during persist

### DIFF
--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -741,6 +741,10 @@ proc procBlkEpilogue(
   if vmState.balTrackerEnabled:
     vmState.balTracker.commitCallFrame()
 
+  # Catch a fatal condition from the reward persist or the post-execution system
+  # calls before getStateRoot below, which would otherwise assert on it.
+  vmState.ledger.abortOnFatalError()
+
   if not skipValidation:
     if not skipPostExecBalCheck and vmState.com.isAmsterdamOrLater(header.timestamp):
       doAssert vmState.balTrackerEnabled

--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -161,13 +161,6 @@ proc processTransaction*(
   var callResult = tx.txCallEvm(sender, vmState, intrinsic)
   vmState.captureTxEnd(tx.gasLimit - callResult.gasUsed)
 
-  # A fatal condition recorded during execution aborts the block immediately
-  if vmState.ledger.fatalError.isSome:
-    if vmState.ledger.stateless:
-      return err(vmState.ledger.fatalError.get())
-    else:
-      raiseAssert vmState.ledger.fatalError.get()
-
   let
     tmp = commitOrRollbackDependingOnGasUsed(
       vmState, savePoint, tx, callResult, blobGasUsed, rollbackReads)
@@ -178,6 +171,10 @@ proc processTransaction*(
 
   if persist:
     vmState.ledger.persist(clearEmptyAccount = vmState.hardFork >= Spurious)
+
+  # Checked after persist so both a BLOCKHASH miss (set during the EVM run)
+  # and a partial witness persist failure are caught here.
+  vmState.ledger.abortOnFatalError()
 
   res
 

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -337,19 +337,40 @@ proc persistCode(acc: AccountRef, ledger: LedgerRef) =
       # code cache must also be cleared!
       acc.code.persisted = true
 
-proc persistStorage(acc: AccountRef, ledger: LedgerRef) =
+template setFatalErrorOrAssert(ledger: LedgerRef, msg: string) =
+  ## Handle a failed trie write during persist:
+  ## - under stateless execution record a fatal error and stop
+  ## - on a full node the state is complete, so assert
+  if ledger.stateless:
+    ledger.fatalError = Opt.some(msg)
+    return
+  else:
+    raiseAssert msg
+
+template abortOnFatalError*(ledger: LedgerRef) =
+  ## Abort the current block if a fatal condition was recorded during execution
+  ## or persist, abort meaning:
+  ## - a validation error under stateless execution
+  ## - otherwise a defect (corrupt database)
+  if ledger.fatalError.isSome:
+    if ledger.stateless:
+      return err(ledger.fatalError.get())
+    else:
+      raiseAssert ledger.fatalError.get()
+
+proc persistStorage(acc: AccountRef, ledger: LedgerRef): Result[void, string] =
   const info = "persistStorage(): "
 
   if acc.overlayStorage.len == 0:
     # TODO: remove the storage too if we figure out
     # how to create 'virtual' storage room for each account
-    return
+    return ok()
 
   # Make sure that there is an account entry on the database. This is needed by
   # `Aristo` for updating the account's storage area reference. As a side effect,
   # this action also updates the latest statement data.
   ledger.txFrame.mergeAccount(acc.accPath, acc.statement).isOkOr:
-    raiseAssert info & $$error
+    return err(info & $$error)
 
   # Save `overlayStorage[]` on database
   let original = acc.original
@@ -367,14 +388,14 @@ proc persistStorage(acc: AccountRef, ledger: LedgerRef) =
 
     if value > 0:
       ledger.txFrame.mergeSlot(acc.accPath, slotKey, value).isOkOr:
-        raiseAssert info & $$error
+        return err(info & $$error)
 
       # move the overlayStorage to originalStorage, related to EIP2200, EIP1283
       original.storage[slot] = value
 
     else:
       ledger.txFrame.deleteSlot(acc.accPath, slotKey).isOkOr:
-        raiseAssert info & $$error
+        return err(info & $$error)
       original.storage.del(slot)
 
     if ledger.storeSlotHash and not cached:
@@ -387,6 +408,7 @@ proc persistStorage(acc: AccountRef, ledger: LedgerRef) =
         warn logTxt "persistStorage()", slot, error=($$rc.error)
 
   acc.overlayStorage.clear()
+  ok()
 
 proc makeDirty(ledger: LedgerRef, address: Address, cloneStorage = true): AccountRef =
   ledger.isDirty = true
@@ -862,19 +884,20 @@ proc persist*(ledger: LedgerRef,
         ledger.txFrame.clearStorage(acc.accPath).expect("can clear storage of account")
 
       if StorageChanged in acc.flags:
-        acc.persistStorage(ledger)
+        acc.persistStorage(ledger).isOkOr:
+          ledger.setFatalErrorOrAssert(error)
       else:
         # This one is only necessary unless `persistStorage()` is run which needs
         # to `merge()` the latest statement as well.
         ledger.txFrame.mergeAccount(acc.accPath, acc.statement).isOkOr:
-          raiseAssert info & $$error
+          ledger.setFatalErrorOrAssert(info & $$error)
 
       acc.original.statement = acc.statement
       acc.original.code = acc.code
     of Remove:
       ledger.txFrame.deleteAccount(acc.accPath).isOkOr:
         if error.error != AccNotFound:
-          raiseAssert info & $$error
+          ledger.setFatalErrorOrAssert(info & $$error)
       ledger.savePoint.cache.del address
       acc.original.statement = EMPTY_STATEMENT
       acc.original.code = nil

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -51,27 +51,20 @@ const skipFiles = [
   # The test code only support Prague request types, need to add Amsterdam request types
   "invalid_multi_type_requests.json",
 
-  "stateless_input_opposite_y_parity_public_key_is_rejected.json",
+  # No fail yet as we don't verify chain_config
   "validation_chain_config_wrong_chain_id_legacy_signature.json",
 
   # No fail yet as we don't check/use public keys. We could check them easily
   # but the better way is to use them as optimization and check automatically
   # that way.
   "stateless_input_invalid_public_key_is_rejected.json",
-
-  # We AssertionDefect currently on these missing nodes. Need to adjust this
-  # to properly  return a Result.err() instead of crashing.
-  "validation_state_missing_absent_account_proof_node.json",
-  "validation_state_missing_absent_slot_proof_leaf_node.json",
+  "stateless_input_opposite_y_parity_public_key_is_rejected.json",
 
   # cases of missing code in witness, which we currently don't check for
   "validation_codes_missing_delegated_code_on_insufficient_balance_call.json",
   "validation_codes_missing_sender_delegation_marker.json",
   "validation_codes_missing_redelegation_old_marker.json",
   "validation_codes_missing_external_code_read_target.json",
-
-  # cases of missing headers in witness, which we currently don't check for
-  "validation_headers_missing_oldest_blockhash_ancestor.json",
 
   # cases of missing states in witness, which we currently don't check for
   "validation_state_missing_failed_call_target_account_proof_node.json",

--- a/tests/test_stateless/test_stateless_execution.nim
+++ b/tests/test_stateless/test_stateless_execution.nim
@@ -58,6 +58,32 @@ procSuite "Stateless Execution Tests":
         statelessProcessBlockRlp(witnessRlpBytes, com, blkRlpBytes).isOk()
         statelessProcessBlockRlp(witnessRlpBytes.to0xHex(), com, blkRlpBytes.to0xHex()).isOk()
 
+  asyncTest "Stateless incomplete witness - fail at block-reward persist without crashing":
+    # These early mainnet blocks are empty, but the block-reward persist still runs
+    # in procBlkEpilogue so this runs the fatal error path caught by the abortOnFatalError.
+    # Dropping the coinbase's node makes that reward persist fail. Dropping a node
+    # that breaks the trie root is rejected even earlier at the witness subtrie root
+    # check. Either way execution must return an error, never assert/crash on the
+    # resulting partial trie.
+    var blk: EthBlock
+    for i in 1..100:
+      era0.getEthBlock(i.BlockNumber, blk).expect("block in test database")
+      check (await fc.importBlock(blk)).isOk()
+
+    let witness =
+      fc.getExecutionWitness(blk.header.computeBlockHash()).expect("ok").toExecutionWitness()
+
+    # The complete witness validates.
+    check statelessProcessBlock(witness, com, blk).isOk()
+
+    # Every incomplete variant (one state node dropped) is rejected with an error
+    # and never crashes.
+    check witness.state.len() > 0
+    for dropIdx in 0 ..< witness.state.len():
+      var partial = witness
+      partial.state.asSeq.delete(dropIdx)
+      check statelessProcessBlock(partial, com, blk).isErr()
+
   asyncTest "Stateless process block json files - mainnet block 100":
     let
       witnessJsonFile = sourcePath / "mainnet_100_witness.json"


### PR DESCRIPTION
A stateless witness is untrusted and may be partial/incomplete. A write (merge/delete) into a path whose node is absent from the witness fails in Aristo, and the ledger persist path escalates that to raiseAssert. This is fine for stateful execution, as it is a scenario that should not occur under proper working circumstances. However, due to the nature of stateless it can occur there and would be crashing the guest on untrusted input instead of rejecting the block.

We handle this type of error for stateless with the combination of stateless/fataError flags, like is done already for the blockhash miss. We could continue to make the persist call also result based but the issue (aside from handling all call sites of this) is that the the system calls where persist is done also do not propagate these errors. Two of them are void and need to (spec demands to) error silently. So if we were to start using result system there too, this would require a bigger re-architecture.

However, this fix does perhaps look/feel hacky due to the nature that an error is not immediatly handled but later checked upon.

We could also investigate just throwing an exception up, similar to how now the assert is thrown.