### PR TITLE
update txpool vmState as head moves

### DIFF
--- a/execution_chain/core/tx_pool/tx_desc.nim
+++ b/execution_chain/core/tx_pool/tx_desc.nim
@@ -358,7 +358,16 @@ proc removeExpiredTxs*(xp: TxPoolRef, lifeTime: Duration = TX_ITEM_LIFETIME) =
     xp.removeTx(txHash)
 
 proc addTxImpl(xp: TxPoolRef, ptx: PooledTransaction): Result[void, TxError] =
-  if xp.pos.timestamp != xp.vmState.blockCtx.timestamp:
+  if xp.chain.latestHash != xp.vmState.blockCtx.parentHash:
+    # The chain head moved without a block-building cycle (payload import,
+    # fork choice, or syncer progress): re-anchor the validation state on
+    # the new head, or txs keep being judged against stale nonces, balances
+    # and base fee. The context timestamp only moves forward so that an
+    # in-flight build cycle's slot timestamp (always beyond the head's) is
+    # preserved.
+    xp.pos.timestamp = max(xp.pos.timestamp, xp.chain.latestHeader.timestamp)
+    xp.updateVmState()
+  elif xp.pos.timestamp != xp.vmState.blockCtx.timestamp:
     xp.updateVmState()
 
   let

--- a/tests/test_txpool.nim
+++ b/tests/test_txpool.nim
@@ -1186,3 +1186,73 @@ suite "TxPool expiry":
     waitFor sleepAsync(chronos.milliseconds(50))
     check xp.len == 0
     waitFor ev.stop()
+
+suite "TxPool validation state follows chain head":
+  ## Repro for the hive devp2p `eth/Transaction` failure: the pool used to
+  ## validate incoming txs against the state captured when the pool was
+  ## created (or when it last built a block). A node that never builds
+  ## blocks - hive's devp2p client, or any non-validating node - kept
+  ## judging txs against that birth state: stale base fee, nonces and
+  ## balances.
+
+  test "tx nonce is checked against the moved head, not the pool birth state":
+    let
+      env = initEnv(Cancun)
+      xp = env.xp
+      mx = env.sender
+      builder = TxPoolRef.new(env.chain)
+      acc = mx.getAccount(20)
+      tc = BaseTx(gasLimit: 75000, recipient: Opt.some(recipient), amount: amount)
+
+    builder.prevRandao = prevRandao
+    builder.feeRecipient = feeRecipient
+    builder.timestamp = EthTime.now()
+
+    # The "network" (builder pool) mines acc's nonce-0 tx; the pool under
+    # test never assembles a block, so nothing else re-anchors it.
+    builder.checkAddTx(mx.makeTx(tc, acc, 0))
+    builder.checkImportBlock(1, 0)
+
+    # A different nonce-0 tx from the same sender must be rejected: the
+    # account nonce is 1 at the new head. Against the stale birth state
+    # it would be accepted.
+    var tc2 = tc
+    tc2.amount = amount * 2
+    xp.checkAddTx(mx.makeTx(tc2, acc, 0), txErrorNonceTooSmall)
+
+  test "base fee is checked against the moved head (hive eth/Transaction)":
+    let
+      env = initEnv(Cancun)
+      xp = env.xp
+      mx = env.sender
+      builder = TxPoolRef.new(env.chain)
+      acc = mx.getAccount(21)
+
+    builder.prevRandao = prevRandao
+    builder.feeRecipient = feeRecipient
+    builder.timestamp = EthTime.now()
+
+    # Advance the head with empty blocks: the base fee decays by 1/8 per
+    # block, well below what the pool's birth state predicts.
+    for _ in 0 ..< 4:
+      builder.checkImportBlock(0, 0)
+
+    # Ground truth: a pool created NOW anchors on the current head.
+    let probe = TxPoolRef.new(env.chain)
+    check xp.baseFee > probe.baseFee
+
+    # Pay exactly the real next-block base fee, like hive's simulator does
+    # (GasFeeCap = head base fee). Against the stale anchor this fails
+    # "maxFeePerGas lower than baseFee" and the tx never enters the pool.
+    let ptx = mx.makeTx(BaseTx(
+      txType: Opt.some(TxEip1559),
+      gasLimit: 75000,
+      recipient: Opt.some(recipient),
+      amount: amount,
+      gasFee: probe.baseFee,
+      gasTip: 1.GasInt,
+    ), acc, 0)
+    xp.checkAddTx(ptx)
+
+    # The add re-anchored the pool on the live head.
+    check xp.baseFee == probe.baseFee


### PR DESCRIPTION
If we don't update, we reject few transactions which we are not supposed to reject 