### PR TITLE
optimize PREVRANDAO benchmarks

### DIFF
--- a/execution_chain/core/executor/process_block_parallel.nim
+++ b/execution_chain/core/executor/process_block_parallel.nim
@@ -36,6 +36,7 @@ type
     txFrame: CoreDbTxRef
     parent: Header
     blockCtx: BlockContext
+    proofOfStake: bool
     cancelled: Atomic[bool]
 
   OptimisticTxEntry* = object
@@ -55,6 +56,7 @@ type
     txFrame: CoreDbTxRef
     parent: Header
     blockCtx: BlockContext
+    proofOfStake: bool
     balPtr: ptr BlockAccessList
     sharedBuilder: ptr BlockAccessListBuilder
     cancelled: Atomic[bool]
@@ -102,6 +104,7 @@ proc recoverAndPrefetchTask*(
   vmState.ledger = ledger
   assign(vmState.parent, ctx[].parent)
   assign(vmState.blockCtx, ctx[].blockCtx)
+  vmState.proofOfStake = ctx[].proofOfStake
   const txCtx = default(TxContext)
   assign(vmState.txCtx, txCtx)
   vmState.hardFork = vmState.determineFork
@@ -141,6 +144,7 @@ template withSenderParallel*(
       not vmState.com.balStatePrefetchEnabled(vmState.blockCtx.timestamp, bal):
     ctx.parent = vmState.parent
     ctx.blockCtx = vmState.blockCtx
+    ctx.proofOfStake = vmState.proofOfStake
     ctx.com = vmState.com
     # Run the prefetch on the parent frame because the current frame will
     # be writen to during block execution and this way we avoid having to
@@ -380,6 +384,7 @@ proc processTxTask(
   vmState.ledger = ledger
   assign(vmState.parent, ctx[].parent)
   assign(vmState.blockCtx, ctx[].blockCtx)
+  vmState.proofOfStake = ctx[].proofOfStake
   const txCtx = default(TxContext)
   assign(vmState.txCtx, txCtx)
   vmState.hardFork = vmState.determineFork
@@ -435,6 +440,7 @@ proc processTransactionsParallel*(
   ctx.txFrame = vmState.ledger.txFrame
   ctx.parent = vmState.parent
   ctx.blockCtx = vmState.blockCtx
+  ctx.proofOfStake = vmState.proofOfStake
   ctx.balPtr = balRef[].addr
   ctx.sharedBuilder = if vmState.balTrackerEnabled: vmState.balTracker.builder else: nil
 

--- a/execution_chain/evm/state.nim
+++ b/execution_chain/evm/state.nim
@@ -8,10 +8,10 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
-  std/[options, sets, strformat],
+  std/strformat,
   stew/assign2,
   ../db/ledger,
   ../common/common,
@@ -56,6 +56,11 @@ proc init(
   self.allLogs.setLen(0)
   self.gasRefunded = 0
   self.balTracker = tracker
+  self.proofOfStake = com.proofOfStake(Header(
+    number: parent.number + 1,
+    parentHash: blockCtx.parentHash,
+    difficulty: blockCtx.difficulty,
+  ), ledger.txFrame)
 
 func blockCtx(header: Header): BlockContext =
   BlockContext(
@@ -72,7 +77,7 @@ func blockCtx(header: Header): BlockContext =
 
 # --------------
 
-proc `$`*(vmState: BaseVMState): string =
+func `$`*(vmState: BaseVMState): string =
   if vmState.isNil:
     result = "nil"
   else:
@@ -266,15 +271,8 @@ func blockNumber*(vmState: BaseVMState): BlockNumber =
   # and not head.number
   vmState.parent.number + 1
 
-proc proofOfStake*(vmState: BaseVMState): bool =
-  vmState.com.proofOfStake(Header(
-    number: vmState.blockNumber,
-    parentHash: vmState.blockCtx.parentHash,
-    difficulty: vmState.blockCtx.difficulty,
-  ), vmState.ledger.txFrame)
-
-proc difficultyOrPrevRandao*(vmState: BaseVMState): UInt256 =
-  if vmState.proofOfStake():
+func difficultyOrPrevRandao*(vmState: BaseVMState): UInt256 =
+  if vmState.proofOfStake:
     # EIP-4399/EIP-3675
     UInt256.fromBytesBE(vmState.blockCtx.prevRandao.data)
   else:
@@ -284,7 +282,7 @@ method getAncestorHash*(
     vmState: BaseVMState, blockNumber: BlockNumber): Hash32 {.gcsafe, base.} =
   vmState.ledger.getBlockHash(blockNumber)
 
-proc readOnlyLedger*(vmState: BaseVMState): ReadOnlyLedger {.inline.} =
+func readOnlyLedger*(vmState: BaseVMState): ReadOnlyLedger {.inline.} =
   ReadOnlyLedger(vmState.ledger)
 
 template mutateLedger*(vmState: BaseVMState, body: untyped): untyped =
@@ -292,10 +290,10 @@ template mutateLedger*(vmState: BaseVMState, body: untyped): untyped =
     let ledger {.inject.} = vmState.ledger
     body
 
-proc status*(vmState: BaseVMState): bool =
+func status*(vmState: BaseVMState): bool =
   ExecutionOK in vmState.flags
 
-proc `status=`*(vmState: BaseVMState, status: bool) =
+func `status=`*(vmState: BaseVMState, status: bool) =
  if status: vmState.flags.incl ExecutionOK
  else: vmState.flags.excl ExecutionOK
 
@@ -311,46 +309,46 @@ template blockAccessList*(vmState: BaseVMState): Opt[BlockAccessListRef] =
   else:
     Opt.none(BlockAccessListRef)
 
-proc captureTxStart*(vmState: BaseVMState, gasLimit: GasInt) =
+func captureTxStart*(vmState: BaseVMState, gasLimit: GasInt) =
   if vmState.tracingEnabled:
     vmState.tracer.captureTxStart(gasLimit)
 
-proc captureTxEnd*(vmState: BaseVMState, restGas: GasInt) =
+func captureTxEnd*(vmState: BaseVMState, restGas: GasInt) =
   if vmState.tracingEnabled:
     vmState.tracer.captureTxEnd(restGas)
 
-proc captureStart*(vmState: BaseVMState, comp: Computation,
+func captureStart*(vmState: BaseVMState, comp: Computation,
                    sender: Address, to: Address,
                    create: bool, input: openArray[byte],
                    gasLimit: GasInt, value: UInt256) =
   if vmState.tracingEnabled:
     vmState.tracer.captureStart(comp, sender, to, create, input, gasLimit, value)
 
-proc captureEnd*(vmState: BaseVMState, comp: Computation, output: openArray[byte],
+func captureEnd*(vmState: BaseVMState, comp: Computation, output: openArray[byte],
                  gasUsed: GasInt, error: Opt[string]) =
   if vmState.tracingEnabled:
     vmState.tracer.captureEnd(comp, output, gasUsed, error)
 
-proc captureEnter*(vmState: BaseVMState, comp: Computation, op: Op,
+func captureEnter*(vmState: BaseVMState, comp: Computation, op: Op,
                    sender: Address, to: Address,
                    input: openArray[byte], gasLimit: GasInt,
                    value: UInt256) =
   if vmState.tracingEnabled:
     vmState.tracer.captureEnter(comp, op, sender, to, input, gasLimit, value)
 
-proc captureExit*(vmState: BaseVMState, comp: Computation, output: openArray[byte],
+func captureExit*(vmState: BaseVMState, comp: Computation, output: openArray[byte],
                   gasUsed: GasInt, error: Opt[string]) =
   if vmState.tracingEnabled:
     vmState.tracer.captureExit(comp, output, gasUsed, error)
 
-proc captureOpStart*(vmState: BaseVMState, comp: Computation, pc: int,
+func captureOpStart*(vmState: BaseVMState, comp: Computation, pc: int,
                    op: Op, gas: GasInt,
                    depth: int): int =
   if vmState.tracingEnabled:
     let fixed = vmState.gasCosts[op].kind == GckFixed
     result = vmState.tracer.captureOpStart(comp, fixed, pc, op, gas, depth)
 
-proc captureGasCost*(vmState: BaseVMState,
+func captureGasCost*(vmState: BaseVMState,
                     comp: Computation,
                     op: Op, gasCost: GasInt, gasRemaining: GasInt,
                     depth: int) =
@@ -358,7 +356,7 @@ proc captureGasCost*(vmState: BaseVMState,
     let fixed = vmState.gasCosts[op].kind == GckFixed
     vmState.tracer.captureGasCost(comp, fixed, op, gasCost, gasRemaining, depth)
 
-proc captureOpEnd*(vmState: BaseVMState, comp: Computation, pc: int,
+func captureOpEnd*(vmState: BaseVMState, comp: Computation, pc: int,
                    op: Op, gas: GasInt, refund: int64,
                    rData: openArray[byte],
                    depth: int, opIndex: int) =
@@ -366,7 +364,7 @@ proc captureOpEnd*(vmState: BaseVMState, comp: Computation, pc: int,
     let fixed = vmState.gasCosts[op].kind == GckFixed
     vmState.tracer.captureOpEnd(comp, fixed, pc, op, gas, refund, rData, depth, opIndex)
 
-proc captureFault*(vmState: BaseVMState, comp: Computation, pc: int,
+func captureFault*(vmState: BaseVMState, comp: Computation, pc: int,
                    op: Op, gas: GasInt, refund: int64,
                    rData: openArray[byte],
                    depth: int, error: Opt[string]) =
@@ -374,6 +372,6 @@ proc captureFault*(vmState: BaseVMState, comp: Computation, pc: int,
     let fixed = vmState.gasCosts[op].kind == GckFixed
     vmState.tracer.captureFault(comp, fixed, pc, op, gas, refund, rData, depth, error)
 
-proc capturePrepare*(vmState: BaseVMState, comp: Computation, depth: int) =
+func capturePrepare*(vmState: BaseVMState, comp: Computation, depth: int) =
   if vmState.tracingEnabled:
     vmState.tracer.capturePrepare(comp, depth)

--- a/execution_chain/evm/types.nim
+++ b/execution_chain/evm/types.nim
@@ -8,10 +8,10 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
-  "."/[stack, memory, code_stream, evm_errors],
+  ./[stack, memory, code_stream, evm_errors],
   ./interpreter/[gas_costs, op_codes],
   ./transient_storage,
   ../db/ledger,
@@ -62,6 +62,7 @@ type
     allLogs*          : seq[Log] # EIP-6110
     gasRefunded*      : int64    # Global gasRefunded counter
     balTracker*       : BlockAccessListTrackerRef
+    proofOfStake*     : bool
 
   Computation* = ref object
     # The execution computation

--- a/execution_chain/utils/debug.nim
+++ b/execution_chain/utils/debug.nim
@@ -8,6 +8,8 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
+{.push raises: [], gcsafe.}
+
 import
   std/json,
   ../common/common,
@@ -37,35 +39,38 @@ func `$`[T](x: Opt[T]): string =
     "none"
 
 func debug*(h: Header): string =
-  result.add "parentHash     : " & $h.parentHash   & "\n"
-  result.add "ommersHash     : " & $h.ommersHash   & "\n"
-  result.add "coinbase       : " & $h.coinbase     & "\n"
-  result.add "stateRoot      : " & $h.stateRoot    & "\n"
-  result.add "txRoot         : " & $h.txRoot       & "\n"
-  result.add "receiptsRoot   : " & $h.receiptsRoot & "\n"
-  result.add "logsBloom      : " & $h.logsBloom    & "\n"
-  result.add "difficulty     : " & $h.difficulty   & "\n"
-  result.add "number         : " & $h.number       & "\n"
-  result.add "gasLimit       : " & $h.gasLimit     & "\n"
-  result.add "gasUsed        : " & $h.gasUsed      & "\n"
-  result.add "timestamp      : " & $h.timestamp    & "\n"
-  result.add "extraData      : " & $h.extraData    & "\n"
-  result.add "mixHash        : " & $h.mixHash      & "\n"
-  result.add "nonce          : " & $h.nonce        & "\n"
-  result.add "baseFeePerGas  : " & $h.baseFeePerGas   & "\n"
-  result.add "withdrawalsRoot: " & $h.withdrawalsRoot & "\n"
-  result.add "blobGasUsed    : " & $h.blobGasUsed     & "\n"
-  result.add "excessBlobGas  : " & $h.excessBlobGas   & "\n"
-  result.add "beaconRoot     : " & $h.parentBeaconBlockRoot & "\n"
-  result.add "requestsHash   : " & $h.requestsHash    & "\n"
-  result.add "blockAccessListHash:" & $h.blockAccessListHash & "\n"
-  result.add "slotNumber     : " & $h.slotNumber      & "\n"
-  result.add "blockHash      : " & $computeBlockHash(h) & "\n"
+  var res: string
+  res.add "parentHash     : " & $h.parentHash   & "\n"
+  res.add "ommersHash     : " & $h.ommersHash   & "\n"
+  res.add "coinbase       : " & $h.coinbase     & "\n"
+  res.add "stateRoot      : " & $h.stateRoot    & "\n"
+  res.add "txRoot         : " & $h.txRoot       & "\n"
+  res.add "receiptsRoot   : " & $h.receiptsRoot & "\n"
+  res.add "logsBloom      : " & $h.logsBloom    & "\n"
+  res.add "difficulty     : " & $h.difficulty   & "\n"
+  res.add "number         : " & $h.number       & "\n"
+  res.add "gasLimit       : " & $h.gasLimit     & "\n"
+  res.add "gasUsed        : " & $h.gasUsed      & "\n"
+  res.add "timestamp      : " & $h.timestamp    & "\n"
+  res.add "extraData      : " & $h.extraData    & "\n"
+  res.add "mixHash        : " & $h.mixHash      & "\n"
+  res.add "nonce          : " & $h.nonce        & "\n"
+  res.add "baseFeePerGas  : " & $h.baseFeePerGas   & "\n"
+  res.add "withdrawalsRoot: " & $h.withdrawalsRoot & "\n"
+  res.add "blobGasUsed    : " & $h.blobGasUsed     & "\n"
+  res.add "excessBlobGas  : " & $h.excessBlobGas   & "\n"
+  res.add "beaconRoot     : " & $h.parentBeaconBlockRoot & "\n"
+  res.add "requestsHash   : " & $h.requestsHash    & "\n"
+  res.add "blockAccessListHash:" & $h.blockAccessListHash & "\n"
+  res.add "slotNumber     : " & $h.slotNumber      & "\n"
+  res.add "blockHash      : " & $computeBlockHash(h) & "\n"
+  res
 
 proc dumpAccounts*(vmState: BaseVMState): JsonNode =
   %dumpAccounts(vmState.ledger)
 
-proc debugAccounts*(ledger: LedgerRef, addresses: openArray[string]): string =
+proc debugAccounts*(
+    ledger: LedgerRef, addresses: openArray[string]): string {.raises: [ValueError].} =
   var accountList = newSeq[Address]()
   for address in addresses:
     accountList.add Address.fromHex(address)
@@ -85,77 +90,87 @@ proc debugAccounts*(vmState: BaseVMState): string =
   res.pretty
 
 proc debug*(vms: BaseVMState): string =
-  result.add "proofOfStake     : " & $vms.proofOfStake()      & "\n"
-  result.add "parent           : " & $vms.parent.computeBlockHash    & "\n"
-  result.add "timestamp        : " & $vms.blockCtx.timestamp  & "\n"
-  result.add "gasLimit         : " & $vms.blockCtx.gasLimit   & "\n"
-  result.add "baseFeePerGas    : " & $vms.blockCtx.baseFeePerGas & "\n"
-  result.add "prevRandao       : " & $vms.blockCtx.prevRandao & "\n"
-  result.add "blockDifficulty  : " & $vms.blockCtx.difficulty & "\n"
-  result.add "coinbase         : " & $vms.blockCtx.coinbase   & "\n"
-  result.add "excessBlobGas    : " & $vms.blockCtx.excessBlobGas & "\n"
-  result.add "parentHash       : " & $vms.blockCtx.parentHash & "\n"
-  result.add "slotNumber       : " & $vms.blockCtx.slotNumber & "\n"
-  result.add "flags            : " & $vms.flags               & "\n"
-  result.add "receipts.len     : " & $vms.receipts.len        & "\n"
-  result.add "ledger.root      : " & $vms.ledger.getStateRoot() & "\n"
-  result.add "cumulativeGasUsed: " & $vms.cumulativeGasUsed   & "\n"
-  result.add "tx.origin        : " & $vms.txCtx.origin        & "\n"
-  result.add "tx.gasPrice      : " & $vms.txCtx.gasPrice      & "\n"
-  result.add "tx.blobHash.len  : " & $vms.txCtx.versionedHashes.len & "\n"
-  result.add "tx.blobBaseFee   : " & $vms.txCtx.blobBaseFee   & "\n"
-  result.add "fork             : " & $vms.fork                & "\n"
+  var res: string
+  res.add "proofOfStake     : " & $vms.proofOfStake        & "\n"
+  res.add "parent           : " & $vms.parent.computeBlockHash    & "\n"
+  res.add "timestamp        : " & $vms.blockCtx.timestamp  & "\n"
+  res.add "gasLimit         : " & $vms.blockCtx.gasLimit   & "\n"
+  res.add "baseFeePerGas    : " & $vms.blockCtx.baseFeePerGas & "\n"
+  res.add "prevRandao       : " & $vms.blockCtx.prevRandao & "\n"
+  res.add "blockDifficulty  : " & $vms.blockCtx.difficulty & "\n"
+  res.add "coinbase         : " & $vms.blockCtx.coinbase   & "\n"
+  res.add "excessBlobGas    : " & $vms.blockCtx.excessBlobGas & "\n"
+  res.add "parentHash       : " & $vms.blockCtx.parentHash & "\n"
+  res.add "slotNumber       : " & $vms.blockCtx.slotNumber & "\n"
+  res.add "flags            : " & $vms.flags               & "\n"
+  res.add "receipts.len     : " & $vms.receipts.len        & "\n"
+  res.add "ledger.root      : " & $vms.ledger.getStateRoot() & "\n"
+  res.add "cumulativeGasUsed: " & $vms.cumulativeGasUsed   & "\n"
+  res.add "tx.origin        : " & $vms.txCtx.origin        & "\n"
+  res.add "tx.gasPrice      : " & $vms.txCtx.gasPrice      & "\n"
+  res.add "tx.blobHash.len  : " & $vms.txCtx.versionedHashes.len & "\n"
+  res.add "tx.blobBaseFee   : " & $vms.txCtx.blobBaseFee   & "\n"
+  res.add "fork             : " & $vms.fork                & "\n"
+  res
 
-proc `$`(acl: transactions.AccessList): string =
+func `$`(acl: transactions.AccessList): string =
   if acl.len == 0:
     return "zero length"
 
+  var res: string
   if acl.len > 0:
-    result.add "\n"
+    res.add "\n"
 
   for ap in acl:
-    result.add " * " & $ap.address & "\n"
+    res.add " * " & $ap.address & "\n"
     for i, k in ap.storageKeys:
-      result.add "   - " & k.toHex
+      res.add "   - " & k.toHex
       if i < ap.storageKeys.len - 1:
-        result.add "\n"
+        res.add "\n"
+  res
 
-proc debug*(tx: Transaction): string =
-  result.add "txType        : " & $tx.txType         & "\n"
-  result.add "chainId       : " & $tx.chainId        & "\n"
-  result.add "nonce         : " & $tx.nonce          & "\n"
-  result.add "gasPrice      : " & $tx.gasPrice       & "\n"
-  result.add "maxPriorityFee: " & $tx.maxPriorityFeePerGas & "\n"
-  result.add "maxFee        : " & $tx.maxFeePerGas         & "\n"
-  result.add "gasLimit      : " & $tx.gasLimit       & "\n"
-  result.add "to            : " & $tx.to             & "\n"
-  result.add "value         : " & $tx.value          & "\n"
-  result.add "payload       : " & $tx.payload        & "\n"
-  result.add "accessList    : " & $tx.accessList     & "\n"
-  result.add "maxFeePerBlobGas: " & $tx.maxFeePerBlobGas & "\n"
-  result.add "versionedHashes.len: " & $tx.versionedHashes.len & "\n"
-  result.add "V             : " & $tx.V              & "\n"
-  result.add "R             : " & $tx.R              & "\n"
-  result.add "S             : " & $tx.S              & "\n"
+func debug*(tx: Transaction): string =
+  var res: string
+  res.add "txType        : " & $tx.txType         & "\n"
+  res.add "chainId       : " & $tx.chainId        & "\n"
+  res.add "nonce         : " & $tx.nonce          & "\n"
+  res.add "gasPrice      : " & $tx.gasPrice       & "\n"
+  res.add "maxPriorityFee: " & $tx.maxPriorityFeePerGas & "\n"
+  res.add "maxFee        : " & $tx.maxFeePerGas         & "\n"
+  res.add "gasLimit      : " & $tx.gasLimit       & "\n"
+  res.add "to            : " & $tx.to             & "\n"
+  res.add "value         : " & $tx.value          & "\n"
+  res.add "payload       : " & $tx.payload        & "\n"
+  res.add "accessList    : " & $tx.accessList     & "\n"
+  res.add "maxFeePerBlobGas: " & $tx.maxFeePerBlobGas & "\n"
+  res.add "versionedHashes.len: " & $tx.versionedHashes.len & "\n"
+  res.add "V             : " & $tx.V              & "\n"
+  res.add "R             : " & $tx.R              & "\n"
+  res.add "S             : " & $tx.S              & "\n"
+  res
 
-proc debug*(tx: PooledTransaction): string =
-  result.add debug(tx.tx)
+func debug*(tx: PooledTransaction): string =
+  var res: string
+  res.add debug(tx.tx)
   if tx.blobsBundle.isNil:
-    result.add "networkPaylod : nil\n"
+    res.add "networkPaylod : nil\n"
   else:
-    result.add "networkPaylod : \n"
-    result.add " - blobs       : " & $tx.blobsBundle.blobs.len & "\n"
-    result.add " - commitments : " & $tx.blobsBundle.commitments.len & "\n"
-    result.add " - proofs      : " & $tx.blobsBundle.proofs.len & "\n"
+    res.add "networkPaylod : \n"
+    res.add " - blobs       : " & $tx.blobsBundle.blobs.len & "\n"
+    res.add " - commitments : " & $tx.blobsBundle.commitments.len & "\n"
+    res.add " - proofs      : " & $tx.blobsBundle.proofs.len & "\n"
+  res
 
-proc debugSum*(h: Header): string =
-  result.add "txRoot         : " & $h.txRoot      & "\n"
-  result.add "ommersHash     : " & $h.ommersHash  & "\n"
-  if h.withdrawalsRoot.isSome:
-    result.add "withdrawalsRoot: " & $h.withdrawalsRoot.get() & "\n"
-  result.add "sumHash        : " & $sumHash(h)   & "\n"
+func debugSum*(h: Header): string =
+  var res: string
+  res.add "txRoot         : " & $h.txRoot      & "\n"
+  res.add "ommersHash     : " & $h.ommersHash  & "\n"
+  h.withdrawalsRoot.isErrOr:
+    res.add "withdrawalsRoot: " & $value & "\n"
+  res.add "sumHash        : " & $sumHash(h)   & "\n"
+  res
 
-proc debugSum*(body: BlockBody): string =
+func debugSum*(body: BlockBody): string =
   let ommersHash = keccak256(rlp.encode(body.uncles))
   let txRoot = calcTxRoot(body.transactions)
   let wdRoot = if body.withdrawals.isSome:
@@ -165,11 +180,13 @@ proc debugSum*(body: BlockBody): string =
                 $body.withdrawals.get().len
               else:
                 "none"
-  result.add "txRoot     : " & $txRoot        & "\n"
-  result.add "ommersHash : " & $ommersHash    & "\n"
-  if body.withdrawals.isSome:
-    result.add "wdRoot     : " & $wdRoot      & "\n"
-  result.add "num tx     : " & $body.transactions.len & "\n"
-  result.add "num uncles : " & $body.uncles.len & "\n"
-  result.add "num wd     : " & numwd          & "\n"
-  result.add "sumHash    : " & $sumHash(body) & "\n"
+  var res: string
+  res.add "txRoot     : " & $txRoot        & "\n"
+  res.add "ommersHash : " & $ommersHash    & "\n"
+  body.withdrawals.isErrOr:
+    res.add "wdRoot     : " & $wdRoot      & "\n"
+  res.add "num tx     : " & $body.transactions.len & "\n"
+  res.add "num uncles : " & $body.uncles.len & "\n"
+  res.add "num wd     : " & numwd          & "\n"
+  res.add "sumHash    : " & $sumHash(body) & "\n"
+  res


### PR DESCRIPTION
Benchmarkoor results files:
[result_prevrandao_opt.json](https://github.com/user-attachments/files/30252918/result_prevrandao_opt.json)
[result_statusquo.json](https://github.com/user-attachments/files/30252919/result_statusquo.json)

Each is aggregate time running the PREVRANDAO tests in `master` compared with this PR. Mgas/s in `master` is flat at 4Mgas/s across across the sizes (it's mostly measuring database read times, because it's taking the slow path in https://github.com/status-im/nimbus-eth1/blob/1728ad55f0185bff4ae5dd6595ac5e88f5202d6f/execution_chain/common/common.nim#L507-L515
`  1M` gas: 0.252s in `master`; 0.005s in this branch (217Mgas/s)
`  5M` gas: 1.248s in `master`; 0.019s in this branch (279Mgas/s)
` 10M` gas: 2.56s in `master`; 0.033s in this branch (311Mgas/s)
` 30M` gas: 7.77s in `master`; 0.102s is this branch (297Mgas/s)
` 60M` gas: 15.373s in `master`; 0.196s in this branch (308Mgas/s)
`100M` gas: 25.711s in `master`; 0.315s in this branch (318Mgas/s)
`150M` gas: 39.159s in `master`; 0.474s in this branch (317Mgas/s)

There's a tradeoff here regarding always running
```nim
  self.proofOfStake = com.proofOfStake(Header(
    number: parent.number + 1,
    parentHash: blockCtx.parentHash,
    difficulty: blockCtx.difficulty,
  ), ledger.txFrame)
```
regardless of whether that any given block will actually contain it, but it's both slow enough that makes a significant difference hoisted out of a hot inner loop, yet fast enough that running it once costs on the order of milliseconds or less even from RocksDB. There are other approaches here, but they potentially create data races in parallel BALs, require pre-scanning transactions for the `PREVRANDAO` opcode,
 or have other architectural tradeoffs.