### PR TITLE
Optimize the KZG point evaluation precompile - WIP

### DIFF
--- a/execution_chain/core/eip4844.nim
+++ b/execution_chain/core/eip4844.nim
@@ -11,15 +11,21 @@
 {.push raises: [], gcsafe.}
 
 import
+  std/importutils,
   stew/arrayops,
   nimcrypto/sha2,
   results,
   stint,
-  kzg4844/kzg,
   ./eip7691,
   ./pooled_txs,
   ../constants,
-  ../common/common
+  ../common/common,
+  ../evm/blscurve
+
+# Imported with {.all.} to reach gCtx and lazyLoadTrustedSetup, both private
+# upstream, so that the precompile reads [tau]G2 from the same loaded setup
+# c-kzg uses rather than loading or parsing one of its own.
+import kzg4844/kzg {.all.}
 
 from std/sequtils import mapIt
 
@@ -48,9 +54,54 @@ proc kzgToVersionedHash*(commitment: array[48, byte]): VersionedHash =
   result = sha256.digest(commitment).to(Hash32)
   result.data[0] = VERSIONED_HASH_VERSION_KZG
 
+type
+  # A view over the parts of c-kzg's KZGSettings this module reads. The full
+  # struct is declared in the header, so only the fields used need naming here.
+  KzgSettingsView {.importc: "KZGSettings", header: "ckzg.h".} = object
+    g2_values_monomial {.importc.}: ptr UncheckedArray[BLS_G2]
+
+proc loadLines(Q: BLS_G2P): BLS_LINES =
+  result.precomputeLines(Q)
+
+let
+  GeneratorG2Lines = loadLines(generatorG2())
+  GeneratorG1Table = initFixedBase(generatorG1())
+
+var
+  SetupG2TauLines: BLS_LINES
+  SetupG2TauLoaded = false
+
+# kzgSetupG2Tau returns g2_values_monomial[1], the [tau]G2 that c-kzg's
+# verify_kzg_proof_impl pairs the proof against, taken from whichever trusted
+# setup is loaded. The setup is loaded on demand exactly as verifyKzgProof does.
+proc kzgSetupG2Tau(): Result[BLS_G2P, string] =
+  privateAccess(KzgCtx)
+
+  if not gCtx.initialized:
+    ?lazyLoadTrustedSetup()
+
+  let settings = cast[ptr KzgSettingsView](gCtx.settings)
+  if settings.isNil or settings.g2_values_monomial.isNil:
+    return err(TrustedSetupNotLoadedErr)
+
+  var tau {.noinit.}: BLS_G2P
+  tau.toAffine(settings.g2_values_monomial[1])
+  ok(tau)
+
+proc ensureSetupG2TauLines(): Result[void, string] =
+  if not SetupG2TauLoaded:
+    SetupG2TauLines = loadLines(?kzgSetupG2Tau())
+    SetupG2TauLoaded = true
+  ok()
+
 # pointEvaluation implements point_evaluation_precompile from EIP-4844
 # return value and gas consumption is handled by pointEvaluation in
 # precompiles.nim
+#
+# The pairing check is the spec's
+#   e(C - [y]G1, G2) == e(proof, [tau]G2 - [z]G2)
+# with z moved across by bilinearity into the equivalent
+#   e(C - [y]G1 + [z]proof, G2) == e(proof, [tau]G2)
 proc pointEvaluation*(input: openArray[byte]): Result[void, string] =
   # Verify p(z) = y given commitment that corresponds to the polynomial p(x) and a KZG proof.
   # Also verify that the provided commitment matches the provided versioned_hash.
@@ -59,27 +110,55 @@ proc pointEvaluation*(input: openArray[byte]): Result[void, string] =
   if input.len != PrecompileInputLength:
     return err("invalid input length")
 
-  template copyFrom(T: type, input, a, b): auto =
-    type X = (type T().bytes)
-    T(bytes: X.initCopyFrom(input.toOpenArray(a, b)))
+  ?ensureSetupG2TauLines()
 
   let
-    versionedHash = KzgBytes32.copyFrom(input, 0, 31)
-    z =  KzgBytes32.copyFrom(input, 32, 63)
-    y =  KzgBytes32.copyFrom(input, 64, 95)
-    commitment =  KzgBytes48.copyFrom(input, 96, 143)
-    kzgProof =  KzgBytes48.copyFrom(input, 144, 191)
+    versionedHash = array[32, byte].initCopyFrom(input.toOpenArray(0, 31))
+    commitmentBytes = array[48, byte].initCopyFrom(input.toOpenArray(96, 143))
 
-  if kzgToVersionedHash(commitment.bytes).data != versionedHash.bytes:
+  if kzgToVersionedHash(commitmentBytes).data != versionedHash:
     return err("versionedHash should equal to kzgToVersionedHash(commitment)")
 
-  # Verify KZG proof
-  let res = kzg.verifyKzgProof(commitment, z, y, kzgProof)
-  if res.isErr:
-    return err(res.error)
+  var commitment, proof: BLS_G1P
+  if not commitment.uncompress(input.toOpenArray(96, 143)):
+    return err("invalid commitment")
 
-  # The actual verify result
-  if not res.get():
+  if not proof.uncompress(input.toOpenArray(144, 191)):
+    return err("invalid proof")
+
+  if not commitment.isInf and not commitment.subgroupCheck:
+    return err("commitment is not in G1")
+
+  if not proof.isInf and not proof.subgroupCheck:
+    return err("proof is not in G1")
+
+  var z, y: BLS_SCALAR
+  if not z.fromBytesCanonical(input.toOpenArray(32, 63)):
+    return err("invalid z")
+
+  if not y.fromBytesCanonical(input.toOpenArray(64, 95)):
+    return err("invalid y")
+
+  var yG1 = GeneratorG1Table.mul(y)
+  yG1.neg()
+
+  var zProof: BLS_G1
+  zProof.fromAffine(proof)
+  zProof.mul(z)
+
+  var lhs: BLS_G1
+  lhs.fromAffine(commitment)
+  lhs.add(yG1)
+  lhs.add(zProof)
+  lhs.neg()
+
+  var lhsAffine: BLS_G1P
+  lhsAffine.toAffine(lhs)
+
+  var acc = millerLoop(lhsAffine, GeneratorG2Lines)
+  acc.mul(millerLoop(proof, SetupG2TauLines))
+
+  if not acc.check():
     return err("Failed to verify KZG proof")
 
   ok()

--- a/execution_chain/evm/blscurve.nim
+++ b/execution_chain/evm/blscurve.nim
@@ -12,6 +12,12 @@ import blscurve/bls_backend, stint
 
 import blscurve/blst/[blst_lowlevel]
 
+const
+  FixedBasePoints = 8
+  FixedBaseWBits = 8
+  FixedBaseNBits = 256 div FixedBasePoints
+  FixedBaseTableLen = FixedBasePoints shl (FixedBaseWBits - 1)
+
 type
   BLS_G1* = blst_p1
   BLS_G2* = blst_p2
@@ -21,6 +27,10 @@ type
   BLS_ACC* = blst_fp12
   BLS_G1P* = blst_p1_affine
   BLS_G2P* = blst_p2_affine
+  BLS_LINES* = array[68, cblst_fp6]
+
+  BLS_G1_TABLE* = object
+    table: array[FixedBaseTableLen, BLS_G1P]
 
 template toCV(x: auto): auto =
   when x is BLS_G1:
@@ -75,6 +85,14 @@ func fromBytes*(ret: var BLS_SCALAR, raw: openArray[byte]): bool =
   discard blst_scalar_from_be_bytes(toCV(ret), raw.toOpenArray(0, L-1))
   true
 
+func fromBytesCanonical*(ret: var BLS_SCALAR, raw: openArray[byte]): bool =
+  const L = 32
+  if raw.len != L:
+    return false
+  let pa = cast[ptr array[L, byte]](raw[0].unsafeAddr)
+  blst_scalar_from_bendian(toCV(ret), pa[])
+  blst_scalar_fr_check(toCV(ret)).int == 1
+
 func fromBytes(ret: var BLS_FP, raw: openArray[byte]): bool =
   const L = 48
   if raw.len < L:
@@ -119,17 +137,74 @@ func add*(a: var BLS_G2, b: BLS_G2) {.inline.} =
 func mul*(a: var BLS_G2, b: BLS_SCALAR) {.inline.} =
   blst_p2_mult(toCV(a), toCV(a), b.b[0].unsafeAddr, b.nbits)
 
+func double*(a: var BLS_G1) {.inline.} =
+  blst_p1_double(toCV(a), toCV(a))
+
+func neg*(a: var BLS_G1) {.inline.} =
+  blst_p1_cneg(toCV(a), true)
+
 func fromAffine*(a: var BLS_G1, b: BLS_G1P) {.inline.} =
   blst_p1_from_affine(toCV(a), toCC(b))
 
 func fromAffine*(a: var BLS_G2, b: BLS_G2P) {.inline.} =
   blst_p2_from_affine(toCV(a), toCC(b))
 
+func toAffine*(a: var BLS_G1P, b: BLS_G1) {.inline.} =
+  blst_p1_to_affine(toCV(a), toCC(b))
+
+func toAffine*(a: var BLS_G2P, b: BLS_G2) {.inline.} =
+  blst_p2_to_affine(toCV(a), toCC(b))
+
+func generatorG1*(): BLS_G1P {.inline.} =
+  cast[ptr BLS_G1P](blst_p1_affine_generator())[]
+
+func generatorG2*(): BLS_G2P {.inline.} =
+  cast[ptr BLS_G2P](blst_p2_affine_generator())[]
+
+func uncompress*(g: var BLS_G1P, data: openArray[byte]): bool =
+  const L = 48
+  if data.len != L:
+    return false
+  let pa = cast[ptr array[L, byte]](data[0].unsafeAddr)
+  blst_p1_uncompress(toCV(g), pa[]) == BLST_SUCCESS
+
+func uncompress*(g: var BLS_G2P, data: openArray[byte]): bool =
+  const L = 96
+  if data.len != L:
+    return false
+  let pa = cast[ptr array[L, byte]](data[0].unsafeAddr)
+  blst_p2_uncompress(toCV(g), pa[]) == BLST_SUCCESS
+
 const
   MSMScalarBits = 256
 
 func scratchLen(numBytes: uint): int {.inline.} =
   (numBytes.int + sizeof(limb_t) - 1) div sizeof(limb_t)
+
+func initFixedBase*(g: BLS_G1P): BLS_G1_TABLE =
+  doAssert blst_p1s_mult_wbits_precompute_sizeof(
+    FixedBaseWBits, FixedBasePoints).int == sizeof(result.table)
+
+  var
+    points {.noinit.}: array[FixedBasePoints, BLS_G1P]
+    acc {.noinit.}: BLS_G1
+  acc.fromAffine(g)
+
+  for i in 0 ..< FixedBasePoints:
+    points[i].toAffine(acc)
+    for _ in 0 ..< FixedBaseNBits:
+      acc.double()
+
+  let p = [toCC(points[0], cblst_p1_affine), nil]
+  blst_p1s_mult_wbits_precompute(toCV(result.table[0], cblst_p1_affine),
+    FixedBaseWBits, p[0].unsafeAddr, FixedBasePoints)
+
+func mul*(t: BLS_G1_TABLE, s: BLS_SCALAR): BLS_G1 =
+  var scratch {.noinit.}: array[FixedBasePoints, BLS_G1]
+  let sc = [toCC(s, byte), nil]
+  blst_p1s_mult_wbits(toCV(result, cblst_p1),
+    toCC(t.table[0], cblst_p1_affine), FixedBaseWBits, FixedBasePoints,
+    sc[0].unsafeAddr, FixedBaseNBits, toCV(scratch[0], limb_t))
 
 func multiExp*(acc: var BLS_G1, points: openArray[BLS_G1P],
                scalars: openArray[BLS_SCALAR]) =
@@ -179,6 +254,12 @@ func isInf*(P: BLS_G2P): bool {.inline.} =
 
 func millerLoop*(P: BLS_G1P, Q: BLS_G2P): BLS_ACC {.inline.} =
   blst_miller_loop(toCV(result), toCC(Q), toCC(P))
+
+func precomputeLines*(lines: var BLS_LINES, Q: BLS_G2P) {.inline.} =
+  blst_precompute_lines(lines, toCC(Q))
+
+func millerLoop*(P: BLS_G1P, lines: BLS_LINES): BLS_ACC {.inline.} =
+  blst_miller_loop_lines(toCV(result), lines, toCC(P))
 
 proc mul*(a: var BLS_ACC, b: BLS_ACC) {.inline.} =
   blst_fp12_mul(toCV(a), toCC(a), toCC(b))

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -27,7 +27,6 @@ import
     test_aristo_subtries_json,
     test_jwt_auth,
     test_kvt,
-    test_kzg_point_eval,
     test_ledger,
     test_stateroot_mismatch,
     test_op_arith,

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -27,6 +27,7 @@ import
     test_aristo_subtries_json,
     test_jwt_auth,
     test_kvt,
+    test_kzg_point_eval,
     test_ledger,
     test_stateroot_mismatch,
     test_op_arith,

--- a/tests/bench_kzg_point_eval.nim
+++ b/tests/bench_kzg_point_eval.nim
@@ -1,0 +1,213 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# Compares the KZG point evaluation precompile against the c-kzg backed
+# implementation it replaced, and isolates the contribution of each step:
+#
+#   opt1  move z from G2 to G1 in the pairing equation
+#   opt2  precomputed miller loop lines for the two constant G2 operands
+#   opt3  fixed base comb table for [y]G1
+#
+# Run with: ./env.sh nim c -r -d:release tests/bench_kzg_point_eval.nim
+
+import
+  std/[times, monotimes, strutils],
+  stew/arrayops,
+  results,
+  eth/common/hashes,
+  kzg4844/kzg,
+  kzg4844/kzg_abi,
+  ../execution_chain/core/eip4844 {.all.},
+  ../execution_chain/evm/blscurve
+
+proc loadLines(Q: BLS_G2P): BLS_LINES =
+  result.precomputeLines(Q)
+
+# the staged variants below need [tau]G2 too; take it from the same place the
+# precompile does rather than restating it
+proc setupTauG2(): BLS_G2P =
+  loadTrustedSetupFromString(kzg.trustedSetup, 8).expect("trusted setup")
+  kzgSetupG2Tau().expect("tau G2 from the loaded setup")
+
+let
+  tauG2 = setupTauG2()
+  genG2 = generatorG2()
+  genG1 = generatorG1()
+  tauLines = loadLines(tauG2)
+  genLines = loadLines(genG2)
+  genTable = initFixedBase(genG1)
+
+# The implementation on master, verbatim apart from being inlined here.
+proc masterPointEvaluation(input: openArray[byte]): Result[void, string] =
+  if input.len != 192:
+    return err("invalid input length")
+
+  template copyFrom(T: type, input, a, b): auto =
+    type X = (type T().bytes)
+    T(bytes: X.initCopyFrom(input.toOpenArray(a, b)))
+
+  let
+    versionedHash = KzgBytes32.copyFrom(input, 0, 31)
+    z = KzgBytes32.copyFrom(input, 32, 63)
+    y = KzgBytes32.copyFrom(input, 64, 95)
+    commitment = KzgBytes48.copyFrom(input, 96, 143)
+    kzgProof = KzgBytes48.copyFrom(input, 144, 191)
+
+  if kzgToVersionedHash(commitment.bytes).data != versionedHash.bytes:
+    return err("versionedHash should equal to kzgToVersionedHash(commitment)")
+
+  let res = kzg.verifyKzgProof(commitment, z, y, kzgProof)
+  if res.isErr:
+    return err(res.error)
+  if not res.get():
+    return err("Failed to verify KZG proof")
+  ok()
+
+proc staged(input: openArray[byte],
+            useLines: static bool, useComb: static bool): bool =
+  if input.len != 192:
+    return false
+
+  let
+    versionedHash = array[32, byte].initCopyFrom(input.toOpenArray(0, 31))
+    commitmentBytes = array[48, byte].initCopyFrom(input.toOpenArray(96, 143))
+  if kzgToVersionedHash(commitmentBytes).data != versionedHash:
+    return false
+
+  var commitment, proof: BLS_G1P
+  if not commitment.uncompress(input.toOpenArray(96, 143)):
+    return false
+  if not proof.uncompress(input.toOpenArray(144, 191)):
+    return false
+  if not commitment.isInf and not commitment.subgroupCheck:
+    return false
+  if not proof.isInf and not proof.subgroupCheck:
+    return false
+
+  var z, y: BLS_SCALAR
+  if not z.fromBytesCanonical(input.toOpenArray(32, 63)):
+    return false
+  if not y.fromBytesCanonical(input.toOpenArray(64, 95)):
+    return false
+
+  var yG1: BLS_G1
+  when useComb:
+    yG1 = genTable.mul(y)
+  else:
+    yG1.fromAffine(genG1)
+    yG1.mul(y)
+  yG1.neg()
+
+  var zProof: BLS_G1
+  zProof.fromAffine(proof)
+  zProof.mul(z)
+
+  var lhs: BLS_G1
+  lhs.fromAffine(commitment)
+  lhs.add(yG1)
+  lhs.add(zProof)
+  lhs.neg()
+
+  var lhsAffine: BLS_G1P
+  lhsAffine.toAffine(lhs)
+
+  var acc: BLS_ACC
+  when useLines:
+    acc = millerLoop(lhsAffine, genLines)
+    acc.mul(millerLoop(proof, tauLines))
+  else:
+    acc = millerLoop(lhsAffine, genG2)
+    acc.mul(millerLoop(proof, tauG2))
+
+  acc.check()
+
+proc makeBlob(seed: int): KzgBlob =
+  for i in 0 ..< FIELD_ELEMENTS_PER_BLOB:
+    let v = (i * 2654435761 + seed) and 0xffffff
+    result.bytes[i * 32 + 31] = byte(v and 0xff)
+    result.bytes[i * 32 + 30] = byte((v shr 8) and 0xff)
+    result.bytes[i * 32 + 29] = byte((v shr 16) and 0xff)
+
+proc makeInput(seed: int): seq[byte] =
+  let
+    blob = makeBlob(seed)
+    commitment = blobToKzgCommitment(blob).expect("commitment")
+  var z: KzgBytes32
+  z.bytes[31] = byte(seed and 0xff)
+  z.bytes[30] = byte((seed shr 8) and 0xff)
+  let
+    proofAndY = computeKzgProof(blob, z).expect("proof")
+    versionedHash = kzgToVersionedHash(commitment.bytes)
+  result = newSeq[byte](192)
+  result[0 .. 31] = versionedHash.data
+  result[32 .. 63] = z.bytes
+  result[64 .. 95] = proofAndY.y.bytes
+  result[96 .. 143] = commitment.bytes
+  result[144 .. 191] = proofAndY.proof.bytes
+
+proc report(name: string, perOp: float, baseline: float) =
+  var line = alignLeft(name, 30) & align(formatFloat(perOp, ffDecimal, 4), 8) &
+    " ms/op"
+  if baseline > 0.0:
+    line.add "   " & align(formatFloat(100.0 * (1.0 - perOp / baseline),
+      ffDecimal, 1), 5) & "% vs master"
+  echo line
+
+proc main() =
+  var inputs: seq[seq[byte]]
+  for s in 1 .. 8:
+    inputs.add makeInput(s)
+
+  for input in inputs:
+    doAssert masterPointEvaluation(input).isOk
+    doAssert pointEvaluation(input).isOk
+    doAssert staged(input, false, false)
+    doAssert staged(input, true, false)
+    doAssert staged(input, false, true)
+    doAssert staged(input, true, true)
+
+  var bad = inputs[0]
+  bad[95] = bad[95] xor 1
+  doAssert masterPointEvaluation(bad).isErr
+  doAssert pointEvaluation(bad).isErr
+  echo "all variants agree with the master implementation"
+  echo ""
+
+  const
+    warmup = 200
+    iters = 2000
+
+  for i in 0 ..< warmup:
+    doAssert masterPointEvaluation(inputs[i mod inputs.len]).isOk
+    doAssert pointEvaluation(inputs[i mod inputs.len]).isOk
+
+  template run(body: untyped): float =
+    block:
+      let start = getMonoTime()
+      for i {.inject.} in 0 ..< iters:
+        body
+      (getMonoTime() - start).inNanoseconds.float / 1e6 / iters.float
+
+  let master = run:
+    doAssert masterPointEvaluation(inputs[i mod inputs.len]).isOk
+  report("master (c-kzg)", master, 0.0)
+
+  report("opt1", run((doAssert staged(inputs[i mod inputs.len], false, false))),
+    master)
+  report("opt1 + opt2", run((
+    doAssert staged(inputs[i mod inputs.len], true, false))), master)
+  report("opt1 + opt3", run((
+    doAssert staged(inputs[i mod inputs.len], false, true))), master)
+
+  let current = run:
+    doAssert pointEvaluation(inputs[i mod inputs.len]).isOk
+  report("opt1 + opt2 + opt3 (this)", current, master)
+
+main()

--- a/tests/test_kzg_point_eval.nim
+++ b/tests/test_kzg_point_eval.nim
@@ -1,0 +1,206 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+import
+  std/strutils,
+  unittest2,
+  stew/[arrayops, byteutils],
+  results,
+  eth/common/hashes,
+  kzg4844/kzg,
+  kzg4844/kzg_abi,
+  ../execution_chain/core/eip4844 {.all.},
+  ../execution_chain/evm/blscurve
+
+proc referencePointEvaluation(input: openArray[byte]): Result[void, string] =
+  if input.len != 192:
+    return err("invalid input length")
+
+  template copyFrom(T: type, input, a, b): auto =
+    type X = (type T().bytes)
+    T(bytes: X.initCopyFrom(input.toOpenArray(a, b)))
+
+  let
+    versionedHash = KzgBytes32.copyFrom(input, 0, 31)
+    z = KzgBytes32.copyFrom(input, 32, 63)
+    y = KzgBytes32.copyFrom(input, 64, 95)
+    commitment = KzgBytes48.copyFrom(input, 96, 143)
+    kzgProof = KzgBytes48.copyFrom(input, 144, 191)
+
+  if kzgToVersionedHash(commitment.bytes).data != versionedHash.bytes:
+    return err("versionedHash should equal to kzgToVersionedHash(commitment)")
+
+  let res = kzg.verifyKzgProof(commitment, z, y, kzgProof)
+  if res.isErr:
+    return err(res.error)
+
+  if not res.get():
+    return err("Failed to verify KZG proof")
+
+  ok()
+
+proc makeBlob(seed: int): KzgBlob =
+  for i in 0 ..< FIELD_ELEMENTS_PER_BLOB:
+    let v = (i * 2654435761 + seed) and 0xffffff
+    result.bytes[i * 32 + 31] = byte(v and 0xff)
+    result.bytes[i * 32 + 30] = byte((v shr 8) and 0xff)
+    result.bytes[i * 32 + 29] = byte((v shr 16) and 0xff)
+
+proc makeInput(seed: int): seq[byte] =
+  let
+    blob = makeBlob(seed)
+    commitment = blobToKzgCommitment(blob).expect("commitment")
+
+  var z: KzgBytes32
+  z.bytes[31] = byte(seed and 0xff)
+  z.bytes[30] = byte((seed shr 8) and 0xff)
+
+  let
+    proofAndY = computeKzgProof(blob, z).expect("proof")
+    versionedHash = kzgToVersionedHash(commitment.bytes)
+
+  result = newSeq[byte](192)
+  result[0 .. 31] = versionedHash.data
+  result[32 .. 63] = z.bytes
+  result[64 .. 95] = proofAndY.y.bytes
+  result[96 .. 143] = commitment.bytes
+  result[144 .. 191] = proofAndY.proof.bytes
+
+proc withCommitment(input: seq[byte], commitment: openArray[byte]): seq[byte] =
+  result = input
+  result[96 .. 143] = commitment
+  let versionedHash = kzgToVersionedHash(
+    array[48, byte].initCopyFrom(commitment))
+  result[0 .. 31] = versionedHash.data
+
+proc toBytes(p: BLS_G2P): seq[byte] =
+  var g {.noinit.}: BLS_G2
+  g.fromAffine(p)
+  result = newSeq[byte](256)
+  doAssert encodePoint(g, result)
+
+proc checkAgreement(input: seq[byte]) =
+  let
+    expected = referencePointEvaluation(input)
+    actual = pointEvaluation(input)
+  check expected.isOk == actual.isOk
+
+suite "KZG point evaluation precompile":
+  loadTrustedSetupFromString(kzg.trustedSetup, 8).expect("trusted setup")
+
+  const
+    infinityG1 = "c0" & repeat("00", 47)
+    notInG1 = "8123456789abcdef" & repeat("0123456789abcdef", 5)
+    blsModulus =
+      "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
+
+  let inputs = block:
+    var res: seq[seq[byte]]
+    for seed in 1 .. 4:
+      res.add makeInput(seed)
+    res
+
+  test "tau G2 comes from the loaded trusted setup":
+    # the known EIP-4844 ceremony value, as an independent check on what the
+    # library hands back
+    const knownTauG2 =
+      "b5bfd7dd8cdeb128843bc287230af38926187075cbfbefa81009a2ce615ac53d" &
+      "2914e5870cb452d2afaaab24f3499f72185cbfee53492714734429b7b38608e2" &
+      "3926c911cceceac9a36851477ba4c60b087041de621000edc98edada20c1def2"
+
+    var expected {.noinit.}: BLS_G2P
+    check expected.uncompress(hexToByteArray[96](knownTauG2))
+
+    let tau = kzgSetupG2Tau()
+    check tau.isOk
+    check tau.get().toBytes == expected.toBytes
+
+  test "valid proofs are accepted":
+    for input in inputs:
+      check pointEvaluation(input).isOk
+      checkAgreement(input)
+
+  test "tampered fields are rejected":
+    for offset in [0, 32, 64, 96, 144]:
+      var input = inputs[0]
+      input[offset + 31] = input[offset + 31] xor 1
+      check pointEvaluation(input).isErr
+      checkAgreement(input)
+
+  test "mismatched versioned hash is rejected":
+    var input = inputs[0]
+    input[0 .. 31] = inputs[1][0 .. 31]
+    check pointEvaluation(input).isErr
+    checkAgreement(input)
+
+  test "invalid input lengths are rejected":
+    for len in [0, 191, 193]:
+      var input = inputs[0]
+      input.setLen(len)
+      check pointEvaluation(input).isErr
+      checkAgreement(input)
+
+  test "non canonical z and y are rejected":
+    let overModulus = [blsModulus, repeat("ff", 32)]
+    for offset in [32, 64]:
+      for value in overModulus:
+        var input = inputs[0]
+        input[offset ..< offset + 32] = value.hexToSeqByte()
+        check pointEvaluation(input).isErr
+        checkAgreement(input)
+
+  test "commitment and proof outside G1 are rejected":
+    var input = withCommitment(inputs[0], notInG1.hexToSeqByte())
+    check pointEvaluation(input).isErr
+    checkAgreement(input)
+
+    input = inputs[0]
+    input[144 .. 191] = notInG1.hexToSeqByte()
+    check pointEvaluation(input).isErr
+    checkAgreement(input)
+
+  test "the point at infinity is handled like c-kzg":
+    var input = withCommitment(inputs[0], infinityG1.hexToSeqByte())
+    checkAgreement(input)
+
+    input = inputs[0]
+    input[144 .. 191] = infinityG1.hexToSeqByte()
+    checkAgreement(input)
+
+    input = withCommitment(inputs[0], infinityG1.hexToSeqByte())
+    input[144 .. 191] = infinityG1.hexToSeqByte()
+    checkAgreement(input)
+
+  test "a zero z and y are handled like c-kzg":
+    var input = inputs[0]
+    input[32 .. 95] = newSeq[byte](64)
+    checkAgreement(input)
+
+  test "proof of a zero polynomial verifies":
+    let
+      blob = default(KzgBlob)
+      commitment = blobToKzgCommitment(blob).expect("commitment")
+
+    var z: KzgBytes32
+    z.bytes[31] = 3
+
+    let
+      proofAndY = computeKzgProof(blob, z).expect("proof")
+      versionedHash = kzgToVersionedHash(commitment.bytes)
+
+    var input = newSeq[byte](192)
+    input[0 .. 31] = versionedHash.data
+    input[32 .. 63] = z.bytes
+    input[64 .. 95] = proofAndY.y.bytes
+    input[96 .. 143] = commitment.bytes
+    input[144 .. 191] = proofAndY.proof.bytes
+
+    check pointEvaluation(input).isOk
+    checkAgreement(input)


### PR DESCRIPTION
This improves the performance of the point evaluation precompile by:
- Rearranging the pairing equation to remove expensive G2 scalar multiplication.
- Precompute Miller-loop lines

The improvement is not that much and it requires accessing the trusted setup which is not yet exported by the nim kzg library. If going ahead with this the optimization it should perhaps be upstreamed into the nim and/or c kzg library.

**Before**
<img width="956" height="697" alt="Screenshot_2026-07-24_01-08-07" src="https://github.com/user-attachments/assets/eefd1895-d7a8-4901-a65b-143c246f51dc" />

**After**
<img width="918" height="693" alt="Screenshot_2026-07-24_01-09-00" src="https://github.com/user-attachments/assets/f6b75227-41de-423b-8ce4-529d669b0da2" />
