### PR TITLE
Encode the eth ENR entry as an RLP list

### DIFF
--- a/execution_chain/networking/eth1_discovery.nim
+++ b/execution_chain/networking/eth1_discovery.nim
@@ -24,7 +24,8 @@ import
 export
   discoveryv4.NodeId,
   discoveryv4.Node,
-  discoveryv4.ENode
+  discoveryv4.ENode,
+  discoveryv5.Record
 
 logScope:
   topics = "p2p"
@@ -228,20 +229,23 @@ proc getRandomBootnode*(proto: Eth1Discovery): Opt[NodeV4] =
           return Opt.none(NodeV4)
       return Opt.some(newNode(enode))
 
-func getEnr*(proto: Eth1Discovery): Opt[string] =
-  ## Get the ENR URI string of the local node from DiscoveryV5.
+func getEnr*(proto: Eth1Discovery): Opt[discoveryv5.Record] =
+  ## Get the ENR of the local node from DiscoveryV5.
+  # Note: `Record` is qualified as `chronicles` also exports a `Record` symbol.
   if proto.discv5.isNil.not:
-    return Opt.some(proto.discv5.getRecord().toURI())
-  Opt.none(string)
+    return Opt.some(proto.discv5.getRecord())
+  Opt.none(discoveryv5.Record)
+
+func getEnrUri*(proto: Eth1Discovery): Opt[string] =
+  ## Get the ENR URI string of the local node from DiscoveryV5.
+  let record = proto.getEnr().valueOr:
+    return Opt.none(string)
+  Opt.some(record.toURI())
 
 func updateForkId*(proto: Eth1Discovery, forkId: ForkId) =
   # https://github.com/ethereum/devp2p/blob/bc76b9809a30e6dc5c8dcda996273f0f9bcf7108/enr-entries/eth.md
   if proto.discv5.isNil.not:
-    let
-      list = [forkId]
-      bytes = rlp.encode(list)
-      kv = ("eth", bytes)
-    proto.discv5.updateRecord([kv]).isOkOr:
+    proto.discv5.updateRecord(enrFields({"eth": [forkId]})).isOkOr:
       return
 
 proc closeWait*(proto: Eth1Discovery) {.async: (raises: []).} =

--- a/execution_chain/rpc/common.nim
+++ b/execution_chain/rpc/common.nim
@@ -87,7 +87,7 @@ proc setupAdminRpc*(nimbus: NimbusNode, config: ExecutionClientConf, server: Rpc
       let
         enode = toENode(node)
         nodeId = toNodeId(node.keys.pubkey)
-        enr = node.peerPool.eth1Discovery.getEnr()
+        enr = node.peerPool.eth1Discovery.getEnrUri()
         nodeInfo = NodeInfo(
           id: nodeId.toHex,
           name: config.agentString,

--- a/tests/networking/test_eth1_discovery.nim
+++ b/tests/networking/test_eth1_discovery.nim
@@ -1,0 +1,63 @@
+# nimbus-execution-client
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.used.}
+
+import
+  std/net,
+  results,
+  stew/byteutils,
+  testutils/unittests,
+  eth/common/base,
+  eth/common/base_rlp,
+  eth/common/keys,
+  eth/enr/enr,
+  ./stubloglevel,
+  ../../execution_chain/networking/eth1_discovery,
+  ../../execution_chain/networking/bootnodes
+
+suite "Eth1 discovery ENR":
+  let privKey = PrivateKey.fromHex(
+    "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a617")[]
+
+  proc newDiscovery(): Eth1Discovery =
+    Eth1Discovery.new(
+      privKey = privKey,
+      enrIp = Opt.some(parseIpAddress("127.0.0.1")),
+      enrTcpPort = Opt.some(Port(30303)),
+      enrUdpPort = Opt.some(Port(30303)),
+      bootstrapNodes = BootstrapNodes(),
+      bindPort = Port(30303))
+
+  test "updateForkId encodes `eth` entry as an RLP list":
+    let
+      disc = newDiscovery()
+      forkId = ForkId(hash: [0xf5'u8, 0x7a, 0xab, 0xec].to(Bytes4), next: 0'u64)
+
+    disc.updateForkId(forkId)
+
+    let
+      record = disc.getEnr().get()
+      ethRaw = record.rawFieldValue("eth").get()
+
+    check ethRaw == hexToSeqByte("c7c684f57aabec80")
+
+  test "`eth` entry round-trips back to the fork id":
+    let
+      disc = newDiscovery()
+      forkId = ForkId(hash: [0x01'u8, 0x02, 0x03, 0x04].to(Bytes4), next: 42'u64)
+
+    disc.updateForkId(forkId)
+
+    let
+      record = disc.getEnr().get()
+      ethBytes = record.get("eth", seq[byte]).value()
+      decoded = rlp.decode(ethBytes, array[1, ForkId])
+
+    check decoded[0] == forkId

--- a/tests/test_networking.nim
+++ b/tests/test_networking.nim
@@ -11,6 +11,7 @@ import
   ./networking/test_auth,
   ./networking/test_crypt,
   ./networking/test_discoveryv4,
+  ./networking/test_eth1_discovery,
   ./networking/test_ecies,
   ./networking/test_bootnodes,
   ./networking/test_rlpx_thunk,


### PR DESCRIPTION
Use enrFields so the fork id list is stored as an RLP list instead of a byte string. Also split `getEnr` from `getEnrUri`. Fixes #4546.