### PR TITLE
engine_api: Restore -32602 for undecodable blockAccessList

### DIFF
--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -198,8 +198,7 @@ proc newPayload*(ben: BeaconEngineRef,
       except RlpError as e:
         warn "Failed to decode payload",
           error = e.msg
-        return invalidStatus(Opt.none(Hash32),
-          "Failed to decode BAL in payload: " & e.msg)
+        raise invalidParams("Failed to decode BAL in payload: " & e.msg)
 
   template header: Header = blk.header
 


### PR DESCRIPTION
Regression from #4623, which changed both newPayload decode sites when only the block one needed the change apparently..

The specs do not cover this case in a clear manner, and it makes this inconsistent between two fields of the same call:
- a malformed transaction yields INVALID
- a malformed blockAccessList yields -32602.

But, making this change as it is what Hive expects (and what other clients do).