### PR TITLE
Disable leaves caches when compiling with threads disabled

### DIFF
--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -25,19 +25,18 @@ import
   std/[atomics, hashes, sequtils, sets, tables, heapqueue],
   eth/common/hashes, eth/trie/nibbles,
   results,
-  ../../concurrency/lru,
   ./aristo_constants,
   ./aristo_desc/[desc_error, desc_identifiers, desc_structural],
   ./aristo_desc/desc_backend
 
 when compileOption("threads"):
-  import taskpools, ../../concurrency/readwritelock
-  export taskpools, readwritelock
+  import taskpools, ../../concurrency/lru, ../../concurrency/readwritelock
+  export taskpools, readwritelock, lru
 
 # Not auto-exporting backend
 export
   tables, aristo_constants, desc_error, desc_identifiers, nibbles,
-  desc_structural, lru, hashes, heapqueue, PutHdlRef
+  desc_structural, hashes, heapqueue, PutHdlRef
 
 type
   AristoTxRef* = ref object
@@ -134,17 +133,21 @@ type
 
     txRef*: AristoTxRef              ## Bottom-most in-memory frame
 
-    accLeaves*: ConcurrentLruCache[Hash32, CachedAccLeaf]
-      ## Account path to payload cache - accounts are frequently accessed by
-      ## account path when contracts interact with them - this cache ensures
-      ## that we don't have to re-traverse the storage trie for every such
-      ## interaction
-      ## TODO a better solution would probably be to cache this in a type
-      ## exposed to the high-level API
+    # Caches only available with threads enabled.
+    # The current only threads disabled use case is the stateless guest, for which
+    # these caches are not useful anyhow.
+    when compileOption("threads"):
+      accLeaves*: ConcurrentLruCache[Hash32, CachedAccLeaf]
+        ## Account path to payload cache - accounts are frequently accessed by
+        ## account path when contracts interact with them - this cache ensures
+        ## that we don't have to re-traverse the storage trie for every such
+        ## interaction
+        ## TODO a better solution would probably be to cache this in a type
+        ## exposed to the high-level API
 
-    stoLeaves*: ConcurrentLruCache[Hash32, CachedStoLeaf]
-      ## Mixed account/storage path to payload cache - same as above but caches
-      ## the full lookup of storage slots
+      stoLeaves*: ConcurrentLruCache[Hash32, CachedStoLeaf]
+        ## Mixed account/storage path to payload cache - same as above but caches
+        ## the full lookup of storage slots
 
     staticLevel*: Atomic[int]
       ## MPT level where "most" leaves can be found, for static vid lookups

--- a/execution_chain/db/aristo/aristo_fetch.nim
+++ b/execution_chain/db/aristo/aristo_fetch.nim
@@ -40,16 +40,27 @@ proc retrieveLeaf(
 
   return err(FetchPathNotFound)
 
+template cacheAccLeaf(db: AristoTxRef; accPath: Hash32; cached: CachedAccLeaf) =
+  when compileOption("threads"):
+    db.db.accLeaves.put(accPath, cached)
+
+template cacheStoLeaf(db: AristoTxRef; mixPath: Hash32; cached: CachedStoLeaf) =
+  when compileOption("threads"):
+    db.db.stoLeaves.put(mixPath, cached)
+
 proc cachedAccLeaf*(db: AristoTxRef; accPath: Hash32): Opt[AccLeafRef] =
   # Return vertex from layers or cache, `nil` if it's known to not exist and
   # none otherwise
   db.layersGetAccLeaf(accPath).isErrOr:
     return Opt.some(value)
 
-  db.db.accLeaves.withGet(accPath, cached):
-    return Opt.some(cached.toLeaf())
-  do:
-    return Opt.none(AccLeafRef)
+  when compileOption("threads"):
+    db.db.accLeaves.withGet(accPath, cached):
+      return Opt.some(cached.toLeaf())
+    do:
+      return Opt.none(AccLeafRef)
+  else:
+    Opt.none(AccLeafRef)
 
 proc cachedStoLeaf*(db: AristoTxRef; mixPath: Hash32): Opt[StoLeafRef] =
   # Return vertex from layers or cache, `nil` if it's known to not exist and
@@ -57,10 +68,13 @@ proc cachedStoLeaf*(db: AristoTxRef; mixPath: Hash32): Opt[StoLeafRef] =
   db.layersGetStoLeaf(mixPath).isErrOr:
     return Opt.some(value)
 
-  db.db.stoLeaves.withGet(mixPath, cached):
-    return Opt.some(cached.toLeaf())
-  do:
-    return Opt.none(StoLeafRef)
+  when compileOption("threads"):
+    db.db.stoLeaves.withGet(mixPath, cached):
+      return Opt.some(cached.toLeaf())
+    do:
+      return Opt.none(StoLeafRef)
+  else:
+    Opt.none(StoLeafRef)
 
 proc retrieveAccStatic(
     db: AristoTxRef;
@@ -155,11 +169,11 @@ proc retrieveAccLeaf(
 
   let (staticVtx, path, next) = db.retrieveAccStatic(accPath).valueOr:
     if error == FetchPathNotFound:
-      db.db.accLeaves.put(accPath, emptyCachedAccLeaf)
+      db.cacheAccLeaf(accPath, emptyCachedAccLeaf)
     return err(error)
 
   if staticVtx.isValid():
-    db.db.accLeaves.put(accPath, CachedAccLeaf.init(staticVtx.pfx, staticVtx.account, staticVtx.stoID))
+    db.cacheAccLeaf(accPath, CachedAccLeaf.init(staticVtx.pfx, staticVtx.account, staticVtx.stoID))
     return ok staticVtx
 
   # Updated payloads are stored in the layers so if we didn't find them there,
@@ -171,13 +185,13 @@ proc retrieveAccLeaf(
         # meaning that it was a hit - else searches for non-existing paths would
         # skew the results towards more depth than exists in the MPT
         discard db.db.lookupsHits.fetchAdd(1, moRelaxed)
-        db.db.accLeaves.put(accPath, emptyCachedAccLeaf)
+        db.cacheAccLeaf(accPath, emptyCachedAccLeaf)
       return err(error)
 
   discard db.db.lookupsHigher.fetchAdd(1, moRelaxed)
 
   let accLeaf = AccLeafRef(leafVtx)
-  db.db.accLeaves.put(accPath, CachedAccLeaf.init(accLeaf.pfx, accLeaf.account, accLeaf.stoID))
+  db.cacheAccLeaf(accPath, CachedAccLeaf.init(accLeaf.pfx, accLeaf.account, accLeaf.stoID))
 
   ok accLeaf
 
@@ -303,31 +317,32 @@ proc fetchSlot*(
     # because the value will be updated from the layers during persist
     return ok value.toStoData()
 
-  db.db.stoLeaves.withGet(mixPath, cached):
-    return ok cached.toStoData()
-  do:
-    # Updated payloads are stored in the layers so if we didn't find them there,
-    # it must have been in the database
+  when compileOption("threads"):
+    db.db.stoLeaves.withGet(mixPath, cached):
+      return ok cached.toStoData()
 
-    let stoID = ?db.fetchStorageID(accPath)
-    if not stoID.isValid():
-      db.db.stoLeaves.put(mixPath, emptyCachedStoLeaf)
+  # Updated payloads are stored in the layers so if we didn't find them there,
+  # it must have been in the database
+
+  let stoID = ?db.fetchStorageID(accPath)
+  if not stoID.isValid():
+    db.cacheStoLeaf(mixPath, emptyCachedStoLeaf)
+    return ok 0'u256
+
+  let leafRc = db.retrieveLeaf(stoID, NibblesBuf.fromBytes(stoPath.data))
+  if leafRc.isErr:
+    if leafRc.error == FetchPathNotFound:
+      db.cacheStoLeaf(mixPath, emptyCachedStoLeaf)
       return ok 0'u256
 
-    let leafRc = db.retrieveLeaf(stoID, NibblesBuf.fromBytes(stoPath.data))
-    if leafRc.isErr:
-      if leafRc.error == FetchPathNotFound:
-        db.db.stoLeaves.put(mixPath, emptyCachedStoLeaf)
-        return ok 0'u256
+    # `HikeDanglingEdge` / `HikeBranchUnresolvedEdge`: missing state in
+    # witness or not-yet-fetched node, or a backend (db corruption) error.
+    # Can't know if slot is absent.
+    return err(leafRc.error)
 
-      # `HikeDanglingEdge` / `HikeBranchUnresolvedEdge`: missing state in
-      # witness or not-yet-fetched node, or a backend (db corruption) error.
-      # Can't know if slot is absent.
-      return err(leafRc.error)
-
-    let leaf = StoLeafRef(leafRc.value)
-    db.db.stoLeaves.put(mixPath, CachedStoLeaf.init(leaf.pfx, leaf.stoData))
-    return ok leaf.toStoData()
+  let leaf = StoLeafRef(leafRc.value)
+  db.cacheStoLeaf(mixPath, CachedStoLeaf.init(leaf.pfx, leaf.stoData))
+  return ok leaf.toStoData()
 
 proc fetchStorageRoot*(
     db: AristoTxRef;

--- a/execution_chain/db/aristo/aristo_init/init_common.nim
+++ b/execution_chain/db/aristo/aristo_init/init_common.nim
@@ -93,12 +93,12 @@ proc initInstance*(
   when compileOption("threads"):
     db.txRef.lock.init()
 
-  if threadSafeCaches:
-    db.accLeaves.init(accLeavesLruSize)
-    db.stoLeaves.init(stoLeavesLruSize)
-  else:
-    db.accLeaves.init(accLeavesLruSize, shardBits = 0, threadSafe = false)
-    db.stoLeaves.init(stoLeavesLruSize, shardBits = 0, threadSafe = false)
+    if threadSafeCaches:
+      db.accLeaves.init(accLeavesLruSize)
+      db.stoLeaves.init(stoLeavesLruSize)
+    else:
+      db.accLeaves.init(accLeavesLruSize, shardBits = 0, threadSafe = false)
+      db.stoLeaves.init(stoLeavesLruSize, shardBits = 0, threadSafe = false)
   db.maxSnapshots = maxSnapshots
   db.parallelStateRootComputation = parallelStateRootComputation
 
@@ -115,10 +115,11 @@ proc close*(db: AristoDbRef; wipe = false) =
   ##
   ## This distructor may be used on already *destructed* descriptors.
   ##
-  db.accLeaves.dispose()
-  db.stoLeaves.dispose()
-  db.accLeaves.reset()
-  db.stoLeaves.reset()
+  when compileOption("threads"):
+    db.accLeaves.dispose()
+    db.stoLeaves.dispose()
+    db.accLeaves.reset()
+    db.stoLeaves.reset()
 
   db.closeFn wipe
 

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -261,32 +261,33 @@ proc persist*(db: AristoDbRef, batch: PutHdlRef, txFrame: AristoTxRef) =
   #      in-memory and on-disk state)
 
   # Copy back updated payloads into the shared database LRU caches.
+  # Caches only available with threads enabled.
+  when compileOption("threads"):
+    # Copy cached values from the snapshot
+    for accPath, v in txFrame.snapshot.acc:
+      if v[0] == nil:
+        db.accLeaves.del(accPath)
+      else:
+        discard db.accLeaves.update(accPath, CachedAccLeaf.init(v[0].pfx, v[0].account, v[0].stoID))
 
-  # Copy cached values from the snapshot
-  for accPath, v in txFrame.snapshot.acc:
-    if v[0] == nil:
-      db.accLeaves.del(accPath)
-    else:
-      discard db.accLeaves.update(accPath, CachedAccLeaf.init(v[0].pfx, v[0].account, v[0].stoID))
+    for mixPath, v in txFrame.snapshot.sto:
+      if v[0] == nil:
+        db.stoLeaves.del(mixPath)
+      else:
+        discard db.stoLeaves.update(mixPath, CachedStoLeaf.init(v[0].pfx, v[0].stoData))
 
-  for mixPath, v in txFrame.snapshot.sto:
-    if v[0] == nil:
-      db.stoLeaves.del(mixPath)
-    else:
-      discard db.stoLeaves.update(mixPath, CachedStoLeaf.init(v[0].pfx, v[0].stoData))
+    # Copy cached values from the txFrame
+    for accPath, vtx in txFrame.accLeaves:
+      if vtx == nil:
+        db.accLeaves.del(accPath)
+      else:
+        discard db.accLeaves.update(accPath, CachedAccLeaf.init(vtx.pfx, vtx.account, vtx.stoID))
 
-  # Copy cached values from the txFrame
-  for accPath, vtx in txFrame.accLeaves:
-    if vtx == nil:
-      db.accLeaves.del(accPath)
-    else:
-      discard db.accLeaves.update(accPath, CachedAccLeaf.init(vtx.pfx, vtx.account, vtx.stoID))
-
-  for mixPath, vtx in txFrame.stoLeaves:
-    if vtx == nil:
-      db.stoLeaves.del(mixPath)
-    else:
-      discard db.stoLeaves.update(mixPath, CachedStoLeaf.init(vtx.pfx, vtx.stoData))
+    for mixPath, vtx in txFrame.stoLeaves:
+      if vtx == nil:
+        db.stoLeaves.del(mixPath)
+      else:
+        discard db.stoLeaves.update(mixPath, CachedStoLeaf.init(vtx.pfx, vtx.stoData))
 
   # Remove snapshot data that has been persisted to disk to save memory.
   # All snapshot records with a level lower than the current base level


### PR DESCRIPTION
The current only threads disabled use case is the stateless guest, for which these caches are not useful anyhow.