### PR TITLE
optimize bls12 pairing check

### DIFF
--- a/execution_chain/evm/blscurve.nim
+++ b/execution_chain/evm/blscurve.nim
@@ -180,6 +180,29 @@ func isInf*(P: BLS_G2P): bool {.inline.} =
 func millerLoop*(P: BLS_G1P, Q: BLS_G2P): BLS_ACC {.inline.} =
   blst_miller_loop(toCV(result), toCC(Q), toCC(P))
 
+func millerLoopN*(acc: var BLS_ACC, Ps: openArray[BLS_G1P],
+                  Qs: openArray[BLS_G2P]) =
+  ## Miller loop over all (Pᵢ, Qᵢ) pairs at once, accumulating into `acc`.
+  ##
+  ## The pairs are processed interleaved, so the loop's Fp12 squarings and line
+  ## accumulation are shared across pairs rather than repeated per pair. blst
+  ## chunks the batch at MILLER_LOOP_N_MAX (16) internally and multiplies the
+  ## partial results together, so the whole batch can be passed in one call.
+  ##
+  ## Neither point of any pair may be the point at infinity. Unlike
+  ## `blst_miller_loop`, `blst_miller_loop_n` has no infinity special case and
+  ## would feed the identity straight into the line functions — callers must
+  ## filter those pairs out first (they pair to 1 and contribute nothing).
+  doAssert Ps.len == Qs.len and Ps.len > 0
+
+  # A nil second element tells blst the first pointer is a contiguous array,
+  # the same convention `blst_pXs_mult_pippenger` uses above.
+  let
+    p = [toCC(Ps[0], cblst_p1_affine), nil]
+    q = [toCC(Qs[0], cblst_p2_affine), nil]
+
+  blst_miller_loop_n(toCV(acc), q[0].unsafeAddr, p[0].unsafeAddr, Ps.len.uint)
+
 proc mul*(a: var BLS_ACC, b: BLS_ACC) {.inline.} =
   blst_fp12_mul(toCV(a), toCC(a), toCC(b))
 

--- a/execution_chain/evm/blscurve.nim
+++ b/execution_chain/evm/blscurve.nim
@@ -182,21 +182,15 @@ func millerLoop*(P: BLS_G1P, Q: BLS_G2P): BLS_ACC {.inline.} =
 
 func millerLoopN*(acc: var BLS_ACC, Ps: openArray[BLS_G1P],
                   Qs: openArray[BLS_G2P]) =
-  ## Miller loop over all (Pᵢ, Qᵢ) pairs at once, accumulating into `acc`.
+  ## Miller loop over all (Pᵢ, Qᵢ) pairs at once, sharing the Fp12 squarings
+  ## and line accumulation. blst chunks at 16 internally, so pass the lot.
   ##
-  ## The pairs are processed interleaved, so the loop's Fp12 squarings and line
-  ## accumulation are shared across pairs rather than repeated per pair. blst
-  ## chunks the batch at MILLER_LOOP_N_MAX (16) internally and multiplies the
-  ## partial results together, so the whole batch can be passed in one call.
-  ##
-  ## Neither point of any pair may be the point at infinity. Unlike
-  ## `blst_miller_loop`, `blst_miller_loop_n` has no infinity special case and
-  ## would feed the identity straight into the line functions — callers must
-  ## filter those pairs out first (they pair to 1 and contribute nothing).
+  ## WARNING: no point may be infinity. `blst_miller_loop_n` has no infinity
+  ## case (unlike `blst_miller_loop`) and would feed it to the line functions.
+  ## Callers must filter those pairs first.
   doAssert Ps.len == Qs.len and Ps.len > 0
 
-  # A nil second element tells blst the first pointer is a contiguous array,
-  # the same convention `blst_pXs_mult_pippenger` uses above.
+  # nil 2nd element = "first pointer is a contiguous array", as in pippenger.
   let
     p = [toCC(Ps[0], cblst_p1_affine), nil]
     q = [toCC(Qs[0], cblst_p2_affine), nil]

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -616,13 +616,17 @@ func blsPairing(c: Computation): EvmResultVoid =
   ? c.gasMeter.consumeGas(gas, reason="blsG2Pairing Precompile")
 
   var
-    g1 {.noinit.}: BLS_G1P
-    g2 {.noinit.}: BLS_G2P
-    acc {.noinit.}: BLS_ACC
+    g1s = newSeqUninit[BLS_G1P](K)
+    g2s = newSeqUninit[BLS_G2P](K)
+    n = 0
 
   # Decode pairs
   for i in 0..<K:
     let off = L * i
+
+    var
+      g1 {.noinit.}: BLS_G1P
+      g2 {.noinit.}: BLS_G2P
 
     # Decode G1 point
     if not g1.decodePoint(input.toOpenArray(off, off+127)):
@@ -640,13 +644,31 @@ func blsPairing(c: Computation): EvmResultVoid =
     if not g2.subgroupCheck:
       return err(prcErr(PrcInvalidPoint))
 
-    # Update pairing engine with G1 and G2 points
-    if i == 0:
-      acc = millerLoop(g1, g2)
-    else:
-      acc.mul(millerLoop(g1, g2))
+    # A pair involving the point at infinity pairs to 1, so it contributes
+    # nothing to the product. It has to be dropped rather than passed along:
+    # the batched Miller loop has no infinity special case, unlike the
+    # per-pair `millerLoop` this used to call.
+    if g1.isInf or g2.isInf:
+      continue
+
+    g1s[n] = g1
+    g2s[n] = g2
+    inc n
 
   c.output.setLen(32)
+
+  if n == 0:
+    # Every pair involved the point at infinity, so the product is 1.
+    c.output[^1] = 1.byte
+    return ok()
+
+  # Run all the Miller loops as one batch so the loop's Fp12 squarings and line
+  # accumulation are shared across pairs, instead of one full Miller loop per
+  # pair multiplied together afterwards. The final exponentiation was already
+  # shared - `check()` performs it once on the accumulated product.
+  var acc {.noinit.}: BLS_ACC
+  acc.millerLoopN(g1s.toOpenArray(0, n-1), g2s.toOpenArray(0, n-1))
+
   if acc.check():
     c.output[^1] = 1.byte
   ok()

--- a/execution_chain/evm/precompiles.nim
+++ b/execution_chain/evm/precompiles.nim
@@ -644,10 +644,8 @@ func blsPairing(c: Computation): EvmResultVoid =
     if not g2.subgroupCheck:
       return err(prcErr(PrcInvalidPoint))
 
-    # A pair involving the point at infinity pairs to 1, so it contributes
-    # nothing to the product. It has to be dropped rather than passed along:
-    # the batched Miller loop has no infinity special case, unlike the
-    # per-pair `millerLoop` this used to call.
+    # Infinity pairs to 1, so it drops out of the product. Must be filtered:
+    # millerLoopN has no infinity case. See its doc comment.
     if g1.isInf or g2.isInf:
       continue
 
@@ -658,14 +656,12 @@ func blsPairing(c: Computation): EvmResultVoid =
   c.output.setLen(32)
 
   if n == 0:
-    # Every pair involved the point at infinity, so the product is 1.
+    # All pairs were infinity, so the product is 1.
     c.output[^1] = 1.byte
     return ok()
 
-  # Run all the Miller loops as one batch so the loop's Fp12 squarings and line
-  # accumulation are shared across pairs, instead of one full Miller loop per
-  # pair multiplied together afterwards. The final exponentiation was already
-  # shared - `check()` performs it once on the accumulated product.
+  # One batched Miller loop, not K separate ones multiplied together.
+  # `check()` does the single final exponentiation, as before.
   var acc {.noinit.}: BLS_ACC
   acc.millerLoopN(g1s.toOpenArray(0, n-1), g2s.toOpenArray(0, n-1))
 


### PR DESCRIPTION
run one batched Miller loop instead of K separate ones multiplied together