### PR TITLE
Fix receipt status for txs failing in preExecComputation

### DIFF
--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -341,10 +341,15 @@ proc runComputation*(params: CallParams, T: type): T =
   c.preExecComputation(params)
   if c.isSuccess:
     c.execCallOrCreate()
-    c.postExecComputation()
   else:
     # execCallOrCreate normally disposes the computation, dispose here too
     # otherwise the EVM stack leaks.
     c.dispose()
+  # postExecComputation must also run when preExecComputation fails:
+  # it records the outcome in vmState.status, which the receipt reads.
+  # Skipping it leaves the previous transaction's status in place and
+  # a top-frame failure would be receipted as successful, diverging on
+  # receiptsRoot.
+  c.postExecComputation()
 
   finishRunningComputation(c, params, T)


### PR DESCRIPTION
## Problem

Since 1f8dd21 (#4552), `runComputation` skips `postExecComputation` when a transaction fails during `preExecComputation` (top-frame auth/delegation OOG, create nonce/deployable failure):

```nim
c.preExecComputation(params)
if c.isSuccess:
  c.execCallOrCreate()
  c.postExecComputation()
else:
  c.dispose()          # <-- postExecComputation never runs
```

`postExecComputation` is the only writer of `vmState.status`, which `makeReceipt` reads. A transaction that fails at the top frame therefore gets a receipt carrying the **previous** transaction's status. In any block where a top-frame-failing tx follows a successful tx, the failed tx is receipted `status=1` and the computed `receiptsRoot` diverges — nimbus rejects **valid** blocks with `receiptRoot mismatch`. Everything else still matches (stateRoot, BAL hash, logsBloom, header gasUsed), because the status byte is receipt-only and top-frame failures emit no logs.

## Impact on glamsterdam-devnet-7

Within minutes of the `1f8dd21` image rollout (05:30 UTC 2026-07-24), every upgraded nimbus-el node began rejecting blocks; among them **canonical, finalized** block 61754 (`0xecbd618c…`), whose txs 22 and 29 are CREATEs that OOG on the top-frame account-creation state charge (EIP-8037) right after successful txs. Reconstructing that block's receipts trie and flipping exactly those two status bytes to `1` reproduces nimbus's computed root `0x22f0346a…` bit-for-bit (two independent nodes logged the identical wrong root). All four nimbus-el pairings on the devnet fell off the canonical chain ("links to previously rejected block" cascade); recovery requires this fix — resync deterministically re-rejects.

The parallel path (`process_block_parallel.nim`) is unaffected: each worker starts from a fresh `vmState`, so the stale value happens to be `false`.

## Fix

Always run `postExecComputation` so the outcome is recorded in `vmState.status` regardless of where the failure happened. When `preExecComputation` failed, `c.isSuccess` is false, so the only effect is `vmState.status = false` (the pre-London selfdestruct-refund branch is not taken).

## Verification

New EEST test (multi-tx block `[success, top-frame OOG, success]`, parametrized over the three top-frame charge classes — create NEW_ACCOUNT state gas, value-to-empty NEW_ACCOUNT state gas, delegated-recipient COLD_ACCOUNT_ACCESS regular gas), proposed to execution-specs `devnets/glamsterdam/7`:

| client | result |
|---|---|
| `ethpandaops/nimbus-eth1:glamsterdam-devnet-7` (= `1f8dd21`) | 3/3 **FAILED** — `newPayload` INVALID, client log `Error importing block … error="receiptRoot mismatch"` |
| same + this fix | 3/3 passed |
| geth `glamsterdam-devnet-7` head (`5749cbce`, control) | 3/3 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpkqKnXjpdXGJ4ChNGsxEY