### PR TITLE
stateless: change to latest specs

### DIFF
--- a/execution_chain/stateless/stateless_execution.nim
+++ b/execution_chain/stateless/stateless_execution.nim
@@ -115,7 +115,7 @@ template statelessProcessBlock*(
 ): Result[void, string] =
   statelessProcessBlock(witness, id, chainConfigForNetwork(id), blk)
 
-# https://github.com/ethereum/execution-specs/blob/b6b764ff21bb754b79e11ef5dc7ad1f79996e923/src/ethereum/forks/amsterdam/execution_engine/validation_helpers.py#L22
+# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/execution_engine/validation_helpers.py#L22
 func toBlock(
     p: ExecutionPayload, parentBeaconBlockRoot: Opt[Hash32], requestsHash: Opt[Hash32]
 ): Block {.raises: [RlpError].} =
@@ -209,7 +209,7 @@ func chainConfigForStateless(cc: StatelessChainConfig): ChainConfig =
   )
 
 # Encode execution requests into EL format:
-# https://github.com/ethereum/execution-specs/blob/b6b764ff21bb754b79e11ef5dc7ad1f79996e923/src/ethereum/forks/amsterdam/execution_engine/requests.py#L131
+# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/execution_engine/requests.py#L135
 func encodeDeposits(
     deposits: List[DepositRequest, Limit MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]
 ): seq[byte] =
@@ -288,7 +288,7 @@ proc executeNewPayload(input: StatelessInput): Result[void, string] =
 
   statelessProcessBlock(input.witness, com, blk)
 
-# https://github.com/ethereum/execution-specs/blob/b6b764ff21bb754b79e11ef5dc7ad1f79996e923/src/ethereum/forks/amsterdam/stateless.py#L344
+# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless.py#L368
 proc verify_stateless_new_payload*(input: StatelessInput): StatelessValidationResult =
   let new_payload_request_root = hash_tree_root(input.new_payload_request)
 

--- a/execution_chain/stateless/stateless_guest.nim
+++ b/execution_chain/stateless/stateless_guest.nim
@@ -15,7 +15,7 @@ export stateless_types, stateless_execution
 
 ## Stateless guest interfaces
 ## Spec:
-## https://github.com/ethereum/execution-specs/blob/b6b764ff21bb754b79e11ef5dc7ad1f79996e923/src/ethereum/forks/amsterdam/stateless_guest.py#L1
+## https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless_guest.py#L1
 
 func deserialize_stateless_input*(
     data: openArray[byte]

--- a/execution_chain/stateless/stateless_types.nim
+++ b/execution_chain/stateless/stateless_types.nim
@@ -31,10 +31,7 @@ const
   MAX_WITNESS_NODES* = 1 shl 22 # 2^22
   MAX_WITNESS_CODES* = 1 shl 18 # 2^18
   MAX_WITNESS_HEADERS* = 256
-  # Should be 2^16 but there are test vectors that violate this limit and must pass currently
-  # TODO: retest with 2^16 for tests-zkevm@v0.5.0 as limit got fixed there.
-  # MAX_BYTES_PER_CODE* = 1 shl 16            # 2^16
-  MAX_BYTES_PER_CODE* = 1 shl 24 # 2^24
+  MAX_BYTES_PER_CODE* = 1 shl 16 # 2^16
   MAX_BYTES_PER_HEADER* = 1 shl 10 # 2^10
   MAX_BYTES_PER_WITNESS_NODE* = 1 shl 10 # 2^10
   MAX_OPTIONAL_FORK_ACTIVATION_VALUES* = 1

--- a/execution_chain/stateless/witness_verification.nim
+++ b/execution_chain/stateless/witness_verification.nim
@@ -74,7 +74,7 @@ func validateKeys*(witness: Witness, expectedKeys: WitnessTable): Result[void, s
 
   ok()
 
-# https://github.com/ethereum/execution-specs/blob/b6b764ff21bb754b79e11ef5dc7ad1f79996e923/src/ethereum/forks/amsterdam/stateless.py#L257
+# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless.py#L281
 func verifyHeaders*(
     witness: ExecutionWitness, header: Header
 ): Result[seq[Header], string] =

--- a/tests/eest/eest_blockchain.nim
+++ b/tests/eest/eest_blockchain.nim
@@ -204,24 +204,11 @@ proc runTest(
 
       expectedSuccessful = expectedOutput.successful_validation
 
-      if output.successful_validation != expectedOutput.successful_validation:
+      if output != expectedOutput:
         return err(
-          "Stateless guest: expected successful_validation=" &
-            $expectedOutput.successful_validation & " got " &
-            $output.successful_validation
+          "Stateless guest: validation result mismatch, got: " & $output &
+            " expected: " & $expectedOutput
         )
-
-      # TODO: new_payload_request_root comparison disabled
-      # the block_access_list field in ExecutionPayload uses MAX_BYTES_PER_TRANSACTION (2^30)
-      # in our gloas.nim data types but the stateless_ssz.py spec uses
-      # MAX_BLOCK_ACCESS_LIST_BYTES = (2^24), causing a hash_tree_root mismatch.
-      # Expected to be fixed in the next release of test vectors.
-      # if output.new_payload_request_root != expectedOutput.new_payload_request_root:
-      #   return err(
-      #     "Stateless guest: new_payload_request_root mismatch, got " &
-      #     $output.new_payload_request_root &
-      #     " expected " & $expectedOutput.new_payload_request_root
-      #   )
 
       # Verify that the SSZ input witness matches the JSON witness field.
       # This rather validates the test vector itself, not our implementation.


### PR DESCRIPTION
With the update to the latest zkevm test fixtures we can update also MAX_BYTES_PER_CODE to the correct value.

And we can now properly verify the new_payload_request_root in the stateless output as the block_access_list in the ExecutionPayload in the Python spec got fixed.