### PR TITLE
fcu handle empty finalizedBlockHash when headBlockHash is not latest

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -830,12 +830,18 @@ proc forkChoice*(c: ForkedChainRef,
   let
     # Find the unique branch where `headHash` is a member of.
     head = ?c.findHeadPos(headHash)
+
+  # Head maybe moved backward or moved to other branch.
+  c.updateHead(head)
+  if finalizedHash == zeroHash32:
+    # Do nothing else if there is no request to new finality.
+    return ok()
+
+  let
     # Finalized block must be parent or on the new canonical chain which is
     # represented by `head`.
     finalized = ?c.findFinalizedPos(finalizedHash, head)
 
-  # Head maybe moved backward or moved to other branch.
-  c.updateHead(head)
   c.updateFinalized(finalized, head)
 
   let base = c.calculateNewBase(finalized.number, head)

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -243,11 +243,16 @@ template checkVerdictErr(chain, blk, expected) =
       " expected err(", expected, ") got ok(", res.value, ")"
 
 template checkForkChoice(chain, a, b) =
-  let res = waitFor chain.forkChoice(a.blockHash, b.blockHash)
+  let bHash = when typeof(b) is Hash32: b
+              else: b.blockHash
+  let res = waitFor chain.forkChoice(a.blockHash, bHash)
   check res.isOk
   if res.isErr:
     debugEcho "FORK CHOICE FAIL: ", res.error
-    debugEcho "Block Number: ", a.header.number, " ", b.header.number
+    when typeof(b) is Hash32:
+      debugEcho "Block Number: ", a.header.number, ", ", bHash
+    else:
+      debugEcho "Block Number: ", a.header.number, ", ", b.header.number
 
 template checkForkChoiceErr(chain, a, b) =
   let res = waitFor chain.forkChoice(a.blockHash, b.blockHash)
@@ -1284,6 +1289,16 @@ suite "ForkedChainRef tests":
     checkHeadHash chain, B4.blockHash
     check chain.heads.len == 1
     check chain.validate info & " (2)"
+
+  test "fcu with empty fin":
+    const info = "setHead finalized"
+    let com = env.newCom()
+    let chain = ForkedChainRef.init(com)
+    checkImportBlock(chain, blk1)
+    checkForkChoice(chain, genesis, default(Hash32))
+    check chain.validate info & " (1)"
+    check chain.latestHash == blk1.blockHash
+    check chain.fcuHead.number == 0
 
   test "BaseVMState.reinit with per-block BAL tracker flags":
     let


### PR DESCRIPTION
in hive consume-enginex test, nimbus-el fail to pass 50K test cases. The scenario is block import to block number 1. fcu with headBlockHash=genesis and finalizedBlockHash=zeroes.

So the headBlockHash is behind latest imported block and nimbus respond with PayloadStatusEnum.INVALID.

It's not explicit from the spec, but I guess it's related to reorg path.
https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_forkchoiceupdatedv1