### PR TITLE
Make aristo staticLevel and lookup stats updates thread safe

### DIFF
--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -22,7 +22,7 @@
 {.push raises: [].}
 
 import
-  std/[hashes, sequtils, sets, tables, heapqueue],
+  std/[atomics, hashes, sequtils, sets, tables, heapqueue],
   eth/common/hashes, eth/trie/nibbles,
   results,
   ../../concurrency/lru,
@@ -146,9 +146,9 @@ type
       ## Mixed account/storage path to payload cache - same as above but caches
       ## the full lookup of storage slots
 
-    staticLevel*: int
+    staticLevel*: Atomic[int]
       ## MPT level where "most" leaves can be found, for static vid lookups
-    lookups*: tuple[lower, hits, higher: int]
+    lookupsLower*, lookupsHits*, lookupsHigher*: Atomic[int]
 
     snapshots*: HeapQueue[AristoTxRef]
       ## A priority queue of txFrames holding snapshots. Used to limit the number
@@ -270,18 +270,28 @@ proc deltaAtLevel*(db: AristoTxRef, level: int): AristoTxRef =
         return frame
     nil
 
-func getStaticLevel*(db: AristoDbRef): int =
+proc getStaticLevel*(db: AristoDbRef): int =
   # Retrieve the level where we can expect to find a leaf, updating it based on
   # recent lookups
+  let
+    lower = db.lookupsLower.load(moRelaxed)
+    hits = db.lookupsHits.load(moRelaxed)
+    higher = db.lookupsHigher.load(moRelaxed)
 
-  if db.lookups[0] + db.lookups[1] + db.lookups[2] >= 1024:
-    if db.lookups.lower > db.lookups.hits + db.lookups.higher:
-      db.staticLevel = max(1, db.staticLevel - 1)
-    elif db.lookups.higher > db.lookups.hits + db.lookups.lower:
-      db.staticLevel = min(STATIC_VID_LEVELS, db.staticLevel + 1)
-    reset(db.lookups)
+  var level = db.staticLevel.load(moRelaxed)
 
-  if db.staticLevel == 0:
-    db.staticLevel = 1
+  if lower + hits + higher >= 1024:
+    if lower > hits + higher:
+      level = max(1, level - 1)
+    elif higher > hits + lower:
+      level = min(STATIC_VID_LEVELS, level + 1)
+    db.lookupsLower.store(0, moRelaxed)
+    db.lookupsHits.store(0, moRelaxed)
+    db.lookupsHigher.store(0, moRelaxed)
 
-  db.staticLevel
+  if level == 0:
+    level = 1
+
+  db.staticLevel.store(level, moRelaxed)
+
+  level

--- a/execution_chain/db/aristo/aristo_fetch.nim
+++ b/execution_chain/db/aristo/aristo_fetch.nim
@@ -14,7 +14,7 @@
 {.push raises: [].}
 
 import
-  std/typetraits,
+  std/[atomics, typetraits],
   eth/common/[base, hashes],
   results,
   "."/[aristo_compute, aristo_desc, aristo_get, aristo_layers, aristo_hike, aristo_vid]
@@ -80,9 +80,9 @@ proc retrieveAccStatic(
   for sl in countdown(staticLevel, 0):
     template countHitOrLower() =
       if sl == staticLevel:
-        db.db.lookups.hits += 1
+        discard db.db.lookupsHits.fetchAdd(1, moRelaxed)
       else:
-        db.db.lookups.lower += 1
+        discard db.db.lookupsLower.fetchAdd(1, moRelaxed)
 
     let
       svid = path.staticVid(sl)
@@ -166,11 +166,11 @@ proc retrieveAccLeaf(
         # The branch was the deepest level where a vertex actually existed
         # meaning that it was a hit - else searches for non-existing paths would
         # skew the results towards more depth than exists in the MPT
-        db.db.lookups.hits += 1
+        discard db.db.lookupsHits.fetchAdd(1, moRelaxed)
         db.db.accLeaves.put(accPath, emptyCachedAccLeaf)
       return err(error)
 
-  db.db.lookups.higher += 1
+  discard db.db.lookupsHigher.fetchAdd(1, moRelaxed)
 
   let accLeaf = AccLeafRef(leafVtx)
   db.db.accLeaves.put(accPath, CachedAccLeaf.init(accLeaf.pfx, accLeaf.account, accLeaf.stoID))


### PR DESCRIPTION
Since we now support concurrent reads on the database from multiple threads (for bal state prefetching, optimistic state prefetching and bal parallel execution) the aristo static level updates ideally should be thread safe. This updates the static level and stats to use atomics to avoid data races.