### PR TITLE
Dispose vmState instances after use

### DIFF
--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -87,9 +87,10 @@ proc getVmState(
   ok(p.vmState)
 
 proc dispose*(p: var Persister) =
-  p.vmState.ledger.txFrame.dispose()
-  p.vmState.dispose()
-  p.vmState = nil
+  if not p.vmState.isNil():
+    p.vmState.ledger.txFrame.dispose()
+    p.vmState.dispose()
+    p.vmState = nil
 
 func init*(T: type Persister, com: CommonRef, flags: PersistBlockFlags): T =
   T(com: com, flags: flags)

--- a/execution_chain/core/executor/process_block_parallel.nim
+++ b/execution_chain/core/executor/process_block_parallel.nim
@@ -98,6 +98,7 @@ proc recoverAndPrefetchTask*(
   let vmState = BaseVMState()
   vmState.com.borrowRef(ctx[].com)
   defer:
+    vmState.dispose()
     vmState.com.unborrowRef()
   vmState.ledger = ledger
   assign(vmState.parent, ctx[].parent)
@@ -376,6 +377,7 @@ proc processTxTask(
   let vmState = BaseVMState()
   vmState.com.borrowRef(ctx[].com)
   defer:
+    vmState.dispose()
     vmState.com.unborrowRef()
   vmState.ledger = ledger
   assign(vmState.parent, ctx[].parent)

--- a/execution_chain/evm/async_evm.nim
+++ b/execution_chain/evm/async_evm.nim
@@ -334,10 +334,12 @@ proc call*(
   defer:
     txFrame.dispose() # always dispose state changes
 
-  let
-    vmState = evm.setupVmState(txFrame, header)
-    callResult =
-      ?(await evm.callFetchingState(vmState, header, tx, optimisticStateFetch))
+  let vmState = evm.setupVmState(txFrame, header)
+  defer:
+    vmState.dispose()
+
+  let callResult =
+    ?(await evm.callFetchingState(vmState, header, tx, optimisticStateFetch))
 
   ok(callResult)
 
@@ -352,8 +354,11 @@ proc createAccessList*(
   defer:
     txFrame.dispose() # always dispose state changes
 
+  let vmState = evm.setupVmState(txFrame, header)
+  defer:
+    vmState.dispose()
+
   let
-    vmState = evm.setupVmState(txFrame, header)
     _ =
       ?(await evm.callFetchingState(vmState, header, tx, optimisticStateFetch))
     witnessKeys = vmState.ledger.getWitnessKeys()
@@ -413,10 +418,12 @@ proc estimateGas*(
   defer:
     txFrame.dispose() # always dispose state changes
 
-  let
-    vmState = evm.setupVmState(txFrame, header)
-    callResult =
-      ?(await evm.callFetchingState(vmState, header, tx, optimisticStateFetch))
+  let vmState = evm.setupVmState(txFrame, header)
+  defer:
+    vmState.dispose()
+
+  let callResult =
+    ?(await evm.callFetchingState(vmState, header, tx, optimisticStateFetch))
   # we only invoke callFetchingState in order to collect the state in the BaseVMState
   discard callResult
 

--- a/execution_chain/nimbus_import.nim
+++ b/execution_chain/nimbus_import.nim
@@ -136,6 +136,7 @@ proc importBlocks*(config: ExecutionClientConf, com: CommonRef, params: NetworkP
     cstats: PersistStats # stats at start of chunk
 
   defer:
+    persister.dispose()
     if csv != nil:
       close(csv)
 

--- a/execution_chain/rpc/rpc_utils.nim
+++ b/execution_chain/rpc/rpc_utils.nim
@@ -296,6 +296,9 @@ proc createAccessList*(header: Header,
               else: generateAddress(sender, nonce)
     precompiles = activePrecompilesList(fork)
 
+  defer:
+    vmState.dispose()
+
   var
     prevTracer = AccessListTracer.new(
       args.accessList.get(@[]),
@@ -317,9 +320,11 @@ proc createAccessList*(header: Header,
       tracer  = AccessListTracer.new(accessList, sender, to, precompiles)
       vmState = BaseVMState.new(parent, header, com, txFrame, tracer)
       res     = rpcCallEvm(args, header, vmState).valueOr:
+                  vmState.dispose()
                   txFrame.dispose()
                   handleError("failed to call evm: " & $error.code)
 
+    vmState.dispose()
     txFrame.dispose()
 
     if res.isError:

--- a/execution_chain/tracer.nim
+++ b/execution_chain/tracer.nim
@@ -138,6 +138,9 @@ proc traceTransactionImpl(
     vmState = BaseVMState.new(parent, header, com, txFrame, storeSlotHash = true)
     ledger = vmState.ledger
 
+  defer:
+    vmState.dispose()
+
   doAssert(transactions.calcTxRoot == header.txRoot)
   doAssert(transactions.len != 0)
 
@@ -211,6 +214,9 @@ proc dumpBlockStateImpl(
     vmState = BaseVMState.new(parent, header, com, txFrame, tracerInst, storeSlotHash = true)
     miner = vmState.coinbase()
 
+  defer:
+    vmState.dispose()
+
   var
     before = newJArray()
     after = newJArray()
@@ -269,6 +275,9 @@ proc traceBlockImpl(
     parent = txFrame.getBlockHeader(header.parentHash).valueOr:
       return newJNull()
     vmState = BaseVMState.new(parent, header, com, txFrame, tracerInst, storeSlotHash = true)
+
+  defer:
+    vmState.dispose()
 
   if header.txRoot == EMPTY_ROOT_HASH: return newJNull()
   doAssert(blk.transactions.calcTxRoot == header.txRoot)

--- a/execution_chain/transaction/call_evm_rpc.nim
+++ b/execution_chain/transaction/call_evm_rpc.nim
@@ -43,9 +43,11 @@ proc rpcCallEvm*(
   defer:
     txFrame.dispose() # always dispose state changes
 
-  let
-    vmState = BaseVMState.new(header, topHeader, com, txFrame)
-    params = ?toCallParams(vmState, args, globalGasCap, header)
+  let vmState = BaseVMState.new(header, topHeader, com, txFrame)
+  defer:
+    vmState.dispose()
+
+  let params = ?toCallParams(vmState, args, globalGasCap, header)
 
   ok(runComputation(params, CallResult))
 
@@ -192,4 +194,7 @@ proc rpcEstimateGas*(
     txFrame.dispose() # always dispose state changes
 
   let vmState = BaseVMState.new(header, topHeader, com, txFrame)
+  defer:
+    vmState.dispose()
+
   rpcEstimateGas(args, header, vmState, gasCap)

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -254,6 +254,8 @@ proc generateVMProxy(masm: MacroAssembler): VMProxy =
     vmProxyProc = quote do:
       proc `vmProxySym`(): bool =
         let `vmState` = initVMEnv(`fork`)
+        defer:
+          `vmState`.dispose()
         `setup`
         let boa = `body`
         runVM(`vmState`, boa)

--- a/tests/test_evm_support.nim
+++ b/tests/test_evm_support.nim
@@ -357,6 +357,8 @@ proc runTestOverflow() =
       com,
       com.db.baseTxFrame()
     )
+    defer:
+      s.dispose()
 
     s.ledger.setCode(codeAddress, @data)
     let unsignedTx = Transaction(

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -79,6 +79,9 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
       com.db.baseTxFrame()
     )
 
+  defer:
+    vmState.dispose()
+
   case toLowerAscii(label)
   of "ecrecover": data.doTest(vmState, paEcRecover)
   of "sha256"   : data.doTest(vmState, paSha256)

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -127,6 +127,9 @@ proc runExecution(ctx: var StateContext, conf: StateConf, pre: JsonNode): StateR
     txFrame = com.db.baseTxFrame(),
     tracer = tracer)
 
+  defer:
+    vmState.dispose()
+
   vmState.mutateLedger:
     setupLedger(pre, ledger)
     ledger.persist(clearEmptyAccount = false) # settle accounts storage
@@ -159,7 +162,6 @@ proc runExecution(ctx: var StateContext, conf: StateConf, pre: JsonNode): StateR
     if conf.jsonEnabled:
       writeRootHashToStderr(stateRoot)
     vmState.ledger.txFrame.dispose()
-    vmState.dispose()
     com.db.close()
 
   try:

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -613,6 +613,10 @@ proc transitionAction*(ctx: var TransContext,
       enableBalTracker = com.isAmsterdamOrLater(ctx.env.currentTimestamp),
     )
 
+    defer:
+      if not vmState.isNil():
+        vmState.dispose()
+
     vmState.mutateLedger:
       ledger.setupAlloc(ctx.alloc)
       ledger.persist(clearEmptyAccount = false)


### PR DESCRIPTION
The vmState only holds manually allocated memory when the BAL tracker is enabled (for amsterdam blocks) but this PR makes sure dispose is always called regardless in the locations where we create a vmState instance.