### PR TITLE
stateless: Fix witness generation for precompile

### DIFF
--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -221,7 +221,7 @@ proc newPayload*(ben: BeaconEngineRef,
       number = header.number, hash = blockHash.short
     return
       if withWitness:
-        validStatus(blockHash, ben.collectWitness(blockHash))
+        validStatus(blockHash, ben.collectWitness(blk))
       else:
         validStatus(blockHash)
 
@@ -301,6 +301,6 @@ proc newPayload*(ben: BeaconEngineRef,
 
   return
     if withWitness:
-      validStatus(blockHash, ben.collectWitness(blockHash))
+      validStatus(blockHash, ben.collectWitness(blk))
     else:
       validStatus(blockHash)

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -18,7 +18,8 @@ import
   ../web3_eth_conv,
   ../beacon_engine,
   ../payload_conv,
-  ./api_utils
+  ./api_utils,
+  ./api_witness
 
 {.push gcsafe, raises:[].}
 
@@ -152,7 +153,8 @@ proc newPayload*(ben: BeaconEngineRef,
                  payload: ExecutionPayload,
                  versionedHashes = Opt.none(seq[Hash32]),
                  beaconRoot = Opt.none(Hash32),
-                 executionRequests = Opt.none(seq[seq[byte]])):
+                 executionRequests = Opt.none(seq[seq[byte]]),
+                 withWitness = false):
                    Future[PayloadStatusV1] {.async: (raises: [CancelledError, ApplicationError, RlpError]).} =
 
   trace "Engine API request received",
@@ -217,7 +219,11 @@ proc newPayload*(ben: BeaconEngineRef,
   if chain.haveBlockAndState(blockHash):
     debug "Ignoring already known beacon payload",
       number = header.number, hash = blockHash.short
-    return validStatus(blockHash)
+    return
+      if withWitness:
+        validStatus(blockHash, ben.collectWitness(blockHash))
+      else:
+        validStatus(blockHash)
 
   # If this block was rejected previously, keep rejecting it
   let res = ben.checkInvalidAncestor(blockHash, blockHash)
@@ -293,4 +299,8 @@ proc newPayload*(ben: BeaconEngineRef,
     gasUsed = header.gasUsed,
     blobGas = header.blobGasUsed.get(0'u64)
 
-  return validStatus(blockHash)
+  return
+    if withWitness:
+      validStatus(blockHash, ben.collectWitness(blockHash))
+    else:
+      validStatus(blockHash)

--- a/execution_chain/beacon/api_handler/api_utils.nim
+++ b/execution_chain/beacon/api_handler/api_utils.nim
@@ -138,6 +138,13 @@ proc validStatus*(validHash: common.Hash32): PayloadStatusV1 =
     latestValidHash: toValidHash(validHash)
   )
 
+proc validStatus*(validHash: common.Hash32, witness: Opt[seq[byte]]): PayloadStatusV1 =
+  PayloadStatusV1(
+    status: PayloadExecutionStatus.valid,
+    latestValidHash: toValidHash(validHash),
+    witness: witness,
+  )
+
 proc invalidParams*(msg: string): ref ApplicationError =
   (ref ApplicationError)(
     code: engineApiInvalidParams,

--- a/execution_chain/beacon/api_handler/api_witness.nim
+++ b/execution_chain/beacon/api_handler/api_witness.nim
@@ -1,0 +1,62 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+# Support for the engine_newPayloadWithWitness* methods. These are not (yet)
+# part of the Engine API spec.
+
+{.push gcsafe, raises: [].}
+
+import results, chronicles, eth/common, eth/rlp, ../beacon_engine
+
+from ../../stateless/witness_generation import ExecutionWitnessWithKeys
+from ../../utils/utils import short
+
+logScope:
+  topics = "beacon engine"
+
+type
+  # Current execution witness wire shape, returned by the engine_newPayloadWithWitness*
+  # methods as an RLP blob. The field order (headers, codes, state, keys)
+  # is significant and must match go-ethereum / ethrex:
+  # https://github.com/ethereum/go-ethereum/blob/master/core/stateless/encoding.go
+  # This is currently not specced out in the Engine API.
+  # Note that it is different from debug_executionWitness encoding.
+  ExtWitness = object
+    headers: seq[Header]
+    codes: seq[seq[byte]]
+    state: seq[seq[byte]]
+    keys: seq[seq[byte]]
+
+func encodeExtWitness(w: ExecutionWitnessWithKeys): Result[seq[byte], string] =
+  ## RLP-encode the witness into geth's execution witness wire format.
+  var headers: seq[Header]
+  for encodedHeader in w.headers:
+    let header =
+      try:
+        rlp.decode(encodedHeader, Header)
+      except RlpError as e:
+        return err("Failed to decode witness header: " & e.msg)
+    headers.add(header)
+
+  ok(
+    rlp.encode(ExtWitness(headers: headers, codes: w.codes, state: w.state, keys: @[]))
+  )
+
+proc collectWitness*(ben: BeaconEngineRef, blockHash: Hash32): Opt[seq[byte]] =
+  ## Return the RLP-encoded witness for `blockHash`, or none if unavailable
+  let witness = ben.chain.getExecutionWitness(blockHash).valueOr:
+    warn "Execution witness not available, is --stateless-provider enabled?",
+      hash = blockHash.short, error = error
+    return Opt.none(seq[byte])
+
+  let encoded = encodeExtWitness(witness).valueOr:
+    warn "Failed to encode execution witness", hash = blockHash.short, error = error
+    return Opt.none(seq[byte])
+
+  Opt.some(encoded)

--- a/execution_chain/beacon/api_handler/api_witness.nim
+++ b/execution_chain/beacon/api_handler/api_witness.nim
@@ -48,14 +48,24 @@ func encodeExtWitness(w: ExecutionWitnessWithKeys): Result[seq[byte], string] =
     rlp.encode(ExtWitness(headers: headers, codes: w.codes, state: w.state, keys: @[]))
   )
 
-proc collectWitness*(ben: BeaconEngineRef, blockHash: Hash32): Opt[seq[byte]] =
-  ## Return the RLP-encoded witness for `blockHash`, or none if unavailable
-  let witness = ben.chain.getExecutionWitness(blockHash).valueOr:
-    warn "Execution witness not available, is --stateless-provider enabled?",
-      hash = blockHash.short, error = error
+proc collectWitness*(ben: BeaconEngineRef, blk: Block): Opt[seq[byte]] =
+  ## Return the RLP-encoded execution witness for `blk`, or none if unavailable.
+  ## When the node runs with `--stateless-provider` the witness stored during
+  ## import is used else it is generated on demand by re-executing the block
+  ## against its parent state.
+  let blockHash = blk.header.computeBlockHash()
+
+  let witness =
+    if ben.chain.com.statelessProvider:
+      ben.chain.getExecutionWitness(blockHash)
+    else:
+      ben.chain.generateExecutionWitness(blk)
+
+  let w = witness.valueOr:
+    warn "Execution witness not available", hash = blockHash.short, error = error
     return Opt.none(seq[byte])
 
-  let encoded = encodeExtWitness(witness).valueOr:
+  let encoded = encodeExtWitness(w).valueOr:
     warn "Failed to encode execution witness", hash = blockHash.short, error = error
     return Opt.none(seq[byte])
 

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -20,6 +20,7 @@ import
   ../../evm/types,
   ../../evm/state,
   ../validate,
+  ../executor/process_block,
   ../../portal/portal,
   ../../stateless/witness_generation,
   ./forked_chain/[
@@ -1371,5 +1372,42 @@ proc getExecutionWitness*(
 
   let witness = txFrame.getWitness(blockHash).valueOr:
     return err("Witness not found")
+
+  ok(ExecutionWitnessWithKeys.build(witness, txFrame))
+
+proc generateExecutionWitness*(
+    c: ForkedChainRef, blk: Block
+): Result[ExecutionWitnessWithKeys, string] =
+  ## Build the execution witness for `blk` on demand by re-executing it against
+  ## its parent state, without requiring `--stateless-provider` and without
+  ## persisting anything. Works for a freshly imported or already known block as
+  ## long as the parent state is available, else the state root check errors.
+  template header(): Header = blk.header
+
+  let parentHeader = ?c.headerByHash(header.parentHash)
+
+  # Execute on a throwaway frame so the shared parent state is never modified.
+  let
+    parentFrame = c.txFrame(header.parentHash)
+    txFrame = parentFrame.txFrameBegin()
+  defer:
+    txFrame.dispose()
+
+  let vmState = BaseVMState()
+  vmState.init(parentHeader, header, c.com, txFrame, collectWitness = true)
+
+  # No block access list keeps execution sequential (parallel skips witness keys).
+  ?vmState.processBlock(
+    blk,
+    blockAccessList = Opt.none(BlockAccessListRef),
+    skipValidation = true,
+    skipReceipts = true,
+    skipUncles = true,
+    skipStateRootCheck = false,
+    skipPostExecBalCheck = true)
+
+  let
+    preStateLedger = LedgerRef.init(parentFrame)
+    witness = Witness.build(preStateLedger, vmState.ledger, parentHeader, header)
 
   ok(ExecutionWitnessWithKeys.build(witness, txFrame))

--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -21,6 +21,7 @@ import
   ../../evm/state,
   ../validate,
   ../../portal/portal,
+  ../../stateless/witness_generation,
   ./forked_chain/[
     chain_desc,
     chain_branch,
@@ -1359,3 +1360,16 @@ proc getBlockAccessList*(c: ForkedChainRef, blockHash: Hash32): Opt[BlockAccessL
     return Opt.none(BlockAccessList)
 
   bal.map(proc (v: auto): auto = v[])
+
+proc getExecutionWitness*(
+    c: ForkedChainRef, blockHash: Hash32
+): Result[ExecutionWitnessWithKeys, string] =
+  ## Return the execution witness created when importing the given block
+  let txFrame = c.txFrame(blockHash).txFrameBegin()
+  defer:
+    txFrame.dispose()
+
+  let witness = txFrame.getWitness(blockHash).valueOr:
+    return err("Witness not found")
+
+  ok(ExecutionWitnessWithKeys.build(witness, txFrame))

--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -99,7 +99,8 @@ type
       ## over and over again to the database to avoid the WAL and compation
       ## write amplification that ensues
 
-    collectWitness: bool
+    collectWitness*: bool
+
     witnessKeys: WitnessTable
       ## Used to collect the keys of all read accounts, code and storage slots.
       ## Maps a tuple of address and slot (optional) to the codeTouched flag.

--- a/execution_chain/evm/interpreter/op_handlers/oph_call.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_call.nim
@@ -208,12 +208,13 @@ proc loadCallCode(c: Computation, flags: set[MsgFlags]): CodeBytesRef =
   ## after the opcode gas charge but before the depth/balance early exits,
   ## so the read hits the witness even when the call fails early (spec order).
   ##
-  ## TODO: the precompile short-circuit below differs from the spec.
-  ## The spec's `call()` always does `get_account(code_address)` to fetch
-  ## the code hash (precompile dispatch only happens later), so on a
-  ## zero-value CALL to a precompile a spec witness probably includes the
-  ## account's exclusion-proof nodes while ours does not. TBI
+  ## Precompiles execute natively and don't need their account, but the spec's
+  ## `call()` does `get_account(code_address)` before precompile dispatch, so the
+  ## account access must appear in the witness. Replicate that read only when a
+  ## witness is being collected, keeping normal precompile calls on the fast path.
   if MsgFlags.Precompile in flags:
+    if c.vmState.collectWitness:
+      discard c.vmState.readOnlyLedger.getCode(c.msg.delegateTo)
     return CodeBytesRef(nil)
 
   c.vmState.readOnlyLedger.getCode(c.msg.delegateTo)

--- a/execution_chain/evm/state.nim
+++ b/execution_chain/evm/state.nim
@@ -291,6 +291,9 @@ method getAncestorHash*(
 proc readOnlyLedger*(vmState: BaseVMState): ReadOnlyLedger {.inline.} =
   ReadOnlyLedger(vmState.ledger)
 
+func collectWitness*(vmState: BaseVMState): bool =
+  vmState.ledger.collectWitness
+
 template mutateLedger*(vmState: BaseVMState, body: untyped): untyped =
   block:
     let ledger {.inject.} = vmState.ledger

--- a/execution_chain/evm/state.nim
+++ b/execution_chain/evm/state.nim
@@ -207,7 +207,8 @@ proc init*(
       tracer: TracerRef = nil,
       storeSlotHash = false,
       enableBalTracker = false,
-      stateless = false) =
+      stateless = false,
+      collectWitness = com.statelessProvider) =
 
   ## Variant of `new()` constructor above for in-place initalisation. The
   ## `parent` argument is used to sync the accounts cache and the `header`
@@ -216,9 +217,11 @@ proc init*(
   ##
   ## It requires the `header` argument properly initalised so that for PoA
   ## networks, the miner address is retrievable via `ecRecover()`.
+  ## `collectWitness` defaults to the global `--stateless-provider` setting but
+  ## can be forced on to build a witness for a single block on demand.
   let
     ledger = LedgerRef.init(
-      txFrame, storeSlotHash, com.statelessProvider, stateless)
+      txFrame, storeSlotHash, collectWitness, stateless)
     tracker =
       if enableBalTracker:
         BlockAccessListTrackerRef.init(ledger.ReadOnlyLedger)

--- a/execution_chain/rpc/debug.nim
+++ b/execution_chain/rpc/debug.nim
@@ -63,16 +63,6 @@ ExecutionWitnessWithKeys.useDefaultSerializationIn EthJson
 #     if opts.disableState.isTrue  : result.incl TracerFlags.DisableState
 #     if opts.disableStateDiff.isTrue: result.incl TracerFlags.DisableStateDiff
 
-proc getExecutionWitness*(chain: ForkedChainRef, blockHash: Hash32): Result[ExecutionWitnessWithKeys, string] =
-  let txFrame = chain.txFrame(blockHash).txFrameBegin()
-  defer:
-    txFrame.dispose()
-
-  let witness = txFrame.getWitness(blockHash).valueOr:
-    return err("Witness not found")
-
-  ok(ExecutionWitnessWithKeys.build(witness, txFrame))
-
 proc setupDebugRpc*(com: CommonRef, txPool: TxPoolRef, server: RpcServer) =
   let
     # chainDB = com.db

--- a/execution_chain/rpc/engine_api.nim
+++ b/execution_chain/rpc/engine_api.nim
@@ -45,6 +45,8 @@ const supportedMethods: HashSet[string] =
     "engine_newPayloadV3",
     "engine_newPayloadV4",
     "engine_newPayloadV5",
+    "engine_newPayloadWithWitnessV4",
+    "engine_newPayloadWithWitnessV5",
     "engine_getPayloadV1",
     "engine_getPayloadV2",
     "engine_getPayloadV3",
@@ -57,7 +59,7 @@ const supportedMethods: HashSet[string] =
     "engine_forkchoiceUpdatedV4",
     "engine_getPayloadBodiesByHashV1",
     "engine_getPayloadBodiesByHashV2",
-    "engine_getPayloadBodiesByRangeV1",    
+    "engine_getPayloadBodiesByRangeV1",
     "engine_getPayloadBodiesByRangeV2",
     "engine_getClientVersionV1",
     "engine_getBlobsV1",
@@ -103,6 +105,38 @@ proc setupEngineAPI*(engine: BeaconEngineRef, server: RpcServer) =
       apiTiming("engine_newPayloadV5"):
         await engine.newPayload(Version.V5, payload,
           expectedBlobVersionedHashes, parentBeaconBlockRoot, executionRequests)
+
+    proc engine_newPayloadWithWitnessV4(
+        payload: ExecutionPayload,
+        expectedBlobVersionedHashes: Opt[seq[Hash32]],
+        parentBeaconBlockRoot: Opt[Hash32],
+        executionRequests: Opt[seq[seq[byte]]],
+    ): PayloadStatusV1 {.async: (raises: [CancelledError, ApplicationError, RlpError]).} =
+      apiTiming("engine_newPayloadWithWitnessV4"):
+        await engine.newPayload(
+          Version.V4,
+          payload,
+          expectedBlobVersionedHashes,
+          parentBeaconBlockRoot,
+          executionRequests,
+          withWitness = true,
+        )
+
+    proc engine_newPayloadWithWitnessV5(
+        payload: ExecutionPayload,
+        expectedBlobVersionedHashes: Opt[seq[Hash32]],
+        parentBeaconBlockRoot: Opt[Hash32],
+        executionRequests: Opt[seq[seq[byte]]],
+    ): PayloadStatusV1 {.async: (raises: [CancelledError, ApplicationError, RlpError]).} =
+      apiTiming("engine_newPayloadWithWitnessV5"):
+        await engine.newPayload(
+          Version.V5,
+          payload,
+          expectedBlobVersionedHashes,
+          parentBeaconBlockRoot,
+          executionRequests,
+          withWitness = true,
+        )
 
     proc engine_getPayloadV1(payloadId: Bytes8): ExecutionPayloadV1 {.raises: [CatchableError].} =
       apiTiming("engine_getPayloadV1"):

--- a/tests/eest/eest_blockchain.nim
+++ b/tests/eest/eest_blockchain.nim
@@ -34,8 +34,6 @@ import
   ./eest_helpers,
   ./bal_parser
 
-from ../../execution_chain/rpc/debug import getExecutionWitness
-
 proc fromJson(T: type ExecutionWitness, n: JsonNode): ExecutionWitness =
   var res: ExecutionWitness
   for item in n["state"]:

--- a/tests/test_stateless/test_stateless_execution.nim
+++ b/tests/test_stateless/test_stateless_execution.nim
@@ -22,7 +22,6 @@ import
   ../../execution_chain/db/core_db/memory_only,
   ../../execution_chain/db/ledger,
   ../../execution_chain/history/db/ere_db,
-  ../../execution_chain/rpc/debug,
   ../../execution_chain/stateless/[stateless_execution, stateless_execution_helpers]
 
 const


### PR DESCRIPTION
The execution-specs still access the account which causes that to end up in the witness. We always shortcut that for precompiles as it isn't necessary for precompiles and wastes an access.

Add the access anyhow when collectWitness is set.