### PR TITLE
Parallel stateroot computation - lock free merge keys

### DIFF
--- a/execution_chain/concurrency/shared_types.nim
+++ b/execution_chain/concurrency/shared_types.nim
@@ -93,10 +93,13 @@ proc `[]`*[E](s: var SharedSeq[E], i: int): var E =
 template len*[E](s: SharedSeq[E]): int =
   s.count
 
-
+const seqGrowThresholdBytes = 128 * 1024
 
 proc grow[E](s: var SharedSeq[E], minCap: int) =
-  s.reallocTo(nextPowerOfTwo(max(minCap, seqInitialCapacity)))
+  if max(s.cap, minCap) * sizeof(E) >= seqGrowThresholdBytes:
+    s.reallocTo(max(minCap, s.cap + (s.cap div 2)))
+  else:
+    s.reallocTo(nextPowerOfTwo(max(minCap, seqInitialCapacity)))
 
 proc setLen*[E](s: var SharedSeq[E], newLen: int, zeroed = true, exact = false) =
   if newLen > s.cap:

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -17,9 +17,9 @@ import
   eth/common/hashes_rlp,
   ./[aristo_desc, aristo_get, aristo_layers, aristo_blobify, aristo_serialise],
   ./aristo_desc/desc_backend,
-  ../../concurrency/queue
+  ../../concurrency/[queue, shared_types]
 
-export aristo_desc, chronicles, hashes_rlp
+export aristo_desc, chronicles, hashes_rlp, shared_types
 
 type
   WriteBatch* = object
@@ -32,15 +32,7 @@ type
 
   ConcurrentVertexBufQueue* = ConcurrentQueue[3, (RootedVertexID, VertexBuf)]
 
-  ComputedKey = (RootedVertexID, HashKey, int)
-
-  KeyWriteBuf* = object
-    ## Keys computed by a single task, kept on the shared heap and merged into
-    ## the layers by the spawning thread once all tasks have finished. Nothing
-    ## reads a key computed during a run before then, so neither the buffer nor
-    ## the layers need any locking while the tasks are hashing.
-    data: ptr UncheckedArray[ComputedKey]
-    len, cap: int
+  KeyWriteBuf* = SharedSeq[(RootedVertexID, HashKey, int)]
 
 proc `=copy`(
     dest: var WriteBatch, src: WriteBatch
@@ -209,29 +201,7 @@ proc computeKeyImpl(
 ): Result[(HashKey, int), AristoError]
 
 when compileOption("threads"):
-  proc add(buf: var KeyWriteBuf, item: ComputedKey) =
-    if buf.len == buf.cap:
-      buf.cap = max(2 * buf.cap, 1024)
-      let size = buf.cap * sizeof(ComputedKey)
-      buf.data = cast[ptr UncheckedArray[ComputedKey]](
-        if buf.data == nil:
-          allocShared(size)
-        else:
-          reallocShared(buf.data, size)
-      )
-    buf.data[buf.len] = item
-    inc buf.len
-
-  proc dispose(buf: var KeyWriteBuf) =
-    if buf.data != nil:
-      deallocShared(buf.data)
-    buf.reset()
-
   proc mergeKeys(txRef: AristoTxRef, bufs: openArray[KeyWriteBuf]) =
-    ## Merge the tasks' keys into the layers they belong to. Frames are indexed
-    ## by level up front because a `deltaAtLevel` walk per key is what dominates
-    ## the merge when keys are spread across many frames, and each frame's key
-    ## table is pre-sized so that the bulk insert does not grow it repeatedly.
     let baseLevel = txRef.db.baseTxFrame().level
     var
       frames = newSeq[AristoTxRef](txRef.level - baseLevel + 1)
@@ -244,8 +214,8 @@ when compileOption("threads"):
         frame = frame.parent
 
     for buf in bufs:
-      for i in 0 ..< buf.len:
-        let level = buf.data[i][2]
+      for item in buf:
+        let level = item[2]
 
         doAssert level >= baseLevel and level <= txRef.level,
           "Cannot write keys at level < baseTxFrame level. Found level = " &
@@ -258,10 +228,8 @@ when compileOption("threads"):
         frames[i].layersReserveKeys(count)
 
     for buf in bufs:
-      for i in 0 ..< buf.len:
-        frames[buf.data[i][2] - baseLevel].layersMergeKey(
-          buf.data[i][0], buf.data[i][1]
-        )
+      for item in buf:
+        frames[item[2] - baseLevel].layersMergeKey(item[0], item[1])
 
   proc putVtxBlob(
       batch: var WriteBatch, db: AristoDbRef, rvid: RootedVertexID, vtx: openArray[byte]
@@ -493,7 +461,7 @@ proc computeKeyImpl(
           cpuRelax()
 
         # At this point all futures have finished running.
-        # Now we process any remaining data in the queues and buffers.
+        # Now we process any remaining data in the queues.
         for i, f in futs:
           if f.isSpawned():
             if not vtxBufQueues[i].isEmpty():

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -122,8 +122,17 @@ proc putKeyAtLevel(
   ## corresponding hash!)
 
   if level >= txRef.db.baseTxFrame().level:
-    let frame = txRef.deltaAtLevel(level)
+    var
+      frame = txRef
+      snapFrame: AristoTxRef
+    while frame.level > level:
+      if snapFrame.isNil and frame.snapshot.level.isSome():
+        snapFrame = frame
+      frame = frame.parent
+
     frame.layersMergeKey(rvid, key)
+    if not snapFrame.isNil:
+      snapFrame.layersMergeKeyInSnapshot(rvid, key)
   elif level == dbLevel:
     ?batch.putVtx(txRef.db, rvid, vtx, key)
   else: # level > dbLevel but less than baseTxFrame level
@@ -219,10 +228,13 @@ when compileOption("threads"):
     var
       frames = newSeq[AristoTxRef](txRef.level - baseLevel + 1)
       counts = newSeq[int](frames.len)
+      snapFrame: AristoTxRef
 
     block:
       var frame = txRef
       while not frame.isNil and frame.level >= baseLevel:
+        if snapFrame.isNil and frame.snapshot.level.isSome():
+          snapFrame = frame
         frames[frame.level - baseLevel] = frame
         frame = frame.parent
 
@@ -243,6 +255,8 @@ when compileOption("threads"):
     for buf in bufs:
       for item in buf:
         frames[item[2] - baseLevel].layersMergeKey(item[0], item[1])
+        if not snapFrame.isNil and item[2] < snapFrame.level:
+          snapFrame.layersMergeKeyInSnapshot(item[0], item[1])
 
   proc putVtxBlob(
       batch: var WriteBatch, db: AristoDbRef, rvid: RootedVertexID, vtx: openArray[byte]

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -108,42 +108,51 @@ proc putVtx(
 
   ok()
 
-proc putKeyAtLevel(
-    txRef: AristoTxRef,
-    rvid: RootedVertexID,
-    vtx: BranchRef,
-    key: HashKey,
-    level: int,
-    batch: var WriteBatch,
-): Result[void, AristoError] =
-  ## Store a hash key in the given layer or directly to the underlying database
+proc mergeKeys(txRef: AristoTxRef, bufs: openArray[KeyWriteBuf]) =
+  ## Merge buffered hash keys into the layer that each key was computed against
   ## which helps ensure that memory usage is proportional to the pending change
   ## set (vertex data may have been committed to disk without computing the
   ## corresponding hash!)
+  var total = 0
+  for buf in bufs:
+    total += buf.len
 
-  if level >= txRef.db.baseTxFrame().level:
-    var
-      frame = txRef
-      snapFrame: AristoTxRef
-    while frame.level > level:
-      if snapFrame.isNil and frame.snapshot.level.isSome():
-        snapFrame = frame
+  if total == 0:
+    return
+
+  let baseLevel = txRef.db.baseTxFrame().level
+  var
+    frames = newSeq[AristoTxRef](txRef.level - baseLevel + 1)
+    counts = newSeq[int](frames.len)
+    snapshotFrame: AristoTxRef
+
+  block:
+    var frame = txRef
+    while not frame.isNil and frame.level >= baseLevel:
+      if snapshotFrame.isNil and frame.snapshot.level.isSome():
+        snapshotFrame = frame
+      frames[frame.level - baseLevel] = frame
       frame = frame.parent
 
-    frame.layersMergeKey(rvid, key)
-    if not snapFrame.isNil:
-      snapFrame.layersMergeKeyInSnapshot(rvid, key)
-  elif level == dbLevel:
-    ?batch.putVtx(txRef.db, rvid, vtx, key)
-  else: # level > dbLevel but less than baseTxFrame level
-    # Throw defect here because we should not be writing vertexes to the database if
-    # from a lower level than the baseTxFrame level.
-    raiseAssert(
-      "Cannot write keys at level < baseTxFrame level. Found level = " & $level &
-        ", baseTxFrame level = " & $txRef.db.baseTxFrame().level
-    )
+  for buf in bufs:
+    for item in buf:
+      let level = item[2]
 
-  ok()
+      doAssert level >= baseLevel and level <= txRef.level,
+        "Cannot write keys at level < baseTxFrame level. Found level = " & $level &
+          ", baseTxFrame level = " & $baseLevel
+
+      inc counts[level - baseLevel]
+
+  for i, count in counts:
+    if count > 0:
+      frames[i].layersReserveKeys(count)
+
+  for buf in bufs:
+    for item in buf:
+      frames[item[2] - baseLevel].layersMergeKey(item[0], item[1])
+      if not snapshotFrame.isNil and item[2] < snapshotFrame.level:
+        snapshotFrame.layersMergeKeyInSnapshot(item[0], item[1])
 
 func layersGetKeyOrVtx*(
     db: AristoTxRef, rvid: RootedVertexID
@@ -222,41 +231,6 @@ when compileOption("threads"):
     proc idleSleep() =
       var req = Timespec(tv_sec: posix.Time(0), tv_nsec: 100_000)
       discard nanosleep(req, req)
-
-  proc mergeKeys(txRef: AristoTxRef, bufs: openArray[KeyWriteBuf]) =
-    let baseLevel = txRef.db.baseTxFrame().level
-    var
-      frames = newSeq[AristoTxRef](txRef.level - baseLevel + 1)
-      counts = newSeq[int](frames.len)
-      snapFrame: AristoTxRef
-
-    block:
-      var frame = txRef
-      while not frame.isNil and frame.level >= baseLevel:
-        if snapFrame.isNil and frame.snapshot.level.isSome():
-          snapFrame = frame
-        frames[frame.level - baseLevel] = frame
-        frame = frame.parent
-
-    for buf in bufs:
-      for item in buf:
-        let level = item[2]
-
-        doAssert level >= baseLevel and level <= txRef.level,
-          "Cannot write keys at level < baseTxFrame level. Found level = " &
-            $level & ", baseTxFrame level = " & $baseLevel
-
-        inc counts[level - baseLevel]
-
-    for i, count in counts:
-      if count > 0:
-        frames[i].layersReserveKeys(count)
-
-    for buf in bufs:
-      for item in buf:
-        frames[item[2] - baseLevel].layersMergeKey(item[0], item[1])
-        if not snapFrame.isNil and item[2] < snapFrame.level:
-          snapFrame.layersMergeKeyInSnapshot(item[0], item[1])
 
   proc putVtxBlob(
       batch: var WriteBatch, db: AristoDbRef, rvid: RootedVertexID, vtx: openArray[byte]
@@ -533,20 +507,22 @@ proc computeKeyImpl(
   # their hash being saved directly to the backend.
 
   if vtx.vType in Branches:
-    when parallel and not spawnTpTasks:
-      if level >= txRef.db.baseTxFrame().level:
-        keyBuf[].add((rvid, key, level))
-      elif level == dbLevel:
+    if level >= txRef.db.baseTxFrame().level:
+      keyBuf[].add((rvid, key, level))
+    elif level == dbLevel:
+      when parallel and not spawnTpTasks:
         var vtxBuf: VertexBuf
         vtx.blobifyTo(key, vtxBuf)
         vtxBufQueue[].push((rvid, vtxBuf))
       else:
-        raiseAssert(
-          "Cannot write keys at level < baseTxFrame level. Found level = " & $level &
-            ", baseTxFrame level = " & $txRef.db.baseTxFrame().level
-        )
-    else:
-      ?txRef.putKeyAtLevel(rvid, BranchRef(vtx), key, level, batch)
+        ?batch.putVtx(txRef.db, rvid, BranchRef(vtx), key)
+    else: # level > dbLevel but less than baseTxFrame level
+      # Throw defect here because we should not be writing vertexes to the database if
+      # from a lower level than the baseTxFrame level.
+      raiseAssert(
+        "Cannot write keys at level < baseTxFrame level. Found level = " & $level &
+          ", baseTxFrame level = " & $txRef.db.baseTxFrame().level
+      )
 
   ok (key, level)
 
@@ -566,12 +542,22 @@ proc computeKeyImpl(
   if keyvtx[0].isValid:
     return ok(keyvtx[0])
 
-  var batch: WriteBatch
+  var
+    batch: WriteBatch
+    keyBufs: array[1, KeyWriteBuf]
+
+  defer:
+    keyBufs[0].dispose()
+
   let res = computeKeyImpl(
-    txRef, rvid, batch, keyvtx[1], level, skipLayers, spawnTpTasks, parallel, nil, nil
+    txRef, rvid, batch, keyvtx[1], level, skipLayers, spawnTpTasks, parallel,
+    keyBufs[0].addr, nil,
   )
 
   if res.isOk:
+    txRef.mergeKeys(keyBufs)
+    keyBufs[0].dispose()
+
     ?batch.flush(txRef.db)
 
     if batch.count > 0:

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -32,7 +32,7 @@ type
 
   ConcurrentVertexBufQueue* = ConcurrentQueue[3, (RootedVertexID, VertexBuf)]
 
-  KeyWriteBuf* = SharedSeq[(RootedVertexID, HashKey, int)]
+  KeyWriteBuf* = SharedSeq[(RootedVertexID, HashKey, uint32)]
 
 proc `=copy`(
     dest: var WriteBatch, src: WriteBatch
@@ -108,51 +108,42 @@ proc putVtx(
 
   ok()
 
-proc mergeKeys(txRef: AristoTxRef, bufs: openArray[KeyWriteBuf]) =
-  ## Merge buffered hash keys into the layer that each key was computed against
+proc putKeyAtLevel(
+    txRef: AristoTxRef,
+    rvid: RootedVertexID,
+    vtx: BranchRef,
+    key: HashKey,
+    level: int,
+    batch: var WriteBatch,
+    snapshotFrame: AristoTxRef,
+): Result[void, AristoError] =
+  ## Store a hash key in the given layer or directly to the underlying database
   ## which helps ensure that memory usage is proportional to the pending change
   ## set (vertex data may have been committed to disk without computing the
   ## corresponding hash!)
-  var total = 0
-  for buf in bufs:
-    total += buf.len
 
-  if total == 0:
-    return
-
-  let baseLevel = txRef.db.baseTxFrame().level
-  var
-    frames = newSeq[AristoTxRef](txRef.level - baseLevel + 1)
-    counts = newSeq[int](frames.len)
-    snapshotFrame: AristoTxRef
-
-  block:
+  if level >= txRef.db.baseTxFrame().level:
     var frame = txRef
-    while not frame.isNil and frame.level >= baseLevel:
-      if snapshotFrame.isNil and frame.snapshot.level.isSome():
-        snapshotFrame = frame
-      frames[frame.level - baseLevel] = frame
+    while frame.level > level:
       frame = frame.parent
 
-  for buf in bufs:
-    for item in buf:
-      let level = item[2]
+    frame.layersMergeKey(rvid, key)
+    # A snapshot frame at or below the merge level must not be patched - the
+    # equal-level case is already covered by layersMergeKey updating its own
+    # frame's snapshot.
+    if not snapshotFrame.isNil and level < snapshotFrame.level:
+      snapshotFrame.layersMergeKeyInSnapshot(rvid, key)
+  elif level == dbLevel:
+    ?batch.putVtx(txRef.db, rvid, vtx, key)
+  else: # level > dbLevel but less than baseTxFrame level
+    # Throw defect here because we should not be writing vertexes to the database if
+    # from a lower level than the baseTxFrame level.
+    raiseAssert(
+      "Cannot write keys at level < baseTxFrame level. Found level = " & $level &
+        ", baseTxFrame level = " & $txRef.db.baseTxFrame().level
+    )
 
-      doAssert level >= baseLevel and level <= txRef.level,
-        "Cannot write keys at level < baseTxFrame level. Found level = " & $level &
-          ", baseTxFrame level = " & $baseLevel
-
-      inc counts[level - baseLevel]
-
-  for i, count in counts:
-    if count > 0:
-      frames[i].layersReserveKeys(count)
-
-  for buf in bufs:
-    for item in buf:
-      frames[item[2] - baseLevel].layersMergeKey(item[0], item[1])
-      if not snapshotFrame.isNil and item[2] < snapshotFrame.level:
-        snapshotFrame.layersMergeKeyInSnapshot(item[0], item[1])
+  ok()
 
 func layersGetKeyOrVtx*(
     db: AristoTxRef, rvid: RootedVertexID
@@ -214,6 +205,7 @@ proc computeKeyImpl(
     skipLayers: static bool,
     spawnTpTasks: static bool,
     parallel: static bool,
+    snapshotFrame: AristoTxRef,
     keyBuf: ptr KeyWriteBuf,
     vtxBufQueue: ptr ConcurrentVertexBufQueue,
 ): Result[(HashKey, int), AristoError]
@@ -221,6 +213,51 @@ proc computeKeyImpl(
 when compileOption("threads"):
   when not defined(windows):
     import std/posix
+
+  proc mergeKeys(
+      txRef: AristoTxRef, bufs: openArray[KeyWriteBuf], snapshotFrame: AristoTxRef
+  ) =
+    ## Merge buffered hash keys into the layer that each key was computed against
+    ## which helps ensure that memory usage is proportional to the pending change
+    ## set (vertex data may have been committed to disk without computing the
+    ## corresponding hash!)
+    var total = 0
+    for buf in bufs:
+      total += buf.len
+
+    if total == 0:
+      return
+
+    let baseLevel = txRef.db.baseTxFrame().level
+    var
+      frames = newSeq[AristoTxRef](txRef.level - baseLevel + 1)
+      counts = newSeq[int](frames.len)
+
+    block:
+      var frame = txRef
+      while not frame.isNil and frame.level >= baseLevel:
+        frames[frame.level - baseLevel] = frame
+        frame = frame.parent
+
+    for buf in bufs:
+      for item in buf:
+        let level = item[2].int
+
+        doAssert level >= baseLevel and level <= txRef.level,
+          "Cannot write keys at level < baseTxFrame level. Found level = " & $level &
+            ", baseTxFrame level = " & $baseLevel
+
+        inc counts[level - baseLevel]
+
+    for i, count in counts:
+      if count > 0:
+        frames[i].layersReserveKeys(count)
+
+    for buf in bufs:
+      for item in buf:
+        frames[item[2].int - baseLevel].layersMergeKey(item[0], item[1])
+        if not snapshotFrame.isNil and item[2].int < snapshotFrame.level:
+          snapshotFrame.layersMergeKeyInSnapshot(item[0], item[1])
 
   proc putVtxBlob(
       batch: var WriteBatch, db: AristoDbRef, rvid: RootedVertexID, vtx: openArray[byte]
@@ -253,6 +290,7 @@ when compileOption("threads"):
         skipLayers = true,
         spawnTpTasks = false,
         parallel = true,
+        snapshotFrame = nil,
         keyBuf,
         vtxBufQueue,
       )
@@ -265,6 +303,7 @@ when compileOption("threads"):
         skipLayers = false,
         spawnTpTasks = false,
         parallel = true,
+        snapshotFrame = nil,
         keyBuf,
         vtxBufQueue,
       )
@@ -278,6 +317,7 @@ proc computeKeyImpl(
     skipLayers: static bool,
     spawnTpTasks: static bool,
     parallel: static bool,
+    snapshotFrame: AristoTxRef,
     keyBuf: ptr KeyWriteBuf,
     vtxBufQueue: ptr ConcurrentVertexBufQueue,
 ): Result[(HashKey, int), AristoError] =
@@ -308,6 +348,7 @@ proc computeKeyImpl(
                   skipLayers = skipLayers,
                   spawnTpTasks = false,
                   parallel,
+                  snapshotFrame,
                   keyBuf,
                   vtxBufQueue,
                 )
@@ -377,6 +418,7 @@ proc computeKeyImpl(
                 skipLayers = skipLayers,
                 spawnTpTasks = false,
                 parallel,
+                snapshotFrame,
                 keyBuf,
                 vtxBufQueue,
               )
@@ -420,6 +462,7 @@ proc computeKeyImpl(
               skipLayers,
               spawnTpTasks = false,
               parallel,
+              snapshotFrame,
               keyBuf,
               vtxBufQueue,
             )
@@ -479,7 +522,7 @@ proc computeKeyImpl(
             (keyvtxs[i][0][0], keyvtxs[i][1]) = ?sync(f)
             vtxBufQueues[i].dispose()
 
-        txRef.mergeKeys(keyBufs)
+        txRef.mergeKeys(keyBufs, snapshotFrame)
 
       template branchSubKey(): untyped =
         if subvid.isValid:
@@ -502,22 +545,20 @@ proc computeKeyImpl(
   # their hash being saved directly to the backend.
 
   if vtx.vType in Branches:
-    if level >= txRef.db.baseTxFrame().level:
-      keyBuf[].add((rvid, key, level))
-    elif level == dbLevel:
-      when parallel and not spawnTpTasks:
+    when parallel and not spawnTpTasks:
+      if level >= txRef.db.baseTxFrame().level:
+        keyBuf[].add((rvid, key, level.uint32))
+      elif level == dbLevel:
         var vtxBuf: VertexBuf
         vtx.blobifyTo(key, vtxBuf)
         vtxBufQueue[].push((rvid, vtxBuf))
       else:
-        ?batch.putVtx(txRef.db, rvid, BranchRef(vtx), key)
-    else: # level > dbLevel but less than baseTxFrame level
-      # Throw defect here because we should not be writing vertexes to the database if
-      # from a lower level than the baseTxFrame level.
-      raiseAssert(
-        "Cannot write keys at level < baseTxFrame level. Found level = " & $level &
-          ", baseTxFrame level = " & $txRef.db.baseTxFrame().level
-      )
+        raiseAssert(
+          "Cannot write keys at level < baseTxFrame level. Found level = " & $level &
+            ", baseTxFrame level = " & $txRef.db.baseTxFrame().level
+        )
+    else:
+      ?txRef.putKeyAtLevel(rvid, BranchRef(vtx), key, level, batch, snapshotFrame)
 
   ok (key, level)
 
@@ -537,22 +578,22 @@ proc computeKeyImpl(
   if keyvtx[0].isValid:
     return ok(keyvtx[0])
 
-  var
-    batch: WriteBatch
-    keyBufs: array[1, KeyWriteBuf]
+  var batch: WriteBatch
 
-  defer:
-    keyBufs[0].dispose()
+  # Find the topmost frame holding a snapshot, if any, so that key writes can
+  # patch it directly instead of searching the frame stack for every key.
+  var snapshotFrame: AristoTxRef
+  for frame in txRef.rstack(stopAtSnapshot = true):
+    if frame.snapshot.level.isSome():
+      snapshotFrame = frame
+      break
 
   let res = computeKeyImpl(
     txRef, rvid, batch, keyvtx[1], level, skipLayers, spawnTpTasks, parallel,
-    keyBufs[0].addr, nil,
+    snapshotFrame, nil, nil,
   )
 
   if res.isOk:
-    txRef.mergeKeys(keyBufs)
-    keyBufs[0].dispose()
-
     ?batch.flush(txRef.db)
 
     if batch.count > 0:

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -219,18 +219,8 @@ proc computeKeyImpl(
 ): Result[(HashKey, int), AristoError]
 
 when compileOption("threads"):
-  when defined(windows):
-    import std/os
-
-    proc idleSleep() =
-      sleep(1)
-
-  else:
+  when not defined(windows):
     import std/posix
-
-    proc idleSleep() =
-      var req = Timespec(tv_sec: posix.Time(0), tv_nsec: 100_000)
-      discard nanosleep(req, req)
 
   proc putVtxBlob(
       batch: var WriteBatch, db: AristoDbRef, rvid: RootedVertexID, vtx: openArray[byte]
@@ -466,11 +456,16 @@ proc computeKeyImpl(
 
           if progressed:
             idleRounds = 0
-          elif idleRounds < 64:
-            inc idleRounds
-            cpuRelax()
           else:
-            idleSleep()
+            when defined(windows):
+              cpuRelax()
+            else:
+              if idleRounds < 64:
+                inc idleRounds
+                cpuRelax()
+              else:
+                var req = Timespec(tv_sec: posix.Time(0), tv_nsec: 100_000)
+                discard nanosleep(req, req)
 
         # At this point all futures have finished running.
         # Now we process any remaining data in the queues.

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -11,7 +11,7 @@
 {.push raises: [], gcsafe.}
 
 import
-  std/strformat,
+  std/[atomics, strformat],
   chronicles,
   results,
   eth/common/hashes_rlp,
@@ -30,8 +30,17 @@ type
     tasksCompleted*: int
     tasksTotal*: int
 
-  ConcurrentHashKeyQueue* = ConcurrentQueue[3, (RootedVertexID, HashKey, int)]
   ConcurrentVertexBufQueue* = ConcurrentQueue[3, (RootedVertexID, VertexBuf)]
+
+  ComputedKey = (RootedVertexID, HashKey, int)
+
+  KeyWriteBuf* = object
+    ## Keys computed by a single task, kept on the shared heap and merged into
+    ## the layers by the spawning thread once all tasks have finished. Nothing
+    ## reads a key computed during a run before then, so neither the buffer nor
+    ## the layers need any locking while the tasks are hashing.
+    data: ptr UncheckedArray[ComputedKey]
+    len, cap: int
 
 proc `=copy`(
     dest: var WriteBatch, src: WriteBatch
@@ -136,23 +145,13 @@ proc putKeyAtLevel(
   ok()
 
 func layersGetKeyOrVtx*(
-    db: AristoTxRef, rvid: RootedVertexID, parallel: static bool
+    db: AristoTxRef, rvid: RootedVertexID
 ): Opt[((HashKey, VertexRef), int)] =
   for w in db.rstack(stopAtSnapshot = true):
     if w.snapshot.level.isSome():
-      when parallel:
-        w.lock.lockRead()
-        defer:
-          w.lock.unlockRead()
-
       w.snapshot.vtx.withValue(rvid, item):
         return Opt.some(((item[][1], item[][0]), item[][2]))
       break
-
-    when parallel:
-      w.lock.lockRead()
-      defer:
-        w.lock.unlockRead()
 
     w.kMap.withValue(rvid, item):
       return ok(((item[], nil), w.level))
@@ -174,7 +173,7 @@ proc getKey(
       {}
 
   when not skipLayers:
-    let keyVtxRes = txRef.layersGetKeyOrVtx(rvid, parallel)
+    let keyVtxRes = txRef.layersGetKeyOrVtx(rvid)
     if keyVtxRes.isSome():
       return ok(keyVtxRes[])
 
@@ -205,19 +204,64 @@ proc computeKeyImpl(
     skipLayers: static bool,
     spawnTpTasks: static bool,
     parallel: static bool,
-    keyQueue: ptr ConcurrentHashKeyQueue,
+    keyBuf: ptr KeyWriteBuf,
     vtxBufQueue: ptr ConcurrentVertexBufQueue,
 ): Result[(HashKey, int), AristoError]
 
 when compileOption("threads"):
-  proc mergeKeyAtLevel(
-      txRef: AristoTxRef, rvid: RootedVertexID, key: HashKey, level: int
-  ) =
-    doAssert level >= txRef.db.baseTxFrame().level
+  proc add(buf: var KeyWriteBuf, item: ComputedKey) =
+    if buf.len == buf.cap:
+      buf.cap = max(2 * buf.cap, 1024)
+      let size = buf.cap * sizeof(ComputedKey)
+      buf.data = cast[ptr UncheckedArray[ComputedKey]](
+        if buf.data == nil:
+          allocShared(size)
+        else:
+          reallocShared(buf.data, size)
+      )
+    buf.data[buf.len] = item
+    inc buf.len
 
-    let frame = txRef.deltaAtLevel(level)
-    withWriteLock(frame.lock):
-      frame.layersMergeKey(rvid, key)
+  proc dispose(buf: var KeyWriteBuf) =
+    if buf.data != nil:
+      deallocShared(buf.data)
+    buf.reset()
+
+  proc mergeKeys(txRef: AristoTxRef, bufs: openArray[KeyWriteBuf]) =
+    ## Merge the tasks' keys into the layers they belong to. Frames are indexed
+    ## by level up front because a `deltaAtLevel` walk per key is what dominates
+    ## the merge when keys are spread across many frames, and each frame's key
+    ## table is pre-sized so that the bulk insert does not grow it repeatedly.
+    let baseLevel = txRef.db.baseTxFrame().level
+    var
+      frames = newSeq[AristoTxRef](txRef.level - baseLevel + 1)
+      counts = newSeq[int](frames.len)
+
+    block:
+      var frame = txRef
+      while not frame.isNil and frame.level >= baseLevel:
+        frames[frame.level - baseLevel] = frame
+        frame = frame.parent
+
+    for buf in bufs:
+      for i in 0 ..< buf.len:
+        let level = buf.data[i][2]
+
+        doAssert level >= baseLevel and level <= txRef.level,
+          "Cannot write keys at level < baseTxFrame level. Found level = " &
+            $level & ", baseTxFrame level = " & $baseLevel
+
+        inc counts[level - baseLevel]
+
+    for i, count in counts:
+      if count > 0:
+        frames[i].layersReserveKeys(count)
+
+    for buf in bufs:
+      for i in 0 ..< buf.len:
+        frames[buf.data[i][2] - baseLevel].layersMergeKey(
+          buf.data[i][0], buf.data[i][1]
+        )
 
   proc putVtxBlob(
       batch: var WriteBatch, db: AristoDbRef, rvid: RootedVertexID, vtx: openArray[byte]
@@ -238,7 +282,7 @@ when compileOption("threads"):
       vtx: ptr VertexRef,
       level: int,
       skipLayers: bool,
-      keyQueue: ptr ConcurrentHashKeyQueue,
+      keyBuf: ptr KeyWriteBuf,
       vtxBufQueue: ptr ConcurrentVertexBufQueue,
   ): Result[(HashKey, int), AristoError] =
     if skipLayers:
@@ -250,7 +294,7 @@ when compileOption("threads"):
         skipLayers = true,
         spawnTpTasks = false,
         parallel = true,
-        keyQueue,
+        keyBuf,
         vtxBufQueue,
       )
     else:
@@ -262,7 +306,7 @@ when compileOption("threads"):
         skipLayers = false,
         spawnTpTasks = false,
         parallel = true,
-        keyQueue,
+        keyBuf,
         vtxBufQueue,
       )
 
@@ -275,7 +319,7 @@ proc computeKeyImpl(
     skipLayers: static bool,
     spawnTpTasks: static bool,
     parallel: static bool,
-    keyQueue: ptr ConcurrentHashKeyQueue,
+    keyBuf: ptr KeyWriteBuf,
     vtxBufQueue: ptr ConcurrentVertexBufQueue,
 ): Result[(HashKey, int), AristoError] =
   # The bloom filter available used only when creating the key cache from an
@@ -305,7 +349,7 @@ proc computeKeyImpl(
                   skipLayers = skipLayers,
                   spawnTpTasks = false,
                   parallel,
-                  keyQueue,
+                  keyBuf,
                   vtxBufQueue,
                 )
           level = max(level, sl)
@@ -333,8 +377,12 @@ proc computeKeyImpl(
       when spawnTpTasks:
         var
           futs: array[16, Flowvar[Result[(HashKey, int), AristoError]]]
-          keyQueues: array[16, ConcurrentHashKeyQueue]
+          keyBufs: array[16, KeyWriteBuf]
           vtxBufQueues: array[16, ConcurrentVertexBufQueue]
+
+        defer:
+          for buf in keyBufs.mitems:
+            buf.dispose()
 
       # Make sure we have keys computed for each hash
       block keysComputed:
@@ -370,7 +418,7 @@ proc computeKeyImpl(
                 skipLayers = skipLayers,
                 spawnTpTasks = false,
                 parallel,
-                keyQueue,
+                keyBuf,
                 vtxBufQueue,
               )
               n += 1
@@ -390,7 +438,6 @@ proc computeKeyImpl(
               vtxPtr = keyvtxs[minIdx][0][1].addr
               level = keyvtxs[minIdx][1]
 
-            keyQueues[minIdx].init()
             vtxBufQueues[minIdx].init()
             futs[minIdx] = txRef.db.taskpool.spawn computeKeyImplTask(
               txRef.addr,
@@ -399,7 +446,7 @@ proc computeKeyImpl(
               vtxPtr,
               level,
               skipLayers,
-              keyQueues[minIdx].addr,
+              keyBufs[minIdx].addr,
               vtxBufQueues[minIdx].addr,
             )
             inc batch.tasksTotal
@@ -414,7 +461,7 @@ proc computeKeyImpl(
               skipLayers,
               spawnTpTasks = false,
               parallel,
-              keyQueue,
+              keyBuf,
               vtxBufQueue,
             )
             when not parallel:
@@ -435,12 +482,6 @@ proc computeKeyImpl(
               inc batch.tasksCompleted
               continue
 
-            when not skipLayers:
-              if not keyQueues[i].isEmpty():
-                var k: (RootedVertexID, HashKey, int)
-                if keyQueues[i].tryPop(k):
-                  txRef.mergeKeyAtLevel(k[0], k[1], k[2])
-
             if not vtxBufQueues[i].isEmpty():
               var v: (RootedVertexID, VertexBuf)
               if vtxBufQueues[i].tryPop(v):
@@ -449,24 +490,21 @@ proc computeKeyImpl(
           for i in indexesToRemove:
             runningFutsIndexes.excl(i)
 
+          cpuRelax()
+
         # At this point all futures have finished running.
-        # Now we process any remaining data in the queues.
+        # Now we process any remaining data in the queues and buffers.
         for i, f in futs:
           if f.isSpawned():
-            when not skipLayers:
-              if not keyQueues[i].isEmpty():
-                var k: (RootedVertexID, HashKey, int)
-                while keyQueues[i].tryPop(k):
-                  txRef.mergeKeyAtLevel(k[0], k[1], k[2])
-
             if not vtxBufQueues[i].isEmpty():
               var v: (RootedVertexID, VertexBuf)
               while vtxBufQueues[i].tryPop(v):
                 ?batch.putVtxBlob(txRef.db, v[0], v[1].data())
 
             (keyvtxs[i][0][0], keyvtxs[i][1]) = ?sync(f)
-            keyQueues[i].dispose()
             vtxBufQueues[i].dispose()
+
+        txRef.mergeKeys(keyBufs)
 
       template branchSubKey(): untyped =
         if subvid.isValid:
@@ -491,7 +529,7 @@ proc computeKeyImpl(
   if vtx.vType in Branches:
     when parallel and not spawnTpTasks:
       if level >= txRef.db.baseTxFrame().level:
-        keyQueue[].push((rvid, key, level))
+        keyBuf[].add((rvid, key, level))
       elif level == dbLevel:
         var vtxBuf: VertexBuf
         vtx.blobifyTo(key, vtxBuf)

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -201,6 +201,19 @@ proc computeKeyImpl(
 ): Result[(HashKey, int), AristoError]
 
 when compileOption("threads"):
+  when defined(windows):
+    import std/os
+
+    proc idleSleep() =
+      sleep(1)
+
+  else:
+    import std/posix
+
+    proc idleSleep() =
+      var req = Timespec(tv_sec: posix.Time(0), tv_nsec: 100_000)
+      discard nanosleep(req, req)
+
   proc mergeKeys(txRef: AristoTxRef, bufs: openArray[KeyWriteBuf]) =
     let baseLevel = txRef.db.baseTxFrame().level
     var
@@ -441,24 +454,35 @@ proc computeKeyImpl(
           if f.isSpawned() and not f.isReady():
             runningFutsIndexes.incl(i.uint8)
 
+        var idleRounds = 0
         while runningFutsIndexes.len() > 0:
-          var indexesToRemove: seq[uint8]
+          var
+            indexesToRemove: seq[uint8]
+            progressed = false
 
           for i in runningFutsIndexes:
             if futs[i].isReady():
               indexesToRemove.add(i)
               inc batch.tasksCompleted
+              progressed = true
               continue
 
             if not vtxBufQueues[i].isEmpty():
               var v: (RootedVertexID, VertexBuf)
               if vtxBufQueues[i].tryPop(v):
+                progressed = true
                 ?batch.putVtxBlob(txRef.db, v[0], v[1].data())
 
           for i in indexesToRemove:
             runningFutsIndexes.excl(i)
 
-          cpuRelax()
+          if progressed:
+            idleRounds = 0
+          elif idleRounds < 64:
+            inc idleRounds
+            cpuRelax()
+          else:
+            idleSleep()
 
         # At this point all futures have finished running.
         # Now we process any remaining data in the queues.

--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -30,8 +30,8 @@ import
   ./aristo_desc/desc_backend
 
 when compileOption("threads"):
-  import taskpools, ../../concurrency/lru, ../../concurrency/readwritelock
-  export taskpools, readwritelock, lru
+  import taskpools, ../../concurrency/lru
+  export taskpools, lru
 
 # Not auto-exporting backend
 export
@@ -101,11 +101,6 @@ type
       ## used to order data by age when working with layers.
       ## -1 = stored in database, where relevant though typically should be
       ## compared with the base layer level instead.
-
-    when compileOption("threads"):
-      lock*: ReadWriteLock
-        ## A read-write lock used to support thread safe reads and writes to the
-        ## database from multiple threads.
 
   Snapshot* = object
     vtx*: Table[RootedVertexID, VtxSnapshot]

--- a/execution_chain/db/aristo/aristo_desc.nim
+++ b/execution_chain/db/aristo/aristo_desc.nim
@@ -259,15 +259,6 @@ iterator stack*(tx: AristoTxRef, stopAtSnapshot = false): AristoTxRef =
   while frames.len > 0:
     yield frames.pop()
 
-proc deltaAtLevel*(db: AristoTxRef, level: int): AristoTxRef =
-  if level < db.db.txRef.level:
-    nil
-  else:
-    for frame in db.rstack():
-      if frame.level == level:
-        return frame
-    nil
-
 proc getStaticLevel*(db: AristoDbRef): int =
   # Retrieve the level where we can expect to find a leaf, updating it based on
   # recent lookups

--- a/execution_chain/db/aristo/aristo_init/init_common.nim
+++ b/execution_chain/db/aristo/aristo_init/init_common.nim
@@ -91,8 +91,6 @@ proc initInstance*(
 
   db.txRef = AristoTxRef(db: db, vTop: vTop, snapshot: Snapshot(level: Opt.some(0)))
   when compileOption("threads"):
-    db.txRef.lock.init()
-
     if threadSafeCaches:
       db.accLeaves.init(accLeavesLruSize)
       db.stoLeaves.init(stoLeavesLruSize)

--- a/execution_chain/db/aristo/aristo_layers.nim
+++ b/execution_chain/db/aristo/aristo_layers.nim
@@ -160,11 +160,8 @@ func layersPutKey*(
     db.snapshot.vtx[rvid] = (VertexRef(vtx), key, db.level)
 
 func layersReserveKeys*(db: AristoTxRef, extra: int) =
-  if extra > db.kMap.len:
-    var tab = initTable[RootedVertexID, HashKey](db.kMap.len + extra)
-    for k, v in db.kMap:
-      tab[k] = v
-    db.kMap = move(tab)
+  if db.kMap.len == 0 and extra > 0:
+    db.kMap = initTable[RootedVertexID, HashKey](extra)
 
 template layersMergeKeyInSnapshot*(db: AristoTxRef; rvid: RootedVertexID; key: HashKey) =
   if db.snapshot.level.isSome():

--- a/execution_chain/db/aristo/aristo_layers.nim
+++ b/execution_chain/db/aristo/aristo_layers.nim
@@ -159,6 +159,15 @@ func layersPutKey*(
   if db.snapshot.level.isSome():
     db.snapshot.vtx[rvid] = (VertexRef(vtx), key, db.level)
 
+func layersReserveKeys*(db: AristoTxRef, extra: int) =
+  ## Make room for `extra` upcoming `layersMergeKey` inserts so that a bulk
+  ## insert does not grow the table repeatedly along the way.
+  if extra > db.kMap.len:
+    var tab = initTable[RootedVertexID, HashKey](db.kMap.len + extra)
+    for k, v in db.kMap:
+      tab[k] = v
+    db.kMap = move(tab)
+
 func layersMergeKey*(
     db: AristoTxRef;
     rvid: RootedVertexID;

--- a/execution_chain/db/aristo/aristo_layers.nim
+++ b/execution_chain/db/aristo/aristo_layers.nim
@@ -166,10 +166,10 @@ func layersReserveKeys*(db: AristoTxRef, extra: int) =
       tab[k] = v
     db.kMap = move(tab)
 
-func layersMergeKeyInSnapshot*(db: AristoTxRef; rvid: RootedVertexID; key: HashKey) =
+template layersMergeKeyInSnapshot*(db: AristoTxRef; rvid: RootedVertexID; key: HashKey) =
   if db.snapshot.level.isSome():
-    db.snapshot.vtx.withValue(rvid, value):
-      value[1] = key
+    db.snapshot.vtx.withValue(rvid, entry):
+      entry[1] = key
 
 func layersMergeKey*(
     db: AristoTxRef;

--- a/execution_chain/db/aristo/aristo_layers.nim
+++ b/execution_chain/db/aristo/aristo_layers.nim
@@ -166,6 +166,11 @@ func layersReserveKeys*(db: AristoTxRef, extra: int) =
       tab[k] = v
     db.kMap = move(tab)
 
+func layersMergeKeyInSnapshot*(db: AristoTxRef; rvid: RootedVertexID; key: HashKey) =
+  if db.snapshot.level.isSome():
+    db.snapshot.vtx.withValue(rvid, value):
+      value[1] = key
+
 func layersMergeKey*(
     db: AristoTxRef;
     rvid: RootedVertexID;
@@ -175,10 +180,7 @@ func layersMergeKey*(
   ## for leaves since these are trivial to compute
   # Precondition: the vertex for the given rvid should exist
   db.kMap[rvid] = key
-
-  if db.snapshot.level.isSome():
-    db.snapshot.vtx.withValue(rvid, value):
-      value[1] = key
+  db.layersMergeKeyInSnapshot(rvid, key)
 
 func layersResKey*(db: AristoTxRef; rvid: RootedVertexID, vtx: BranchRef) =
   ## Shortcut for `db.layersPutKey(vid, VOID_HASH_KEY)` which resets the hash

--- a/execution_chain/db/aristo/aristo_layers.nim
+++ b/execution_chain/db/aristo/aristo_layers.nim
@@ -160,8 +160,6 @@ func layersPutKey*(
     db.snapshot.vtx[rvid] = (VertexRef(vtx), key, db.level)
 
 func layersReserveKeys*(db: AristoTxRef, extra: int) =
-  ## Make room for `extra` upcoming `layersMergeKey` inserts so that a bulk
-  ## insert does not grow the table repeatedly along the way.
   if extra > db.kMap.len:
     var tab = initTable[RootedVertexID, HashKey](db.kMap.len + extra)
     for k, v in db.kMap:

--- a/execution_chain/db/aristo/aristo_tx_frame.nim
+++ b/execution_chain/db/aristo/aristo_tx_frame.nim
@@ -139,15 +139,9 @@ proc txFrameBegin*(
     vTop: parent.vTop,
     level: parent.level + 1)
 
-  when compileOption("threads"):
-    txRef.lock.init()
-  
   txRef
 
 proc dispose*(txFrame: AristoTxRef) =
-  when compileOption("threads"):
-    txFrame.lock.dispose()
-
   if not txFrame.db.isNil():
     txFrame.db.removeSnapshotFrame(txFrame)
   txFrame[].reset()

--- a/tests/test_aristo/bench_compute.nim
+++ b/tests/test_aristo/bench_compute.nim
@@ -11,7 +11,7 @@
 {.used.}
 
 import
-  std/times,
+  std/[times, cpuinfo],
   unittest2,
   ../../execution_chain/db/aristo/[
     aristo_compute,
@@ -22,10 +22,11 @@ import
   ]
 
 suite "Aristo compute benchmark":
-  const 
-    NUM_THREADS = 16
-    NUM_FRAMES = 1000
+  const
+    NUM_FRAMES = 500
     NUM_ACCOUNTS_PER_FRAME = 10000
+
+  let NUM_THREADS = countProcessors()
 
   setup:
     let db = AristoDbRef.init()
@@ -35,29 +36,29 @@ suite "Aristo compute benchmark":
     for i in 0 ..< NUM_ACCOUNTS_PER_FRAME:
       check:
         txFrame.mergeAccount(
-          cast[Hash32](i), 
+          cast[Hash32](i),
           AristoAccount(balance: i.u256(), codeHash: EMPTY_CODE_HASH)) == Result[bool, AristoError].ok(true)
     txFrame.checkpoint(1, skipSnapshot = true)
 
     let batch = db.putBegFn()[]
     db.persist(batch, txFrame)
     check db.putEndFn(batch).isOk()
-    
+
     txFrame = db.baseTxFrame()
-    
+
     for n in 1 .. NUM_FRAMES:
       txFrame = db.txFrameBegin(txFrame)
 
-      let 
+      let
         startIdx = NUM_ACCOUNTS_PER_FRAME * n
         endIdx = startIdx + NUM_ACCOUNTS_PER_FRAME
 
       for i in startIdx ..< endIdx:
         check:
           txFrame.mergeAccount(
-            cast[Hash32](i * i), 
+            cast[Hash32](i * i),
             AristoAccount(balance: i.u256(), codeHash: EMPTY_CODE_HASH)) == Result[bool, AristoError].ok(true)
-      
+
       txFrame.checkpoint(1, skipSnapshot = false)
 
   test "Serial benchmark - skipLayers = false":
@@ -67,7 +68,7 @@ suite "Aristo compute benchmark":
     let before = cpuTime()
     check txFrame.computeStateRoot(skipLayers = false).isOk()
     let elapsed = cpuTime() - before
-    
+
     debugEcho "Serial benchmark (skipLayers = false) cpu time: ", elapsed
 
   test "Parallel benchmark - skipLayers = false":
@@ -77,6 +78,6 @@ suite "Aristo compute benchmark":
     let before = cpuTime()
     check txFrame.computeStateRoot(skipLayers = false).isOk()
     let elapsed = cpuTime() - before
-    
+
     debugEcho "Parallel benchmark (skipLayers = false) cpu time: ", elapsed
 

--- a/tests/test_aristo/bench_state_root.nim
+++ b/tests/test_aristo/bench_state_root.nim
@@ -64,30 +64,37 @@ proc ms(d: Duration): float =
 
 # Steady-state import: root computed for every block, snapshot per block as in
 # forked_chain live import. Reports mean root time over the last 100 blocks.
-proc scenarioSteady(parallel: bool): (float, Hash32) =
+# `mainCpu` is the cpu time of the calling thread alone (`cpuTime` is
+# thread-scoped on Linux), i.e. how busy the main thread is kept while the
+# workers hash.
+proc scenarioSteady(parallel: bool): (float, float, Hash32) =
   let (db, base) = newDb(100_000)
   db.parallelStateRootComputation = parallel
   var
     txFrame = base
-    times: seq[float]
+    times, cpuTimes: seq[float]
     root: Hash32
   for blk in 1 .. 130:
     txFrame = db.txFrameBegin(txFrame)
     txFrame.addAccounts(2000)
-    let t0 = getMonoTime()
+    let
+      c0 = cpuTime()
+      t0 = getMonoTime()
     let res = txFrame.computeStateRoot(skipLayers = false)
     times.add ms(getMonoTime() - t0)
+    cpuTimes.add (cpuTime() - c0) * 1e3
     doAssert res.isOk()
     root = res[].to(Hash32)
     txFrame.checkpoint(uint64(blk + 1), skipSnapshot = false)
-  var s = 0.0
+  var s, c = 0.0
   for i in 30 ..< times.len:
     s += times[i]
-  (s / float(times.len - 30), root)
+    c += cpuTimes[i]
+  (s / float(times.len - 30), c / float(times.len - 30), root)
 
 # Batch catch-up: 130 blocks imported without root computation, then one deep
 # root over all of them (keys span all 130 levels).
-proc scenarioCatchup(parallel: bool): (float, Hash32) =
+proc scenarioCatchup(parallel: bool): (float, float, Hash32) =
   let (db, base) = newDb(100_000)
   db.parallelStateRootComputation = parallel
   var txFrame = base
@@ -95,44 +102,52 @@ proc scenarioCatchup(parallel: bool): (float, Hash32) =
     txFrame = db.txFrameBegin(txFrame)
     txFrame.addAccounts(2000)
     txFrame.checkpoint(uint64(blk + 1), skipSnapshot = true)
-  let t0 = getMonoTime()
+  let
+    c0 = cpuTime()
+    t0 = getMonoTime()
   let res = txFrame.computeStateRoot(skipLayers = false)
   let elapsed = ms(getMonoTime() - t0)
+  let mainCpu = (cpuTime() - c0) * 1e3
   doAssert res.isOk()
-  (elapsed, res[].to(Hash32))
+  (elapsed, mainCpu, res[].to(Hash32))
 
 # Flat bulk import: one large frame on top of the base.
-proc scenarioFlat(parallel: bool): (float, Hash32) =
+proc scenarioFlat(parallel: bool): (float, float, Hash32) =
   let (db, base) = newDb(100_000)
   db.parallelStateRootComputation = parallel
   var txFrame = db.txFrameBegin(base)
   txFrame.addAccounts(500_000)
-  let t0 = getMonoTime()
+  let
+    c0 = cpuTime()
+    t0 = getMonoTime()
   let res = txFrame.computeStateRoot(skipLayers = false)
   let elapsed = ms(getMonoTime() - t0)
+  let mainCpu = (cpuTime() - c0) * 1e3
   doAssert res.isOk()
-  (elapsed, res[].to(Hash32))
+  (elapsed, mainCpu, res[].to(Hash32))
 
 proc median(xs: var seq[float]): float =
   xs.sort()
   xs[xs.len div 2]
 
 proc run(
-    name: string, scenario: proc(parallel: bool): (float, Hash32), repeats: int
+    name: string, scenario: proc(parallel: bool): (float, float, Hash32), repeats: int
 ) =
   var
-    serialTimes, parTimes: seq[float]
+    serialTimes, parTimes, parCpuTimes: seq[float]
     serialRoot, parRoot: Hash32
   for _ in 0 ..< repeats:
-    let (t, r) = scenario(false)
+    let (t, _, r) = scenario(false)
     serialTimes.add t
     serialRoot = r
   for _ in 0 ..< repeats:
-    let (t, r) = scenario(true)
+    let (t, c, r) = scenario(true)
     parTimes.add t
+    parCpuTimes.add c
     parRoot = r
   doAssert serialRoot == parRoot, "serial and parallel roots differ!"
-  echo &"{name}: serial {median(serialTimes):8.2f} ms | parallel {median(parTimes):8.2f} ms"
+  echo &"{name}: serial {median(serialTimes):8.2f} ms | parallel {median(parTimes):8.2f} ms" &
+    &" (mainCpu {median(parCpuTimes):8.2f} ms)"
 
 echo &"threads: {numThreads}"
 run("steady-state (mean/root, 100 blocks)", scenarioSteady, 1)

--- a/tests/test_aristo/bench_state_root.nim
+++ b/tests/test_aristo/bench_state_root.nim
@@ -1,0 +1,140 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or
+# distributed except according to those terms.
+
+# Benchmarks serial vs parallel state root computation over realistic in-memory
+# scenarios: steady-state block import, batch catch-up and flat bulk import.
+
+import
+  std/[algorithm, cpuinfo, monotimes, times, strformat],
+  ../../execution_chain/db/aristo/[
+    aristo_compute, aristo_merge, aristo_desc, aristo_init/memory_only,
+    aristo_tx_frame,
+  ]
+
+let numThreads = countProcessors()
+
+proc mix(x: uint64): uint64 =
+  var z = x + 0x9E3779B97F4A7C15'u64
+  z = (z xor (z shr 30)) * 0xBF58476D1CE4E5B9'u64
+  z = (z xor (z shr 27)) * 0x94D049BB133111EB'u64
+  z xor (z shr 31)
+
+proc path(i: uint64): Hash32 =
+  var b: array[32, byte]
+  for j in 0'u64 ..< 4:
+    let z = mix(i * 4 + j)
+    copyMem(addr b[j * 8], unsafeAddr z, 8)
+  cast[Hash32](b)
+
+var pathCounter: uint64
+
+proc addAccounts(txFrame: AristoTxRef, n: int) =
+  for _ in 0 ..< n:
+    let p = path(pathCounter)
+    inc pathCounter
+    doAssert txFrame.mergeAccount(
+      p, AristoAccount(balance: pathCounter.u256(), codeHash: EMPTY_CODE_HASH)
+    ).isOk()
+
+proc newDb(baseAccounts: int): (AristoDbRef, AristoTxRef) =
+  # Base state with computed keys, persisted to the (memory) backend so the
+  # per-block scenarios start from a warm, realistic baseline.
+  pathCounter = 0
+  let db = AristoDbRef.init()
+  db.taskpool = Taskpool.new(numThreads = numThreads)
+  db.parallelStateRootComputation = false
+  var txFrame = db.txRef
+  txFrame.addAccounts(baseAccounts)
+  doAssert txFrame.computeStateRoot(skipLayers = false).isOk()
+  txFrame.checkpoint(1, skipSnapshot = true)
+  let batch = db.putBegFn()[]
+  db.persist(batch, txFrame)
+  doAssert db.putEndFn(batch).isOk()
+  (db, db.baseTxFrame())
+
+proc ms(d: Duration): float =
+  d.inNanoseconds.float / 1e6
+
+# Steady-state import: root computed for every block, snapshot per block as in
+# forked_chain live import. Reports mean root time over the last 100 blocks.
+proc scenarioSteady(parallel: bool): (float, Hash32) =
+  let (db, base) = newDb(100_000)
+  db.parallelStateRootComputation = parallel
+  var
+    txFrame = base
+    times: seq[float]
+    root: Hash32
+  for blk in 1 .. 130:
+    txFrame = db.txFrameBegin(txFrame)
+    txFrame.addAccounts(2000)
+    let t0 = getMonoTime()
+    let res = txFrame.computeStateRoot(skipLayers = false)
+    times.add ms(getMonoTime() - t0)
+    doAssert res.isOk()
+    root = res[].to(Hash32)
+    txFrame.checkpoint(uint64(blk + 1), skipSnapshot = false)
+  var s = 0.0
+  for i in 30 ..< times.len:
+    s += times[i]
+  (s / float(times.len - 30), root)
+
+# Batch catch-up: 130 blocks imported without root computation, then one deep
+# root over all of them (keys span all 130 levels).
+proc scenarioCatchup(parallel: bool): (float, Hash32) =
+  let (db, base) = newDb(100_000)
+  db.parallelStateRootComputation = parallel
+  var txFrame = base
+  for blk in 1 .. 130:
+    txFrame = db.txFrameBegin(txFrame)
+    txFrame.addAccounts(2000)
+    txFrame.checkpoint(uint64(blk + 1), skipSnapshot = true)
+  let t0 = getMonoTime()
+  let res = txFrame.computeStateRoot(skipLayers = false)
+  let elapsed = ms(getMonoTime() - t0)
+  doAssert res.isOk()
+  (elapsed, res[].to(Hash32))
+
+# Flat bulk import: one large frame on top of the base.
+proc scenarioFlat(parallel: bool): (float, Hash32) =
+  let (db, base) = newDb(100_000)
+  db.parallelStateRootComputation = parallel
+  var txFrame = db.txFrameBegin(base)
+  txFrame.addAccounts(500_000)
+  let t0 = getMonoTime()
+  let res = txFrame.computeStateRoot(skipLayers = false)
+  let elapsed = ms(getMonoTime() - t0)
+  doAssert res.isOk()
+  (elapsed, res[].to(Hash32))
+
+proc median(xs: var seq[float]): float =
+  xs.sort()
+  xs[xs.len div 2]
+
+proc run(
+    name: string, scenario: proc(parallel: bool): (float, Hash32), repeats: int
+) =
+  var
+    serialTimes, parTimes: seq[float]
+    serialRoot, parRoot: Hash32
+  for _ in 0 ..< repeats:
+    let (t, r) = scenario(false)
+    serialTimes.add t
+    serialRoot = r
+  for _ in 0 ..< repeats:
+    let (t, r) = scenario(true)
+    parTimes.add t
+    parRoot = r
+  doAssert serialRoot == parRoot, "serial and parallel roots differ!"
+  echo &"{name}: serial {median(serialTimes):8.2f} ms | parallel {median(parTimes):8.2f} ms"
+
+echo &"threads: {numThreads}"
+run("steady-state (mean/root, 100 blocks)", scenarioSteady, 1)
+run("catch-up (130 blocks, one root)     ", scenarioCatchup, 3)
+run("flat 500k accounts (one root)       ", scenarioFlat, 3)

--- a/tests/test_aristo/bench_state_root.nim
+++ b/tests/test_aristo/bench_state_root.nim
@@ -43,12 +43,13 @@ proc addAccounts(txFrame: AristoTxRef, n: int) =
       p, AristoAccount(balance: pathCounter.u256(), codeHash: EMPTY_CODE_HASH)
     ).isOk()
 
-proc newDb(baseAccounts: int): (AristoDbRef, AristoTxRef) =
+proc newDb(baseAccounts: int, parallel: bool): (AristoDbRef, AristoTxRef) =
   # Base state with computed keys, persisted to the (memory) backend so the
   # per-block scenarios start from a warm, realistic baseline.
   pathCounter = 0
   let db = AristoDbRef.init()
-  db.taskpool = Taskpool.new(numThreads = numThreads)
+  if parallel:
+    db.taskpool = Taskpool.new(numThreads = numThreads)
   db.parallelStateRootComputation = false
   var txFrame = db.txRef
   txFrame.addAccounts(baseAccounts)
@@ -62,13 +63,19 @@ proc newDb(baseAccounts: int): (AristoDbRef, AristoTxRef) =
 proc ms(d: Duration): float =
   d.inNanoseconds.float / 1e6
 
+proc release(db: AristoDbRef) =
+  # Without this every scenario invocation leaks a full set of worker threads,
+  # whose wakeups then land inside the measurement window of later scenarios.
+  if not db.taskpool.isNil():
+    db.taskpool.shutdown()
+
 # Steady-state import: root computed for every block, snapshot per block as in
 # forked_chain live import. Reports mean root time over the last 100 blocks.
 # `mainCpu` is the cpu time of the calling thread alone (`cpuTime` is
 # thread-scoped on Linux), i.e. how busy the main thread is kept while the
 # workers hash.
 proc scenarioSteady(parallel: bool): (float, float, Hash32) =
-  let (db, base) = newDb(100_000)
+  let (db, base) = newDb(100_000, parallel)
   db.parallelStateRootComputation = parallel
   var
     txFrame = base
@@ -90,12 +97,13 @@ proc scenarioSteady(parallel: bool): (float, float, Hash32) =
   for i in 30 ..< times.len:
     s += times[i]
     c += cpuTimes[i]
+  db.release()
   (s / float(times.len - 30), c / float(times.len - 30), root)
 
 # Batch catch-up: 130 blocks imported without root computation, then one deep
 # root over all of them (keys span all 130 levels).
 proc scenarioCatchup(parallel: bool): (float, float, Hash32) =
-  let (db, base) = newDb(100_000)
+  let (db, base) = newDb(100_000, parallel)
   db.parallelStateRootComputation = parallel
   var txFrame = base
   for blk in 1 .. 130:
@@ -109,11 +117,12 @@ proc scenarioCatchup(parallel: bool): (float, float, Hash32) =
   let elapsed = ms(getMonoTime() - t0)
   let mainCpu = (cpuTime() - c0) * 1e3
   doAssert res.isOk()
+  db.release()
   (elapsed, mainCpu, res[].to(Hash32))
 
 # Flat bulk import: one large frame on top of the base.
 proc scenarioFlat(parallel: bool): (float, float, Hash32) =
-  let (db, base) = newDb(100_000)
+  let (db, base) = newDb(100_000, parallel)
   db.parallelStateRootComputation = parallel
   var txFrame = db.txFrameBegin(base)
   txFrame.addAccounts(500_000)
@@ -124,6 +133,7 @@ proc scenarioFlat(parallel: bool): (float, float, Hash32) =
   let elapsed = ms(getMonoTime() - t0)
   let mainCpu = (cpuTime() - c0) * 1e3
   doAssert res.isOk()
+  db.release()
   (elapsed, mainCpu, res[].to(Hash32))
 
 proc median(xs: var seq[float]): float =

--- a/tests/test_aristo/test_compute.nim
+++ b/tests/test_aristo/test_compute.nim
@@ -11,7 +11,7 @@
 {.used.}
 
 import
-  std/[algorithm, sets, times],
+  std/[cpuinfo, algorithm, sets, times],
   unittest2,
   ../../execution_chain/db/aristo/[
     aristo_check,
@@ -76,7 +76,7 @@ suite "Aristo compute":
         txFrame = db.txRef
         root = STATE_ROOT_VID
       db.parallelStateRootComputation = false
-      
+
       for (k, v, r) in sample:
         checkpoint("k = " & k.toHex & ", v = " & $v)
 
@@ -116,7 +116,7 @@ suite "Aristo compute":
         root = STATE_ROOT_VID
       db.parallelStateRootComputation = true
       db.taskpool = Taskpool.new(numThreads = 4)
-      
+
       for (k, v, r) in sample:
         checkpoint("k = " & k.toHex & ", v = " & $v)
 
@@ -193,7 +193,7 @@ suite "Aristo compute":
 
     let w = txFrame.computeKey((root, root)).value.to(Hash32)
     check w == samples[^1][^1][2]
-  
+
   test "Max size RLP encoding of all MPT node types":
     ## This test exercises the RlpArrayBufWriter stack-allocated buffer paths in
     ## aristo_compute.nim by constructing a trie that produces the largest
@@ -292,7 +292,7 @@ suite "Aristo compute":
       hash32"ABCDEF0123456789000000000000000000000000000000000000000000000001"
     let extPath2 =
       hash32"ABCDEF0123456789000000000000000000000000000000000000000000000002"
-    
+
     check txFrame.mergeAccount(extPath1, extAcc) == Result[bool, AristoError].ok(true)
     check txFrame.mergeAccount(extPath2, extAcc) == Result[bool, AristoError].ok(true)
 
@@ -317,10 +317,11 @@ suite "Aristo compute":
 
 
 suite "Aristo compute short benchmark":
-  const 
-    NUM_THREADS = 4
-    NUM_FRAMES = 1000
-    NUM_ACCOUNTS_PER_FRAME = 100
+  const
+    NUM_FRAMES = 130
+    NUM_ACCOUNTS_PER_FRAME = 2000
+
+  let NUM_THREADS = countProcessors()
 
   setup:
     let db = AristoDbRef.init()
@@ -331,29 +332,29 @@ suite "Aristo compute short benchmark":
     for i in 0 ..< NUM_ACCOUNTS_PER_FRAME:
       check:
         txFrame.mergeAccount(
-          cast[Hash32](i), 
+          cast[Hash32](i),
           AristoAccount(balance: i.u256(), codeHash: EMPTY_CODE_HASH)) == Result[bool, AristoError].ok(true)
     txFrame.checkpoint(1, skipSnapshot = true)
 
     let batch = db.putBegFn()[]
     db.persist(batch, txFrame)
     check db.putEndFn(batch).isOk()
-    
+
     txFrame = db.baseTxFrame()
-    
+
     for n in 1 .. NUM_FRAMES:
       txFrame = db.txFrameBegin(txFrame)
 
-      let 
+      let
         startIdx = NUM_ACCOUNTS_PER_FRAME * n
         endIdx = startIdx + NUM_ACCOUNTS_PER_FRAME
 
       for i in startIdx ..< endIdx:
         check:
           txFrame.mergeAccount(
-            cast[Hash32](i * i), 
+            cast[Hash32](i * i),
             AristoAccount(balance: i.u256(), codeHash: EMPTY_CODE_HASH)) == Result[bool, AristoError].ok(true)
-      
+
       txFrame.checkpoint(1, skipSnapshot = false)
 
   test "Serial benchmark - skipLayers = false":
@@ -363,7 +364,7 @@ suite "Aristo compute short benchmark":
     let before = cpuTime()
     check txFrame.computeStateRoot(skipLayers = false).isOk()
     let elapsed = cpuTime() - before
-    
+
     debugEcho "Serial benchmark (skipLayers = false) cpu time: ", elapsed
 
   test "Parallel benchmark - skipLayers = false":
@@ -373,5 +374,5 @@ suite "Aristo compute short benchmark":
     let before = cpuTime()
     check txFrame.computeStateRoot(skipLayers = false).isOk()
     let elapsed = cpuTime() - before
-    
+
     debugEcho "Parallel benchmark (skipLayers = false) cpu time: ", elapsed

--- a/tests/test_concurrency/test_shared_types.nim
+++ b/tests/test_concurrency/test_shared_types.nim
@@ -707,6 +707,26 @@ suite "SharedSeq growth Tests":
       t.capacity == 4096
     t.dispose()
 
+  test "large buffers grow by 1.5x instead of doubling":
+    # threshold is 128 KiB; for int that is 16384 elements
+    var s: SharedSeq[int]
+    for i in 0 ..< 20_000:
+      s.add(i)
+    check:
+      s.len == 20_000
+      s.capacity == 16_384 + 8_192 # one 1.5x step past the threshold, not 32768
+    for i in 0 ..< 20_000:
+      check s[i] == i
+    s.dispose()
+
+    # a one-shot large setLen allocates exactly, not the next power of two
+    var t: SharedSeq[int]
+    t.setLen(100_000, zeroed = true)
+    check:
+      t.len == 100_000
+      t.capacity == 100_000
+    t.dispose()
+
   test "setLen with exact sizes capacity exactly, no power-of-two rounding":
     var s: SharedSeq[int]
     s.setLen(2050, zeroed = true, exact = true)


### PR DESCRIPTION
This improves the performance of the parallel stateroot computation by:
1. Removes the locking when writing keys back into the txFrame layers. Instead we write each key into a SharedSeq buffer (one per task), then after the tasks complete the keys are updated into the layers in the main thread. The merge function is also optimized to avoid the linear time `deltaAtLevel` for every key.
2. Reduces cpu usage in the main thread when it has no work to do by implementing a backoff mechanism. First we use cpuRelax and then sleep so that the main thread doesn't spin needlessly while waiting for the tasks.

This also fixes an issue where the newest snapshot was not having its keys updated which could cause rehashing of those in memory keys over time.