### PR TITLE
Increase stateroot computation flush batch size

### DIFF
--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -41,7 +41,7 @@ proc `=copy`(
 # Keep write batch size _around_ 1mb, give or take some overhead - this is a
 # tradeoff between efficiency and memory usage with diminishing returns the
 # larger it is..
-const batchSize = 1024 * 1024 div (sizeof(RootedVertexID) + sizeof(HashKey))
+const batchSize = 32 * 1024 * 1024 div (sizeof(RootedVertexID) + sizeof(VertexBuf))
 
 func progress(batch: WriteBatch, parallel: static bool): string =
   when parallel:
@@ -76,14 +76,14 @@ template flushCheck(
     ?batch.flush(db)
 
     when parallel:
-      if batch.count mod (batchSize * 100) == 0:
+      if batch.count mod (batchSize * 10) == 0:
         info "Writing computeKey cache",
           keys = batch.count, tasksCompleted = batch.progress(parallel)
       else:
         debug "Writing computeKey cache",
           keys = batch.count, tasksCompleted = batch.progress(parallel)
     else:
-      if batch.count mod (batchSize * 100) == 0:
+      if batch.count mod (batchSize * 10) == 0:
         info "Writing computeKey cache",
           keys = batch.count, accounts = batch.progress(parallel)
       else:
@@ -532,14 +532,14 @@ proc computeKeyImpl(
 
     if batch.count > 0:
       when parallel:
-        if batch.count >= batchSize * 100:
+        if batch.count >= batchSize * 10:
           info "Wrote computeKey cache",
             keys = batch.count, tasksCompleted = batch.progress(parallel)
         else:
           debug "Wrote computeKey cache",
             keys = batch.count, tasksCompleted = batch.progress(parallel)
       else:
-        if batch.count >= batchSize * 100:
+        if batch.count >= batchSize * 10:
           info "Wrote computeKey cache", keys = batch.count, accounts = "100.00%"
         else:
           debug "Wrote computeKey cache", keys = batch.count, accounts = "100.00%"


### PR DESCRIPTION
This speeds up the stateroot computation when writing keys to disk by increasing the batch size from around 1mb to 32mb. There is some fixed overhead in each flush call and so making the batches larger and doing less flushes speeds up the overall performance.

For a full parallel stateroot computation of an unhashed state at block 5 million the time goes from around 3 minutes to 2 minutes. The single threaded version goes from around 7.5 minutes to 5 minutes.


