### PR TITLE
Remove unneeded chronos import

### DIFF
--- a/execution_chain/db/core_db/base.nim
+++ b/execution_chain/db/core_db/base.nim
@@ -148,6 +148,7 @@ proc persist*(db: CoreDbRef, txFrame: CoreDbTxRef) =
       db.mpt.putEndFn(mptBatch[]).isOkOr:
         raiseAssert $error
 
+      debug "Core DB persisted"
   else:
     discard kvtBatch.expect("should always be able to create batch")
     discard mptBatch.expect("should always be able to create batch")

--- a/execution_chain/evm/computation.nim
+++ b/execution_chain/evm/computation.nim
@@ -24,7 +24,7 @@ import
   ../utils/[utils, mergeutils],
   ../common/common,
   eth/common/eth_types_rlp,
-  chronicles, chronos
+  chronicles
 
 export
   common, balTrackerEnabled,


### PR DESCRIPTION
And add a debug log to avoid a chronicles import that goes unused under standalone (seems cleaner than when clausing or used).