### PR TITLE
Use BoringSSL P-256 for the P256VERIFY precompile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ OS_PLATFORM = $(shell $(CC) -dumpmachine)
 VERIF_PROXY_OUT_PATH ?= build/libverifproxy/
 ifneq (, $(findstring darwin, $(OS_PLATFORM)))
   VERIFPROXY_LDFLAGS = -lc++ -framework Security
-else ifneq (, $(findstring mingw, $(OS_PLATFORM)))
+else ifneq (, $(findstring windows, $(OS_PLATFORM)))
   VERIFPROXY_LDFLAGS = -lc++ -lbcrypt -lpthread -lws2_32
 else
   VERIFPROXY_LDFLAGS = -lstdc++ -lm

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -719,14 +719,7 @@ proc p256verify(c: Computation): EvmResultVoid =
   if c.msg.data.len != 160:
     failed()
 
-  # Check scalar and field bounds (r, s ∈ (0, n), qx, qy ∈ [0, p))
-  var
-    pk {.noinit.}: EcPublicKey
-
-  if not pk.initRaw(data[96, 159]):
-    failed()
-
-  if verifyRaw(data[32, 95], data[0, 31], pk):
+  if verifyRaw(data[32, 95], data[0, 31], data[96, 159]):
     c.output.setLen(32)
     c.output[^1] = 1.byte  # return 0x...01
   else:

--- a/execution_chain/evm/secp256r1verify.nim
+++ b/execution_chain/evm/secp256r1verify.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2025 Status Research & Development GmbH
+# Copyright (c) 2025-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -8,57 +8,34 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import
-  bearssl/secp256r1_verify as ec,
-  stew/assign2,
-  stint
+{.push raises: [].}
 
-type
-  EcPublicKey* = object
-    buf: array[65, byte]
-    pk: ec.EcPublicKey
+import boringssl
 
-proc isInfinityByte(data: openArray[byte]): bool =
-  ## Check if all values in ``data`` are zero.
-  for b in data:
-    if b != 0:
-      return false
-  return true
-
-func checkPublicKey(key: openArray[byte]): bool =
-  ## Return ``true`` if public key ``key`` is on curve.
-  let
-    x = [byte 0x00, 0x01]
-    impl = ecGetDefault()
-  impl.mul(key[0].addr, key.len.uint, x[0].addr, x.len.uint, EC_secp256r1) != 0
-
-func initRaw*(pk: var EcPublicKey, data: openArray[byte]): bool =
-  # bearSSL have no infinity check for public key
-  if data.isInfinityByte:
+proc verifyRaw*(
+    sig: openArray[byte], hash: openArray[byte], pubkey: openArray[byte]
+): bool =
+  if sig.len != 64 or hash.len != 32 or pubkey.len != 64:
     return false
 
-  # bearSSL have no range check for public key
-  const
-    P = UInt256.fromHex("0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff")
+  let key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1)
+  if key.isNil:
+    return false
+  defer:
+    EC_KEY_free(key)
 
   let
-    x = UInt256.fromBytesBE(data.toOpenArray(0, 31))
-    y = UInt256.fromBytesBE(data.toOpenArray(32, 63))
+    x = BN_bin2bn(pubkey[0].addr, 32, nil)
+    y = BN_bin2bn(pubkey[32].addr, 32, nil)
+  defer:
+    BN_free(x)
+    BN_free(y)
 
-  if x >= P or y >= P:
+  if x.isNil or y.isNil:
     return false
 
-  pk.buf[0] = 4.byte
-  assign(pk.buf.toOpenArray(1, 64), data)
-  pk.pk.curve = EC_secp256r1
-  pk.pk.q = pk.buf[0].addr
-  pk.pk.qlen = 65
-  checkPublicKey(pk.buf)
+  if EC_KEY_set_public_key_affine_coordinates(key, x, y) != 1:
+    return false
 
-func verifyRaw*(sig: openArray[byte], hash: openArray[byte], pk: EcPublicKey): bool =
-  secp256r1_i31_vrfy_raw(
-    hash[0].addr,
-    hash.len.uint,
-    pk.pk.addr,
-    sig[0].addr,
-    sig.len.uint) == 1
+  ECDSA_verify_p1363(
+    hash[0].addr, csize_t(hash.len), sig[0].addr, csize_t(sig.len), key) == 1


### PR DESCRIPTION
Performance testing results using benchmarkoor running the p256verify tests:

**Before**
<img width="1177" height="737" alt="Screenshot_2026-07-20_10-45-59" src="https://github.com/user-attachments/assets/e3b93463-4592-44b2-b0fb-1dfd91e5764f" />


**After**
<img width="1183" height="750" alt="Screenshot_2026-07-20_10-59-27" src="https://github.com/user-attachments/assets/1d18e3c6-0b06-4d6f-ba4f-13863cb0b1f8" />
