### PR TITLE
avoid expensive, pointless proof blob computation

### DIFF
--- a/execution_chain/core/eip7594.nim
+++ b/execution_chain/core/eip7594.nim
@@ -1,5 +1,5 @@
 # nimbus-execution-client
-# Copyright (c) 2025 Status Research & Development GmbH
+# Copyright (c) 2025-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -7,7 +7,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   ../constants,
@@ -17,7 +17,7 @@ import
 from std/sequtils import mapIt
 
 proc validateBlobTransactionWrapper7594*(tx: PooledTransaction):
-                                     Result[void, string] =
+                                         Result[void, string] =
   doAssert(tx.blobsBundle.isNil.not)
   doAssert(tx.blobsBundle.wrapperVersion == WrapperVersionEIP7594)
 
@@ -67,8 +67,7 @@ proc validateBlobTransactionWrapper7594*(tx: PooledTransaction):
       cellIndices.add i.uint64
 
     # bullet 3.iii.c
-    let cf = ?kzg.computeCellsAndKzgProofs(blobs[k])
-    cells.add cf.cells
+    cells.add ?kzg.computeCells(blobs[k])
 
   let res = kzg.verifyCellKzgProofBatch(
     commitments,


### PR DESCRIPTION
Root cause of miss by `nimbus-nimbusel-1` at https://dora.glamsterdam-devnet-7.ethpandaops.io/slot/130795
```
DBG 2026-08-02 03:28:12.601+00:00 Received JSON-RPC request                  topics="jsonrpc server http" address=172.18.0.3:42236 len=145
DBG 2026-08-02 03:28:12.625+00:00 Received new pooled tx hashes              topics="tx-broadcast" hashes=1
DBG 2026-08-02 03:28:12.625+00:00 Invoking broadcast action                  topics="tx-broadcast" desc="Handle broadcast transactions hashes"
DBG 2026-08-02 03:28:13.541+00:00 Transaction added to txpool                topics="txpool" txHash=0xdf2a770fc310ca10af79d0a8bbbbd46b420e7edc674960d6b470ac8342ddb3e9 sender=0x62c84fcccc6865893e9b1db52d69519e71793a43 txType=TxEip4844 recipient=0x64fa494b82362bb7a03e6bbe734850a0c436f93b nonce=22719 gasLimit=49324 gasPrice=0 value=935046264881103 numBlobs=3 wrapperVersion=WrapperVersionEIP7594
DBG 2026-08-02 03:28:13.873+00:00 Transaction added to txpool                topics="txpool" txHash=0x40ed35bb356a9fe1cdc1371363d9992e864a47a4bf32037324199e2a602d5f2f sender=0x46d719524862ac03df2a477127daa0879b154d97 txType=TxEip4844 recipient=0xe9b08d8f353a6671705a900ceb55763598661610 nonce=46190 gasLimit=21000 gasPrice=0 value=0 numBlobs=1 wrapperVersion=WrapperVersionEIP7594
```
the event loop is getting blocked by upwards of a second each time it's handling some of these tx batches.

A synthetic benchmark:
```
blobs | computeCellsAndKzgProofs (ms) | computeCells (ms)
------+-------------------------------+------------------
    1 |                         266.3 |              2.8
    2 |                         538.7 |              5.7
    3 |                         823.3 |              8.6
    4 |                        1061.3 |             12.0
    5 |                        1357.7 |             14.6
    6 |                        1766.1 |             18.6
    7 |                        2028.9 |             22.0
    8 |                        2219.0 |             24.4
    9 |                        2458.5 |             27.3
   10 |                        2742.5 |             28.8
   11 |                        2988.4 |             31.9
   12 |                        3202.8 |             35.7
   13 |                        3568.6 |             36.5
   14 |                        3806.2 |             40.7
   15 |                        4055.1 |             42.7
   16 |                        4342.4 |             49.1
   17 |                        4633.9 |             51.1
   18 |                        4937.1 |             56.8
   19 |                        5356.9 |             54.3
   20 |                        5513.9 |             61.6
   21 |                        6116.5 |             63.1
```
Effectively all the time (~99%) is spent on this proofs which are ignored.