### PR TITLE
stateless: Fix missing account reads in witness generation

### DIFF
--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -99,7 +99,8 @@ type
       ## over and over again to the database to avoid the WAL and compation
       ## write amplification that ensues
 
-    collectWitness: bool
+    collectWitness*: bool
+
     witnessKeys: WitnessTable
       ## Used to collect the keys of all read accounts, code and storage slots.
       ## Maps a tuple of address and slot (optional) to the codeTouched flag.
@@ -720,6 +721,11 @@ proc addBalance*(
       let acc = ledger.getAccount(address)
       if acc.isEmpty:
         ledger.makeDirty(address).flags.incl Touched
+    elif ledger.collectWitness:
+      # The reference implementation reads the account even for a zero-value
+      # credit (e.g. zero-amount withdrawals, zero-fee coinbase payments), so
+      # the address must be part of the execution witness.
+      discard ledger.getAccount(address, shouldCreate = false)
     return
   ledger.setBalance(address, ledger.getBalance(address) + delta)
 

--- a/execution_chain/evm/interpreter/op_handlers/oph_call.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_call.nim
@@ -208,12 +208,13 @@ proc loadCallCode(c: Computation, flags: set[MsgFlags]): CodeBytesRef =
   ## after the opcode gas charge but before the depth/balance early exits,
   ## so the read hits the witness even when the call fails early (spec order).
   ##
-  ## TODO: the precompile short-circuit below differs from the spec.
-  ## The spec's `call()` always does `get_account(code_address)` to fetch
-  ## the code hash (precompile dispatch only happens later), so on a
-  ## zero-value CALL to a precompile a spec witness probably includes the
-  ## account's exclusion-proof nodes while ours does not. TBI
+  ## Precompiles execute natively and don't need their account, but the spec's
+  ## `call()` does `get_account(code_address)` before precompile dispatch, so the
+  ## account access must appear in the witness. Replicate that read only when a
+  ## witness is being collected, keeping normal precompile calls on the fast path.
   if MsgFlags.Precompile in flags:
+    if c.vmState.collectWitness:
+      discard c.vmState.readOnlyLedger.getCode(c.msg.delegateTo)
     return CodeBytesRef(nil)
 
   c.vmState.readOnlyLedger.getCode(c.msg.delegateTo)

--- a/execution_chain/evm/state.nim
+++ b/execution_chain/evm/state.nim
@@ -288,6 +288,9 @@ method getAncestorHash*(
 proc readOnlyLedger*(vmState: BaseVMState): ReadOnlyLedger {.inline.} =
   ReadOnlyLedger(vmState.ledger)
 
+func collectWitness*(vmState: BaseVMState): bool =
+  vmState.ledger.collectWitness
+
 template mutateLedger*(vmState: BaseVMState, body: untyped): untyped =
   block:
     let ledger {.inject.} = vmState.ledger

--- a/tests/eest/eest_blockchain.nim
+++ b/tests/eest/eest_blockchain.nim
@@ -122,6 +122,19 @@ proc shortLog(witness: ExecutionWitness): string =
     res.add header.asSeq().to0xHex() & "\n"
   res
 
+const
+  # Fixtures with a deliberately mutated `executionWitness` (extra unused
+  # nodes, or complete but unsorted) to test the resilience of the stateless
+  # executor. The generated witness legitimately differs from these, so the
+  # comparison falls back to the subset check instead of the strict one.
+  mutatedWitnessFiles = [
+    "validation_state_extra_unused_trie_node.json",
+    "validation_state_unsorted_but_complete.json",
+    "validation_codes_extra_unused_bytecode.json",
+    "validation_codes_unsorted_but_complete.json",
+    "witness_headers_extra_unused_older_ancestor.json",
+  ]
+
 proc compare(
     generated, expected: ExecutionWitness, strict = false
 ): Result[void, string] =
@@ -163,7 +176,10 @@ proc compare(
   ok()
 
 proc runTest(
-    env: TestEnv, unit: BlockchainUnitEnv, statelessEnabled = false
+    env: TestEnv,
+    unit: BlockchainUnitEnv,
+    statelessEnabled = false,
+    strictWitness = true,
 ): Future[Result[void, string]] {.async.} =
   let blocks = parseBlocks(unit.blocks)
   var latestStateRoot = unit.genesisBlockHeader.stateRoot
@@ -255,13 +271,14 @@ proc runTest(
           # Execution requests are derived from execution output, which is no
           # longer available after import. An actualy production setup would
           # receive them prepped in the engine API newPayload call instead.
-          input = ?build_stateless_input(
-            blk.blk,
-            generatedWitness,
-            fixtureInput.new_payload_request.executionRequests,
-            encode(bal),
-            env.chain.com.chainId.truncate(uint64),
-          )
+          input =
+            ?build_stateless_input(
+              blk.blk,
+              generatedWitness,
+              fixtureInput.new_payload_request.executionRequests,
+              encode(bal),
+              env.chain.com.chainId.truncate(uint64),
+            )
           outputBytes = run_stateless_guest(serialize_stateless_input(input))
           output = ?deserialize_stateless_output(outputBytes)
 
@@ -288,9 +305,10 @@ proc runTest(
           return err("Host-built chain config does not match the test vector")
         if input.public_keys != fixtureInput.public_keys:
           return err("Host-built public keys do not match the test vector")
-        # The generated witness must be a subset of the test vector witness,
-        # which may deliberately contain extra nodes and differ in order.
-        ?compare(generatedWitness, fixtureInput.witness)
+        # The generated witness must be identical to the test vector witness,
+        # except for fixtures that deliberately mutate the witness (see
+        # mutatedWitnessFiles) where the generated witness must be a subset.
+        ?compare(generatedWitness, fixtureInput.witness, strict = strictWitness)
 
         # TODO:
         #Disabled for the same reason as the new payload request comparison
@@ -347,7 +365,9 @@ proc processFile*(
           testUnit, header, rpcEnabled = false, statelessEnabled, parallelEnabled
         )
 
-        let testResult = waitFor env.runTest(testUnit, statelessEnabled)
+        let testResult = waitFor env.runTest(
+          testUnit, statelessEnabled, strictWitness = fileName notin mutatedWitnessFiles
+        )
         check testResult == Result[void, string].ok()
 
         env.close()


### PR DESCRIPTION
The execution-specs read the recipient account even for a zero-value credit (zero-amount withdrawals, zero-fee coinbase payments). We shortcut that in addBalance. Add the read when collectWitness is set.

The execution-specs also access the account when calling a precompile, which causes it to end up in the witness. We always shortcut that as it isn't necessary. Add the access anyhow when collectWitness is set.

The eest witness comparison is now strict, except for fixtures that deliberately mutate the witness to test stateless-executor resilience.