### PR TITLE
Use BoringSSL for the modexp precompile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -201,11 +201,6 @@
 	url = https://github.com/vacp2p/nim-intops.git
 	ignore = untracked
 	branch = master
-[submodule "vendor/libtommath"]
-	path = vendor/libtommath
-	url = https://github.com/libtom/libtommath
-	ignore = untracked
-	branch = develop
 [submodule "vendor/nim-mcl"]
 	path = vendor/nim-mcl
 	url = https://github.com/status-im/nim-mcl

--- a/config.nims
+++ b/config.nims
@@ -48,8 +48,8 @@ if defined(release) and not defined(disableLTO) and not defined(windows):
   extend "icl.cpp.options.always", " /Qipo"
   extend "gcc.options.always", " -flto=auto -finline-limit=100000"
   extend "gcc.cpp.options.always", " -flto=auto -finline-limit=100000"
-  extend "gcc.options.linker", " -flto=auto -Wno-stringop-overflow -Wno-stringop-overread -finline-limit=100000"  # https://github.com/nim-lang/Nim/issues/21595
-  extend "gcc.cpp.options.linker", " -flto=auto -Wno-stringop-overflow -Wno-stringop-overread -finline-limit=100000"
+  extend "gcc.options.linker", " -flto=auto -Wno-stringop-overflow -Wno-stringop-overread -Wno-free-nonheap-object -finline-limit=100000"  # https://github.com/nim-lang/Nim/issues/21595
+  extend "gcc.cpp.options.linker", " -flto=auto -Wno-stringop-overflow -Wno-stringop-overread -Wno-free-nonheap-object -finline-limit=100000"
 
   if defined(macosx) and not defined(emscripten):
     # https://clang.llvm.org/docs/CommandGuide/clang.html#cmdoption-flto
@@ -134,7 +134,7 @@ switch("passL", "-fno-omit-frame-pointer")
 --styleCheck:usages
 --styleCheck:error
 
-# Disable ABI warning: 
+# Disable ABI warning:
 # 'the ABI for passing parameters with 64-byte alignment has changed in GCC 4.6'
 # The fix on the nim side is underway https://github.com/nim-lang/Nim/issues/25968
 # TODO: Remove after the workaround once the linked issue is resolved

--- a/execution_chain/evm/modexp.nim
+++ b/execution_chain/evm/modexp.nim
@@ -17,6 +17,28 @@ template getPtr(x: openArray[byte]): ptr uint8 =
   else:
     nil
 
+proc modExpFallback(base, exp, modulo, res: ptr BIGNUM, ctx: ptr BN_CTX): bool =
+  ## Square-and-multiply fallback mirroring BoringSSL's internal mod_exp_even.
+
+  if BN_nnmod(base, base, modulo, ctx) != 1:
+    return false
+
+  let bits = BN_num_bits(exp).cint
+  if bits == 0:
+    return BN_one(res) == 1
+
+  if BN_copy(res, base).isNil:
+    return false
+
+  for i in countdown(bits - 2, 0.cint):
+    if BN_mod_sqr(res, res, modulo, ctx) != 1:
+      return false
+    if BN_is_bit_set(exp, i) == 1 and
+       BN_mod_mul(res, res, base, modulo, ctx) != 1:
+      return false
+
+  true
+
 proc modExp*(b, e, m: openArray[byte]): seq[byte] =
   if m.len == 0:
     return @[0.byte]
@@ -39,13 +61,25 @@ proc modExp*(b, e, m: openArray[byte]): seq[byte] =
     return
 
   if BN_is_zero(modulo) == 1 or BN_is_one(modulo) == 1:
+    # EVM special case 1
+    # If m == 0: EVM returns 0.
+    # If m == 1: we can shortcut that to 0 as well
     return @[0.byte]
 
   if BN_is_zero(exp) == 1:
+    # EVM special case 2
+    # If 0^0: EVM returns 1
+    # For all x != 0, x^0 == 1 as well
     return @[1.byte]
 
-  if BN_mod_exp(res, base, exp, modulo, ctx) == 1:
-    let size = BN_num_bytes(res)
-    if size > 0:
-      result = newSeq[byte](size.int)
-      discard BN_bn2bin(res, result[0].addr)
+  if BN_mod_exp(res, base, exp, modulo, ctx) != 1:
+    # BN_mod_exp rejects odd moduli wider than 16384 bits (BN_MONTGOMERY_MAX_WORDS),
+    # but pre-Osaka modexp has no operand length cap, so in this case we compute
+    # using the fallback square and multiply algorithm.
+    if not modExpFallback(base, exp, modulo, res, ctx):
+      return
+
+  let size = BN_num_bytes(res)
+  if size > 0:
+    result = newSeq[byte](size.int)
+    discard BN_bn2bin(res, result[0].addr)

--- a/execution_chain/evm/modexp.nim
+++ b/execution_chain/evm/modexp.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)
@@ -9,227 +9,43 @@
 # according to those terms.
 
 import
-  std/strutils
+  boringssl
 
-from os import DirSep, AltSep
-
-const
-  vendorPath  = currentSourcePath.rsplit({DirSep, AltSep}, 3)[0] & "/vendor"
-  srcPath = vendorPath & "/libtommath"
-
-{.passc: "-DMP_32BIT"}
-{.compile: srcPath & "/mp_radix_size.c"}
-{.compile: srcPath & "/mp_to_radix.c"}
-{.compile: srcPath & "/mp_init_u64.c"}
-{.compile: srcPath & "/mp_init_i32.c"}
-{.compile: srcPath & "/mp_init_multi.c"}
-{.compile: srcPath & "/mp_init.c"}
-{.compile: srcPath & "/mp_init_size.c"}
-{.compile: srcPath & "/mp_init_copy.c"}
-{.compile: srcPath & "/mp_invmod.c"}
-{.compile: srcPath & "/mp_abs.c"}
-{.compile: srcPath & "/mp_set_u64.c"}
-{.compile: srcPath & "/mp_set_u32.c"}
-{.compile: srcPath & "/mp_set_i32.c"}
-{.compile: srcPath & "/mp_get_i32.c"}
-{.compile: srcPath & "/mp_get_i64.c"}
-{.compile: srcPath & "/mp_exptmod.c"}
-{.compile: srcPath & "/mp_clear_multi.c"}
-{.compile: srcPath & "/mp_clear.c"}
-{.compile: srcPath & "/mp_montgomery_reduce.c"}
-{.compile: srcPath & "/mp_clamp.c"}
-{.compile: srcPath & "/mp_grow.c"}
-{.compile: srcPath & "/mp_mul.c"}
-{.compile: srcPath & "/mp_mul_2.c"}
-{.compile: srcPath & "/mp_mul_2d.c"}
-{.compile: srcPath & "/mp_mod_2d.c"}
-{.compile: srcPath & "/mp_log_n.c"}
-{.compile: srcPath & "/mp_div_2.c"}
-{.compile: srcPath & "/mp_div_d.c"}
-{.compile: srcPath & "/mp_add.c"}
-{.compile: srcPath & "/mp_sub.c"}
-{.compile: srcPath & "/mp_exch.c"}
-{.compile: srcPath & "/mp_rshd.c"}
-{.compile: srcPath & "/mp_lshd.c"}
-{.compile: srcPath & "/mp_zero.c"}
-{.compile: srcPath & "/mp_dr_reduce.c"}
-{.compile: srcPath & "/mp_cmp_mag.c"}
-{.compile: srcPath & "/mp_cutoffs.c"}
-{.compile: srcPath & "/mp_reduce.c"}
-{.compile: srcPath & "/mp_count_bits.c"}
-{.compile: srcPath & "/mp_montgomery_setup.c"}
-{.compile: srcPath & "/mp_dr_setup.c"}
-{.compile: srcPath & "/mp_reduce_2k_setup.c"}
-{.compile: srcPath & "/mp_reduce_2k_setup_l.c"}
-{.compile: srcPath & "/mp_reduce_2k.c"}
-{.compile: srcPath & "/mp_reduce_2k_l.c"}
-{.compile: srcPath & "/mp_reduce_is_2k_l.c"}
-{.compile: srcPath & "/mp_reduce_is_2k.c"}
-{.compile: srcPath & "/mp_reduce_setup.c"}
-{.compile: srcPath & "/mp_dr_is_modulus.c"}
-{.compile: srcPath & "/mp_mulmod.c"}
-{.compile: srcPath & "/mp_set.c"}
-{.compile: srcPath & "/mp_mod.c"}
-{.compile: srcPath & "/mp_copy.c"}
-{.compile: srcPath & "/mp_div.c"}
-{.compile: srcPath & "/mp_div_2d.c"}
-{.compile: srcPath & "/mp_mul_d.c"}
-{.compile: srcPath & "/mp_2expt.c"}
-{.compile: srcPath & "/mp_cmp.c"}
-{.compile: srcPath & "/mp_cmp_d.c"}
-{.compile: srcPath & "/mp_log.c"}
-{.compile: srcPath & "/mp_sub_d.c"}
-{.compile: srcPath & "/mp_add_d.c"}
-{.compile: srcPath & "/mp_cnt_lsb.c"}
-{.compile: srcPath & "/mp_expt_n.c"}
-{.compile: srcPath & "/mp_get_mag_u32.c"}
-{.compile: srcPath & "/mp_get_mag_u64.c"}
-{.compile: srcPath & "/mp_from_ubin.c"}
-{.compile: srcPath & "/mp_ubin_size.c"}
-{.compile: srcPath & "/mp_to_ubin.c"}
-{.compile: srcPath & "/mp_montgomery_calc_normalization.c"}
-{.compile: srcPath & "/s_mp_exptmod.c"}
-{.compile: srcPath & "/s_mp_exptmod_fast.c"}
-{.compile: srcPath & "/s_mp_zero_digs.c"}
-{.compile: srcPath & "/s_mp_montgomery_reduce_comba.c"}
-{.compile: srcPath & "/s_mp_add.c"}
-{.compile: srcPath & "/s_mp_sub.c"}
-{.compile: srcPath & "/s_mp_mul.c"}
-{.compile: srcPath & "/s_mp_mul_comba.c"}
-{.compile: srcPath & "/s_mp_mul_toom.c"}
-{.compile: srcPath & "/s_mp_mul_karatsuba.c"}
-{.compile: srcPath & "/s_mp_mul_balance.c"}
-{.compile: srcPath & "/s_mp_copy_digs.c"}
-{.compile: srcPath & "/s_mp_div_3.c"}
-{.compile: srcPath & "/s_mp_sqr.c"}
-{.compile: srcPath & "/s_mp_sqr_comba.c"}
-{.compile: srcPath & "/s_mp_sqr_toom.c"}
-{.compile: srcPath & "/s_mp_sqr_karatsuba.c"}
-{.compile: srcPath & "/s_mp_zero_buf.c"}
-{.compile: srcPath & "/s_mp_radix_map.c"}
-{.compile: srcPath & "/s_mp_invmod.c"}
-{.compile: srcPath & "/s_mp_invmod_odd.c"}
-{.compile: srcPath & "/s_mp_mul_high.c"}
-{.compile: srcPath & "/s_mp_mul_high_comba.c"}
-{.compile: srcPath & "/s_mp_div_recursive.c"}
-{.compile: srcPath & "/s_mp_div_school.c"}
-{.compile: srcPath & "/s_mp_fp_log_d.c"}
-{.compile: srcPath & "/s_mp_fp_log.c"}
-
-{.passc: "-I" & srcPath .}
-
-type
-  mp_int {.importc: "mp_int",
-    header: "tommath.h", byref.} = object
-
-  mp_digit = uint32
-
-  mp_err {.importc: "mp_err",
-    header: "tommath.h".} = cint
-
-  mp_ord = cint
-
-{.pragma: mp_abi, importc, cdecl, header: "tommath.h".}
-
-const
-  MP_OKAY = 0.mp_err
-
-  MP_LT* = -1
-  MP_EQ* = 0
-  MP_GT* = 1
-
-template getPtr(z: untyped): untyped =
-  when (NimMajor, NimMinor) > (1,6):
-    z.addr
+template getPtr(x: openArray[byte]): ptr uint8 =
+  if x.len > 0:
+    cast[ptr uint8](x[0].unsafeAddr)
   else:
-    z.unsafeAddr
-
-# init a bignum
-# proc mp_init(a: mp_int): mp_err {.mp_abi.}
-# proc mp_init_size(a: mp_int, size: cint): mp_err {.mp_abi.}
-
-# init multiple bignum, 2nd, 3rd, and soon use addr, terminated with nil
-proc mp_init_multi(mp: mp_int): mp_err {.mp_abi, varargs.}
-
-# free a bignum
-when false:
-  proc mp_clear(a: mp_int) {.mp_abi.}
-
-# clear multiple mp_ints, terminated with nil
-proc mp_clear_multi(mp: mp_int) {.mp_abi, varargs.}
-
-# compare against a single digit
-proc mp_cmp_d(a: mp_int, b: mp_digit): mp_ord {.mp_abi.}
-
-# conversion from/to big endian bytes
-proc mp_ubin_size(a: mp_int): csize_t {.mp_abi.}
-proc mp_from_ubin(a: mp_int, buf: ptr byte, size: csize_t): mp_err {.mp_abi.}
-proc mp_to_ubin(a: mp_int, buf: ptr byte, maxlen: csize_t, written: var csize_t): mp_err {.mp_abi.}
-
-# Y = G**X (mod P)
-proc mp_exptmod(G, X, P, Y: mp_int): mp_err {.mp_abi.}
-
-#proc mp_get_i32(a: mp_int): int32 {.mp_abi.}
-#proc mp_get_u32(a: mp_int): uint32 =
-#  cast[uint32](mp_get_i32(a))
-
-# proc mp_init_u64(a: mp_int, b: uint64): mp_err {.mp_abi.}
-# proc mp_set_u64(a: mp_int, b: uint64) {.mp_abi.}
-
-proc mp_to_radix(a: mp_int, str: ptr char, maxlen: csize_t, written: var csize_t, radix: cint): mp_err {.mp_abi.}
-proc mp_radix_size(a: mp_int, radix: cint, size: var csize_t): mp_err {.mp_abi.}
-
-proc toString*(a: mp_int): string =
-  var size: csize_t
-  if mp_radix_size(a, 10.cint, size) != MP_OKAY:
-    return
-  if size.int == 0:
-    return
-  result = newString(size.int)
-  if mp_to_radix(a, result[0].getPtr, size, size, 10.cint) != MP_OKAY:
-    return
-  result.setLen(size-1)
+    nil
 
 proc modExp*(b, e, m: openArray[byte]): seq[byte] =
-  var
-    base, exp, modulo, res: mp_int
-
   if m.len == 0:
     return @[0.byte]
 
-  if mp_init_multi(base, exp.addr, modulo.addr, nil) != MP_OKAY:
+  let
+    ctx = BN_CTX_new()
+    base = BN_bin2bn(b.getPtr, b.len.csize_t, nil)
+    exp = BN_bin2bn(e.getPtr, e.len.csize_t, nil)
+    modulo = BN_bin2bn(m.getPtr, m.len.csize_t, nil)
+    res = BN_new()
+
+  defer:
+    BN_free(res)
+    BN_free(modulo)
+    BN_free(exp)
+    BN_free(base)
+    BN_CTX_free(ctx)
+
+  if ctx.isNil or base.isNil or exp.isNil or modulo.isNil or res.isNil:
     return
 
-  if m.len > 0:
-    discard mp_from_ubin(modulo, m[0].getPtr, m.len.csize_t)
-    if mp_cmp_d(modulo, 1.mp_digit) <= MP_EQ:
-      # EVM special case 1
-      # If m == 0: EVM returns 0.
-      # If m == 1: we can shortcut that to 0 as well
-      mp_clear_multi(base, exp.addr, modulo.addr, nil)
-      return @[0.byte]
+  if BN_is_zero(modulo) == 1 or BN_is_one(modulo) == 1:
+    return @[0.byte]
 
-  if e.len > 0:
-    discard mp_from_ubin(exp, e[0].getPtr, e.len.csize_t)
-    if mp_cmp_d(exp, 0.mp_digit) == MP_EQ:
-      # EVM special case 2
-      # If 0^0: EVM returns 1
-      # For all x != 0, x^0 == 1 as well
-      mp_clear_multi(base, exp.addr, modulo.addr, nil)
-      return @[1.byte]
-  else:
-    mp_clear_multi(base, exp.addr, modulo.addr, nil)
+  if BN_is_zero(exp) == 1:
     return @[1.byte]
 
-  if b.len > 0:
-    discard mp_from_ubin(base, b[0].getPtr, b.len.csize_t)
-
-  if mp_exptmod(base, exp, modulo, res) == MP_OKAY:
-    let size = mp_ubin_size(res)
-    if size.int > 0:
-      var written: csize_t
+  if BN_mod_exp(res, base, exp, modulo, ctx) == 1:
+    let size = BN_num_bytes(res)
+    if size > 0:
       result = newSeq[byte](size.int)
-      discard mp_to_ubin(res, result[0].getPtr, size, written)
-      result.setLen(written)
-
-  mp_clear_multi(base, exp.addr, modulo.addr, res.addr, nil)
+      discard BN_bn2bin(res, result[0].addr)


### PR DESCRIPTION
Performance testing results using benchmarkoor running the modexp tests:

**Before (libtommath 64bit)**
<img width="1058" height="704" alt="623584940-53c1c728-cdfe-4242-9e32-82a7326d3cc1" src="https://github.com/user-attachments/assets/083479cd-c06d-46ee-8a07-eb3195aaeb79" />

**After**
<img width="1036" height="702" alt="Screenshot_2026-07-20_20-08-07" src="https://github.com/user-attachments/assets/80414bb0-bb0e-415e-9442-2d2a752528ec" />


