### PR TITLE
stateless: fail block on incomplete witness during persist

### DIFF
--- a/execution_chain/common/genesis.nim
+++ b/execution_chain/common/genesis.nim
@@ -34,7 +34,11 @@ proc writeGenesisAlloc*(alloc: GenesisAlloc, db: CoreDbTxRef): Hash32 =
     for k, v in account.storage:
       ledger.setStorage(address, k, v)
 
-  ledger.persist()
+  # Genesis is never stateless, so persist cannot abort the block here.
+  try:
+    ledger.persist()
+  except BlockAbortError as e:
+    raiseAssert e.msg
   ledger.getStateRoot()
 
 proc writeGenesis*(g: Genesis, db: CoreDbTxRef, fork: HardFork): Header =

--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -307,7 +307,7 @@ proc procBlkPreamble(
     vmState: BaseVMState,
     blk: Block,
     skipValidation, skipReceipts, skipUncles: bool
-): Result[void, string] =
+): Result[void, string] {.raises: [BlockAbortError].} =
   template header(): Header =
     blk.header
 
@@ -428,7 +428,7 @@ proc procBlkEpilogue(
     skipReceipts: bool,
     skipStateRootCheck: bool,
     skipPostExecBalCheck: bool
-): Result[void, string] =
+): Result[void, string] {.raises: [BlockAbortError].} =
   template header(): Header =
     blk.header
 
@@ -546,14 +546,26 @@ proc processBlock*(
 ): Result[void, string] =
   ## Generalised function to processes `blk` for any network.
 
+  # A partial-witness persist raises during stateless execution; contain it at
+  # the raising calls so that (stateful) callers are unaffected.
   vmState.withBalPrefetch(blockAccessList):
-    ?vmState.procBlkPreamble(blk, skipValidation, skipReceipts, skipUncles)
+    try:
+      ?vmState.procBlkPreamble(blk, skipValidation, skipReceipts, skipUncles)
+    except BlockAbortError as e:
+      if vmState.ledger.stateless:
+        return err(e.msg)
+      raiseAssert e.msg
 
     # EIP-3675: no reward for miner in POA/POS
     if not vmState.com.proofOfStake(blk.header, vmState.ledger.txFrame):
       vmState.calculateReward(blk.header, blk.uncles)
 
-    ?vmState.procBlkEpilogue(blk, skipValidation, skipReceipts, skipStateRootCheck, skipPostExecBalCheck)
+    try:
+      ?vmState.procBlkEpilogue(blk, skipValidation, skipReceipts, skipStateRootCheck, skipPostExecBalCheck)
+    except BlockAbortError as e:
+      if vmState.ledger.stateless:
+        return err(e.msg)
+      raiseAssert e.msg
 
   ok()
 

--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -184,7 +184,12 @@ proc processTransaction*(
     else:
       ok(move(callResult))
 
-  vmState.ledger.persist(clearEmptyAccount = vmState.hardFork >= Spurious)
+  try:
+    vmState.ledger.persist(clearEmptyAccount = vmState.hardFork >= Spurious)
+  except BlockAbortError as e:
+    if vmState.ledger.stateless:
+      return err(e.msg)
+    raiseAssert e.msg
 
   res
 
@@ -200,7 +205,7 @@ proc prefetchTransaction*(
   tx.txCallEvm(sender, vmState, intrinsic, discardResult = true)
   vmState.ledger.rollback(savePoint)
 
-proc processBeaconBlockRoot*(vmState: BaseVMState, beaconRoot: Hash32) =
+proc processBeaconBlockRoot*(vmState: BaseVMState, beaconRoot: Hash32) {.raises: [BlockAbortError].} =
   ## processBeaconBlockRoot applies the EIP-4788 system call to the
   ## beacon block root contract. This method is exported to be used in tests.
   ## If EIP-4788 is enabled, we need to invoke the beaconroot storage
@@ -217,7 +222,7 @@ proc processBeaconBlockRoot*(vmState: BaseVMState, beaconRoot: Hash32) =
   # EIP-4788: fail silently
   call.systemCall(void)
 
-proc processParentBlockHash*(vmState: BaseVMState, prevHash: Hash32) =
+proc processParentBlockHash*(vmState: BaseVMState, prevHash: Hash32) {.raises: [BlockAbortError].} =
   ## processParentBlockHash stores the parent block hash in the
   ## history storage contract as per EIP-2935.
   let
@@ -232,7 +237,7 @@ proc processParentBlockHash*(vmState: BaseVMState, prevHash: Hash32) =
   # EIP-2923: fail silently
   call.systemCall(void)
 
-proc processDequeueWithdrawalRequests*(vmState: BaseVMState): Result[seq[byte], string] =
+proc processDequeueWithdrawalRequests*(vmState: BaseVMState): Result[seq[byte], string] {.raises: [BlockAbortError].} =
   ## processDequeueWithdrawalRequests applies the EIP-7002 system call
   ## to the withdrawal requests contract.
   let
@@ -248,7 +253,7 @@ proc processDequeueWithdrawalRequests*(vmState: BaseVMState): Result[seq[byte], 
     return err("processDequeueWithdrawalRequests: " & res.error)
   ok(move(res.output))
 
-proc processDequeueConsolidationRequests*(vmState: BaseVMState): Result[seq[byte], string] =
+proc processDequeueConsolidationRequests*(vmState: BaseVMState): Result[seq[byte], string] {.raises: [BlockAbortError].} =
   ## processDequeueConsolidationRequests applies the EIP-7251 system call
   ## to the consolidation requests contract.
   let

--- a/execution_chain/core/tx_pool/tx_packer.nim
+++ b/execution_chain/core/tx_pool/tx_packer.nim
@@ -78,7 +78,7 @@ func classifyPackedNext(vmState: BaseVMState): bool =
 # Private functions: packer packerVmExec() helpers
 # ------------------------------------------------------------------------------
 
-proc vmExecInit(xp: TxPoolRef): Result[TxPacker, string] =
+proc vmExecInit(xp: TxPoolRef): Result[TxPacker, string] {.raises: [BlockAbortError].} =
   let
     vmState = xp.vmState
     packer = TxPacker(
@@ -159,7 +159,7 @@ proc vmExecGrabItem(pst: var TxPacker; item: TxItemRef, xp: TxPoolRef): bool =
 
   ContinueWithNextAccount
 
-proc vmExecCommit(pst: var TxPacker, xp: TxPoolRef): Result[void, string] =
+proc vmExecCommit(pst: var TxPacker, xp: TxPoolRef): Result[void, string] {.raises: [BlockAbortError].} =
   let
     vmState = pst.vmState
     ledger = vmState.ledger
@@ -207,8 +207,14 @@ proc vmExecCommit(pst: var TxPacker, xp: TxPoolRef): Result[void, string] =
 
 proc packerVmExec*(xp: TxPoolRef): Result[TxPacker, string] =
   ## Execute as much transactions as possible.
-  var pst = xp.vmExecInit.valueOr:
-    return err(error)
+  # Block building is never stateless, so persist cannot abort here; the guards
+  # below only satisfy the static exception effect at the two raising calls.
+  var pst: TxPacker
+  try:
+    pst = xp.vmExecInit.valueOr:
+      return err(error)
+  except BlockAbortError as e:
+    raiseAssert e.msg
 
   if xp.isOrdered:
     for item in xp.byOrder:
@@ -221,7 +227,10 @@ proc packerVmExec*(xp: TxPoolRef): Result[TxPacker, string] =
       if rc == StopCollecting:
         break
 
-  ?pst.vmExecCommit(xp)
+  try:
+    ?pst.vmExecCommit(xp)
+  except BlockAbortError as e:
+    raiseAssert e.msg
   ok(pst)
 
 func getExtraData(com: CommonRef): seq[byte] =

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -316,7 +316,15 @@ proc persistCode(acc: AccountRef, ledger: LedgerRef) =
       # code cache must also be cleared!
       acc.code.persisted = true
 
-proc persistStorage(acc: AccountRef, ledger: LedgerRef) =
+type BlockAbortError* = object of CatchableError
+  ## Fatal condition during a persist (e.g. a write into an incomplete witness).
+  ## Caught at the block boundary, where it is turned into a validation error
+  ## under stateless execution and asserted (corrupt DB) otherwise.
+
+template raiseBlockAbort(message: string) =
+  raise (ref BlockAbortError)(msg: message)
+
+proc persistStorage(acc: AccountRef, ledger: LedgerRef) {.raises: [BlockAbortError].} =
   const info = "persistStorage(): "
 
   if acc.overlayStorage.len == 0:
@@ -331,7 +339,7 @@ proc persistStorage(acc: AccountRef, ledger: LedgerRef) =
   # `Aristo` for updating the account's storage area reference. As a side effect,
   # this action also updates the latest statement data.
   ledger.txFrame.mergeAccount(acc.accPath, acc.statement).isOkOr:
-    raiseAssert info & $$error
+    raiseBlockAbort(info & $$error)
 
   # Save `overlayStorage[]` on database
   for slot, value in acc.overlayStorage:
@@ -348,14 +356,14 @@ proc persistStorage(acc: AccountRef, ledger: LedgerRef) =
 
     if value > 0:
       ledger.txFrame.mergeSlot(acc.accPath, slotKey, value).isOkOr:
-        raiseAssert info & $$error
+        raiseBlockAbort(info & $$error)
 
       # move the overlayStorage to originalStorage, related to EIP2200, EIP1283
       acc.originalStorage[slot] = value
 
     else:
       ledger.txFrame.deleteSlot(acc.accPath, slotKey).isOkOr:
-        raiseAssert info & $$error
+        raiseBlockAbort(info & $$error)
       acc.originalStorage.del(slot)
 
     if ledger.storeSlotHash and not cached:
@@ -770,7 +778,7 @@ proc clearBlockHashesCache*(ledger: LedgerRef) =
 proc persist*(ledger: LedgerRef,
               clearEmptyAccount: bool = false,
               clearCache = false,
-              clearWitness = false) =
+              clearWitness = false) {.raises: [BlockAbortError].} =
   const info = "persist(): "
 
   # make sure all savePoint already committed
@@ -800,11 +808,11 @@ proc persist*(ledger: LedgerRef,
         # This one is only necessary unless `persistStorage()` is run which needs
         # to `merge()` the latest statement as well.
         ledger.txFrame.mergeAccount(acc.accPath, acc.statement).isOkOr:
-          raiseAssert info & $$error
+          raiseBlockAbort(info & $$error)
     of Remove:
       ledger.txFrame.deleteAccount(acc.accPath).isOkOr:
         if error.error != AccNotFound:
-          raiseAssert info & $$error
+          raiseBlockAbort(info & $$error)
       ledger.savePoint.cache.del address
     of DoNothing:
       # dead man tell no tales

--- a/execution_chain/tracer.nim
+++ b/execution_chain/tracer.nim
@@ -160,7 +160,10 @@ proc traceTransactionImpl(
       before.captureAccount(ledger, sender, senderName)
       before.captureAccount(ledger, recipient, recipientName)
       before.captureAccount(ledger, miner, minerName)
-      ledger.persist()
+      try:
+        ledger.persist()
+      except BlockAbortError as e:
+        raiseAssert e.msg
       stateDiff["beforeRoot"] = %(ledger.getStateRoot().toHex)
       stateCtx = CaptCtxRef.init(com, ledger.getStateRoot())
 
@@ -172,7 +175,10 @@ proc traceTransactionImpl(
       after.captureAccount(ledger, recipient, recipientName)
       after.captureAccount(ledger, miner, minerName)
       tracerInst.removeTracedAccounts(sender, recipient, miner)
-      ledger.persist()
+      try:
+        ledger.persist()
+      except BlockAbortError as e:
+        raiseAssert e.msg
       stateDiff["afterRoot"] = %(ledger.getStateRoot().toHex)
       break
 

--- a/execution_chain/transaction/system_call.nim
+++ b/execution_chain/transaction/system_call.nim
@@ -67,7 +67,7 @@ proc finishRunningComputation(c: Computation, T: type): T =
   else:
     {.error: "Unknown systemCall output".}
 
-proc systemCall*(call: CallParams, T: type): T =
+proc systemCall*(call: CallParams, T: type): T {.raises: [BlockAbortError].} =
   let
     ledger = call.vmState.ledger
     c = setupComputation(call)

--- a/tests/eest/eest_helpers.nim
+++ b/tests/eest/eest_helpers.nim
@@ -68,7 +68,10 @@ proc prepareEnv*(
     config.blobSchedule = unit.config.blobSchedule
 
     setupLedger(unit.pre, ledger)
-    ledger.persist()
+    try:
+      ledger.persist()
+    except BlockAbortError as e:
+      raiseAssert e.msg
 
     ledger.txFrame.persistHeaderAndSetHead(genesis).isOkOr:
       debugEcho "Failed to put genesis header into database: ", error

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -37,11 +37,6 @@ const skipFiles = [
   # that way.
   "stateless_input_invalid_public_key_is_rejected.json",
 
-  # We AssertionDefect currently on these missing nodes. Need to adjust this
-  # to properly  return a Result.err() instead of crashing.
-  "validation_state_missing_absent_account_proof_node.json",
-  "validation_state_missing_absent_slot_proof_leaf_node.json",
-
   # cases of missing code in witness, which we currently don't check for
   "validation_codes_missing_delegated_code_on_insufficient_balance_call.json",
   "validation_codes_missing_sender_delegation_marker.json",

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -77,7 +77,10 @@ proc makeBlk(txFrame: CoreDbTxRef, number: BlockNumber, parentBlk: Block): Block
   for wd in wds:
     ledger.addBalance(wd.address, wd.weiAmount)
 
-  ledger.persist()
+  try:
+    ledger.persist()
+  except BlockAbortError as e:
+    raiseAssert e.msg
 
   let wdRoot = calcWithdrawalsRoot(wds)
   let body = BlockBody(


### PR DESCRIPTION
Make persist raise a BlockAbortError on a write failure. Turn it into a validation error under stateless execution, and assert for stateful.

Note that we cannot do the same easily for the BLOCKHASH opcode error as it would mean changing the raises signature for VmOpFn.