### PR TITLE
stateless: fail block on missing witness code

### DIFF
--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -172,8 +172,8 @@ proc processTransaction*(
   if persist:
     vmState.ledger.persist(clearEmptyAccount = vmState.hardFork >= Spurious)
 
-  # Checked after persist so both a BLOCKHASH miss (set during the EVM run)
-  # and a partial witness persist failure are caught here.
+  # Checked after persist so a BLOCKHASH miss, a missing-code lookup (both set
+  # during the EVM run) and a partial witness persist failure are all caught here.
   vmState.ledger.abortOnFatalError()
 
   res

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -438,7 +438,10 @@ template getCodeSizeImpl(ledger: LedgerRef, acc: AccountRef): int =
       var rc = ledger.txFrame.len(contractHashKey(acc.statement.codeHash).toOpenArray)
 
       return rc.valueOr:
+        # A non-empty code hash whose length is missing from the database: record
+        # a fatalError but still return 0 so the async EVM continues.
         warn logTxt "getCodeSize()", codeHash=acc.statement.codeHash, error=($$rc.error)
+        ledger.fatalError = Opt.some("getCodeSize(): failed to fetch code length from database")
         0
 
   acc.code.len()
@@ -558,7 +561,10 @@ proc getCode*(ledger: LedgerRef,
         ledger.code.get(acc.statement.codeHash).valueOr:
           var rc = ledger.txFrame.get(contractHashKey(acc.statement.codeHash).toOpenArray)
           if rc.isErr:
+            # A non-empty code hash with no code in the database: record a fatalError
+            # but still return empty code so the async EVM continues.
             warn logTxt "getCode()", codeHash=acc.statement.codeHash, error=($$rc.error)
+            ledger.fatalError = Opt.some("getCode(): failed to fetch code from database")
             CodeBytesRef()
           else:
             let newCode = CodeBytesRef.init(move(rc.value), persisted = true)

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -57,13 +57,10 @@ const skipFiles = [
   "stateless_input_invalid_public_key_is_rejected.json",
   "stateless_input_opposite_y_parity_public_key_is_rejected.json",
 
-  # cases of missing code in witness, which we currently don't check for
+  # cases of missing code in witness
   "validation_codes_missing_delegated_code_on_insufficient_balance_call.json",
-  "validation_codes_missing_sender_delegation_marker.json",
-  "validation_codes_missing_redelegation_old_marker.json",
-  "validation_codes_missing_external_code_read_target.json",
 
-  # cases of missing states in witness, which we currently don't check for
+  # cases of missing states in witness
   "validation_state_missing_failed_call_target_account_proof_node.json",
 ]
 


### PR DESCRIPTION
A getCode/getCodeSize lookup for a non-empty codeHash without a matching database entry now records a fatalError.

The read sites still return empty and record the access: the verified proxy's async EVM depends on that to discover and fetch code, so the error cannot be raised inline.