### PR TITLE
reduce open dependabot pull requests limit to 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,4 @@ updates:
       - dependency-name: vendor/nim-rocksdb
     schedule:
       interval: daily
+      open-pull-requests-limit: 2


### PR DESCRIPTION
Reduce Dependabot spam: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-