### PR TITLE
Fix EVM stack memory leak from double setCode on system calls

### DIFF
--- a/execution_chain/evm/computation.nim
+++ b/execution_chain/evm/computation.nim
@@ -143,8 +143,11 @@ func getTransientStorage*(c: Computation, slot: UInt256): UInt256 =
 func setCode*(c: Computation, code = CodeBytesRef(nil)) =
   if not code.isNil:
     c.code = CodeStream.init(code)
-    c.memory = EvmMemory.init()
-    c.stack = EvmStack.init()
+    # A frame created with code (system calls) has setCode run again from prepareDispatch.
+    # Allocate the buffers only once so the empty stack is not orphaned.
+    if c.stack.isNil:
+      c.memory = EvmMemory.init()
+      c.stack = EvmStack.init()
 
 func newComputation*(vmState: BaseVMState,
                      keepStack: bool,

--- a/execution_chain/evm/interpreter/op_handlers/oph_create.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_create.nim
@@ -79,7 +79,9 @@ proc execSubCreate(c: Computation; childMsg: Message;
   if c.fork >= FkAmsterdam:
     newAccountCharged = not c.accountExists(child.msg.contractAddress)
     if newAccountCharged:
-      ? c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "Create op new account")
+      c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "Create op new account").isOkOr:
+        child.dispose()
+        return err(error)
 
   var createMsgGas = c.gasMeter.gasRemaining
   if c.fork >= FkTangerine:

--- a/execution_chain/transaction/system_call.nim
+++ b/execution_chain/transaction/system_call.nim
@@ -96,4 +96,8 @@ proc systemCall*(params: CallParams, T: type): T =
   if c.isSuccess:
     c.execCallOrCreate(params)
     ledger.persist(clearEmptyAccount = true)
+  else:
+    # execCallOrCreate normally disposes the computation, dispose here too
+    # otherwise the EVM stack leaks.
+    c.dispose()
   finishRunningComputation(c, T)


### PR DESCRIPTION
System call frames set their code twice (setupComputation, then prepareDispatch), and each setCode allocated a fresh stack, orphaning the first one. This leak drove the EEST stateless suite to ~17GB VIRT and OOM on CI. setCode now allocates the buffers only when absent and reuses the still empty stack.

Also add dispose for the computation on two other early return paths that skipped it.