### PR TITLE
Adjust discovery flag as just turn on/off bool

### DIFF
--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -263,10 +263,10 @@ type
       defaultValueDesc: "any"
       name: "nat" .}: NatConfig
 
-    discovery* {.
+    discv5* {.
       desc: "Enable peer discovery. When disabled, peers must be added manually"
       defaultValue: true
-      name: "discovery" .}: bool
+      name: "discv5" .}: bool
 
     netKey* {.
       desc: "P2P ethereum node (secp256k1) private key (random, path, hex)"

--- a/execution_chain/conf.nim
+++ b/execution_chain/conf.nim
@@ -75,10 +75,6 @@ type
     Debug                         ## enable debug_ set of RPC API
     Admin                         ## enable admin_ set of RPC API
 
-  DiscoveryType* {.pure.} = enum
-    V4
-    V5
-
   ExecutionClientConf* = object
     ## Main configuration for the execution client - when updating, coordinate
     ## options shared with other executables (logging, metrics etc)
@@ -268,15 +264,9 @@ type
       name: "nat" .}: NatConfig
 
     discovery* {.
-      desc: "Specify method to find suitable peer in an Ethereum network (None, V4, V5)"
-      longDesc:
-        "- None: Disables the peer discovery mechanism (manual peer addition)\n" &
-        "- V4  : Node Discovery Protocol v4\n" &
-        "- V5  : Node Discovery Protocol v5\n" &
-        "- All : V4, V5"
-      defaultValue: @["V4", "V5"]
-      defaultValueDesc: "V4, V5"
-      name: "discovery" .}: seq[string]
+      desc: "Enable peer discovery. When disabled, peers must be added manually"
+      defaultValue: true
+      name: "discovery" .}: bool
 
     netKey* {.
       desc: "P2P ethereum node (secp256k1) private key (random, path, hex)"
@@ -785,23 +775,6 @@ proc getRpcFlags*(config: ExecutionClientConf): set[RpcFlag] =
 
 proc getWsFlags*(config: ExecutionClientConf): set[RpcFlag] =
   getRpcFlags(config.wsApi)
-
-proc getDiscoveryFlags(api: openArray[string]): set[DiscoveryType] =
-  if api.len == 0:
-    return {DiscoveryType.V4, DiscoveryType.V5}
-
-  for item in repeatingList(api):
-    case item.toLowerAscii()
-    of "none": result = {}
-    of "v4": result.incl DiscoveryType.V4
-    of "v5": result.incl DiscoveryType.V5
-    of "all": result = {DiscoveryType.V4, DiscoveryType.V5}
-    else:
-      error "Unknown discovery type: ", name=item
-      quit QuitFailure
-
-proc getDiscoveryFlags*(config: ExecutionClientConf): set[DiscoveryType] =
-  getDiscoveryFlags(config.discovery)
 
 proc getBootstrapNodes*(config: ExecutionClientConf): BootstrapNodes =
   # Ignore standard bootnodes if customNetwork is loaded

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -155,9 +155,11 @@ proc setupP2P(nimbus: NimbusNode, config: ExecutionClientConf, com: CommonRef) =
 
   # Start Eth node
   if config.maxPeers > 0:
+    # The user-facing flag is --discv5, but discv4 is still enabled alongside
+    # it until the discv4 code is removed.
     nimbus.ethNode.connectToNetwork(
-      enableDiscV4 = config.discovery,
-      enableDiscV5 = config.discovery,
+      enableDiscV4 = config.discv5,
+      enableDiscV5 = config.discv5,
     )
 
   # Initalise beacon sync descriptor.

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -155,10 +155,9 @@ proc setupP2P(nimbus: NimbusNode, config: ExecutionClientConf, com: CommonRef) =
 
   # Start Eth node
   if config.maxPeers > 0:
-    let discovery = config.getDiscoveryFlags()
     nimbus.ethNode.connectToNetwork(
-      enableDiscV4 = DiscoveryType.V4 in discovery,
-      enableDiscV5 = DiscoveryType.V5 in discovery,
+      enableDiscV4 = config.discovery,
+      enableDiscV5 = config.discovery,
     )
 
   # Initalise beacon sync descriptor.

--- a/tests/config_file/basic.toml
+++ b/tests/config_file/basic.toml
@@ -37,7 +37,7 @@ tcp-port = 5567
 udp-port = 8899
 max-peers = 45
 nat = "any"
-discovery = false
+discv5 = false
 net-key = "random"
 agent-string = "basic_agent_string"
 

--- a/tests/config_file/basic.toml
+++ b/tests/config_file/basic.toml
@@ -37,7 +37,7 @@ tcp-port = 5567
 udp-port = 8899
 max-peers = 45
 nat = "any"
-discovery = ["V5"]
+discovery = false
 net-key = "random"
 agent-string = "basic_agent_string"
 

--- a/tests/test_configuration.nim
+++ b/tests/test_configuration.nim
@@ -345,7 +345,7 @@ proc configurationMain*() =
       check config.udpPort == 8899.Port
       check config.maxPeers == 45
       check config.nat == NatConfig(hasExtIp: false, nat: NatAny)
-      check config.discovery == false
+      check config.discv5 == false
       check config.netKey == "random"
       check config.agentString == "basic_agent_string"
 

--- a/tests/test_configuration.nim
+++ b/tests/test_configuration.nim
@@ -345,7 +345,7 @@ proc configurationMain*() =
       check config.udpPort == 8899.Port
       check config.maxPeers == 45
       check config.nat == NatConfig(hasExtIp: false, nat: NatAny)
-      check config.discovery == ["V5"]
+      check config.discovery == false
       check config.netKey == "random"
       check config.agentString == "basic_agent_string"
 


### PR DESCRIPTION
Some questions here:
1. OK to adjust flag without backwards compatibility ? 
2. should we name it `--discovery` or `--discv5` to be consistent with `nimbus_beacon_node`? Keeping also in mind `nimbus` unified client
3. Should we wait for discv4 removal or not before making this cli change?


My answers:
1. I'd say yes as the nec is in alpha
2. Not sure here. I would change it to `--discv5` for consistency, but wished we had instead named it `--discovery` in `nimbus_beacon_node`. But I think even calling it `--discv5` is would be ok, even if for the time being it still means also running discv4.
3. I would change it the sooner the better, so that anybody that might want to only set 1 of the two currently doesn't get their setup broken in the future.


