### PR TITLE
use stable nimbus-eth2 image for kurtosis again

### DIFF
--- a/kurtosis-network-params.yml
+++ b/kurtosis-network-params.yml
@@ -13,7 +13,7 @@ participants:
     el_image: <docker-image-placeholder>
     el_extra_params: ["--log-level=DEBUG"]
     cl_type: nimbus
-    cl_image: ethpandaops/nimbus-eth2:unstable-3d22b12
+    cl_image: statusim/nimbus-eth2:multiarch-latest
     cl_extra_params: ["--log-level=DEBUG"]
     use_separate_vc: false
 additional_services:


### PR DESCRIPTION
Effectively revert
- #4462

since the stable/released `nimbus-eth2` supports the newer Kurtosis configuration again.