### PR TITLE
System call should not call topFrameAuthAndDelegation

### DIFF
--- a/execution_chain/evm/computation.nim
+++ b/execution_chain/evm/computation.nim
@@ -141,13 +141,15 @@ func getTransientStorage*(c: Computation, slot: UInt256): UInt256 =
     cpt = cpt.parent
 
 func setCode*(c: Computation, code = CodeBytesRef(nil)) =
+  # If we call setCode when c.code already set to something,
+  # it means c.memory and c.stack also have been set.
+  # If we set it once again, they will become orphaned,
+  # and memory leak occurs.
+  doAssert(c.code.isNil, "c.code should be nil when calling setCode")
   if not code.isNil:
     c.code = CodeStream.init(code)
-    # A frame created with code (system calls) has setCode run again from prepareDispatch.
-    # Allocate the buffers only once so the empty stack is not orphaned.
-    if c.stack.isNil:
-      c.memory = EvmMemory.init()
-      c.stack = EvmStack.init()
+    c.memory = EvmMemory.init()
+    c.stack = EvmStack.init()
 
 func newComputation*(vmState: BaseVMState,
                      keepStack: bool,

--- a/execution_chain/evm/computation.nim
+++ b/execution_chain/evm/computation.nim
@@ -141,11 +141,11 @@ func getTransientStorage*(c: Computation, slot: UInt256): UInt256 =
     cpt = cpt.parent
 
 func setCode*(c: Computation, code = CodeBytesRef(nil)) =
-  # If we call setCode when c.code already set to something,
-  # it means c.memory and c.stack also have been set.
+  # If we call setCode when c.stack already set to something,
+  # it means c.code has been set before.
   # If we set it once again, they will become orphaned,
   # and memory leak occurs.
-  doAssert(c.code.isNil, "c.code should be nil when calling setCode")
+  doAssert(c.stack.isNil, "c.stack and c.memory should be nil when calling setCode")
   if not code.isNil:
     c.code = CodeStream.init(code)
     c.memory = EvmMemory.init()

--- a/execution_chain/evm/interpreter/op_handlers/oph_call.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_call.nim
@@ -108,6 +108,9 @@ proc gasCallDelegate(c: Computation, codeAddress: Address, flags: set[MsgFlags])
       if c.balTrackerEnabled:
         c.vmState.balTracker.trackAddressAccess(codeAddress)
 
+      # Clear delegated flags inherited from parent
+      c.msg.flags.excl MsgFlags.Delegated
+
       # Code does not need to be loaded for precompile addresses because the
       # precompile doesn't exist in the state trie and can never be a 7702
       # delegation, so resolving the delegation target is a no-op.

--- a/execution_chain/evm/interpreter_dispatch.nim
+++ b/execution_chain/evm/interpreter_dispatch.nim
@@ -13,13 +13,10 @@
 import
   std/[macros, strformat],
   chronicles,
-  stew/[byteutils, assign2],
+  stew/[byteutils],
   ../constants,
   ../db/ledger,
-  ../core/eip8037,
-  ../transaction/[call_types, eoa_delegation],
   ./interpreter/[op_dispatcher],
-  ./interpreter/op_handlers/oph_helpers,
   ./[code_stream, computation, evm_errors, message, precompiles, state, types]
 
 logScope:
@@ -69,67 +66,7 @@ macro selectVM(v: VmCpt, fork: EVMFork, tracingEnabled: bool): EvmResultVoid =
     caseStmt.add nnkOfBranch.newTree(forkVal, call)
   caseStmt
 
-proc prepareDispatch(params: CallParams, c: Computation): EvmResultVoid =
-  let
-    vmState = c.vmState
-    ledger = vmState.ledger
-
-  if vmState.balTrackerEnabled:
-    vmState.balTracker.trackAddressAccess(c.msg.contractAddress)
-
-  var
-    code =
-      if params.isCreate:
-        if ledger.originalAccountEmpty(c.msg.contractAddress):
-          ? c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "prepareDispatch create new account")
-        CodeBytesRef.init(params.input)
-      else:
-        if params.value.isZero.not and not ledger.accountExists(c.msg.contractAddress):
-          ? c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "prepareDispatch call new account")
-        assign(c.msg.data, params.input)
-        getRecipientCode(vmState, c.msg)
-
-  if MsgFlags.Delegated in c.msg.flags:
-    # The delegated account access must be charged before its code is read,
-    # or an OOG here would wrongly add the target account to the witness.
-    let delegatedGas = c.gasEip8038AccountCheck(c.msg.delegateTo)
-    ? c.gasMeter.consumeGas(delegatedGas, "prepareDispatch delegatedGas")
-
-    if vmState.balTrackerEnabled:
-      vmState.balTracker.trackAddressAccess(c.msg.delegateTo)
-    code = vmState.readOnlyLedger.getCode(c.msg.delegateTo)
-
-  c.setCode(code)
-  ok()
-
-proc authAndDelegation(params: CallParams, c: Computation): EvmResultVoid =
-  ? params.setDelegation(c)
-  c.vmState.authStateGasUsed = c.frameStateGasUsed()
-  c.msg.stateGasReservoir = c.gasMeter.stateGasLeft
-  c.gasMeter.stateGasSpilled = 0
-  params.prepareDispatch(c)
-
-proc topFrameAuthAndDelegation(params: CallParams, c: Computation): bool =
-  let
-    prepReservoir = c.msg.stateGasReservoir
-
-  c.beginSavePoint()
-  params.authAndDelegation(c).isOkOr:
-    c.rollback()
-    c.msg.stateGasReservoir = prepReservoir
-    c.vmState.authStateGasUsed = 0
-    c.refillFrameStateGas()
-    c.setError($error.code, true)
-    return false
-
-  c.commit()
-  true
-
-proc beforeExecCall(c: Computation, params: CallParams): bool =
-  if c.msg.depth == 0 and c.fork >= FkAmsterdam and MsgFlags.SystemCall notin c.msg.flags:
-    if not params.topFrameAuthAndDelegation(c):
-      return true
-
+proc beforeExecCall(c: Computation): bool =
   c.beginSavePoint()
   if c.msg.kind == CallKind.Call:
     c.vmState.mutateLedger:
@@ -158,18 +95,7 @@ proc afterExecCall(c: Computation) =
       # Special case to account for geth+parity bug
       c.vmState.ledger.ripemdSpecial()
 
-proc beforeExecCreate(c: Computation, params: CallParams): bool =
-  if c.msg.depth == 0:
-    if not c.incrementNonce():
-      return true
-
-    if c.fork >= FkAmsterdam:
-      if not params.topFrameAuthAndDelegation(c):
-        return true
-
-    if not c.accountDeployable():
-      return true
-
+proc beforeExecCreate(c: Computation): bool =
   c.beginSavePoint()
 
   c.vmState.mutateLedger:
@@ -213,7 +139,7 @@ func msgToOp(msg: Message): Op =
     return StaticCall
   MsgKindToOp[msg.kind]
 
-proc beforeExec(c: Computation, params: CallParams): bool =
+proc beforeExec(c: Computation): bool =
   if c.msg.depth > 0:
     c.vmState.captureEnter(
       c,
@@ -226,9 +152,9 @@ proc beforeExec(c: Computation, params: CallParams): bool =
     )
 
   if c.msg.isCreate:
-    c.beforeExecCreate(params)
+    c.beforeExecCreate()
   else:
-    c.beforeExecCall(params)
+    c.beforeExecCall()
 
 proc afterExec(c: Computation) =
   if not c.msg.isCreate:
@@ -295,13 +221,13 @@ proc executeOpcodes*(c: Computation) =
     if c.tracingEnabled:
       c.traceError()
 
-proc execCallOrCreate*(cParam: Computation, params: CallParams) =
+proc execCallOrCreate*(cParam: Computation) =
   var (c, before) = (cParam, true)
 
   # No actual recursion, but simulate recursion including before/after/dispose.
   while true:
     while true:
-      if before and c.beforeExec(params):
+      if before and c.beforeExec():
         break
       c.executeOpcodes()
       if c.continuation.isNil:

--- a/execution_chain/evm/interpreter_dispatch.nim
+++ b/execution_chain/evm/interpreter_dispatch.nim
@@ -126,7 +126,7 @@ proc topFrameAuthAndDelegation(params: CallParams, c: Computation): bool =
   true
 
 proc beforeExecCall(c: Computation, params: CallParams): bool =
-  if c.msg.depth == 0 and c.fork >= FkAmsterdam:
+  if c.msg.depth == 0 and c.fork >= FkAmsterdam and MsgFlags.SystemCall notin c.msg.flags:
     if not params.topFrameAuthAndDelegation(c):
       return true
 

--- a/execution_chain/evm/types.nim
+++ b/execution_chain/evm/types.nim
@@ -120,7 +120,6 @@ type
     Static
     Precompile
     Delegated
-    SystemCall
 
   Message* = ref object
     kind*:             CallKind

--- a/execution_chain/evm/types.nim
+++ b/execution_chain/evm/types.nim
@@ -120,6 +120,7 @@ type
     Static
     Precompile
     Delegated
+    SystemCall
 
   Message* = ref object
     kind*:             CallKind

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -15,9 +15,11 @@ import
   stew/assign2,
   ../evm/[types, state],
   ../evm/[message, precompiles, internals, interpreter_dispatch, evm_errors],
+  ../evm/interpreter/op_handlers/oph_helpers,
   ../db/ledger,
   ../common/evmforks,
   ../core/eip4844,
+  ../core/eip8037,
    ./eoa_delegation,
    ./call_types
 
@@ -255,6 +257,80 @@ proc finishRunningComputation(
   else:
     {.error: "Unknown computation output".}
 
+proc prepareDispatch(params: CallParams, c: Computation): EvmResultVoid =
+  let
+    vmState = c.vmState
+    ledger = vmState.ledger
+
+  if vmState.balTrackerEnabled:
+    vmState.balTracker.trackAddressAccess(c.msg.contractAddress)
+
+  var
+    code =
+      if params.isCreate:
+        if ledger.originalAccountEmpty(c.msg.contractAddress):
+          ? c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "prepareDispatch create new account")
+        CodeBytesRef.init(params.input)
+      else:
+        if params.value.isZero.not and not ledger.accountExists(c.msg.contractAddress):
+          ? c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "prepareDispatch call new account")
+        assign(c.msg.data, params.input)
+        getRecipientCode(vmState, c.msg)
+
+  if MsgFlags.Delegated in c.msg.flags:
+    # The delegated account access must be charged before its code is read,
+    # or an OOG here would wrongly add the target account to the witness.
+    let delegatedGas = c.gasEip8038AccountCheck(c.msg.delegateTo)
+    ? c.gasMeter.consumeGas(delegatedGas, "prepareDispatch delegatedGas")
+
+    if vmState.balTrackerEnabled:
+      vmState.balTracker.trackAddressAccess(c.msg.delegateTo)
+    code = vmState.readOnlyLedger.getCode(c.msg.delegateTo)
+
+  c.setCode(code)
+  ok()
+
+proc authAndDelegation(params: CallParams, c: Computation): EvmResultVoid =
+  ? params.setDelegation(c)
+  c.vmState.authStateGasUsed = c.frameStateGasUsed()
+  c.msg.stateGasReservoir = c.gasMeter.stateGasLeft
+  c.gasMeter.stateGasSpilled = 0
+  params.prepareDispatch(c)
+
+proc topFrameAuthAndDelegation(params: CallParams, c: Computation): bool =
+  let
+    prepReservoir = c.msg.stateGasReservoir
+
+  c.beginSavePoint()
+  params.authAndDelegation(c).isOkOr:
+    c.rollback()
+    c.msg.stateGasReservoir = prepReservoir
+    c.vmState.authStateGasUsed = 0
+    c.refillFrameStateGas()
+    c.setError($error.code, true)
+    return false
+
+  c.commit()
+  true
+
+proc preExecComputation(c: Computation, params: CallParams) =
+  if params.isCreate:
+    if not c.incrementNonce():
+      return
+
+    if c.fork >= FkAmsterdam:
+      if not params.topFrameAuthAndDelegation(c):
+        return
+
+    if not c.accountDeployable():
+      return
+
+    return
+
+  if c.fork >= FkAmsterdam:
+    if not params.topFrameAuthAndDelegation(c):
+      return
+
 proc runComputation*(params: CallParams, T: type): T =
   prepareToRunComputation(params)
   initialAccessListEIP2929(params)
@@ -262,7 +338,13 @@ proc runComputation*(params: CallParams, T: type): T =
   let
     c = setupEVM(params, keepStack = T is DebugCallResult)
 
-  c.execCallOrCreate(params)
-  c.postExecComputation()
+  c.preExecComputation(params)
+  if c.isSuccess:
+    c.execCallOrCreate()
+    c.postExecComputation()
+  else:
+    # execCallOrCreate normally disposes the computation, dispose here too
+    # otherwise the EVM stack leaks.
+    c.dispose()
 
   finishRunningComputation(c, params, T)

--- a/execution_chain/transaction/system_call.nim
+++ b/execution_chain/transaction/system_call.nim
@@ -32,7 +32,6 @@ proc setupComputation(params: CallParams): Computation =
       sender:            params.sender,
       value:             params.value,
       data:              params.input,
-      flags:            {MsgFlags.SystemCall},
     )
     code = vmState.ledger.getCode(msg.codeAddress)
     computation = newComputation(vmState, false, msg, code)
@@ -95,7 +94,7 @@ proc systemCall*(params: CallParams, T: type): T =
   # Pre-execution sanity checks
   c.preExecComputation()
   if c.isSuccess:
-    c.execCallOrCreate(params)
+    c.execCallOrCreate()
     ledger.persist(clearEmptyAccount = true)
   else:
     # execCallOrCreate normally disposes the computation, dispose here too

--- a/execution_chain/transaction/system_call.nim
+++ b/execution_chain/transaction/system_call.nim
@@ -32,6 +32,7 @@ proc setupComputation(params: CallParams): Computation =
       sender:            params.sender,
       value:             params.value,
       data:              params.input,
+      flags:            {MsgFlags.SystemCall},
     )
     code = vmState.ledger.getCode(msg.codeAddress)
     computation = newComputation(vmState, false, msg, code)


### PR DESCRIPTION
This is a follow up after #4550.
`topFrameAuthDelegation` should only be called by message call/create and not by system call.
Check for `MsgFlags.SystemCall` not needed in `beforeExecCreate` because a system call top frame only call `beforeExecCall`.