### PR TITLE
ci: bind exclude_field input via env before shell

### DIFF
--- a/.github/workflows/matrix_config.yml
+++ b/.github/workflows/matrix_config.yml
@@ -39,11 +39,13 @@ jobs:
 
       - name: Prepare matrix JSON object
         id: prepare
+        env:
+          EXCLUDE_FIELD: ${{ inputs.exclude_field }}
         run: |
           PREFIX='json={"include":'
           SUFFIX='}'
           CONF='.github/workflows/matrix_config.json'
-          PARAM='${{ inputs.exclude_field }}'
+          PARAM="$EXCLUDE_FIELD"
 
           if [[ '$PARAM' == '' ]]; then
             echo "$PREFIX$(jq -c . < $CONF)$SUFFIX" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Bind `inputs.exclude_field` into step `env:` before use in the matrix-preparation `run:` script in `matrix_config.yml`.

Keeps the `${{ }}` expansion out of the shell script.

## Test plan
- [ ] Confirm workflow YAML still validates
- [ ] Optional: run matrix_config with and without an `exclude_field` input

Made with [Cursor](https://cursor.com)