### PR TITLE
EIP-8282: include builder requests in payload executionRequests

### DIFF
--- a/execution_chain/core/tx_pool/tx_packer.nim
+++ b/execution_chain/core/tx_pool/tx_packer.nim
@@ -380,6 +380,14 @@ func executionRequests*(pst: var TxPacker): seq[seq[byte]] =
   result.append(WITHDRAWAL_REQUEST_TYPE, pst.withdrawalReqs)
   result.append(CONSOLIDATION_REQUEST_TYPE, pst.consolidationReqs)
 
+  # EIP-8282: must mirror `assembleHeader`, which folds these into
+  # `requestsHash`. Omitting them here yields a payload whose recomputed
+  # requestsHash disagrees with the committed header, i.e. a block hash
+  # mismatch on every `engine_newPayload` receiver -- including ourselves.
+  if pst.vmState.fork >= FkAmsterdam:
+    result.append(BUILDER_DEPOSIT_REQUEST_TYPE, pst.builderDepositReqs)
+    result.append(BUILDER_EXIT_REQUEST_TYPE, pst.builderExitReqs)
+
 iterator packedTxs*(pst: TxPacker): TxItemRef =
   for item in pst.packedTxs:
     yield item


### PR DESCRIPTION
## Problem

`assembleHeader()` folds the EIP-8282 builder deposit (`0x03`) and builder exit (`0x04`) requests into `requestsHash` post-Amsterdam, but `executionRequests()` in the same file only emits deposit / withdrawal / consolidation. A self-built block therefore commits a header hashed over **5** request types while the payload delivers only **3**.

Every `engine_newPayload` receiver recomputes `requestsHash` from the delivered `executionRequests`, rebuilds the header and compares block hashes (`api_newpayload.nim`):

```nim
let requestsHash = calcRequestsHash(executionRequests)
blk = ethBlock(payload, beaconRoot, requestsHash)
```

so the block is rejected as `blockhash mismatch` by every peer — **and by nimbus itself**, since `requestsHash` is the only header field in `payload_conv.nim:blockHeader()` derived from data outside the `ExecutionPayload`.

`calcRequestsHash` skips empty request data (`if req.data.len > 0`), so the two hashes agree whenever no builder request is dequeued. The divergence only surfaces on blocks that actually carry one, which is why this is rare rather than constant.

## Observed on glamsterdam-devnet-7

Twice in 12 h, at blocks **40213** (slot 45058) and **40941** (slot 45830):

```
blockhash mismatch,
  want 0x416ea7636ed65f138e79f18daf9e7b0aa25a0f2e66a32adb754e1c696e47d320
  got  0x7b2ce43427b19c955f1e02e605f6cd030bf5a5319e146a53eb0f5e3dc6cce5b8
```

All peer ELs recomputed the identical hash, and the nimbus EL on the proposing node rejected its own payload. The proposers were on different CLs (`lighthouse-nimbusel-1`, `lodestar-nimbusel-1`) but the same EL.

Trigger confirmed by receipt: the two builder-deposit transactions to `0x0000BFF4…8282` landed in exactly those two blocks —

| tx | block |
|---|---|
| `0x7cb67b25f8e7d1df02448fca0b384baf4b257dd573915a753b83e20d18394288` | `0x9d15` = 40213 |
| `0x445a40be23971de42be702bc4bb51a9ab5c7e6a9bac5903e93b14a1e604d5d82` | `0x9fed` = 40941 |

Of 9 builder deposits in that window, only these 2 landed in nimbus-built blocks; the other 7 landed in blocks built by other ELs and produced no mismatch. Nimbus built 828 payloads over ~3750 slots (≈22 %), so ~2 hits is the expected count.

## Fix

`executionRequests()` now appends the builder requests, gated on the same condition under which `vmExecCommit()` populates them:

```nim
if pst.vmState.fork >= FkAmsterdam:
  result.append(BUILDER_DEPOSIT_REQUEST_TYPE, pst.builderDepositReqs)
  result.append(BUILDER_EXIT_REQUEST_TYPE, pst.builderExitReqs)
```

## Verification

Two Kurtosis enclaves, identical configs except the EL image (2× nimbus + 1× geth, lighthouse CLs, minimal preset, Gloas @ epoch 1), driven by a continuous EIP-8282 builder deposit **and** exit workload.

| | control (`glamsterdam-devnet-7`) | fix |
|---|---|---|
| mismatch log lines — nimbus CL 1 / 2 / geth CL | 38 / 35 / 26 | **0 / 0 / 0** |
| distinct mismatching slots | 15 in slots 372–394 | **none** |
| EL blocks vs slots | 143 / 410 = **34.9 %** | 196 / 196 = **100 %** |
| finalizing | yes | yes |

The block-vs-slot ratio is the clearest signal: with 2 of 3 proposers on nimbus, ~⅔ of control slots produced no execution block at all (410/3 ≈ 137 expected survivors vs 143 observed). With the fix every slot produces a block.

The trigger is positively exercised in the fix run, not merely absent — the builder deposit predeploy accumulated **97.1 ETH** over 196 slots, with a non-zero balance in the exit predeploy. End to end on one block: nimbus built block 203 `hash=0e0a5df1c3be`, and geth's RPC returns canonical block 203 as `0x0e0a5df1c3be5be72ac7bb82e197833f1c721860500141822dc8ee4e0418836a`.

The control run reproduced the production signature first, including rejection by nimbus's own CL, so the fix run's zero is measured against a known-positive baseline.

### Not covered

Verification is the devnet A/B above; nimbus's own unit-test suite was not run locally for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BS4Vu7qUZTiZzjP29HERfh
