### PR TITLE
bump nimbus-eth2 and resolve issue due to EIP-7688 changes

### DIFF
--- a/execution_chain/stateless/stateless_host.nim
+++ b/execution_chain/stateless/stateless_host.nim
@@ -23,9 +23,7 @@ from beacon_chain/spec/datatypes/capella import Withdrawal
 from beacon_chain/spec/datatypes/bellatrix import BloomLogs
 from beacon_chain/spec/datatypes/base import Gwei
 from beacon_chain/spec/beacon_time import Slot
-from beacon_chain/spec/presets import
-  MAX_BYTES_PER_TRANSACTION, MAX_EXTRA_DATA_BYTES, MAX_TRANSACTIONS_PER_PAYLOAD,
-  MAX_WITHDRAWALS_PER_PAYLOAD
+from beacon_chain/spec/presets import MAX_EXTRA_DATA_BYTES
 
 export stateless_types, results
 
@@ -120,11 +118,11 @@ func build_stateless_input*(
   # Encode transactions to bytes, recover public keys, and collect the
   # versioned hashes.
   var
-    transactions = newSeqOfCap[bellatrix.Transaction](blk.transactions.len)
+    transactions = newSeqOfCap[gloas.Transaction](blk.transactions.len)
     public_keys: List[ByteVector[PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS]
     versioned_hashes: List[Digest, MAX_BLOB_COMMITMENTS_PER_BLOCK]
   for tx in blk.transactions:
-    transactions.add(bellatrix.Transaction.init(rlp.encode(tx)))
+    transactions.add(gloas.Transaction.init(rlp.encode(tx)))
 
     let public_key = recover_transaction_public_key(tx).valueOr:
       # Skip transactions without a recoverable key (invalid signature values).
@@ -165,12 +163,11 @@ func build_stateless_input*(
     extra_data: List[byte, MAX_EXTRA_DATA_BYTES].init(header.extraData),
     base_fee_per_gas: base_fee_per_gas,
     block_hash: Digest(data: block_hash.data),
-    transactions:
-      List[bellatrix.Transaction, MAX_TRANSACTIONS_PER_PAYLOAD].init(transactions),
-    withdrawals: List[capella.Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD].init(withdrawals),
+    transactions: transactions,
+    withdrawals: withdrawals,
     blob_gas_used: blob_gas_used,
     excess_blob_gas: excess_blob_gas,
-    block_access_list: List[byte, MAX_BYTES_PER_TRANSACTION].init(@block_access_list),
+    block_access_list: gloas.BlockAccessList.init(@block_access_list),
     slot_number: Slot(slot_number),
   )
 

--- a/portal/bridge/beacon/portal_beacon_bridge.nim
+++ b/portal/bridge/beacon/portal_beacon_bridge.nim
@@ -271,6 +271,8 @@ proc gossipHistoricalSummaries(
       ok()
     except CatchableError as e:
       err("JSON-RPC error: " & $e.msg)
+  of HistoricalSummariesFork.Gloas:
+    err("Gossiping Gloas historical_summaries is not yet implemented")
   of HistoricalSummariesFork.Capella:
     err("No historical summaries pre-Electra should be gossiped")
 

--- a/portal/network/beacon/beacon_chain_historical_roots.nim
+++ b/portal/network/beacon/beacon_chain_historical_roots.nim
@@ -17,7 +17,7 @@
 # simply be verified by checking its root.
 # Thus HistoricalRootsWithProof is currently unused. It could be embedded
 # with its proof and/or send over the network.
-# The proof supported is only the version from >= Electra as it would only
+# The proof supported is only the version from >= Gloas as it would only
 # make sense to verify it against a recent state.
 #
 
@@ -27,23 +27,23 @@ import results, stew/bitops2, beacon_chain/spec/forks
 
 export results
 
-const HISTORICAL_ROOTS_GINDEX_ELECTRA* =
-  get_generalized_index(electra.BeaconState, "historical_roots")
+const HISTORICAL_ROOTS_GINDEX_GLOAS* =
+  get_generalized_index(gloas.BeaconState, "historical_roots")
 
 static:
-  doAssert HISTORICAL_ROOTS_GINDEX_ELECTRA == 71.GeneralizedIndex
+  doAssert HISTORICAL_ROOTS_GINDEX_GLOAS == 354.GeneralizedIndex
 
   for consensusFork in ConsensusFork:
     withConsensusFork(consensusFork):
-      if consensusFork >= ConsensusFork.Electra:
+      if consensusFork >= ConsensusFork.Gloas:
         template check(gindex, T: untyped, path: varargs[untyped]): untyped =
           doAssert gindex == consensusFork.T.get_generalized_index(path)
 
-        check HISTORICAL_ROOTS_GINDEX_ELECTRA, BeaconState, "historical_roots"
+        check HISTORICAL_ROOTS_GINDEX_GLOAS, BeaconState, "historical_roots"
 
 type
   HistoricalRoots* = HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
-  HistoricalRootsProof* = array[log2trunc(HISTORICAL_ROOTS_GINDEX_ELECTRA), Digest]
+  HistoricalRootsProof* = array[log2trunc(HISTORICAL_ROOTS_GINDEX_GLOAS), Digest]
   HistoricalRootsWithProof* = object
     historical_roots: HistoricalRoots
     proof: HistoricalRootsProof
@@ -51,7 +51,7 @@ type
 func buildProof*(state: ForkedHashedBeaconState): Result[HistoricalRootsProof, string] =
   var proof: HistoricalRootsProof
   withState(state):
-    ?forkyState.data.build_proof(HISTORICAL_ROOTS_GINDEX_ELECTRA, proof)
+    ?forkyState.data.build_proof(HISTORICAL_ROOTS_GINDEX_GLOAS, proof)
 
   ok(proof)
 
@@ -60,6 +60,4 @@ func verifyProof*(
 ): bool =
   let leave = hash_tree_root(historical_roots)
 
-  verify_merkle_multiproof(
-    @[leave], proof, @[HISTORICAL_ROOTS_GINDEX_ELECTRA], stateRoot
-  )
+  verify_merkle_multiproof(@[leave], proof, @[HISTORICAL_ROOTS_GINDEX_GLOAS], stateRoot)

--- a/portal/tests/beacon_network_tests/test_beacon_historical_roots.nim
+++ b/portal/tests/beacon_network_tests/test_beacon_historical_roots.nim
@@ -19,11 +19,11 @@ import
 
 suite "Beacon Chain Historical Roots":
   let
-    cfg = genesisTestRuntimeConfig(ConsensusFork.Electra)
+    cfg = genesisTestRuntimeConfig(ConsensusFork.Gloas)
     state = newClone(initGenesisState(cfg = cfg))
   var cache = StateCache()
 
-  var blocks: seq[electra.SignedBeaconBlock]
+  var blocks: seq[gloas.SignedBeaconBlock]
   # Note:
   # Adding 8192 blocks. First block is genesis block and not one of these.
   # Then one extra block is needed to get the historical roots, block
@@ -32,7 +32,7 @@ suite "Beacon Chain Historical Roots":
   # index i = 8190 is 8192th block and last one that is part of the first
   # historical root
   for i in 0 ..< SLOTS_PER_HISTORICAL_ROOT:
-    blocks.add(addTestBlock(state[], cache, cfg = cfg).electraData)
+    blocks.add(addTestBlock(state[], cache, cfg = cfg).gloasData)
 
   test "Historical Roots Proof":
     let historical_roots = state[].historical_roots

--- a/tests/eest/eest_blockchain.nim
+++ b/tests/eest/eest_blockchain.nim
@@ -206,7 +206,13 @@ proc runTest(
 
       expectedSuccessful = expectedOutput.successful_validation
 
-      if output != expectedOutput:
+      # if output != expectedOutput:
+      # TODO: The `new_payload_request_root` comparison is temporarily skipped.
+      # The stateless fixtures are generated from execution-specs, which is no
+      # longer up to date regarding `gloas.ExecutionPayload` usage of progressive
+      # lists (EIP-7688).
+      if output.successful_validation != expectedOutput.successful_validation or
+          output.chain_config != expectedOutput.chain_config:
         return err(
           "Stateless guest: validation result mismatch, got: " & $output & " expected: " &
             $expectedOutput


### PR DESCRIPTION
This bump also moves several Gloas beacon structures to progressive containers (EIP-7688/7916), most changes related to that:

- portal beacon bridge: handle the new Gloas HistoricalSummariesFork case as unsupported for now.
- historical_roots proof: move to the Gloas gindex and adjust test
- stateless_host: use gloas.ExecutionPayload progressive-list fields (transactions/withdrawals/block_access_list). This changes their merkleization, so for now we skip the new_payload_request_root fixture check in eest_blockchain. To be re-enabled when tests fixtures / execution specs catch up.