### PR TITLE
Use BoringSSL for the sha256 precompile

### DIFF
--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -16,7 +16,7 @@ import
   ./interpreter/[gas_meter, gas_costs, utils/utils_numeric],
   eth/common/keys,
   chronicles,
-  nimcrypto/[ripemd, sha2, utils],
+  nimcrypto/[ripemd, utils],
   stew/assign2,
   ../common/evmforks,
   ../core/eip4844,
@@ -26,6 +26,8 @@ import
   ./computation,
   ./secp256r1verify,
   eth/common/[base, addresses]
+
+from boringssl as bssl import nil
 
 when enable_mcl_lib:
   import ./bncurve_mcl
@@ -199,7 +201,11 @@ func sha256(c: Computation): EvmResultVoid =
     gasFee = GasSHA256 + wordCount.GasInt * GasSHA256Word
 
   ? c.gasMeter.consumeGas(gasFee, reason="SHA256 Precompile")
-  assign(c.output, sha2.sha256.digest(c.msg.data).data)
+  var digest: array[32, byte]
+  {.cast(noSideEffect).}:
+    let data = if c.msg.data.len > 0: addr c.msg.data[0] else: nil
+    discard bssl.SHA256(data, csize_t(c.msg.data.len), digest)
+  assign(c.output, digest)
   ok()
 
 func ripemd160(c: Computation): EvmResultVoid =

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -201,11 +201,13 @@ func sha256(c: Computation): EvmResultVoid =
     gasFee = GasSHA256 + wordCount.GasInt * GasSHA256Word
 
   ? c.gasMeter.consumeGas(gasFee, reason="SHA256 Precompile")
-  var digest: array[32, byte]
+
+  # Skip zero-filling since SHA256 overwrites all 32 bytes
+  c.output.setLenUninit(32)
   {.cast(noSideEffect).}:
     let data = if c.msg.data.len > 0: addr c.msg.data[0] else: nil
-    discard bssl.SHA256(data, csize_t(c.msg.data.len), digest)
-  assign(c.output, digest)
+    discard bssl.SHA256(data, csize_t(c.msg.data.len),
+      cast[ptr array[32, byte]](addr c.output[0])[])
   ok()
 
 func ripemd160(c: Computation): EvmResultVoid =
@@ -756,7 +758,7 @@ func activePrecompilesList*(fork: EVMFork): seq[Address] =
 
 # Every precompile address has only its low two bytes populated (the largest
 # is P256VERIFY at 0x0100), so an address can be reverse-mapped to its
-# precompile via a small array indexed by that 16-bit value. A `0` entry means 
+# precompile via a small array indexed by that 16-bit value. A `0` entry means
 # "no precompile maps to this value"; any other entry is `ord(precompile) + 1`.
 const precompileForKey: array[0 .. 0x0100, byte] = static:
   var arr: array[0 .. 0x0100, byte]


### PR DESCRIPTION
The nimcrypto sha2 is already very fast but it appears that boringssl SHA256 is around 10% faster in my benchmarks.

**Before**
<img width="1026" height="659" alt="Screenshot_2026-07-20_22-49-57" src="https://github.com/user-attachments/assets/ef373f85-ac88-4dae-9ea3-69af2149408c" />

**After**
<img width="1040" height="582" alt="Screenshot_2026-07-20_22-50-43" src="https://github.com/user-attachments/assets/65f64652-5a16-41fe-a55a-6ce130ae4b1e" />
