### PR TITLE
Use 64-bit digits for modexp

### DIFF
--- a/execution_chain/evm/modexp.nim
+++ b/execution_chain/evm/modexp.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -16,8 +16,12 @@ from os import DirSep, AltSep
 const
   vendorPath  = currentSourcePath.rsplit({DirSep, AltSep}, 3)[0] & "/vendor"
   srcPath = vendorPath & "/libtommath"
+  useMp64Bit = defined(cpu64) and not defined(vcc)
 
-{.passc: "-DMP_32BIT"}
+when useMp64Bit:
+  {.passc: "-DMP_64BIT"}
+else:
+  {.passc: "-DMP_32BIT"}
 {.compile: srcPath & "/mp_radix_size.c"}
 {.compile: srcPath & "/mp_to_radix.c"}
 {.compile: srcPath & "/mp_init_u64.c"}
@@ -122,7 +126,7 @@ type
   mp_int {.importc: "mp_int",
     header: "tommath.h", byref.} = object
 
-  mp_digit = uint32
+  mp_digit = (when useMp64Bit: uint64 else: uint32)
 
   mp_err {.importc: "mp_err",
     header: "tommath.h".} = cint


### PR DESCRIPTION
Performance testing results using benchmarkoor running the modexp tests:

**Before**
<img width="919" height="717" alt="Screenshot_2026-07-19_01-19-00" src="https://github.com/user-attachments/assets/81a7cd2a-a08e-4437-87fe-8c2f86da2fdc" />

**After**
<img width="1058" height="704" alt="Screenshot_2026-07-19_01-46-08" src="https://github.com/user-attachments/assets/53c1c728-cdfe-4242-9e32-82a7326d3cc1" />
