### PR TITLE
Optimize proofOfStake check for PREVRANDAO opcode

### DIFF
--- a/execution_chain/evm/state.nim
+++ b/execution_chain/evm/state.nim
@@ -267,11 +267,12 @@ func blockNumber*(vmState: BaseVMState): BlockNumber =
   vmState.parent.number + 1
 
 proc proofOfStake*(vmState: BaseVMState): bool =
-  vmState.com.proofOfStake(Header(
-    number: vmState.blockNumber,
-    parentHash: vmState.blockCtx.parentHash,
-    difficulty: vmState.blockCtx.difficulty,
-  ), vmState.ledger.txFrame)
+  vmState.fork >= FkShanghai or
+    vmState.com.proofOfStake(Header(
+      number: vmState.blockNumber,
+      parentHash: vmState.blockCtx.parentHash,
+      difficulty: vmState.blockCtx.difficulty,
+    ), vmState.ledger.txFrame)
 
 proc difficultyOrPrevRandao*(vmState: BaseVMState): UInt256 =
   if vmState.proofOfStake():


### PR DESCRIPTION
When running the benchmarkoor tests (`filter: "regex:.*block_context.*"`) the PREVRANDAO opcode shows up as  slow in some tests (in red). This improves the performance by skipping the proof of stake calculation when the fork is already past the merge fork.

**Before**
<img width="922" height="693" alt="Screenshot_2026-07-22_15-08-00" src="https://github.com/user-attachments/assets/e779225c-9ccd-4ec1-b19f-743602736962" />

**After**
<img width="922" height="745" alt="Screenshot_2026-07-22_15-08-40" src="https://github.com/user-attachments/assets/563cb5e0-85b0-4277-b6b8-e24e716d068a" />