### PR TITLE
stateless: Simplify validation result per execution-specs changes

### DIFF
--- a/execution_chain/stateless/stateless_execution.nim
+++ b/execution_chain/stateless/stateless_execution.nim
@@ -121,7 +121,7 @@ template statelessProcessBlock*(
 ): Result[void, string] =
   statelessProcessBlock(witness, id, chainConfigForNetwork(id), blk)
 
-# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/execution_engine/validation_helpers.py#L22
+# https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/execution_engine/validation_helpers.py#L1
 func toBlock(
     p: ExecutionPayload, parentBeaconBlockRoot: Opt[Hash32], requestsHash: Opt[Hash32]
 ): Block {.raises: [RlpError].} =
@@ -171,76 +171,8 @@ func toBlock(
     withdrawals: Opt.some(wds),
   )
 
-# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless.py#L278
-func isActivationActive(
-    activation: ForkActivation, execution_payload: ExecutionPayload
-): Result[void, string] =
-  ## Return whether an activation point is active for the payload.
-  if activation.block_number.len == 0 and activation.timestamp.len == 0:
-    return err("Fork activation must set block_number or timestamp")
-
-  if activation.block_number.len > 0 and
-      execution_payload.block_number < activation.block_number[0]:
-    return err("ChainConfig active_fork is not active for the target payload")
-
-  if activation.timestamp.len > 0 and
-      execution_payload.timestamp < activation.timestamp[0]:
-    return err("ChainConfig active_fork is not active for the target payload")
-
-  ok()
-
-# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless.py#L303
-func validate_chain_config(
-    chain_config: StatelessChainConfig, execution_payload: ExecutionPayload
-): Result[void, string] =
-  ## Validate the target payload's active fork config.
-  let active_fork = chain_config.active_fork
-
-  isActivationActive(active_fork.activation, execution_payload)
-
-func chainConfigForStateless(cc: StatelessChainConfig): ChainConfig =
-  # Nimbus EVM needs the full fork timeline, but the stateless input only provides
-  # the active fork. Set the rest to 0 to allow for execution. The active fork is
-  # set to the provided values.
-  let networkId = NetworkId(cc.chain_id.u256)
-
-  let amsterdamTime =
-    if cc.active_fork.activation.timestamp.len > 0:
-      Opt.some(EthTime(cc.active_fork.activation.timestamp[0]))
-    else:
-      Opt.some(0.EthTime)
-
-  ChainConfig(
-    chainId: networkId,
-    homesteadBlock: Opt.some(0.BlockNumber),
-    eip150Block: Opt.some(0.BlockNumber),
-    eip155Block: Opt.some(0.BlockNumber),
-    eip158Block: Opt.some(0.BlockNumber),
-    byzantiumBlock: Opt.some(0.BlockNumber),
-    constantinopleBlock: Opt.some(0.BlockNumber),
-    petersburgBlock: Opt.some(0.BlockNumber),
-    istanbulBlock: Opt.some(0.BlockNumber),
-    berlinBlock: Opt.some(0.BlockNumber),
-    londonBlock: Opt.some(0.BlockNumber),
-    posBlock: Opt.some(0.BlockNumber),
-    shanghaiTime: Opt.some(0.EthTime),
-    cancunTime: Opt.some(0.EthTime),
-    pragueTime: Opt.some(0.EthTime),
-    osakaTime: Opt.some(0.EthTime),
-    bpo1Time: Opt.some(0.EthTime),
-    bpo2Time: Opt.some(0.EthTime),
-    bpo3Time: Opt.some(0.EthTime),
-    bpo4Time: Opt.some(0.EthTime),
-    bpo5Time: Opt.some(0.EthTime),
-    amsterdamTime: amsterdamTime,
-    blobSchedule: defaultBlobSchedule(),
-    # Inherit deposit contract address from the known network config
-    # TODO: Separate out the deposit contract address code.
-    depositContractAddress: chainConfigForNetwork(networkId).depositContractAddress,
-  )
-
 # Encode execution requests into EL format:
-# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/execution_engine/requests.py#L108
+# https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/execution_engine/requests.py#L108
 func encodeDeposits(deposits: seq[DepositRequest]): seq[byte] =
   var res: seq[byte]
   for d in deposits:
@@ -284,8 +216,6 @@ func encodeBuilderExits(exits: seq[BuilderExitRequest]): seq[byte] =
   res
 
 proc executeNewPayload(input: StatelessInput): Result[void, string] =
-  ?validate_chain_config(input.chain_config, input.new_payload_request.executionPayload)
-
   let
     reqs = input.new_payload_request.executionRequests
     requestsHash = Opt.some(
@@ -310,8 +240,8 @@ proc executeNewPayload(input: StatelessInput): Result[void, string] =
 
     com = CommonRef.new(
       db = nil,
-      config = chainConfigForStateless(input.chain_config),
-      networkId = NetworkId(input.chain_config.chain_id.u256),
+      config = chainConfigForNetwork(NetworkId(input.chain_id.u256)),
+      networkId = NetworkId(input.chain_id.u256),
       initializeDb = false,
     )
 
@@ -331,12 +261,13 @@ proc executeNewPayload(input: StatelessInput): Result[void, string] =
 
   statelessProcessBlock(input.witness, com, blk)
 
-# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless.py#L321
+# https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/stateless.py#L229
 proc verify_stateless_new_payload*(input: StatelessInput): StatelessValidationResult =
   let new_payload_request_root = compute_new_payload_request_root(input)
 
   StatelessValidationResult(
     new_payload_request_root: new_payload_request_root,
     successful_validation: executeNewPayload(input).isOk(),
-    chain_config: input.chain_config,
+    chain_id: input.chain_id,
+    schema_id: STATELESS_INPUT_SCHEMA_ID,
   )

--- a/execution_chain/stateless/stateless_execution.nim
+++ b/execution_chain/stateless/stateless_execution.nim
@@ -171,6 +171,54 @@ func toBlock(
     withdrawals: Opt.some(wds),
   )
 
+# https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/execution_engine/new_payload.py#L50
+func is_valid_versioned_hashes(
+    expected: openArray[Digest], blk: Block
+): Result[void, string] =
+  ## Return ok if and only if the versioned hashes computed by blob
+  ## transactions in `new_payload_request.execution_payload` match
+  ## `new_payload_request.versioned_hashes`.
+  var versionedHashes: seq[VersionedHash]
+  for tx in blk.transactions:
+    if tx.txType == TxEip4844:
+      versionedHashes.add(tx.versionedHashes)
+
+  if versionedHashes.len != expected.len:
+    return err("Versioned hashes count does not match the payload")
+
+  for i, x in expected:
+    if x.data != versionedHashes[i].data:
+      return err("Versioned hash at index " & $i & " does not match the payload")
+
+  ok()
+
+func chainConfigForStateless(chainId: uint64): ChainConfig =
+  # Normally `chainConfigForNetwork` would be used, but the stateless tests run
+  # the guest fork from genesis, so every fork up to it is activated at zero.
+  # TODO: Might have to change this system once the fork gets scheduled.
+  const lastFork = HardFork.Amsterdam
+
+  var transitions: ForkTransitionTable
+  for f in low(HardFork) .. lastPurelyBlockNumberBasedFork:
+    transitions.blockNumberThresholds[f] = Opt.some(0.BlockNumber)
+  transitions.mergeForkTransitionThreshold.number = Opt.some(0.BlockNumber)
+  transitions.mergeForkTransitionThreshold.ttd = Opt.some(0.u256)
+  for f in firstTimeBasedFork .. lastFork:
+    transitions.timeThresholds[f] = Opt.some(0.EthTime)
+
+  let
+    networkId = NetworkId(chainId.u256)
+    config = ChainConfig(
+      chainId: networkId,
+      blobSchedule: defaultBlobSchedule(),
+      # Inherit deposit contract address from the known network config
+      # TODO: Separate out the deposit contract address code.
+      depositContractAddress: chainConfigForNetwork(networkId).depositContractAddress,
+    )
+  config.populateFromForkTransitionTable(transitions)
+
+  config
+
 # Encode execution requests into EL format:
 # https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/execution_engine/requests.py#L108
 func encodeDeposits(deposits: seq[DepositRequest]): seq[byte] =
@@ -240,10 +288,12 @@ proc executeNewPayload(input: StatelessInput): Result[void, string] =
 
     com = CommonRef.new(
       db = nil,
-      config = chainConfigForNetwork(NetworkId(input.chain_id.u256)),
+      config = chainConfigForStateless(input.chain_id),
       networkId = NetworkId(input.chain_id.u256),
       initializeDb = false,
     )
+
+  ?is_valid_versioned_hashes(input.new_payload_request.versionedHashes, blk)
 
   # Early validation of the input BAL before execution, just like is done for the
   # stateful path. Rejects invalid BALs early without paying the cost of block execution.

--- a/execution_chain/stateless/stateless_guest.nim
+++ b/execution_chain/stateless/stateless_guest.nim
@@ -15,7 +15,7 @@ export stateless_types, stateless_execution
 
 ## Stateless guest interfaces
 ## Spec:
-## https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_guest.py#L1
+## https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/stateless_guest.py#L1
 
 func deserialize_stateless_input*(
     data: openArray[byte]
@@ -38,7 +38,8 @@ func deserialize_stateless_input*(
 const FAILED_STATELESS_OUTPUT = StatelessValidationResult(
   new_payload_request_root: default(Digest),
   successful_validation: false,
-  chain_config: default(StatelessChainConfig),
+  chain_id: 0,
+  schema_id: 0,
 )
 
 proc run_stateless_guest*(data: openArray[byte]): seq[byte] =

--- a/execution_chain/stateless/stateless_host.nim
+++ b/execution_chain/stateless/stateless_host.nim
@@ -27,9 +27,9 @@ export stateless_types, results
 
 ## Stateless host interfaces
 ## Spec:
-## https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_host.py#L1
+## https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/stateless_host.py#L1
 
-## https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/transactions.py#L810
+## https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/transactions.py#L882
 func recover_transaction_public_key*(
     tx: Transaction
 ): Opt[ByteVector[PUBLIC_KEY_BYTES]] =
@@ -59,19 +59,6 @@ func deserialize_stateless_output*(
   except SerializationError as e:
     err("Failed to deserialize StatelessValidationResult: " & e.msg)
 
-func build_chain_config*(chain_id: uint64): StatelessChainConfig =
-  ## Build the chain configuration supported by this host.
-  ##
-  ## For now the Amsterdam stateless host only describes the Amsterdam fork.
-  StatelessChainConfig(
-    chain_id: chain_id,
-    active_fork: ForkConfig(
-      activation: ForkActivation(
-        block_number: List[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES].init(@[]),
-        timestamp: List[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES].init(@[0'u64]),
-      )
-    ),
-  )
 
 func build_stateless_input*(
     blk: Block,
@@ -174,7 +161,7 @@ func build_stateless_input*(
     StatelessInput(
       new_payload_request: new_payload,
       witness: execution_witness,
-      chain_config: build_chain_config(chain_id),
+      chain_id: chain_id,
       public_keys: public_keys,
     )
   )

--- a/execution_chain/stateless/stateless_types.nim
+++ b/execution_chain/stateless/stateless_types.nim
@@ -20,7 +20,7 @@ export ssz_serialization, ssz_codec
 # ---------------------------------------------------------------------------
 
 # As per spec:
-# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_ssz.py#L42
+# https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/stateless_ssz.py#L42
 #
 # Not all consts are defined here as we get some of the types from beacon_chain datatypes
 
@@ -53,7 +53,7 @@ const
 # ---------------------------------------------------------------------------
 
 # As per spec:
-# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_ssz.py#L105
+# https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/stateless_ssz.py#L93
 #
 # Not all types are defined here as we get some of the types from beacon_chain datatypes
 
@@ -69,35 +69,23 @@ type
     codes*: List[ByteList[MAX_BYTES_PER_CODE], MAX_WITNESS_CODES]
     headers*: List[ByteList[MAX_BYTES_PER_HEADER], MAX_WITNESS_HEADERS]
 
-  # Optional uint64 encoded as a List of 0 or 1 elements.
-  ForkActivation* = object
-    block_number*: List[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES]
-    timestamp*: List[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES]
-
-  ForkConfig* = object
-    activation*: ForkActivation
-
-  # Note: named `StatelessChainConfig` to avoid name collision with EL `ChainConfig`
-  StatelessChainConfig* = object
-    chain_id*: uint64
-    active_fork*: ForkConfig
-
   StatelessInput* = object
     new_payload_request*: NewPayloadRequest
     witness*: ExecutionWitness
-    chain_config*: StatelessChainConfig
+    chain_id*: uint64
     public_keys*: List[ByteVector[PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS]
 
   StatelessValidationResult* = object
     new_payload_request_root*: Digest
     successful_validation*: bool
-    chain_config*: StatelessChainConfig
+    chain_id*: uint64
+    schema_id*: uint16
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless.py#L229
+# https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/stateless.py#L183
 func compute_new_payload_request_root*(input: StatelessInput): Digest =
   ## Compute the request root for a stateless input via SSZ hash tree root.
   hash_tree_root(input.new_payload_request)

--- a/execution_chain/stateless/witness_generation.nim
+++ b/execution_chain/stateless/witness_generation.nim
@@ -88,7 +88,7 @@ proc build*(
     raiseAssert "Failed to get multiproof: " & $$error
 
   # Sort the proof nodes lexicographically as is done in execution-specs:
-  # https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L230
+  # https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L230
   multiProof.sort()
   witness.state = move(multiProof)
 
@@ -126,7 +126,7 @@ proc build*(
 
   if earliestBlockNumber.isSome():
     # Add headers in ascending block number order:
-    # https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L175-L176
+    # https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L175-L176
     for n in earliestBlockNumber.get() ..< parent.number:
       let blockHash = ledger.getBlockHash(BlockNumber(n))
       doAssert(blockHash != default(Hash32))
@@ -146,7 +146,7 @@ proc build*(
     codes.add(code)
 
   # Sort codes lexicographically as is done in execution-specs:
-  # https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L268
+  # https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/stateless_host_exec_witness.py#L268
   codes.sort()
 
   var headers: seq[seq[byte]]

--- a/execution_chain/stateless/witness_verification.nim
+++ b/execution_chain/stateless/witness_verification.nim
@@ -74,7 +74,7 @@ func validateKeys*(witness: Witness, expectedKeys: WitnessTable): Result[void, s
 
   ok()
 
-# https://github.com/ethereum/execution-specs/blob/e5a8caf1b8055e4d805c7fb169edfa710914b7da/src/ethereum/forks/amsterdam/stateless.py#L255
+# https://github.com/ethereum/execution-specs/blob/4e7a7177242c3ab3dbc3525c3395933e907d7416/src/ethereum/forks/amsterdam/stateless.py#L255
 func verifyHeaders*(
     witness: ExecutionWitness, header: Header
 ): Result[seq[Header], string] =

--- a/scripts/eest_ci_cache.sh
+++ b/scripts/eest_ci_cache.sh
@@ -29,7 +29,7 @@ EEST_DEVNET_URL="https://github.com/ethereum/execution-specs/releases/download/$
 
 # --- zkevm Release ---
 EEST_ZKEVM_NAME="tests-zkevm"
-EEST_ZKEVM_VERSION="v0.6.2"
+EEST_ZKEVM_VERSION="v0.8.0"
 EEST_ZKEVM_DIR="${FIXTURES_DIR}/eest_zkevm"
 EEST_ZKEVM_ARCHIVE="fixtures_zkevm.tar.gz"
 EEST_ZKEVM_URL="https://github.com/ethereum/execution-specs/releases/download/${EEST_ZKEVM_NAME}%40${EEST_ZKEVM_VERSION}/${EEST_ZKEVM_ARCHIVE}"

--- a/tests/eest/all_eest_tests.nim
+++ b/tests/eest/all_eest_tests.nim
@@ -11,6 +11,6 @@ import
   ./[
     eest_engine_test,
     eest_blockchain_test,
-    #eest_stateless_execution_test,
+    eest_stateless_execution_test,
     eest_txpool_test,
 ]

--- a/tests/eest/eest_blockchain.nim
+++ b/tests/eest/eest_blockchain.nim
@@ -228,7 +228,8 @@ proc runTest(
       # longer up to date regarding `gloas.ExecutionPayload` usage of progressive
       # lists (EIP-7688).
       if output.successful_validation != expectedOutput.successful_validation or
-          output.chain_config != expectedOutput.chain_config:
+          output.chain_id != expectedOutput.chain_id or
+          output.schema_id != expectedOutput.schema_id:
         return err(
           "Stateless guest: validation result mismatch, got: " & $output & " expected: " &
             $expectedOutput
@@ -301,8 +302,8 @@ proc runTest(
         #
         # if input.new_payload_request != fixtureInput.new_payload_request:
         #   return err("Host-built new payload request does not match the test vector")
-        if input.chain_config != fixtureInput.chain_config:
-          return err("Host-built chain config does not match the test vector")
+        if input.chain_id != fixtureInput.chain_id:
+          return err("Host-built chain ID does not match the test vector")
         if input.public_keys != fixtureInput.public_keys:
           return err("Host-built public keys do not match the test vector")
         # The generated witness must be identical to the test vector witness,
@@ -319,8 +320,10 @@ proc runTest(
         #   return err("Guest output for the host-built input does not match the test vector")
         if output.successful_validation != expectedOutput.successful_validation:
           return err("Guest validation result does not match the test vector")
-        if output.chain_config != expectedOutput.chain_config:
-          return err("Guest chain config echo does not match the test vector")
+        if output.chain_id != expectedOutput.chain_id:
+          return err("Guest chain ID echo does not match the test vector")
+        if output.schema_id != expectedOutput.schema_id:
+          return err("Guest schema ID echo does not match the test vector")
       else:
         # Pre-Amsterdam blocks (guest only supports Amsterdam) and blocks without
         # a stateless input expected to validate: run the generated witness through

--- a/tests/eest/eest_blockchain.nim
+++ b/tests/eest/eest_blockchain.nim
@@ -212,7 +212,8 @@ proc runTest(
       # longer up to date regarding `gloas.ExecutionPayload` usage of progressive
       # lists (EIP-7688).
       if output.successful_validation != expectedOutput.successful_validation or
-          output.chain_config != expectedOutput.chain_config:
+          output.chain_id != expectedOutput.chain_id or
+          output.schema_id != expectedOutput.schema_id:
         return err(
           "Stateless guest: validation result mismatch, got: " & $output & " expected: " &
             $expectedOutput
@@ -284,8 +285,8 @@ proc runTest(
         #
         # if input.new_payload_request != fixtureInput.new_payload_request:
         #   return err("Host-built new payload request does not match the test vector")
-        if input.chain_config != fixtureInput.chain_config:
-          return err("Host-built chain config does not match the test vector")
+        if input.chain_id != fixtureInput.chain_id:
+          return err("Host-built chain ID does not match the test vector")
         if input.public_keys != fixtureInput.public_keys:
           return err("Host-built public keys do not match the test vector")
         # The generated witness must be a subset of the test vector witness,
@@ -301,8 +302,10 @@ proc runTest(
         #   return err("Guest output for the host-built input does not match the test vector")
         if output.successful_validation != expectedOutput.successful_validation:
           return err("Guest validation result does not match the test vector")
-        if output.chain_config != expectedOutput.chain_config:
-          return err("Guest chain config echo does not match the test vector")
+        if output.chain_id != expectedOutput.chain_id:
+          return err("Guest chain ID echo does not match the test vector")
+        if output.schema_id != expectedOutput.schema_id:
+          return err("Guest schema ID echo does not match the test vector")
       else:
         # Pre-Amsterdam blocks (guest only supports Amsterdam) and blocks without
         # a stateless input expected to validate: run the generated witness through


### PR DESCRIPTION
Replace chain_config with chain_id + schema_id fields, remove fork activation from private input. This is now baked into guest by using existing network config instead.


This is the simplification done in https://github.com/ethereum/execution-specs/pull/3278

Need to await merging this till new test fixtures are released so it can be tested.
It will probably also have to be rebased on `glamsterdam-devnet-8`, depending if the specs rebase on that.