### PR TITLE
stateless: detect missing trie nodes on account/storage reads

### DIFF
--- a/execution_chain/db/aristo/aristo_desc/desc_error.nim
+++ b/execution_chain/db/aristo/aristo_desc/desc_error.nim
@@ -68,6 +68,7 @@ type
     # Path function `hikeUp()`
     HikeBranchMissingEdge
     HikeBranchTailEmpty
+    HikeBranchUnresolvedEdge
     HikeDanglingEdge
     HikeEmptyPath
     HikeLeafUnexpected

--- a/execution_chain/db/aristo/aristo_fetch.nim
+++ b/execution_chain/db/aristo/aristo_fetch.nim
@@ -105,8 +105,12 @@ proc retrieveAccStatic(
           ok (vtx, path, next)
     of BoundaryNode:
       # Stateless-only boundary: child absent from witness, not traversable.
+      # Same divergence-vs-gap distinction as `aristo_hike.step()`.
+      let vtx = BoundaryNodeRef(vtx[0])
       countHitOrLower()
-      return err FetchPathNotFound
+      if path.slice(sl).sharedPrefixLen(vtx.pfx) < vtx.pfx.len:
+        return err FetchPathNotFound
+      return err HikeBranchUnresolvedEdge
     of ExtBranch:
       let vtx = ExtBranchRef(vtx[0])
 
@@ -293,12 +297,12 @@ proc fetchSlot*(
   ## account does not exist and 0'u256 if the account has not stored anything
   ## at the given slot
   let mixPath = mixUp(accPath, stoPath)
-  
+
   db.layersGetStoLeaf(mixPath).isErrOr:
-    # Found in the layers so we don't need to copy into the cache 
+    # Found in the layers so we don't need to copy into the cache
     # because the value will be updated from the layers during persist
     return ok value.toStoData()
-  
+
   db.db.stoLeaves.withGet(mixPath, cached):
     return ok cached.toStoData()
   do:
@@ -310,10 +314,19 @@ proc fetchSlot*(
       db.db.stoLeaves.put(mixPath, emptyCachedStoLeaf)
       return ok 0'u256
 
-    let leaf = StoLeafRef(db.retrieveLeaf(stoID, 
-        NibblesBuf.fromBytes(stoPath.data)).valueOr(nil))
-    db.db.stoLeaves.put(mixPath, if leaf.isValid(): 
-        CachedStoLeaf.init(leaf.pfx, leaf.stoData) else: emptyCachedStoLeaf)
+    let leafRc = db.retrieveLeaf(stoID, NibblesBuf.fromBytes(stoPath.data))
+    if leafRc.isErr:
+      if leafRc.error == FetchPathNotFound:
+        db.db.stoLeaves.put(mixPath, emptyCachedStoLeaf)
+        return ok 0'u256
+
+      # `HikeDanglingEdge` / `HikeBranchUnresolvedEdge`: missing state in
+      # witness or not-yet-fetched node, or a backend (db corruption) error.
+      # Can't know if slot is absent.
+      return err(leafRc.error)
+
+    let leaf = StoLeafRef(leafRc.value)
+    db.db.stoLeaves.put(mixPath, CachedStoLeaf.init(leaf.pfx, leaf.stoData))
     return ok leaf.toStoData()
 
 proc fetchStorageRoot*(

--- a/execution_chain/db/aristo/aristo_hike.nim
+++ b/execution_chain/db/aristo/aristo_hike.nim
@@ -104,6 +104,11 @@ proc step*(
     if path.len <= vtx.pfx.len:
       return err(HikeBranchTailEmpty)
 
+    if path.sharedPrefixLen(vtx.pfx) < vtx.pfx.len:
+      # Path diverges within this extension's own prefix. This proves absence
+      # regardless of the branch children, so don't route into them.
+      return err(HikeBranchMissingEdge)
+
     let
       nibble = path[vtx.pfx.len]
       nextVid = vtx.bVid(nibble)
@@ -114,8 +119,14 @@ proc step*(
     ok (vtx, vtx.pfx.len + 1, nextVid)
 
   of BoundaryNode:
-    # child absent from witness, no reachable child VID
-    return err(HikeBranchMissingEdge)
+    # Child subtree absent from witness, only its hash is known.
+    # If the path doesn't match the boundary's own prefix, the key is not
+    # there either way. If it does match, we'd need the missing subtree to
+    # know for sure. That means missing state in the witness.
+    let vtx = BoundaryNodeRef(vtx)
+    if path.sharedPrefixLen(vtx.pfx) < vtx.pfx.len:
+      return err(HikeBranchMissingEdge)
+    return err(HikeBranchUnresolvedEdge)
 
 
 iterator stepUp*(

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -161,6 +161,12 @@ const
 template logTxt(info: static[string]): static[string] =
   "LedgerRef " & info
 
+const
+  MissingNodeErrors = {HikeBranchUnresolvedEdge, HikeDanglingEdge}
+    ## A trie node this read's path needs is missing locally, so unlike a
+    ## proof of absence we can't tell if the account/slot exists. Covers an
+    ## incomplete witness (stateless) or a not-yet-fetched trie (verified proxy).
+
 proc applyOverlay(ledger: LedgerRef, address: Address, acc: AccountRef) =
   let overlayAcc = ledger.balOverlay.expect("bal overlay enabled").getAccount(address)
   if overlayAcc.balance.isSome():
@@ -204,6 +210,13 @@ proc getAccount(
   let
     accPath = address.computeAccPath
     rc = ledger.txFrame.fetchAccount accPath
+
+  if rc.isErr and rc.error.isAristo and rc.error.aErr in MissingNodeErrors:
+    # Record a fatalError: never assert here, always fall through to the normal
+    # "not found" path. The async EVM (verified proxy) relies on that.
+    warn logTxt "getAccount()", address, error = ($$rc.error)
+    ledger.fatalError = Opt.some(
+      "getAccount(): witness missing an internal trie node required to resolve account " & $address)
 
   if rc.isOk:
     # Acc found in the database
@@ -261,10 +274,22 @@ proc clone(acc: AccountRef, cloneStorage: bool): AccountRef =
     # it's ok to clone a table this way
     result.overlayStorage = acc.overlayStorage
 
-
-
 template exists(acc: AccountRef): bool =
   Alive in acc.flags
+
+template fetchSlotChecked(ledger: LedgerRef, accPath: Hash32, slotKey: Hash32): UInt256 =
+  ## Like `fetchSlot`, but a witness gap on the slot's path is a fatal
+  ## condition rather than a silent `0`. Records the condition without an
+  ## early return, same reasoning as `getAccount`.
+  let slotRc = ledger.txFrame.fetchSlot(accPath, slotKey)
+  if slotRc.isErr:
+    if slotRc.error.isAristo and slotRc.error.aErr in MissingNodeErrors:
+      warn logTxt "fetchSlot()", error = ($$slotRc.error)
+      ledger.fatalError = Opt.some(
+        "fetchSlot(): witness missing an internal trie node required to resolve storage slot")
+    0'u256
+  else:
+    slotRc.value
 
 proc originalStorageValue(
     acc: AccountRef;
@@ -283,12 +308,12 @@ proc originalStorageValue(
       if ledger.balOverlay.isNone():
         let slotKey = ledger.slots.get(slot).valueOr:
           computeSlotKey(slot)
-        ledger.txFrame.fetchSlot(acc.accPath, slotKey).valueOr(0'u256)
+        ledger.fetchSlotChecked(acc.accPath, slotKey)
       else:
         ledger.balOverlay[].getStorage(address, slot).valueOr:
           let slotKey = ledger.slots.get(slot).valueOr:
             computeSlotKey(slot)
-          ledger.txFrame.fetchSlot(acc.accPath, slotKey).valueOr(0'u256)
+          ledger.fetchSlotChecked(acc.accPath, slotKey)
 
   acc.original.storage[slot] = result
 

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -66,9 +66,6 @@ const skipFiles = [
 
   # cases of missing code in witness
   "validation_codes_missing_delegated_code_on_insufficient_balance_call.json",
-
-  # cases of missing states in witness
-  "validation_state_missing_failed_call_target_account_proof_node.json",
 ]
 
 runEESTSuite(


### PR DESCRIPTION
Distinguish "path needs a node we don't have" from a proof of absence in trie reads, so that an incomplete witness fails validation instead of being silently treated as empty