### PR TITLE
proxy: evm blockhash using eip2935

### DIFF
--- a/nimbus_verified_proxy/engine/blocks.nim
+++ b/nimbus_verified_proxy/engine/blocks.nim
@@ -469,3 +469,36 @@ proc getHeader*(
   ?((await engine.verifyHeader(header, blk.hash)).tagBackend(backendIdx))
 
   ok(header)
+
+# NOTE: this function uses the "latest" tag as the anchor. Hence this
+# function should not be used anywhere else except where the trust 
+# assumption is "latest" and not "finalized"
+proc getBlockHash*(
+    engine: RpcVerificationEngine, number: base.BlockNumber
+): Future[EngineResult[Hash32]] {.async: (raises: [CancelledError]).} =
+  let cached = engine.headerStore.getHash(number)
+  if cached.isSome():
+    return ok(cached.get())
+
+  let latest = engine.headerStore.latest.valueOr:
+    return err(
+      (
+        UnavailableDataError, "latest block is not available yet. Still syncing?",
+        UNTAGGED,
+      )
+    )
+
+  if isInEIP2935VerifiableRange(latest.number, latest.number, number):
+    let
+      slot = (number mod HISTORY_SERVE_WINDOW).u256
+      storedValue = await engine.getStorageAt(
+        HISTORY_STORAGE_ADDRESS, slot, latest.number, latest.stateRoot
+      )
+
+    if storedValue.isOk() and not storedValue.get().isZero():
+      return ok(storedValue.get().toBytesBE().to(Hash32))
+
+  let resolved =
+    ?(await engine.getHeader(BlockTag(kind: bidNumber, number: Quantity(number))))
+
+  ok(resolved.computeBlockHash)

--- a/nimbus_verified_proxy/engine/evm.nim
+++ b/nimbus_verified_proxy/engine/evm.nim
@@ -12,7 +12,7 @@ import
   ../../execution_chain/evm/async_evm_backend,
   ../../execution_chain/evm/async_evm,
   ./accounts,
-  ./header_store,
+  ./blocks,
   ./types
 
 logScope:
@@ -51,6 +51,9 @@ proc toAsyncEvmStateBackend*(engine: RpcVerificationEngine): AsyncEvmStateBacken
     blockHashProc = proc(
         header: Header, number: BlockNumber
     ): Future[Opt[Hash32]] {.async: (raises: [CancelledError]).} =
-      engine.headerStore.getHash(number)
+      let blockHash = (await engine.getBlockHash(number)).valueOr:
+        return Opt.none(Hash32)
+
+      Opt.some(blockHash)
 
   AsyncEvmStateBackend.init(accProc, storageProc, codeProc, blockHashProc)


### PR DESCRIPTION
Previously the async evm was obtaining blockhashes from the header store. At the time, the assumption that the header store maintained a complete list of the last 256 blockhashes was true, it isn't anymore (C-API syncs only on request). This PR replaces the logic, the blockhash is obtained from EIP-2935 contract with `eth_getBlockByNumber` as the fallback (if the EIP is not active or is not fully activated) 