### PR TITLE
Charge EIP-7702 delegation access before loading target code

### DIFF
--- a/execution_chain/evm/interpreter_dispatch.nim
+++ b/execution_chain/evm/interpreter_dispatch.nim
@@ -77,7 +77,7 @@ proc prepareDispatch(params: CallParams, c: Computation): EvmResultVoid =
   if vmState.balTrackerEnabled:
     vmState.balTracker.trackAddressAccess(c.msg.contractAddress)
 
-  let
+  var
     code =
       if params.isCreate:
         if ledger.originalAccountEmpty(c.msg.contractAddress):
@@ -87,16 +87,17 @@ proc prepareDispatch(params: CallParams, c: Computation): EvmResultVoid =
         if params.value.isZero.not and not ledger.accountExists(c.msg.contractAddress):
           ? c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "prepareDispatch call new account")
         assign(c.msg.data, params.input)
-        getCallCode(vmState, c.msg)
+        getRecipientCode(vmState, c.msg)
 
   if MsgFlags.Delegated in c.msg.flags:
-    # TODO: Put both consumeGas and balTracker near delegateTo getCode
-    # specifically after consumeGas
+    # The delegated account access must be charged before its code is read,
+    # or an OOG here would wrongly add the target account to the witness.
     let delegatedGas = c.gasEip8038AccountCheck(c.msg.delegateTo)
     ? c.gasMeter.consumeGas(delegatedGas, "prepareDispatch delegatedGas")
 
     if vmState.balTrackerEnabled:
       vmState.balTracker.trackAddressAccess(c.msg.delegateTo)
+    code = vmState.readOnlyLedger.getCode(c.msg.delegateTo)
 
   c.setCode(code)
   ok()

--- a/execution_chain/evm/message.nim
+++ b/execution_chain/evm/message.nim
@@ -27,7 +27,7 @@ proc generateContractAddress*(vmState: BaseVMState,
   let creationNonce = vmState.readOnlyLedger().getNonce(sender)
   generateAddress(sender, creationNonce)
 
-proc getCallCode*(vmState: BaseVMState, msg: Message): CodeBytesRef =
+proc getRecipientCode*(vmState: BaseVMState, msg: Message): CodeBytesRef =
   # Avoid accessing ledger if it's a precompile address
   if isPrecompile(vmState.fork, msg.codeAddress):
     if vmState.balTrackerEnabled:
@@ -50,7 +50,9 @@ proc getCallCode*(vmState: BaseVMState, msg: Message): CodeBytesRef =
   let delegateTo = parseDelegationAddress(code).valueOr:
     return code
 
-  # If the `call.to` has a delegation, also warm its target.
+  # If the `call.to` has a delegation, mark it and let the caller load the
+  # target code: from Amsterdam the delegated account access must be charged
+  # before its code is read.
   msg.flags.incl MsgFlags.Delegated
   msg.delegateTo = delegateTo
-  vmState.readOnlyLedger.getCode(delegateTo)
+  code

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -58,16 +58,18 @@ proc initialAccessListEIP2929(params: CallParams) =
 
 proc setupComputation(params: CallParams, keepStack: bool, vmState: BaseVMState, msg: Message): Computation =
   if vmState.hardFork < Amsterdam:
-    let
+    var
       code = if params.isCreate:
               msg.contractAddress = generateContractAddress(vmState, params.sender)
               CodeBytesRef.init(params.input)
             else:
               assign(msg.data, params.input)
-              getCallCode(vmState, msg)
+              getRecipientCode(vmState, msg)
 
     if MsgFlags.Delegated in msg.flags:
+      # If the `call.to` has a delegation, also warm its target.
       vmState.ledger.accessList(msg.delegateTo)
+      code = vmState.readOnlyLedger.getCode(msg.delegateTo)
 
     return newComputation(vmState, keepStack, msg, code)
 

--- a/tests/eest/eest_stateless_execution_test.nim
+++ b/tests/eest/eest_stateless_execution_test.nim
@@ -55,16 +55,6 @@ const skipFiles = [
   "builder_exit_contract_deployment.json",
   "builder_deposit_contract_deployment.json",
 
-  # At the top frame, Nimbus loads the EIP-7702 delegation target's code before
-  # charging the delegation access gas, while the spec charges first. When that
-  # charge hits OOG, our witness contains the delegation target's account leaf
-  # and code that the reference implementation never reads. Only the witness
-  # diverges, the execution outcome and state root are identical.
-  "bal_7702_top_frame_delegation_oog.json",
-  "top_frame_regular_charge.json",
-  "recipient_charge_oog_rolls_back_delegations.json",
-  "top_frame_charges_delegation_in_access_list.json",
-
   # No fail yet as we don't check/use public keys. We could check them easily
   # but the better way is to use them as optimization and check automatically
   # that way.


### PR DESCRIPTION
Load the delegation target its code only after the access charge succeeds, so an OOG cannot leak the target account into the witness.