### PR TITLE
builds MUST start on forkchoiceState.headBlockHash

### DIFF
--- a/execution_chain/beacon/api_handler/api_forkchoice.nim
+++ b/execution_chain/beacon/api_handler/api_forkchoice.nim
@@ -214,7 +214,7 @@ proc forkchoiceUpdated*(ben: BeaconEngineRef,
     let attrs = attrsOpt.value
     validateVersion(attrs, com, apiVersion)
 
-    let bundle = ben.generateExecutionBundle(attrs).valueOr:
+    let bundle = ben.generateExecutionBundle(headHash, attrs).valueOr:
       error "Failed to create sealing payload", err = error
       raise invalidAttr(error)
 

--- a/execution_chain/beacon/beacon_engine.nim
+++ b/execution_chain/beacon/beacon_engine.nim
@@ -182,7 +182,7 @@ proc generateExecutionBundle*(
     # someBaseFee = true: make sure bundle.blk.header
     # have the same blockHash with generated payload
     let bundle = xp.assembleBlock(someBaseFee = true,
-                                  parentHash = Opt.some(headHash)).valueOr:
+                                  parentHash = headHash).valueOr:
       return err(error)
 
     if bundle.blk.header.extraData.len > 32:

--- a/execution_chain/beacon/beacon_engine.nim
+++ b/execution_chain/beacon/beacon_engine.nim
@@ -150,13 +150,18 @@ func getPayloadBundle*(ben: BeaconEngineRef, id: Bytes8): Opt[ExecutionBundle] =
 # ------------------------------------------------------------------------------
 proc generateExecutionBundle*(
   ben: BeaconEngineRef,
+  headHash: Hash32,
   attrs: PayloadAttributes
 ): Result[ExecutionBundle, string] =
 
   wrapException:
     let
       xp  = ben.txPool
-      headBlock = ben.chain.latestHeader
+      # Build on the forkchoiceUpdated headBlockHash: `chain.latest` tracks the
+      # most recently imported block, which may be a sibling of the requested
+      # head when multiple valid payloads exist at the same height.
+      headBlock = ben.chain.headerByHash(headHash).valueOr:
+        return err("payload build parent not found: " & headHash.short)
 
     xp.prevRandao   = attrs.prevRandao
     xp.timestamp    = ethTime attrs.timestamp
@@ -176,7 +181,8 @@ proc generateExecutionBundle*(
 
     # someBaseFee = true: make sure bundle.blk.header
     # have the same blockHash with generated payload
-    let bundle = xp.assembleBlock(someBaseFee = true).valueOr:
+    let bundle = xp.assembleBlock(someBaseFee = true,
+                                  parentHash = Opt.some(headHash)).valueOr:
       return err(error)
 
     if bundle.blk.header.extraData.len > 32:

--- a/execution_chain/core/tx_pool.nim
+++ b/execution_chain/core/tx_pool.nim
@@ -166,9 +166,9 @@ func getWrapperVersion(com: CommonRef, timestamp: EthTime): WrapperVersion =
 
 proc assembleBlock*(
     xp: TxPoolRef,
+    parentHash: Hash32,
     someBaseFee: bool = false,
-    gasLimit: Opt[GasInt] = Opt.none(GasInt),
-    parentHash: Opt[Hash32] = Opt.none(Hash32)
+    gasLimit: Opt[GasInt] = Opt.none(GasInt)
 ): Result[AssembledBlock, string] =
   # Packing mutates the ledger (tx nonces/balances are persisted) and the
   # per-block accumulators (blobGasUsed, gas counters, receipts), and
@@ -181,15 +181,11 @@ proc assembleBlock*(
   # clients reject as a blob-gas mismatch. Always start each build from a
   # fresh transaction environment.
   #
-  # When `parentHash` is given, build on that block instead of the most
-  # recently imported one: the engine API requires the payload to sit on
-  # the forkchoiceUpdated headBlockHash, which need not be `chain.latest`
-  # when sibling payloads exist at the same height.
-  if parentHash.isSome:
-    let parentHeader = ?xp.chain.headerByHash(parentHash[])
-    xp.updateVmState(parentHeader, parentHash[])
-  else:
-    xp.updateVmState()
+  # The build parent is always explicit: the engine API requires the payload
+  # to sit on the forkchoiceUpdated headBlockHash, which need not be
+  # `chain.latest` when sibling payloads exist at the same height.
+  let parentHeader = ?xp.chain.headerByHash(parentHash)
+  xp.updateVmState(parentHeader, parentHash)
 
   let com = xp.vmState.com
 

--- a/execution_chain/core/tx_pool.nim
+++ b/execution_chain/core/tx_pool.nim
@@ -167,7 +167,8 @@ func getWrapperVersion(com: CommonRef, timestamp: EthTime): WrapperVersion =
 proc assembleBlock*(
     xp: TxPoolRef,
     someBaseFee: bool = false,
-    gasLimit: Opt[GasInt] = Opt.none(GasInt)
+    gasLimit: Opt[GasInt] = Opt.none(GasInt),
+    parentHash: Opt[Hash32] = Opt.none(Hash32)
 ): Result[AssembledBlock, string] =
   # Packing mutates the ledger (tx nonces/balances are persisted) and the
   # per-block accumulators (blobGasUsed, gas counters, receipts), and
@@ -179,7 +180,16 @@ proc assembleBlock*(
   # (and gasUsed/stateRoot) of the first pack — producing a block other
   # clients reject as a blob-gas mismatch. Always start each build from a
   # fresh transaction environment.
-  xp.updateVmState()
+  #
+  # When `parentHash` is given, build on that block instead of the most
+  # recently imported one: the engine API requires the payload to sit on
+  # the forkchoiceUpdated headBlockHash, which need not be `chain.latest`
+  # when sibling payloads exist at the same height.
+  if parentHash.isSome:
+    let parentHeader = ?xp.chain.headerByHash(parentHash[])
+    xp.updateVmState(parentHeader, parentHash[])
+  else:
+    xp.updateVmState()
 
   let com = xp.vmState.com
 

--- a/execution_chain/core/tx_pool/tx_desc.nim
+++ b/execution_chain/core/tx_pool/tx_desc.nim
@@ -303,15 +303,20 @@ func rmHash*(xp: TxPoolRef): Hash32 =
 func `rmHash=`*(xp: TxPoolRef, val: Hash32) =
   xp.rmHash = val
 
-proc updateVmState*(xp: TxPoolRef) =
-  ## Reset transaction environment, e.g. before packing a new block
+proc updateVmState*(xp: TxPoolRef, parentHeader: Header, parentHash: Hash32) =
+  ## Reset transaction environment, e.g. before packing a new block on
+  ## top of the given parent block.
   if not xp.vmState.isNil():
     xp.vmState.ledger.txFrame.dispose()
     xp.vmState.ledger = nil
     xp.vmState.dispose()
   xp.vmState = setupVMState(xp.chain.com,
-    xp.chain.latestHeader, xp.chain.latestHash,
-    xp.pos, xp.chain.txFrame(xp.chain.latestHash))
+    parentHeader, parentHash,
+    xp.pos, xp.chain.txFrame(parentHash))
+
+proc updateVmState*(xp: TxPoolRef) =
+  ## Reset transaction environment on top of the latest block.
+  xp.updateVmState(xp.chain.latestHeader, xp.chain.latestHash)
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/execution_chain/rpc/debug.nim
+++ b/execution_chain/rpc/debug.nim
@@ -323,7 +323,8 @@ proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
       ## Assembles a block from the current transaction pool using the
       ## production block-building path (TxPoolRef.assembleBlock).
       ## Returns the number of transactions and blobs that were packed.
-      let bundle = txPool.assembleBlock().valueOr:
+      let latestHeadHash = chain.latest.hash
+      let bundle = txPool.assembleBlock(parentHash = latestHeadHash).valueOr:
         raise newException(ValueError, error)
       let blobCount =
         if bundle.blobsBundle.isNil: 0

--- a/tests/eest/eest_txpool.nim
+++ b/tests/eest/eest_txpool.nim
@@ -77,7 +77,7 @@ proc importTxAndAssembleBlock(xp: TxPoolRef, blk: EthBlock): Result[EthBlock, st
   let
     # Override gasLimit
     gasLimit = Opt.some(blk.header.gasLimit)
-    res = ? xp.assembleBlock(someBaseFee = true, gasLimit = gasLimit)
+    res = ? xp.assembleBlock(xp.chain.latestHash, someBaseFee = true, gasLimit = gasLimit)
     blockHash = res.blk.header.computeBlockHash
     expectedBlockHash = blk.header.computeBlockHash
 

--- a/tests/test_engine_api.nim
+++ b/tests/test_engine_api.nim
@@ -264,6 +264,72 @@ proc runPayloadRebuildTest(env: TestEnv): Result[void, string] =
 
   ok()
 
+proc runSiblingHeadPayloadTest(env: TestEnv): Result[void, string] =
+  # Regression: when two VALID sibling payloads exist at the same height, the
+  # payload built for a forkchoiceUpdated carrying attributes must sit on the
+  # fcU headBlockHash, not on whichever sibling happened to be imported last.
+  # The build parent used to be ForkedChain.latest (the most recently imported
+  # block), so getPayload returned a payload with the wrong parent hash and the
+  # consensus client refused to sign it, missing the proposal.
+  let
+    client = env.client
+    genesisHeader = ? client.latestHeader()
+    genesisHash = genesisHeader.computeBlockHash
+    update = ForkchoiceStateV1(
+      headBlockHash: genesisHash
+    )
+    time = getTime().toUnix
+    attrA = PayloadAttributes(
+      timestamp:             w3Qty(time + 1),
+      prevRandao:            default(Bytes32),
+      suggestedFeeRecipient: default(Address),
+      withdrawals:           Opt.some(newSeq[WithdrawalV1]()),
+    )
+  var attrB = attrA
+  attrB.prevRandao = Bytes32 EMPTY_UNCLE_HASH
+
+  # Build two distinct sibling payloads on top of genesis.
+  let
+    fcuResA  = ? client.forkchoiceUpdated(Version.V1, update, Opt.some(attrA))
+    payloadA = (? client.getPayload(Version.V1, fcuResA.payloadId.get)).executionPayload
+    fcuResB  = ? client.forkchoiceUpdated(Version.V1, update, Opt.some(attrB))
+    payloadB = (? client.getPayload(Version.V1, fcuResB.payloadId.get)).executionPayload
+
+  if payloadA.blockHash == payloadB.blockHash:
+    return err("Expected two distinct sibling payloads")
+
+  let npResA = ? client.newPayloadV1(payloadA)
+  if npResA.status != PayloadExecutionStatus.valid:
+    return err("newPayload(A) should be valid, got: " & $npResA.status)
+
+  let npResB = ? client.newPayloadV1(payloadB)
+  if npResB.status != PayloadExecutionStatus.valid:
+    return err("newPayload(B) should be valid, got: " & $npResB.status)
+
+  # Sibling B was imported last. Request a payload on top of sibling A.
+  let
+    attrC = PayloadAttributes(
+      timestamp:             w3Qty(time + 2),
+      prevRandao:            default(Bytes32),
+      suggestedFeeRecipient: default(Address),
+      withdrawals:           Opt.some(newSeq[WithdrawalV1]()),
+    )
+    updateC = ForkchoiceStateV1(
+      headBlockHash: payloadA.blockHash,
+      finalizedBlockHash: genesisHash,
+    )
+    fcuResC  = ? client.forkchoiceUpdated(Version.V1, updateC, Opt.some(attrC))
+    payloadC = (? client.getPayload(Version.V1, fcuResC.payloadId.get)).executionPayload
+
+  if payloadC.parentHash != payloadA.blockHash:
+    return err("Payload must be built on the fcU head " &
+      payloadA.blockHash.toHex & ", got parent: " & payloadC.parentHash.toHex)
+
+  if uint64(payloadC.blockNumber) != 2:
+    return err("Expected block number 2, got: " & $payloadC.blockNumber)
+
+  ok()
+
 proc runNewPayloadV4Test(env: TestEnv): Result[void, string] =
   let
     client = env.client
@@ -498,6 +564,11 @@ const testList = [
     name: "Payload rebuild for identical FCU",
     fork: MergeFork,
     testProc: runPayloadRebuildTest
+  ),
+  TestSpec(
+    name: "Payload built on fcU head, not last imported sibling",
+    fork: MergeFork,
+    testProc: runSiblingHeadPayloadTest
   ),
   TestSpec(
     name: "newPayloadV4",

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -303,7 +303,7 @@ proc runLedgerTransactionTests(noisy = true) =
 
         blockTime = EthTime(blockTime.uint64 + 1'u64)
 
-        let r = env.xp.assembleBlock()
+        let r = env.xp.assembleBlock(env.xp.chain.latestHash)
         if r.isErr:
           debugEcho r.error
           check false

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -276,7 +276,7 @@ proc generateBlock(env: var TestEnv) =
   xp.feeRecipient = feeRecipient
   xp.timestamp = EthTime.now()
 
-  let bundle = xp.assembleBlock().valueOr:
+  let bundle = xp.assembleBlock(xp.chain.latestHash).valueOr:
     debugEcho error
     quit(QuitFailure)
 

--- a/tests/test_tx_frame_blobify.nim
+++ b/tests/test_tx_frame_blobify.nim
@@ -160,7 +160,7 @@ suite "TxFrame blobify round-trip":
         acc, i.AccountNonce)
       check xp.addTx(ptx).isOk
 
-    let bundle1Rc = xp.assembleBlock()
+    let bundle1Rc = xp.assembleBlock(xp.chain.latestHash)
     check bundle1Rc.isOk
     let blk1 = bundle1Rc.get.blk
     check blk1.transactions.len == 3
@@ -240,7 +240,7 @@ suite "TxFrame blobify round-trip":
       check xp.addTx(ptx).isOk
 
     xp.timestamp = xp.timestamp + 1
-    let bundle2Rc = xp.assembleBlock()
+    let bundle2Rc = xp.assembleBlock(xp.chain.latestHash)
     check bundle2Rc.isOk
     let blk2 = bundle2Rc.get.blk
     check blk2.transactions.len == 2
@@ -279,7 +279,7 @@ suite "TxFrame blobify round-trip":
         acc, i.AccountNonce)
       check xp.addTx(ptx).isOk
 
-    let bundle1 = xp.assembleBlock().get
+    let bundle1 = xp.assembleBlock(xp.chain.latestHash).get
     let blk1 = bundle1.blk
     check blk1.transactions.len == 3
     check (waitFor chain.importBlock(blk1)).isOk
@@ -296,7 +296,7 @@ suite "TxFrame blobify round-trip":
       check xp.addTx(ptx).isOk
 
     xp.timestamp = xp.timestamp + 1
-    let bundle2 = xp.assembleBlock().get
+    let bundle2 = xp.assembleBlock(xp.chain.latestHash).get
     let blk2 = bundle2.blk
     check blk2.transactions.len == 2
     check (waitFor chain.importBlock(blk2)).isOk
@@ -388,7 +388,7 @@ suite "TxFrame blobify round-trip":
         acc, i.AccountNonce)
       check xp2.addTx(ptx).isOk
 
-    let bundle3 = xp2.assembleBlock().get
+    let bundle3 = xp2.assembleBlock(xp2.chain.latestHash).get
     let blk3 = bundle3.blk
     check blk3.transactions.len == 2
     check (waitFor fc.importBlock(blk3)).isOk

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -146,7 +146,7 @@ template checkAddTxSupersede(xp, tx) =
 
 template checkAssembleBlock(xp, expCount): auto =
   xp.timestamp = xp.timestamp + 1
-  let rc = xp.assembleBlock()
+  let rc = xp.assembleBlock(xp.chain.latestHash)
   check rc.isOk == true
   if rc.isErr:
     debugEcho "ASSEMBLE BLOCK: ", rc.error
@@ -399,7 +399,7 @@ suite "TxPool test suite":
     var numTxsPacked = 0
     while numTxsPacked < MAX_TXS_GENERATED:
       xp.timestamp = xp.timestamp + 1
-      let bundle = xp.assembleBlock().valueOr:
+      let bundle = xp.assembleBlock(xp.chain.latestHash).valueOr:
         debugEcho error
         check false
         return
@@ -1073,7 +1073,7 @@ suite "TxPool EIP-7934 block RLP size limit":
       inc nonces[accIdx]
 
     xp.timestamp = xp.timestamp + 1
-    let rc = xp.assembleBlock()
+    let rc = xp.assembleBlock(xp.chain.latestHash)
     require rc.isOk
     let bundle = rc.get
 
@@ -1121,7 +1121,7 @@ suite "TxPool payload rebuild consistency":
 
     # advance to a new slot timestamp: first payload build
     xp.timestamp = xp.timestamp + 1
-    let rc1 = xp.assembleBlock()
+    let rc1 = xp.assembleBlock(xp.chain.latestHash)
     require rc1.isOk
     let b1 = rc1.get
     check b1.blk.transactions.len == 2
@@ -1129,7 +1129,7 @@ suite "TxPool payload rebuild consistency":
 
     # rebuild for the SAME slot/timestamp (mimics a repeated forkchoiceUpdated).
     # It must not collapse to an empty body with a stale header.
-    let rc2 = xp.assembleBlock()
+    let rc2 = xp.assembleBlock(xp.chain.latestHash)
     require rc2.isOk
     let b2 = rc2.get
     check b2.blk.transactions.len == 2


### PR DESCRIPTION
Fixes #4382 
- `api_forkchoice` passes headHash to `generateExecutionBundle`
- `generateExecutionBundle` resolves that header (erroring if unknown) and uses it for the parent-timestamp guard
- `assembleBlock` gained an mandatory parentHash and `updateVmState` an overload taking an explicit parent, so the packer VM runs on `chain.txFrame(headHash)`. All other callers have been updated to pass the parentHash