### PR TITLE
Update to zkevm v0.6.1 and spec related changes

### DIFF
--- a/execution_chain/stateless/stateless_execution.nim
+++ b/execution_chain/stateless/stateless_execution.nim
@@ -120,7 +120,7 @@ template statelessProcessBlock*(
 ): Result[void, string] =
   statelessProcessBlock(witness, id, chainConfigForNetwork(id), blk)
 
-# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/execution_engine/validation_helpers.py#L22
+# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/execution_engine/validation_helpers.py#L22
 func toBlock(
     p: ExecutionPayload, parentBeaconBlockRoot: Opt[Hash32], requestsHash: Opt[Hash32]
 ): Block {.raises: [RlpError].} =
@@ -170,7 +170,7 @@ func toBlock(
     withdrawals: Opt.some(wds),
   )
 
-# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless.py#L304
+# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless.py#L278
 func isActivationActive(
     activation: ForkActivation, execution_payload: ExecutionPayload
 ): Result[void, string] =
@@ -188,36 +188,20 @@ func isActivationActive(
 
   ok()
 
-# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless.py#L340
+# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless.py#L303
 func validate_chain_config(
     chain_config: StatelessChainConfig, execution_payload: ExecutionPayload
 ): Result[void, string] =
   ## Validate the target payload's active fork config.
   let active_fork = chain_config.active_fork
 
-  ?isActivationActive(active_fork.activation, execution_payload)
-
-  if active_fork.fork != PROTOCOL_FORK_AMSTERDAM:
-    return err("Amsterdam stateless guest cannot execute fork " & $active_fork.fork)
-
-  # The expected blob schedule is the one compiled into the guest for Amsterdam.
-  let expectedBlobSchedule =
-    defaultBlobSchedule()[Amsterdam].expect("Amsterdam blob schedule is defined")
-  if active_fork.blob_schedule.len == 0 or
-      active_fork.blob_schedule[0] != expectedBlobSchedule:
-    return err("ChainConfig active_fork blob_schedule does not match Amsterdam")
-
-  ok()
+  isActivationActive(active_fork.activation, execution_payload)
 
 func chainConfigForStateless(cc: StatelessChainConfig): ChainConfig =
   # Nimbus EVM needs the full fork timeline, but the stateless input only provides
   # the active fork. Set the rest to 0 to allow for execution. The active fork is
   # set to the provided values.
   let networkId = NetworkId(cc.chain_id.u256)
-
-  var bs = defaultBlobSchedule()
-  if cc.active_fork.blob_schedule.len > 0:
-    bs[Amsterdam] = Opt.some(cc.active_fork.blob_schedule[0])
 
   let amsterdamTime =
     if cc.active_fork.activation.timestamp.len > 0:
@@ -248,14 +232,14 @@ func chainConfigForStateless(cc: StatelessChainConfig): ChainConfig =
     bpo4Time: Opt.some(0.EthTime),
     bpo5Time: Opt.some(0.EthTime),
     amsterdamTime: amsterdamTime,
-    blobSchedule: bs,
+    blobSchedule: defaultBlobSchedule(),
     # Inherit deposit contract address from the known network config
     # TODO: Separate out the deposit contract address code.
     depositContractAddress: chainConfigForNetwork(networkId).depositContractAddress,
   )
 
 # Encode execution requests into EL format:
-# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/execution_engine/requests.py#L135
+# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/execution_engine/requests.py#L108
 func encodeDeposits(
     deposits: List[DepositRequest, Limit MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]
 ): seq[byte] =
@@ -335,7 +319,7 @@ proc executeNewPayload(input: StatelessInput): Result[void, string] =
 
   statelessProcessBlock(input.witness, com, blk)
 
-# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless.py#L368
+# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless.py#L321
 proc verify_stateless_new_payload*(input: StatelessInput): StatelessValidationResult =
   let new_payload_request_root = compute_new_payload_request_root(input)
 

--- a/execution_chain/stateless/stateless_guest.nim
+++ b/execution_chain/stateless/stateless_guest.nim
@@ -15,7 +15,7 @@ export stateless_types, stateless_execution
 
 ## Stateless guest interfaces
 ## Spec:
-## https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless_guest.py#L1
+## https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_guest.py#L1
 
 func deserialize_stateless_input*(
     data: openArray[byte]

--- a/execution_chain/stateless/stateless_host.nim
+++ b/execution_chain/stateless/stateless_host.nim
@@ -14,7 +14,6 @@ import
   secp256k1,
   stew/[endians2, sequtils2],
   eth/common/[blocks, eth_types_rlp, hashes, keys, transaction_utils],
-  ../common/chain_config,
   ./stateless_types
 
 from beacon_chain/spec/datatypes/gloas import ExecutionPayload
@@ -31,9 +30,9 @@ export stateless_types, results
 
 ## Stateless host interfaces
 ## Spec:
-## https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless_host.py#L1
+## https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_host.py#L1
 
-## https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/transactions.py#L779
+## https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/transactions.py#L810
 func recover_transaction_public_key*(
     tx: Transaction
 ): Opt[ByteVector[PUBLIC_KEY_BYTES]] =
@@ -67,18 +66,13 @@ func build_chain_config*(chain_id: uint64): StatelessChainConfig =
   ## Build the chain configuration supported by this host.
   ##
   ## For now the Amsterdam stateless host only describes the Amsterdam fork.
-  var activation: ForkActivation
-  discard activation.timestamp.add(0'u64)
-
-  var blobSchedule: List[BlobSchedule, MAX_BLOB_SCHEDULES_PER_FORK]
-  discard blobSchedule.add(
-    defaultBlobSchedule()[Amsterdam].expect("Amsterdam blob schedule is defined")
-  )
-
   StatelessChainConfig(
     chain_id: chain_id,
     active_fork: ForkConfig(
-      fork: PROTOCOL_FORK_AMSTERDAM, activation: activation, blob_schedule: blobSchedule
+      activation: ForkActivation(
+        block_number: List[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES].init(@[]),
+        timestamp: List[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES].init(@[0'u64]),
+      )
     ),
   )
 

--- a/execution_chain/stateless/stateless_types.nim
+++ b/execution_chain/stateless/stateless_types.nim
@@ -13,7 +13,6 @@ import ssz_serialization, beacon_chain/spec/[eth2_merkleization, ssz_codec]
 
 from beacon_chain/spec/datatypes/gloas import ExecutionPayload
 from beacon_chain/spec/datatypes/electra import ExecutionRequests
-from ../common/hardforks import BlobSchedule
 
 export ssz_serialization, ssz_codec
 
@@ -22,7 +21,7 @@ export ssz_serialization, ssz_codec
 # ---------------------------------------------------------------------------
 
 # As per spec:
-# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless_ssz.py#L41
+# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_ssz.py#L42
 #
 # Not all consts are defined here as we get some of the types from beacon_chain datatypes
 
@@ -35,26 +34,28 @@ const
   MAX_BYTES_PER_HEADER* = 1 shl 10 # 2^10
   MAX_BYTES_PER_WITNESS_NODE* = 1 shl 10 # 2^10
   MAX_OPTIONAL_FORK_ACTIVATION_VALUES* = 1
-  MAX_BLOB_SCHEDULES_PER_FORK* = 1
   MAX_PUBLIC_KEYS* = 1 shl 15 # 2^15
   PUBLIC_KEY_BYTES* = 65
 
-  # Amsterdam SSZ stateless input schema identifier.
-  STATELESS_INPUT_SCHEMA_ID* = 0x0001'u16
-  STATELESS_INPUT_SCHEMA_ID_SIZE* = 2
-
   # We should be using the HardFork enum value for Amsterdam from hardforks.nim
   # but BPO1-BPO5 are already defined there, while in the execution-specs tag
-  # tests-zkevm@v0.5.0 only BPO1-BPO2 is defined, making the enum value differ.
-  # So we hardcode it here for now to the value of the specs/tests used.
-  PROTOCOL_FORK_AMSTERDAM* = 20'u64
+  # tests-zkevm@v0.5.0 only BPO1-BPO2 is defined. Making the enum value different.
+  # So we hardcode it here for now to the value of the specs/tests used, matching
+  # the execution-specs ProtocolFork IntEnum value used to build the schema id.
+  PROTOCOL_FORK_AMSTERDAM* = 0x15'u16
+  STATELESS_INPUT_SCHEMA_REVISION* = 0x01'u16
+
+  # Stateless guest input bytes are schema-prefixed: schema_id || encoded_payload
+  STATELESS_INPUT_SCHEMA_ID* =
+    (PROTOCOL_FORK_AMSTERDAM shl 8) or STATELESS_INPUT_SCHEMA_REVISION
+  STATELESS_INPUT_SCHEMA_ID_SIZE* = 2
 
 # ---------------------------------------------------------------------------
 # SSZ container types
 # ---------------------------------------------------------------------------
 
 # As per spec:
-# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless_ssz.py#L96
+# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_ssz.py#L105
 #
 # Not all types are defined here as we get some of the types from beacon_chain datatypes
 
@@ -75,11 +76,8 @@ type
     block_number*: List[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES]
     timestamp*: List[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES]
 
-  # Optional BlobSchedule encoded as a List of 0 or 1 elements.
   ForkConfig* = object
-    fork*: uint64
     activation*: ForkActivation
-    blob_schedule*: List[BlobSchedule, MAX_BLOB_SCHEDULES_PER_FORK]
 
   # Note: named `StatelessChainConfig` to avoid name collision with EL `ChainConfig`
   StatelessChainConfig* = object
@@ -101,7 +99,7 @@ type
 # Helpers
 # ---------------------------------------------------------------------------
 
-# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless.py#L255
+# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless.py#L229
 func compute_new_payload_request_root*(input: StatelessInput): Digest =
   ## Compute the request root for a stateless input via SSZ hash tree root.
   hash_tree_root(input.new_payload_request)

--- a/execution_chain/stateless/witness_generation.nim
+++ b/execution_chain/stateless/witness_generation.nim
@@ -88,7 +88,7 @@ proc build*(
     raiseAssert "Failed to get multiproof: " & $$error
 
   # Sort the proof nodes lexicographically as is done in execution-specs:
-  # https://github.com/ethereum/execution-specs/blob/33aa038697162a3ba0aedbadf177c4c59ee5b007/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L230
+  # https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L230
   multiProof.sort()
   witness.state = move(multiProof)
 
@@ -126,7 +126,7 @@ proc build*(
 
   if earliestBlockNumber.isSome():
     # Add headers in ascending block number order:
-    # https://github.com/ethereum/execution-specs/blob/33aa038697162a3ba0aedbadf177c4c59ee5b007/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L175-L176
+    # https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L175-L176
     for n in earliestBlockNumber.get() ..< parent.number:
       let blockHash = ledger.getBlockHash(BlockNumber(n))
       doAssert(blockHash != default(Hash32))
@@ -146,7 +146,7 @@ proc build*(
     codes.add(code)
 
   # Sort codes lexicographically as is done in execution-specs:
-  # https://github.com/ethereum/execution-specs/blob/33aa038697162a3ba0aedbadf177c4c59ee5b007/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L268
+  # https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L268
   codes.sort()
 
   var headers: seq[seq[byte]]

--- a/execution_chain/stateless/witness_verification.nim
+++ b/execution_chain/stateless/witness_verification.nim
@@ -74,7 +74,7 @@ func validateKeys*(witness: Witness, expectedKeys: WitnessTable): Result[void, s
 
   ok()
 
-# https://github.com/ethereum/execution-specs/blob/bd8c673552d957dbe9c9f3f2656b87201f5ae646/src/ethereum/forks/amsterdam/stateless.py#L281
+# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless.py#L255
 func verifyHeaders*(
     witness: ExecutionWitness, header: Header
 ): Result[seq[Header], string] =

--- a/scripts/eest_ci_cache.sh
+++ b/scripts/eest_ci_cache.sh
@@ -29,7 +29,7 @@ EEST_DEVNET_URL="https://github.com/ethereum/execution-specs/releases/download/$
 
 # --- zkevm Release ---
 EEST_ZKEVM_NAME="tests-zkevm"
-EEST_ZKEVM_VERSION="v0.5.0"
+EEST_ZKEVM_VERSION="v0.6.1"
 EEST_ZKEVM_DIR="${FIXTURES_DIR}/eest_zkevm"
 EEST_ZKEVM_ARCHIVE="fixtures_zkevm.tar.gz"
 EEST_ZKEVM_URL="https://github.com/ethereum/execution-specs/releases/download/${EEST_ZKEVM_NAME}%40${EEST_ZKEVM_VERSION}/${EEST_ZKEVM_ARCHIVE}"


### PR DESCRIPTION
This is an update of zkevm fixtures and code changes to stateless chain config and schema id as per spec for zkevm v0.6.1

These are however changes on top of tests-glamsterdam-devnet@v7.2.0 so we will first need a new devnet 7 branch. 