### PR TITLE
Do not call computeStateRoot when genesis have no accounts

### DIFF
--- a/execution_chain/common/genesis.nim
+++ b/execution_chain/common/genesis.nim
@@ -25,6 +25,9 @@ import
 # ------------------------------------------------------------------------------
 
 proc writeGenesisAlloc*(alloc: GenesisAlloc, db: CoreDbTxRef): Hash32 =
+  if alloc.len == 0:
+    return EMPTY_ROOT_HASH
+
   let ledger = LedgerRef.init(db)
 
   for address, account in alloc:

--- a/execution_chain/nimbus_execution_client.nim
+++ b/execution_chain/nimbus_execution_client.nim
@@ -447,11 +447,25 @@ proc main*(config = makeConfig(), nimbus = NimbusNode(nil)) {.noinline.} =
   else:
     let (com, keyCacheEnabled) = setupCommonRef(config, params, 0)
 
-  if keyCacheEnabled:
-    # Make sure key cache isn't empty
-    discard com.db.mpt.txRef.computeStateRoot(skipLayers = true).valueOr:
-      fatal "Cannot compute root keys", msg = error
-      quit(QuitFailure)
+  block checkKeyCache:
+    let
+      txFrame = com.db.baseTxFrame()
+      baseNum = txFrame.getSavedStateBlockNumber()
+      base = txFrame.getBlockHeader(baseNum).valueOr:
+        fatal "Cannot load base block header",
+          baseNum, err = error
+        quit(QuitFailure)
+
+    if base.stateRoot == EMPTY_ROOT_HASH:
+      # Prevent calling computeStateRoot if base have no accounts
+      # Usually a genesis block
+      break checkKeyCache
+
+    if keyCacheEnabled:
+      # Make sure key cache isn't empty
+      discard com.db.mpt.txRef.computeStateRoot(skipLayers = true).valueOr:
+        fatal "Cannot compute root keys", msg = error
+        quit(QuitFailure)
 
   defer:
     com.db.close()


### PR DESCRIPTION
hive test `consume-engine` 13 failing test cases with error msg: 
```
FAT 2026-08-11 10:35:19.958+00:00 Cannot compute root keys                   msg=GetKeyNotFound
```