### PR TITLE
Fix hang and slow shutdown

### DIFF
--- a/execution_chain/networking/p2p.nim
+++ b/execution_chain/networking/p2p.nim
@@ -118,10 +118,9 @@ proc connectToNetwork*(
     info "Discovery disabled"
 
 proc stopListening*(node: EthereumNode) =
-  if node.listeningServer.isNil:
-    return
   try:
-    node.listeningServer.stop()
+    if not node.listeningServer.isNil():
+      node.listeningServer.stop()
   except TransportOsError as exc:
     error "Failure when try to stop stop listening server", msg=exc.msg
 
@@ -144,9 +143,10 @@ func numPeers*(node: EthereumNode): int =
 
 proc closeWait*(node: EthereumNode) {.async: (raises: []).} =
   node.stopListening()
-  if node.listeningServer.isNil.not:
+  if not node.listeningServer.isNil():
     await node.listeningServer.closeWait()
-  await node.peerPool.closeWait()
+  if not node.peerPool.isNil():
+    await node.peerPool.closeWait()
 
 proc addCapability*(node: EthereumNode,
                     p: ProtocolInfo,

--- a/execution_chain/networking/p2p.nim
+++ b/execution_chain/networking/p2p.nim
@@ -118,6 +118,8 @@ proc connectToNetwork*(
     info "Discovery disabled"
 
 proc stopListening*(node: EthereumNode) =
+  if node.listeningServer.isNil:
+    return
   try:
     node.listeningServer.stop()
   except TransportOsError as exc:
@@ -142,7 +144,8 @@ func numPeers*(node: EthereumNode): int =
 
 proc closeWait*(node: EthereumNode) {.async: (raises: []).} =
   node.stopListening()
-  await node.listeningServer.closeWait()
+  if node.listeningServer.isNil.not:
+    await node.listeningServer.closeWait()
   await node.peerPool.closeWait()
 
 proc addCapability*(node: EthereumNode,

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -350,6 +350,12 @@ proc setupCommonRef*(
 
 type StopFuture = Future[void].Raising([CancelledError])
 
+const stopCheckInterval = chronos.milliseconds(100)
+
+proc runStopCheckLoop() {.async: (raises: []).} =
+  while true:
+    await noCancel sleepAsync(stopCheckInterval)
+
 proc runExeClient*(
     config: ExecutionClientConf,
     com: CommonRef,
@@ -385,6 +391,8 @@ proc runExeClient*(
   # Be graceful about ctrl-c during init
   if ProcessState.stopping.isNone:
     ProcessState.notifyRunning()
+
+  asyncSpawn runStopCheckLoop()
 
   while true:
     if (let reason = ProcessState.stopping(); reason.isSome()):


### PR DESCRIPTION
When max-peers is set to zero, then on shutdown Nimbus hangs and then would crash with this error. I ran into this when testing nimbus using the benchmarkoor tool which disables the networking by setting zero peers:

```
🟣 2026-07-16T13:16:17.339Z CLIE | nimbus | NTC 2026-07-16 13:16:17.338+00:00 Shutting down                              reason=SIGINT
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | Traceback (most recent call last, using override)
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | ???(0): 0000ffffffffffffffff
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | ???(0): _start
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | ???(0): __libc_start_main
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | ???(0): 000000007b8b660e4ca7
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/execution_chain/sync/snap/worker/session/session_helpers.nim(1461): main
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/execution_chain/sync/snap/worker/session/session_helpers.nim(1449): NimMain
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/execution_chain/nimbus.nim(429): nimbus::main
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/execution_chain/nimbus_execution_client.nim(464): nimbus_execution_client::main(conf::ExecutionClientConf, ref<nimbus_desc::NimbusNodecolonObjectType_>) [clone .constprop.0]
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/execution_chain/nimbus_execution_client.nim(400): nimbus_execution_client::runExeClient(conf::ExecutionClientConf, ref<common::CommonRefcolonObjectType_>, InternalRaisesFuture<void, tuple<futures::CancelledError> >, ref<nimbus_desc::NimbusNodecolonObjectType_>) [clone .constprop.0]
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/execution_chain/nimbus_desc.nim(66): nimbus_desc::closeWait(ref<nimbus_desc::NimbusNodecolonObjectType_>)
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/vendor/nim-chronos/chronos/internal/asyncfutures.nim(384): asyncfutures::futureContinue(ref<futures::FutureBasecolonObjectType_>)
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/execution_chain/nimbus_desc.nim(73): closeWait::closeWait__nimbus95desc_u42(ref<futures::FutureBasecolonObjectType_>)
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/execution_chain/networking/p2p.nim(144): p2p::closeWait(ref<p2p_types::EthereumNodecolonObjectType_>)
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/vendor/nim-chronos/chronos/internal/asyncfutures.nim(384): asyncfutures::futureContinue(ref<futures::FutureBasecolonObjectType_>)
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/execution_chain/networking/p2p.nim(144): closeWait::closeWait__networkingZp2p_u9725(ref<futures::FutureBasecolonObjectType_>)
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/execution_chain/networking/p2p.nim(122): p2p::stopListening(ref<p2p_types::EthereumNodecolonObjectType_>)
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/vendor/nim-chronos/chronos/transports/stream.nim(1865): stream::stop(ref<stream::StreamServercolonObjectType_>)
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/vendor/nim-chronos/chronos/transports/stream.nim(1850): stream::stop2(ref<stream::StreamServercolonObjectType_>)
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | ???(0): 000000007b8b660fadef
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | /nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/system/excpt.nim(704): signalHandler
🟣 2026-07-16T13:16:17.569Z CLIE | nimbus | SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```