### PR TITLE
bump timeout for Nix CI builds to accomodate rocksdb

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: '${{ matrix.system }} / ${{ matrix.test }}'
-    timeout-minutes: 15
+    timeout-minutes: 25
     runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Whe nim-sds or rocksdb is not cached builts take 10+ minutes more.