### PR TITLE
engine_api: Return INVALID status on newPayload decode failure

### DIFF
--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -190,14 +190,16 @@ proc newPayload*(ben: BeaconEngineRef,
       except RlpError as e:
         warn "Failed to decode payload",
           error = e.msg
-        raise invalidParams("Failed to decode block in payload: " & e.msg)
+        return invalidStatus(Opt.none(Hash32),
+          "Failed to decode block in payload: " & e.msg)
     blockAccessList =
       try:
         blockAccessList(payload)
       except RlpError as e:
         warn "Failed to decode payload",
           error = e.msg
-        raise invalidParams("Failed to decode BAL in payload: " & e.msg)
+        return invalidStatus(Opt.none(Hash32),
+          "Failed to decode BAL in payload: " & e.msg)
 
   template header: Header = blk.header
 

--- a/execution_chain/beacon/api_handler/api_utils.nim
+++ b/execution_chain/beacon/api_handler/api_utils.nim
@@ -23,13 +23,13 @@ import
 
 {.push gcsafe, raises:[].}
 
-proc update(ctx: var sha256, wd: WithdrawalV1) =
+func update(ctx: var sha256, wd: WithdrawalV1) =
   ctx.update(toBytesBE distinctBase wd.index)
   ctx.update(toBytesBE distinctBase wd.validatorIndex)
   ctx.update(distinctBase wd.address)
   ctx.update(toBytesBE distinctBase wd.amount)
 
-proc computePayloadId*(blockHash: common.Hash32,
+func computePayloadId*(blockHash: common.Hash32,
                        params: PayloadAttributes): Bytes8 =
   var dest: common.Hash32
   var ctx: sha256
@@ -49,10 +49,9 @@ proc computePayloadId*(blockHash: common.Hash32,
   ctx.clear()
   (distinctBase result)[0..7] = dest.data[0..7]
 
-proc validateBlockHash*(header: common.Header,
+func validateBlockHash*(header: common.Header,
                         wantHash: common.Hash32,
-                        version: Version): Result[void, PayloadStatusV1]
-                          {.gcsafe.} =
+                        version: Version): Result[void, PayloadStatusV1] =
   let gotHash = header.computeBlockHash
   if wantHash != gotHash:
     let status = if version == Version.V1:
@@ -72,13 +71,13 @@ proc validateBlockHash*(header: common.Header,
 template toValidHash*(x: common.Hash32): Opt[Hash32] =
   Opt.some(x)
 
-proc simpleFCU*(status: PayloadStatusV1): ForkchoiceUpdatedResponse =
+func simpleFCU*(status: PayloadStatusV1): ForkchoiceUpdatedResponse =
   ForkchoiceUpdatedResponse(payloadStatus: status)
 
-proc simpleFCU*(status: PayloadExecutionStatus): ForkchoiceUpdatedResponse =
+func simpleFCU*(status: PayloadExecutionStatus): ForkchoiceUpdatedResponse =
   ForkchoiceUpdatedResponse(payloadStatus: PayloadStatusV1(status: status))
 
-proc simpleFCU*(status: PayloadExecutionStatus,
+func simpleFCU*(status: PayloadExecutionStatus,
                 msg: string): ForkchoiceUpdatedResponse =
   ForkchoiceUpdatedResponse(
     payloadStatus: PayloadStatusV1(
@@ -87,7 +86,7 @@ proc simpleFCU*(status: PayloadExecutionStatus,
     )
   )
 
-proc invalidFCU*(
+func invalidFCU*(
     validationError: string,
     hash = default(common.Hash32)): ForkchoiceUpdatedResponse =
   ForkchoiceUpdatedResponse(payloadStatus:
@@ -98,7 +97,7 @@ proc invalidFCU*(
     )
   )
 
-proc validFCU*(id: Opt[Bytes8],
+func validFCU*(id: Opt[Bytes8],
                validHash: common.Hash32): ForkchoiceUpdatedResponse =
   ForkchoiceUpdatedResponse(
     payloadStatus: PayloadStatusV1(
@@ -108,67 +107,71 @@ proc validFCU*(id: Opt[Bytes8],
     payloadId: id
   )
 
-proc invalidStatus*(validHash: common.Hash32, msg: string): PayloadStatusV1 =
+func invalidStatus*(
+    validHash: Opt[common.Hash32], msg: string): PayloadStatusV1 =
   PayloadStatusV1(
     status: PayloadExecutionStatus.invalid,
-    latestValidHash: toValidHash(validHash),
+    latestValidHash: validHash,
     validationError: Opt.some(msg)
   )
 
-proc invalidStatus*(validHash = default(common.Hash32)): PayloadStatusV1 =
+func invalidStatus*(validHash: common.Hash32, msg: string): PayloadStatusV1 =
+  invalidStatus(Opt.some(validHash), msg)
+
+func invalidStatus*(validHash = default(common.Hash32)): PayloadStatusV1 =
   PayloadStatusV1(
     status: PayloadExecutionStatus.invalid,
     latestValidHash: toValidHash(validHash)
   )
 
-proc acceptedStatus*(validHash: common.Hash32): PayloadStatusV1 =
+func acceptedStatus*(validHash: common.Hash32): PayloadStatusV1 =
   PayloadStatusV1(
     status: PayloadExecutionStatus.accepted,
     latestValidHash: toValidHash(validHash)
   )
 
-proc acceptedStatus*(): PayloadStatusV1 =
+func acceptedStatus*(): PayloadStatusV1 =
   PayloadStatusV1(
     status: PayloadExecutionStatus.accepted
   )
 
-proc validStatus*(validHash: common.Hash32): PayloadStatusV1 =
+func validStatus*(validHash: common.Hash32): PayloadStatusV1 =
   PayloadStatusV1(
     status: PayloadExecutionStatus.valid,
     latestValidHash: toValidHash(validHash)
   )
 
-proc invalidParams*(msg: string): ref ApplicationError =
+func invalidParams*(msg: string): ref ApplicationError =
   (ref ApplicationError)(
     code: engineApiInvalidParams,
     msg: msg
   )
 
-proc invalidForkChoiceState*(msg: string): ref ApplicationError =
+func invalidForkChoiceState*(msg: string): ref ApplicationError =
   (ref ApplicationError)(
     code: engineApiInvalidForkchoiceState,
     msg: msg
   )
 
-proc unknownPayload*(msg: string): ref ApplicationError =
+func unknownPayload*(msg: string): ref ApplicationError =
   (ref ApplicationError)(
     code: engineApiUnknownPayload,
     msg: msg
   )
 
-proc invalidAttr*(msg: string): ref ApplicationError =
+func invalidAttr*(msg: string): ref ApplicationError =
   (ref ApplicationError)(
     code: engineApiInvalidPayloadAttributes,
     msg: msg
   )
 
-proc unsupportedFork*(msg: string): ref ApplicationError =
+func unsupportedFork*(msg: string): ref ApplicationError =
   (ref ApplicationError)(
     code: engineApiUnsupportedFork,
     msg: msg
   )
 
-proc tooLargeRequest*(msg: string): ref ApplicationError =
+func tooLargeRequest*(msg: string): ref ApplicationError =
   (ref ApplicationError)(
     code: engineApiTooLargeRequest,
     msg: msg

--- a/tests/test_engine_api.nim
+++ b/tests/test_engine_api.nim
@@ -464,12 +464,16 @@ proc newPayloadInvalidRLP(env: TestEnv): Result[void, string] =
       params.parentBeaconBlockRoot,
       params.executionRequests)
 
-  if res.isOk:
-    return err("res should error on undecodable payload")
+  # An undecodable payload is an invalid block, not an invalid request, so it
+  # is reported as an invalid payload status.
+  if res.isErr:
+    return err("res should not error on undecodable payload: " & res.error)
 
-  if $engineApiInvalidParams notin res.error:
-    return err("invalid error code: " & res.error &
-      " expect: " & $engineApiInvalidParams)
+  if res.get.status != PayloadExecutionStatus.invalid:
+    return err("res.status should be equal to PayloadExecutionStatus.invalid")
+
+  if res.get.latestValidHash.isSome:
+    return err("latestValidHash should be none for an undecodable payload")
 
   ok()
 


### PR DESCRIPTION
A payload that fails to decode is an invalid block, not an invalid request, so the spec wants a PayloadStatusV1 instead of a JSON-RPC error. latestValidHash is null as the valid ancestor is unknown.


This is the cause of 2 failures on https://eth-act.github.io/eest-execution-witness-dashboard/#/group/tests-zkevm%20v0.6.2