### PR TITLE
fix: wrong block labelling as Orphaned

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -772,6 +772,16 @@ proc importBlock*(
     parentHash = header.parentHash.short
 
   if header.number <= c.latest.number:
+    # The parent is gone, but this block may itself be the canonical block at
+    # this height that was already imported and then pruned from memory once it
+    # fell at/below `base` (finality cut off its parent). This happens when a
+    # concurrent importer such as `el_sync` advances and finalizes the chain past
+    # a stale sync target. Tell that apart from a genuine dead fork via the
+    # persisted canonical marker (reorg-safe: matched by hash, not by number).
+    if header.number <= c.base.number and
+       c.baseTxFrame.getBlockHash(header.number).valueOr(default(Hash32)) == blkHash:
+      return ok(AlreadyObserved)
+
     # The in-memory chain already spans this height yet the parent is gone: the
     # parent's branch was pruned (finality cut it off), so this block is on a
     # dead fork. `c.latest` is the reliable frontier here - `c.latestFinalized`

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -387,6 +387,36 @@ suite "ForkedChainRef tests":
     checkVerdictErr(chain, B5, ImportErrorKind.Orphaned)
     check chain.validate info
 
+  test "reorg: canonical block pruned below base is AlreadyObserved":
+    const info = "reorg below-base AlreadyObserved"
+    let com = env.newCom()
+    let chain = ForkedChainRef.init(com, baseDistance = 3, persistBatchSize = 1)
+    checkVerdict(chain, blk1, ImportOutcome.Valid)
+    checkVerdict(chain, blk2, ImportOutcome.Valid)
+    checkVerdict(chain, blk3, ImportOutcome.Valid)
+    checkVerdict(chain, blk4, ImportOutcome.Valid)
+    checkVerdict(chain, blk5, ImportOutcome.Valid)
+    checkVerdict(chain, blk6, ImportOutcome.Valid)
+    checkVerdict(chain, blk7, ImportOutcome.Valid)
+    checkVerdict(chain, blk8, ImportOutcome.Valid)
+    checkVerdict(chain, blk9, ImportOutcome.Valid)
+    # Finalize blk8: `base` advances and blocks below it are pruned from memory.
+    # This emulates a concurrent importer (e.g. `el_sync`) finalizing the chain
+    # past a stale sync target.
+    checkForkChoice(chain, blk9, blk8)
+    check chain.baseNumber == 6'u64
+    # blk4/blk5 are canonical but no longer in memory (their parent was pruned by
+    # finality). Re-importing them must not be mistaken for a dead fork: the FC
+    # matches the persisted canonical marker and reports `AlreadyObserved`, so an
+    # importer/syncer recognises the block as done rather than `Orphaned`.
+    check blk5.header.number <= chain.baseNumber
+    checkVerdict(chain, blk4, ImportOutcome.AlreadyObserved)
+    checkVerdict(chain, blk5, ImportOutcome.AlreadyObserved)
+    # A sibling (non-canonical) block below base still hashes differently from the
+    # marker, so it is correctly rejected as Orphaned.
+    checkVerdictErr(chain, B5, ImportErrorKind.Orphaned)
+    check chain.validate info
+
   test "reorg: full branch switch keeps pre-reorg blocks observable":
     const info = "reorg full switch"
     let com = env.newCom()


### PR DESCRIPTION
When blocks below the base are sent to the FC importer, they get marked as orphaned
This fixes it, and correctly label's it as AlreadySeen