### PR TITLE
Add engine_newPayloadWithWitnessV4 and V5

### DIFF
--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -223,7 +223,7 @@ proc newPayload*(ben: BeaconEngineRef,
       number = header.number, hash = blockHash.short
     return
       if withWitness:
-        validStatus(blockHash, ben.collectWitness(blockHash))
+        validStatus(blockHash, ben.collectWitness(blk))
       else:
         validStatus(blockHash)
 
@@ -303,6 +303,6 @@ proc newPayload*(ben: BeaconEngineRef,
 
   return
     if withWitness:
-      validStatus(blockHash, ben.collectWitness(blockHash))
+      validStatus(blockHash, ben.collectWitness(blk))
     else:
       validStatus(blockHash)

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -18,7 +18,8 @@ import
   ../web3_eth_conv,
   ../beacon_engine,
   ../payload_conv,
-  ./api_utils
+  ./api_utils,
+  ./api_witness
 
 {.push gcsafe, raises:[].}
 
@@ -152,7 +153,8 @@ proc newPayload*(ben: BeaconEngineRef,
                  payload: ExecutionPayload,
                  versionedHashes = Opt.none(seq[Hash32]),
                  beaconRoot = Opt.none(Hash32),
-                 executionRequests = Opt.none(seq[seq[byte]])):
+                 executionRequests = Opt.none(seq[seq[byte]]),
+                 withWitness = false):
                    Future[PayloadStatusV1] {.async: (raises: [CancelledError, ApplicationError, RlpError]).} =
 
   trace "Engine API request received",
@@ -219,7 +221,11 @@ proc newPayload*(ben: BeaconEngineRef,
   if chain.haveBlockAndState(blockHash):
     debug "Ignoring already known beacon payload",
       number = header.number, hash = blockHash.short
-    return validStatus(blockHash)
+    return
+      if withWitness:
+        validStatus(blockHash, ben.collectWitness(blockHash))
+      else:
+        validStatus(blockHash)
 
   # If this block was rejected previously, keep rejecting it
   let res = ben.checkInvalidAncestor(blockHash, blockHash)
@@ -295,4 +301,8 @@ proc newPayload*(ben: BeaconEngineRef,
     gasUsed = header.gasUsed,
     blobGas = header.blobGasUsed.get(0'u64)
 
-  return validStatus(blockHash)
+  return
+    if withWitness:
+      validStatus(blockHash, ben.collectWitness(blockHash))
+    else:
+      validStatus(blockHash)

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -276,7 +276,7 @@ proc newPayload*(ben: BeaconEngineRef,
       number = header.number, hash = blockHash.short
     return
       if withWitness:
-        validStatus(blockHash, ben.collectWitness(blockHash))
+        validStatus(blockHash, ben.collectWitness(blk))
       else:
         validStatus(blockHash)
 
@@ -358,6 +358,6 @@ proc newPayload*(ben: BeaconEngineRef,
 
   return
     if withWitness:
-      validStatus(blockHash, ben.collectWitness(blockHash))
+      validStatus(blockHash, ben.collectWitness(blk))
     else:
       validStatus(blockHash)

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -18,7 +18,8 @@ import
   ../web3_eth_conv,
   ../beacon_engine,
   ../payload_conv,
-  ./api_utils
+  ./api_utils,
+  ./api_witness
 
 {.push gcsafe, raises:[].}
 
@@ -202,7 +203,8 @@ proc newPayload*(ben: BeaconEngineRef,
                  payload: ExecutionPayload,
                  versionedHashes = Opt.none(seq[Hash32]),
                  beaconRoot = Opt.none(Hash32),
-                 executionRequests = Opt.none(seq[seq[byte]])):
+                 executionRequests = Opt.none(seq[seq[byte]]),
+                 withWitness = false):
                    Future[PayloadStatusV1] {.async: (raises: [CancelledError, RpcResponseError, RlpError]).} =
 
   trace "Engine API request received",
@@ -272,7 +274,11 @@ proc newPayload*(ben: BeaconEngineRef,
   if chain.haveBlockAndState(blockHash):
     debug "Ignoring already known beacon payload",
       number = header.number, hash = blockHash.short
-    return validStatus(blockHash)
+    return
+      if withWitness:
+        validStatus(blockHash, ben.collectWitness(blockHash))
+      else:
+        validStatus(blockHash)
 
   # If this block was rejected previously, keep rejecting it
   block:
@@ -350,4 +356,8 @@ proc newPayload*(ben: BeaconEngineRef,
     gasUsed = header.gasUsed,
     blobGas = header.blobGasUsed.get(0'u64)
 
-  return validStatus(blockHash)
+  return
+    if withWitness:
+      validStatus(blockHash, ben.collectWitness(blockHash))
+    else:
+      validStatus(blockHash)

--- a/execution_chain/beacon/api_handler/api_utils.nim
+++ b/execution_chain/beacon/api_handler/api_utils.nim
@@ -141,6 +141,13 @@ func validStatus*(validHash: common.Hash32): PayloadStatusV1 =
     latestValidHash: toValidHash(validHash)
   )
 
+func validStatus*(validHash: common.Hash32, witness: Opt[seq[byte]]): PayloadStatusV1 =
+  PayloadStatusV1(
+    status: PayloadExecutionStatus.valid,
+    latestValidHash: toValidHash(validHash),
+    witness: witness,
+  )
+
 func invalidParams*(msg: string): ref ApplicationError =
   (ref ApplicationError)(
     code: engineApiInvalidParams,

--- a/execution_chain/beacon/api_handler/api_utils.nim
+++ b/execution_chain/beacon/api_handler/api_utils.nim
@@ -144,6 +144,13 @@ func validStatus*(validHash: common.Hash32): PayloadStatusV1 =
     latestValidHash: toValidHash(validHash)
   )
 
+func validStatus*(validHash: common.Hash32, witness: Opt[seq[byte]]): PayloadStatusV1 =
+  PayloadStatusV1(
+    status: PayloadExecutionStatus.valid,
+    latestValidHash: toValidHash(validHash),
+    witness: witness,
+  )
+
 func invalidParams*(msg: string): ref RpcResponseError =
   (ref RpcResponseError)(
     code: engineApiInvalidParams,

--- a/execution_chain/beacon/api_handler/api_witness.nim
+++ b/execution_chain/beacon/api_handler/api_witness.nim
@@ -1,0 +1,62 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+# Support for the engine_newPayloadWithWitness* methods. These are not (yet)
+# part of the Engine API spec.
+
+{.push gcsafe, raises: [].}
+
+import results, chronicles, eth/common, eth/rlp, ../beacon_engine
+
+from ../../stateless/witness_generation import ExecutionWitnessWithKeys
+from ../../utils/utils import short
+
+logScope:
+  topics = "beacon engine"
+
+type
+  # Current execution witness wire shape, returned by the engine_newPayloadWithWitness*
+  # methods as an RLP blob. The field order (headers, codes, state, keys)
+  # is significant and must match go-ethereum / ethrex:
+  # https://github.com/ethereum/go-ethereum/blob/master/core/stateless/encoding.go
+  # This is currently not specced out in the Engine API.
+  # Note that it is different from debug_executionWitness encoding.
+  ExtWitness = object
+    headers: seq[Header]
+    codes: seq[seq[byte]]
+    state: seq[seq[byte]]
+    keys: seq[seq[byte]]
+
+func encodeExtWitness(w: ExecutionWitnessWithKeys): Result[seq[byte], string] =
+  ## RLP-encode the witness into geth's execution witness wire format.
+  var headers: seq[Header]
+  for encodedHeader in w.headers:
+    let header =
+      try:
+        rlp.decode(encodedHeader, Header)
+      except RlpError as e:
+        return err("Failed to decode witness header: " & e.msg)
+    headers.add(header)
+
+  ok(
+    rlp.encode(ExtWitness(headers: headers, codes: w.codes, state: w.state, keys: @[]))
+  )
+
+proc collectWitness*(ben: BeaconEngineRef, blockHash: Hash32): Opt[seq[byte]] =
+  ## Return the RLP-encoded witness for `blockHash`, or none if unavailable
+  let witness = ben.chain.getExecutionWitness(blockHash).valueOr:
+    warn "Execution witness not available, is --stateless-provider enabled?",
+      hash = blockHash.short, error = error
+    return Opt.none(seq[byte])
+
+  let encoded = encodeExtWitness(witness).valueOr:
+    warn "Failed to encode execution witness", hash = blockHash.short, error = error
+    return Opt.none(seq[byte])
+
+  Opt.some(encoded)

--- a/execution_chain/beacon/api_handler/api_witness.nim
+++ b/execution_chain/beacon/api_handler/api_witness.nim
@@ -48,14 +48,24 @@ func encodeExtWitness(w: ExecutionWitnessWithKeys): Result[seq[byte], string] =
     rlp.encode(ExtWitness(headers: headers, codes: w.codes, state: w.state, keys: @[]))
   )
 
-proc collectWitness*(ben: BeaconEngineRef, blockHash: Hash32): Opt[seq[byte]] =
-  ## Return the RLP-encoded witness for `blockHash`, or none if unavailable
-  let witness = ben.chain.getExecutionWitness(blockHash).valueOr:
-    warn "Execution witness not available, is --stateless-provider enabled?",
-      hash = blockHash.short, error = error
+proc collectWitness*(ben: BeaconEngineRef, blk: Block): Opt[seq[byte]] =
+  ## Return the RLP-encoded execution witness for `blk`, or none if unavailable.
+  ## When the node runs with `--stateless-provider` the witness stored during
+  ## import is used else it is generated on demand by re-executing the block
+  ## against its parent state.
+  let blockHash = blk.header.computeBlockHash()
+
+  let witness =
+    if ben.chain.com.statelessProvider:
+      ben.chain.getExecutionWitness(blockHash)
+    else:
+      ben.chain.generateExecutionWitness(blk)
+
+  let w = witness.valueOr:
+    warn "Execution witness not available", hash = blockHash.short, error = error
     return Opt.none(seq[byte])
 
-  let encoded = encodeExtWitness(witness).valueOr:
+  let encoded = encodeExtWitness(w).valueOr:
     warn "Failed to encode execution witness", hash = blockHash.short, error = error
     return Opt.none(seq[byte])
 

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -20,6 +20,7 @@ import
   ../../evm/types,
   ../../evm/state,
   ../validate,
+  ../executor/process_block,
   ../../portal/portal,
   ../../stateless/witness_generation,
   ./forked_chain/[
@@ -1371,5 +1372,42 @@ proc getExecutionWitness*(
 
   let witness = txFrame.getWitness(blockHash).valueOr:
     return err("Witness not found")
+
+  ok(ExecutionWitnessWithKeys.build(witness, txFrame))
+
+proc generateExecutionWitness*(
+    c: ForkedChainRef, blk: Block
+): Result[ExecutionWitnessWithKeys, string] =
+  ## Build the execution witness for `blk` on demand by re-executing it against
+  ## its parent state, without requiring `--stateless-provider` and without
+  ## persisting anything. Works for a freshly imported or already known block as
+  ## long as the parent state is available, else the state root check errors.
+  template header(): Header = blk.header
+
+  let parentHeader = ?c.headerByHash(header.parentHash)
+
+  # Execute on a throwaway frame so the shared parent state is never modified.
+  let
+    parentFrame = c.txFrame(header.parentHash)
+    txFrame = parentFrame.txFrameBegin()
+  defer:
+    txFrame.dispose()
+
+  let vmState = BaseVMState()
+  vmState.init(parentHeader, header, c.com, txFrame, collectWitness = true)
+
+  # No block access list keeps execution sequential (parallel skips witness keys).
+  ?vmState.processBlock(
+    blk,
+    blockAccessList = Opt.none(BlockAccessListRef),
+    skipValidation = true,
+    skipReceipts = true,
+    skipUncles = true,
+    skipStateRootCheck = false,
+    skipPostExecBalCheck = true)
+
+  let
+    preStateLedger = LedgerRef.init(parentFrame)
+    witness = Witness.build(preStateLedger, vmState.ledger, parentHeader, header)
 
   ok(ExecutionWitnessWithKeys.build(witness, txFrame))

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -21,6 +21,7 @@ import
   ../../evm/state,
   ../validate,
   ../../portal/portal,
+  ../../stateless/witness_generation,
   ./forked_chain/[
     chain_desc,
     chain_branch,
@@ -1359,3 +1360,16 @@ proc getBlockAccessList*(c: ForkedChainRef, blockHash: Hash32): Opt[BlockAccessL
     return Opt.none(BlockAccessList)
 
   bal.map(proc (v: auto): auto = v[])
+
+proc getExecutionWitness*(
+    c: ForkedChainRef, blockHash: Hash32
+): Result[ExecutionWitnessWithKeys, string] =
+  ## Return the execution witness created when importing the given block
+  let txFrame = c.txFrame(blockHash).txFrameBegin()
+  defer:
+    txFrame.dispose()
+
+  let witness = txFrame.getWitness(blockHash).valueOr:
+    return err("Witness not found")
+
+  ok(ExecutionWitnessWithKeys.build(witness, txFrame))

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -20,6 +20,7 @@ import
   ../../evm/types,
   ../../evm/state,
   ../validate,
+  ../executor/process_block,
   ../../portal/portal,
   ../../stateless/witness_generation,
   ./forked_chain/[
@@ -1389,5 +1390,42 @@ proc getExecutionWitness*(
 
   let witness = txFrame.getWitness(blockHash).valueOr:
     return err("Witness not found")
+
+  ok(ExecutionWitnessWithKeys.build(witness, txFrame))
+
+proc generateExecutionWitness*(
+    c: ForkedChainRef, blk: Block
+): Result[ExecutionWitnessWithKeys, string] =
+  ## Build the execution witness for `blk` on demand by re-executing it against
+  ## its parent state, without requiring `--stateless-provider` and without
+  ## persisting anything. Works for a freshly imported or already known block as
+  ## long as the parent state is available, else the state root check errors.
+  template header(): Header = blk.header
+
+  let parentHeader = ?c.headerByHash(header.parentHash)
+
+  # Execute on a throwaway frame so the shared parent state is never modified.
+  let
+    parentFrame = c.txFrame(header.parentHash)
+    txFrame = parentFrame.txFrameBegin()
+  defer:
+    txFrame.dispose()
+
+  let vmState = BaseVMState()
+  vmState.init(parentHeader, header, c.com, txFrame, collectWitness = true)
+
+  # No block access list keeps execution sequential (parallel skips witness keys).
+  ?vmState.processBlock(
+    blk,
+    blockAccessList = Opt.none(BlockAccessListRef),
+    skipValidation = true,
+    skipReceipts = true,
+    skipUncles = true,
+    skipStateRootCheck = false,
+    skipPostExecBalCheck = true)
+
+  let
+    preStateLedger = LedgerRef.init(parentFrame)
+    witness = Witness.build(preStateLedger, vmState.ledger, parentHeader, header)
 
   ok(ExecutionWitnessWithKeys.build(witness, txFrame))

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -21,6 +21,7 @@ import
   ../../evm/state,
   ../validate,
   ../../portal/portal,
+  ../../stateless/witness_generation,
   ./forked_chain/[
     chain_desc,
     chain_branch,
@@ -1377,3 +1378,16 @@ proc getBlockAccessList*(c: ForkedChainRef, blockHash: Hash32): Opt[BlockAccessL
     return Opt.none(BlockAccessList)
 
   bal.map(proc (v: auto): auto = v[])
+
+proc getExecutionWitness*(
+    c: ForkedChainRef, blockHash: Hash32
+): Result[ExecutionWitnessWithKeys, string] =
+  ## Return the execution witness created when importing the given block
+  let txFrame = c.txFrame(blockHash).txFrameBegin()
+  defer:
+    txFrame.dispose()
+
+  let witness = txFrame.getWitness(blockHash).valueOr:
+    return err("Witness not found")
+
+  ok(ExecutionWitnessWithKeys.build(witness, txFrame))

--- a/execution_chain/evm/state.nim
+++ b/execution_chain/evm/state.nim
@@ -207,7 +207,8 @@ proc init*(
       tracer: TracerRef = nil,
       storeSlotHash = false,
       enableBalTracker = false,
-      stateless = false) =
+      stateless = false,
+      collectWitness = com.statelessProvider) =
 
   ## Variant of `new()` constructor above for in-place initalisation. The
   ## `parent` argument is used to sync the accounts cache and the `header`
@@ -216,9 +217,11 @@ proc init*(
   ##
   ## It requires the `header` argument properly initalised so that for PoA
   ## networks, the miner address is retrievable via `ecRecover()`.
+  ## `collectWitness` defaults to the global `--stateless-provider` setting but
+  ## can be forced on to build a witness for a single block on demand.
   let
     ledger = LedgerRef.init(
-      txFrame, storeSlotHash, com.statelessProvider, stateless)
+      txFrame, storeSlotHash, collectWitness, stateless)
     tracker =
       if enableBalTracker:
         BlockAccessListTrackerRef.init(ledger.ReadOnlyLedger)

--- a/execution_chain/rpc/debug.nim
+++ b/execution_chain/rpc/debug.nim
@@ -63,16 +63,6 @@ ExecutionWitnessWithKeys.useDefaultSerializationIn EthJson
 #     if opts.disableState.isTrue  : result.incl TracerFlags.DisableState
 #     if opts.disableStateDiff.isTrue: result.incl TracerFlags.DisableStateDiff
 
-proc getExecutionWitness*(chain: ForkedChainRef, blockHash: Hash32): Result[ExecutionWitnessWithKeys, string] =
-  let txFrame = chain.txFrame(blockHash).txFrameBegin()
-  defer:
-    txFrame.dispose()
-
-  let witness = txFrame.getWitness(blockHash).valueOr:
-    return err("Witness not found")
-
-  ok(ExecutionWitnessWithKeys.build(witness, txFrame))
-
 proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
   let
     # chainDB = com.db

--- a/execution_chain/rpc/engine_api.nim
+++ b/execution_chain/rpc/engine_api.nim
@@ -45,6 +45,8 @@ const supportedMethods: HashSet[string] =
     "engine_newPayloadV3",
     "engine_newPayloadV4",
     "engine_newPayloadV5",
+    "engine_newPayloadWithWitnessV4",
+    "engine_newPayloadWithWitnessV5",
     "engine_getPayloadV1",
     "engine_getPayloadV2",
     "engine_getPayloadV3",
@@ -57,7 +59,7 @@ const supportedMethods: HashSet[string] =
     "engine_forkchoiceUpdatedV4",
     "engine_getPayloadBodiesByHashV1",
     "engine_getPayloadBodiesByHashV2",
-    "engine_getPayloadBodiesByRangeV1",    
+    "engine_getPayloadBodiesByRangeV1",
     "engine_getPayloadBodiesByRangeV2",
     "engine_getClientVersionV1",
     "engine_getBlobsV1",
@@ -103,6 +105,38 @@ proc setupEngineAPI*(engine: BeaconEngineRef, server: RpcServer) =
       apiTiming("engine_newPayloadV5"):
         await engine.newPayload(Version.V5, payload,
           expectedBlobVersionedHashes, parentBeaconBlockRoot, executionRequests)
+
+    proc engine_newPayloadWithWitnessV4(
+        payload: ExecutionPayload,
+        expectedBlobVersionedHashes: Opt[seq[Hash32]],
+        parentBeaconBlockRoot: Opt[Hash32],
+        executionRequests: Opt[seq[seq[byte]]],
+    ): PayloadStatusV1 {.async: (raises: [CancelledError, ApplicationError, RlpError]).} =
+      apiTiming("engine_newPayloadWithWitnessV4"):
+        await engine.newPayload(
+          Version.V4,
+          payload,
+          expectedBlobVersionedHashes,
+          parentBeaconBlockRoot,
+          executionRequests,
+          withWitness = true,
+        )
+
+    proc engine_newPayloadWithWitnessV5(
+        payload: ExecutionPayload,
+        expectedBlobVersionedHashes: Opt[seq[Hash32]],
+        parentBeaconBlockRoot: Opt[Hash32],
+        executionRequests: Opt[seq[seq[byte]]],
+    ): PayloadStatusV1 {.async: (raises: [CancelledError, ApplicationError, RlpError]).} =
+      apiTiming("engine_newPayloadWithWitnessV5"):
+        await engine.newPayload(
+          Version.V5,
+          payload,
+          expectedBlobVersionedHashes,
+          parentBeaconBlockRoot,
+          executionRequests,
+          withWitness = true,
+        )
 
     proc engine_getPayloadV1(payloadId: Bytes8): ExecutionPayloadV1 {.raises: [CatchableError].} =
       apiTiming("engine_getPayloadV1"):

--- a/execution_chain/rpc/engine_api.nim
+++ b/execution_chain/rpc/engine_api.nim
@@ -45,6 +45,8 @@ const supportedMethods: HashSet[string] =
     "engine_newPayloadV3",
     "engine_newPayloadV4",
     "engine_newPayloadV5",
+    "engine_newPayloadWithWitnessV4",
+    "engine_newPayloadWithWitnessV5",
     "engine_getPayloadV1",
     "engine_getPayloadV2",
     "engine_getPayloadV3",
@@ -104,6 +106,38 @@ proc setupEngineAPI*(engine: BeaconEngineRef, server: RpcServer) =
       apiTiming("engine_newPayloadV5"):
         await engine.newPayload(Version.V5, payload,
           expectedBlobVersionedHashes, parentBeaconBlockRoot, executionRequests)
+
+    proc engine_newPayloadWithWitnessV4(
+        payload: ExecutionPayload,
+        expectedBlobVersionedHashes: Opt[seq[Hash32]],
+        parentBeaconBlockRoot: Opt[Hash32],
+        executionRequests: Opt[seq[seq[byte]]],
+    ): PayloadStatusV1 {.async: (raises: [CancelledError, RpcResponseError, RlpError]).} =
+      apiTiming("engine_newPayloadWithWitnessV4"):
+        await engine.newPayload(
+          Version.V4,
+          payload,
+          expectedBlobVersionedHashes,
+          parentBeaconBlockRoot,
+          executionRequests,
+          withWitness = true,
+        )
+
+    proc engine_newPayloadWithWitnessV5(
+        payload: ExecutionPayload,
+        expectedBlobVersionedHashes: Opt[seq[Hash32]],
+        parentBeaconBlockRoot: Opt[Hash32],
+        executionRequests: Opt[seq[seq[byte]]],
+    ): PayloadStatusV1 {.async: (raises: [CancelledError, RpcResponseError, RlpError]).} =
+      apiTiming("engine_newPayloadWithWitnessV5"):
+        await engine.newPayload(
+          Version.V5,
+          payload,
+          expectedBlobVersionedHashes,
+          parentBeaconBlockRoot,
+          executionRequests,
+          withWitness = true,
+        )
 
     proc engine_getPayloadV1(payloadId: Bytes8): ExecutionPayloadV1 {.raises: [CatchableError].} =
       apiTiming("engine_getPayloadV1"):

--- a/tests/eest/eest_blockchain.nim
+++ b/tests/eest/eest_blockchain.nim
@@ -34,8 +34,6 @@ import
   ./eest_helpers,
   ./bal_parser
 
-from ../../execution_chain/rpc/debug import getExecutionWitness
-
 proc fromJson(T: type ExecutionWitness, n: JsonNode): ExecutionWitness =
   var res: ExecutionWitness
   for item in n["state"]:

--- a/tests/test_stateless/test_stateless_execution.nim
+++ b/tests/test_stateless/test_stateless_execution.nim
@@ -22,7 +22,6 @@ import
   ../../execution_chain/db/core_db/memory_only,
   ../../execution_chain/db/ledger,
   ../../execution_chain/history/db/ere_db,
-  ../../execution_chain/rpc/debug,
   ../../execution_chain/stateless/[stateless_execution, stateless_execution_helpers]
 
 const


### PR DESCRIPTION
Implement the newPayloadWithWitness methods, returning the execution witness (geth/ethrex ExtWitness RLP) on PayloadStatusV1. Not yet part of the Engine API spec.

Requires --stateless-provider to produce a witness. Might have to adjust this to be turned on just for the call in the future.