### PR TITLE
Fix aristo_compute compilation with --threads:off

### DIFF
--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -134,30 +134,6 @@ proc putKeyAtLevel(
 
   ok()
 
-proc mergeKeyAtLevel(
-    txRef: AristoTxRef, rvid: RootedVertexID, key: HashKey, level: int
-) =
-  doAssert level >= txRef.db.baseTxFrame().level
-
-  let frame = txRef.deltaAtLevel(level)
-  when compileOption("threads"):
-    withWriteLock(frame.lock):
-      frame.layersMergeKey(rvid, key)
-  else:
-    frame.layersMergeKey(rvid, key)
-
-proc putVtxBlob(
-    batch: var WriteBatch, db: AristoDbRef, rvid: RootedVertexID, vtx: openArray[byte]
-): Result[void, AristoError] =
-  if batch.writer == nil:
-    batch.writer = ?db.putBegFn()
-
-  db.putVtxBlobFn(batch.writer, rvid, vtx)
-  inc batch.count
-  ?batch.flushCheck(db, parallel = true)
-
-  ok()
-
 func layersGetKeyOrVtx*(
     db: AristoTxRef, rvid: RootedVertexID, parallel: static bool
 ): Opt[((HashKey, VertexRef), int)] =
@@ -219,16 +195,75 @@ template childVid(vp: VertexRef): VertexID =
   of BoundaryNode, StoLeaf:
     default(VertexID)
 
-proc computeKeyImplTask(
-  txRef: ptr AristoTxRef,
-  rvid: RootedVertexID,
-  batch: ptr WriteBatch,
-  vtx: ptr VertexRef,
-  level: int,
-  skipLayers: bool,
-  keyQueue: ptr ConcurrentHashKeyQueue,
-  vtxBufQueue: ptr ConcurrentVertexBufQueue,
+proc computeKeyImpl(
+    txRef: AristoTxRef,
+    rvid: RootedVertexID,
+    batch: var WriteBatch,
+    vtx: VertexRef,
+    level: int,
+    skipLayers: static bool,
+    spawnTpTasks: static bool,
+    parallel: static bool,
+    keyQueue: ptr ConcurrentHashKeyQueue,
+    vtxBufQueue: ptr ConcurrentVertexBufQueue,
 ): Result[(HashKey, int), AristoError]
+
+when compileOption("threads"):
+  proc mergeKeyAtLevel(
+      txRef: AristoTxRef, rvid: RootedVertexID, key: HashKey, level: int
+  ) =
+    doAssert level >= txRef.db.baseTxFrame().level
+
+    let frame = txRef.deltaAtLevel(level)
+    withWriteLock(frame.lock):
+      frame.layersMergeKey(rvid, key)
+
+  proc putVtxBlob(
+      batch: var WriteBatch, db: AristoDbRef, rvid: RootedVertexID, vtx: openArray[byte]
+  ): Result[void, AristoError] =
+    if batch.writer == nil:
+      batch.writer = ?db.putBegFn()
+
+    db.putVtxBlobFn(batch.writer, rvid, vtx)
+    inc batch.count
+    ?batch.flushCheck(db, parallel = true)
+
+    ok()
+
+  proc computeKeyImplTask(
+      txRef: ptr AristoTxRef,
+      rvid: RootedVertexID,
+      batch: ptr WriteBatch,
+      vtx: ptr VertexRef,
+      level: int,
+      skipLayers: bool,
+      keyQueue: ptr ConcurrentHashKeyQueue,
+      vtxBufQueue: ptr ConcurrentVertexBufQueue,
+  ): Result[(HashKey, int), AristoError] =
+    if skipLayers:
+      txRef[].computeKeyImpl(
+        rvid,
+        batch[],
+        vtx[],
+        level,
+        skipLayers = true,
+        spawnTpTasks = false,
+        parallel = true,
+        keyQueue,
+        vtxBufQueue,
+      )
+    else:
+      txRef[].computeKeyImpl(
+        rvid,
+        batch[],
+        vtx[],
+        level,
+        skipLayers = false,
+        spawnTpTasks = false,
+        parallel = true,
+        keyQueue,
+        vtxBufQueue,
+      )
 
 proc computeKeyImpl(
     txRef: AristoTxRef,
@@ -470,41 +505,6 @@ proc computeKeyImpl(
 
   ok (key, level)
 
-proc computeKeyImplTask(
-    txRef: ptr AristoTxRef,
-    rvid: RootedVertexID,
-    batch: ptr WriteBatch,
-    vtx: ptr VertexRef,
-    level: int,
-    skipLayers: bool,
-    keyQueue: ptr ConcurrentHashKeyQueue,
-    vtxBufQueue: ptr ConcurrentVertexBufQueue,
-): Result[(HashKey, int), AristoError] =
-  if skipLayers:
-    txRef[].computeKeyImpl(
-      rvid,
-      batch[],
-      vtx[],
-      level,
-      skipLayers = true,
-      spawnTpTasks = false,
-      parallel = when compileOption("threads"): true else: false,
-      keyQueue,
-      vtxBufQueue,
-    )
-  else:
-    txRef[].computeKeyImpl(
-      rvid,
-      batch[],
-      vtx[],
-      level,
-      skipLayers = false,
-      spawnTpTasks = false,
-      parallel = when compileOption("threads"): true else: false,
-      keyQueue,
-      vtxBufQueue,
-    )
-
 proc computeKeyImpl(
     txRef: AristoTxRef,
     rvid: RootedVertexID,
@@ -562,23 +562,29 @@ proc computeStateRoot*(
 ): Result[HashKey, AristoError] =
   ## Ensure that key cache is topped up with the latest state root
   ## and return the computed value.
+
+  template computeSerial(): Result[HashKey, AristoError] =
+    txRef.computeKeyImpl(
+      (STATE_ROOT_VID, STATE_ROOT_VID),
+      skipLayers,
+      spawnTpTasks = false,
+      parallel = false,
+    )
+
   when compileOption("threads"):
     # `taskpool` only exists with threads on
     if txRef.db.parallelStateRootComputation and not txRef.db.taskpool.isNil() and
         txRef.db.taskpool.numThreads > 1:
-      return txRef.computeKeyImpl(
+      txRef.computeKeyImpl(
         (STATE_ROOT_VID, STATE_ROOT_VID),
         skipLayers,
         spawnTpTasks = true,
         parallel = true,
       )
-
-  txRef.computeKeyImpl(
-    (STATE_ROOT_VID, STATE_ROOT_VID),
-    skipLayers,
-    spawnTpTasks = false,
-    parallel = false,
-  )
+    else:
+      computeSerial()
+  else:
+    computeSerial()
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -140,7 +140,10 @@ proc mergeKeyAtLevel(
   doAssert level >= txRef.db.baseTxFrame().level
 
   let frame = txRef.deltaAtLevel(level)
-  withWriteLock(frame.lock):
+  when compileOption("threads"):
+    withWriteLock(frame.lock):
+      frame.layersMergeKey(rvid, key)
+  else:
     frame.layersMergeKey(rvid, key)
 
 proc putVtxBlob(
@@ -485,7 +488,7 @@ proc computeKeyImplTask(
       level,
       skipLayers = true,
       spawnTpTasks = false,
-      parallel = true,
+      parallel = when compileOption("threads"): true else: false,
       keyQueue,
       vtxBufQueue,
     )
@@ -497,7 +500,7 @@ proc computeKeyImplTask(
       level,
       skipLayers = false,
       spawnTpTasks = false,
-      parallel = true,
+      parallel = when compileOption("threads"): true else: false,
       keyQueue,
       vtxBufQueue,
     )
@@ -559,21 +562,23 @@ proc computeStateRoot*(
 ): Result[HashKey, AristoError] =
   ## Ensure that key cache is topped up with the latest state root
   ## and return the computed value.
-  if txRef.db.parallelStateRootComputation and not txRef.db.taskpool.isNil() and
-      txRef.db.taskpool.numThreads > 1:
-    txRef.computeKeyImpl(
-      (STATE_ROOT_VID, STATE_ROOT_VID),
-      skipLayers,
-      spawnTpTasks = when compileOption("threads"): true else: false,
-      parallel = when compileOption("threads"): true else: false,
-    )
-  else:
-    txRef.computeKeyImpl(
-      (STATE_ROOT_VID, STATE_ROOT_VID),
-      skipLayers,
-      spawnTpTasks = false,
-      parallel = false,
-    )
+  when compileOption("threads"):
+    # `taskpool` only exists with threads on
+    if txRef.db.parallelStateRootComputation and not txRef.db.taskpool.isNil() and
+        txRef.db.taskpool.numThreads > 1:
+      return txRef.computeKeyImpl(
+        (STATE_ROOT_VID, STATE_ROOT_VID),
+        skipLayers,
+        spawnTpTasks = true,
+        parallel = true,
+      )
+
+  txRef.computeKeyImpl(
+    (STATE_ROOT_VID, STATE_ROOT_VID),
+    skipLayers,
+    spawnTpTasks = false,
+    parallel = false,
+  )
 
 # ------------------------------------------------------------------------------
 # End


### PR DESCRIPTION
Gate references to the threads-only `lock`/`taskpool` fields behind threads compile flag so the module compiles when threads are disabled.