### PR TITLE
KVT block hashes cache

### DIFF
--- a/execution_chain/db/core_db/backend/aristo_memory.nim
+++ b/execution_chain/db/core_db/backend/aristo_memory.nim
@@ -24,7 +24,7 @@ export base_desc
 # ------------------------------------------------------------------------------
 
 proc newMemoryCoreDbRef*(enableCaches: static bool): CoreDbRef =
-  CoreDbRef(mpt: AristoDbRef.init(enableCaches), kvt: KvtDbRef.init())
+  CoreDbRef(mpt: AristoDbRef.init(enableCaches), kvt: KvtDbRef.init(enableCaches))
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/db/core_db/backend/aristo_rocksdb.nim
+++ b/execution_chain/db/core_db/backend/aristo_rocksdb.nim
@@ -200,7 +200,7 @@ proc newRocksDbCoreDbRef*(basePath: string, opts: DbOptions, wipe = false): Core
 
     adb = AristoDbRef.init(opts, baseDb).valueOr:
       raiseAssert "Could not initialize aristo: " & $error
-    kdb = KvtDbRef.init(baseDb)
+    kdb = KvtDbRef.init(opts, baseDb)
 
   CoreDbRef(kvt: kdb, mpt: adb)
 

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -22,6 +22,7 @@ import
   "../.."/[constants],
   "../.."/stateless/witness_types,
   ".."/[aristo, storage_types],
+  "../kvt"/[kvt_desc, kvt_layers, kvt_utils],
   "."/base
 
 logScope:
@@ -140,7 +141,32 @@ proc getBlockHash*(
     n: BlockNumber;
       ): Result[Hash32, string] =
   ## Return the block hash for the given block number.
-  db.getHash(blockNumberToHashKey(n))
+  const info = "getBlockHash()"
+  let key = blockNumberToHashKey(n)
+
+  let pending = db.kTx.layersGet(key.toOpenArray)
+  if pending.isSome():
+    wrapRlpException info:
+      return ok(rlp.decode(pending.unsafeGet(), Hash32))
+
+  when compileOption("threads"):
+    let
+      kvt = db.kTx.db
+      keyHash = kvt.blockHashes.toKeyHash(n)
+
+    kvt.blockHashes.withGetByHash(keyHash, n, cached):
+      return ok(cached)
+
+  let data = db.kTx.db.getBe(key.toOpenArray).valueOr:
+    if error != GetNotFound:
+      warn info, key, error=($error)
+    return err($error)
+
+  wrapRlpException info:
+    let blockHash = rlp.decode(data, Hash32)
+    when compileOption("threads"):
+      kvt.blockHashes.putByHash(keyHash, n, blockHash)
+    return ok(blockHash)
 
 proc getBlockHeader*(
     db: CoreDbTxRef;

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -238,6 +238,8 @@ proc getAncestorsHashes*(
 
 proc addBlockNumberToHashLookup*(
     db: CoreDbTxRef; blockNumber: BlockNumber, blockHash: Hash32) =
+  # TODO: Once we remove the kvt frame layers, this function should
+  # write to the kvt block hashes cache.
   let blockNumberKey = blockNumberToHashKey(blockNumber)
   db.put(blockNumberKey.toOpenArray, rlp.encode(blockHash)).isOkOr:
     warn "addBlockNumberToHashLookup", blockNumberKey, error=($$error)
@@ -404,7 +406,7 @@ proc getBlockAccessLists*(
     bals: var openArray[Opt[BlockAccessListRef]]
       ): Result[void, string] =
   var balValues = newSeq[Opt[seq[byte]]](blockHashes.len())
-  
+
   ?db.getBlockAccessLists(blockHashes, balValues)
 
   for i, balBytes in balValues:
@@ -702,7 +704,7 @@ proc getChainTail*(
     key = tailIdKey()
     blkNum = db.get(key.toOpenArray).valueOr:
       return BlockNumber(0)
-    
+
   BlockNumber(uint64.fromBytesLE(blkNum))
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -158,9 +158,14 @@ proc getBlockHash*(
       return ok(cached)
 
   let data = db.kTx.db.getBe(key.toOpenArray).valueOr:
+    let dbError =
+      if error == GetNotFound:
+        error.toError("", KvtNotFound)
+      else:
+        error.toError("")
     if error != GetNotFound:
-      warn info, key, error=($error)
-    return err($error)
+      warn info, key, error=($$dbError)
+    return err($$dbError)
 
   wrapRlpException info:
     let blockHash = rlp.decode(data, Hash32)

--- a/execution_chain/db/kvt/kvt_constants.nim
+++ b/execution_chain/db/kvt/kvt_constants.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/execution_chain/db/kvt/kvt_constants.nim
+++ b/execution_chain/db/kvt/kvt_constants.nim
@@ -14,4 +14,7 @@ import
 export
   EmptyBlob
 
+const
+  BLOCK_HASH_LRU_SIZE* = 256 * 1024
+
 # End

--- a/execution_chain/db/kvt/kvt_desc.nim
+++ b/execution_chain/db/kvt/kvt_desc.nim
@@ -15,10 +15,15 @@
 
 import
   std/[hashes, tables],
+  eth/common/[base, hashes],
   results,
   ./kvt_init/init_common,
   ./kvt_constants,
   ./kvt_desc/desc_error
+
+when compileOption("threads"):
+  import ../../concurrency/lru
+  export lru
 
 # Not auto-exporting backend
 export hashes, tables, kvt_constants, desc_error
@@ -94,6 +99,24 @@ type
     txRef*: KvtTxRef
       ## Tx holding data scheduled to be written to disk during the next
       ## `persist` call
+
+    when compileOption("threads"):
+      blockHashes*: ConcurrentLruCache[BlockNumber, Hash32]
+        ## Block number to block hash cache mirroring the backend
+
+# ------------------------------------------------------------------------------
+# Public constructor helpers
+# ------------------------------------------------------------------------------
+
+proc initInstance*(db: KvtDbRef) =
+  db.txRef = KvtTxRef(db: db)
+  when compileOption("threads"):
+    db.blockHashes.init(BLOCK_HASH_LRU_SIZE)
+
+proc disposeInstance*(db: KvtDbRef) =
+  when compileOption("threads"):
+    db.blockHashes.dispose()
+    db.blockHashes.reset()
 
 # ------------------------------------------------------------------------------
 # Public helpers

--- a/execution_chain/db/kvt/kvt_desc.nim
+++ b/execution_chain/db/kvt/kvt_desc.nim
@@ -108,10 +108,14 @@ type
 # Public constructor helpers
 # ------------------------------------------------------------------------------
 
-proc initInstance*(db: KvtDbRef) =
+proc initInstance*(
+    db: KvtDbRef, threadSafeCaches = true, blockHashesLruSize = 0) =
   db.txRef = KvtTxRef(db: db)
   when compileOption("threads"):
-    db.blockHashes.init(BLOCK_HASH_LRU_SIZE)
+    if threadSafeCaches:
+      db.blockHashes.init(blockHashesLruSize)
+    else:
+      db.blockHashes.init(blockHashesLruSize, shardBits = 0, threadSafe = false)
 
 proc disposeInstance*(db: KvtDbRef) =
   when compileOption("threads"):

--- a/execution_chain/db/kvt/kvt_init/memory_only.nim
+++ b/execution_chain/db/kvt/kvt_init/memory_only.nim
@@ -28,7 +28,7 @@ proc init*(T: type KvtDbRef): T =
   ## Memory backend constructor.
   ##
   let db = memoryBackend()
-  db.txRef = KvtTxRef(db: db)
+  db.initInstance()
   db
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/db/kvt/kvt_init/memory_only.nim
+++ b/execution_chain/db/kvt/kvt_init/memory_only.nim
@@ -24,11 +24,14 @@ export
 # Public database constuctors, destructor
 # ------------------------------------------------------------------------------
 
-proc init*(T: type KvtDbRef): T =
+proc init*(T: type KvtDbRef, enableCaches: static bool = false): T =
   ## Memory backend constructor.
   ##
   let db = memoryBackend()
-  db.initInstance()
+  when enableCaches:
+    db.initInstance(blockHashesLruSize = BLOCK_HASH_LRU_SIZE)
+  else:
+    db.initInstance(blockHashesLruSize = 0)
   db
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/db/kvt/kvt_init/persistent.nim
+++ b/execution_chain/db/kvt/kvt_init/persistent.nim
@@ -36,7 +36,7 @@ proc init*(
   ## Generic constructor for `RocksDb` backend
   ##
   let db = rocksDbKvtBackend(baseDb, cf)
-  db.txRef = KvtTxRef(db: db)
+  db.initInstance()
   db
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/db/kvt/kvt_init/persistent.nim
+++ b/execution_chain/db/kvt/kvt_init/persistent.nim
@@ -19,6 +19,7 @@
 {.push raises: [].}
 
 import
+  ../../opts,
   ../kvt_desc,
   ./rocks_db
 
@@ -31,12 +32,15 @@ export
 
 proc init*(
     T: type KvtDbRef;
+    opts: DbOptions;
     baseDb: RocksDbInstanceRef;
     cf: static[KvtCFs] = KvtGeneric): T =
   ## Generic constructor for `RocksDb` backend
   ##
   let db = rocksDbKvtBackend(baseDb, cf)
-  db.initInstance()
+  db.initInstance(
+    threadSafeCaches = opts.threadSafeCaches,
+    blockHashesLruSize = BLOCK_HASH_LRU_SIZE)
   db
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/db/kvt/kvt_tx_frame.nim
+++ b/execution_chain/db/kvt/kvt_tx_frame.nim
@@ -1,5 +1,5 @@
 # nimbus-eth1
-# Copyright (c) 2023-2025 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
 #    http://www.apache.org/licenses/LICENSE-2.0)

--- a/execution_chain/db/kvt/kvt_tx_frame.nim
+++ b/execution_chain/db/kvt/kvt_tx_frame.nim
@@ -15,6 +15,7 @@
 
 import
   results,
+  ../storage_types,
   ./kvt_init/init_common,
   ./[kvt_desc, kvt_layers]
 
@@ -59,6 +60,9 @@ proc persist*(
   # Store structural single trie entries
   for k,v in txFrame.sTab:
     db.putKvpFn(batch, k, v)
+    when compileOption("threads"):
+      if k.isBlockNumberToHashKey():
+        db.blockHashes.del(k.blockNumberFromHashKey())
   # TODO above, we only prepare the changes to the database but don't actually
   #      write them to disk - the code below that updates the frame should
   #      really run after things have been written (to maintain sync betweeen

--- a/execution_chain/db/kvt/kvt_tx_frame.nim
+++ b/execution_chain/db/kvt/kvt_tx_frame.nim
@@ -14,6 +14,8 @@
 {.push raises: [].}
 
 import
+  eth/common/hashes_rlp,
+  eth/rlp,
   results,
   ../storage_types,
   ./kvt_init/init_common,
@@ -62,7 +64,14 @@ proc persist*(
     db.putKvpFn(batch, k, v)
     when compileOption("threads"):
       if k.isBlockNumberToHashKey():
-        db.blockHashes.del(k.blockNumberFromHashKey())
+        let number = k.blockNumberFromHashKey()
+        if v.len == 0:
+          db.blockHashes.del(number)
+        else:
+          try:
+            discard db.blockHashes.update(number, rlp.decode(v, Hash32))
+          except RlpError:
+            db.blockHashes.del(number)
   # TODO above, we only prepare the changes to the database but don't actually
   #      write them to disk - the code below that updates the frame should
   #      really run after things have been written (to maintain sync betweeen

--- a/execution_chain/db/kvt/kvt_tx_frame.nim
+++ b/execution_chain/db/kvt/kvt_tx_frame.nim
@@ -14,12 +14,12 @@
 {.push raises: [].}
 
 import
-  eth/common/hashes_rlp,
-  eth/rlp,
   results,
-  ../storage_types,
   ./kvt_init/init_common,
   ./[kvt_desc, kvt_layers]
+
+when compileOption("threads"):
+  import eth/common/hashes_rlp, eth/rlp, ../storage_types
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/execution_chain/db/kvt/kvt_tx_frame.nim
+++ b/execution_chain/db/kvt/kvt_tx_frame.nim
@@ -69,7 +69,7 @@ proc persist*(
           db.blockHashes.del(number)
         else:
           try:
-            discard db.blockHashes.update(number, rlp.decode(v, Hash32))
+            db.blockHashes.put(number, rlp.decode(v, Hash32))
           except RlpError:
             db.blockHashes.del(number)
   # TODO above, we only prepare the changes to the database but don't actually

--- a/execution_chain/db/kvt/kvt_utils.nim
+++ b/execution_chain/db/kvt/kvt_utils.nim
@@ -191,6 +191,7 @@ proc close*(db: KvtDbRef; wipe = false) =
   ## depending on the type of backend (e.g. the `BackendMemory` backend will
   ## always wipe on close.)
   ##
+  db.disposeInstance()
   db.closeFn wipe
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/db/storage_types.nim
+++ b/execution_chain/db/storage_types.nim
@@ -63,6 +63,12 @@ func blockNumberToHashKey*(u: BlockNumber): DbKey {.inline.} =
   copyMem(addr result.data[1], unsafeAddr u, sizeof(u))
   result.dataEndPos = uint8 sizeof(u)
 
+func isBlockNumberToHashKey*(key: openArray[byte]): bool {.inline.} =
+  key.len == sizeof(BlockNumber) + 1 and key[0] == byte(ord(blockNumberToHash))
+
+func blockNumberFromHashKey*(key: openArray[byte]): BlockNumber {.inline.} =
+  copyMem(addr result, unsafeAddr key[1], sizeof(BlockNumber))
+
 func canonicalHeadHashKey*(): DbKey {.inline.} =
   result.data[0] = byte ord(canonicalHeadHash)
   result.dataEndPos = 1

--- a/execution_chain/db/storage_types.nim
+++ b/execution_chain/db/storage_types.nim
@@ -63,11 +63,13 @@ func blockNumberToHashKey*(u: BlockNumber): DbKey {.inline.} =
   copyMem(addr result.data[1], unsafeAddr u, sizeof(u))
   result.dataEndPos = uint8 sizeof(u)
 
-func isBlockNumberToHashKey*(key: openArray[byte]): bool {.inline.} =
+template isBlockNumberToHashKey*(key: openArray[byte]): bool =
   key.len == sizeof(BlockNumber) + 1 and key[0] == byte(ord(blockNumberToHash))
 
-func blockNumberFromHashKey*(key: openArray[byte]): BlockNumber {.inline.} =
-  copyMem(addr result, unsafeAddr key[1], sizeof(BlockNumber))
+template blockNumberFromHashKey*(key: openArray[byte]): BlockNumber =
+  var res {.noinit.}: BlockNumber
+  copyMem(addr res, unsafeAddr key[1], sizeof(BlockNumber))
+  res
 
 func canonicalHeadHashKey*(): DbKey {.inline.} =
   result.data[0] = byte ord(canonicalHeadHash)

--- a/tests/test_kvt.nim
+++ b/tests/test_kvt.nim
@@ -255,6 +255,16 @@ suite "Kvt block hash cache":
 
     db.close()
 
+  test "Persisting inserts an uncached block hash into the cache":
+    let base = db.baseTxFrame()
+    base.addBlockNumberToHashLookup(BlockNumber(2), hashB)
+    db.persist(base)
+
+    db.kvt.delBe(blockNumberToHashKey(BlockNumber(2)).toOpenArray).expect("del")
+    check db.baseTxFrame().getBlockHash(BlockNumber(2)).expect("hash") == hashB
+
+    db.close()
+
   test "A deleted block hash is not resurrected by the cache":
     let base = db.baseTxFrame()
     base.addBlockNumberToHashLookup(BlockNumber(1), hashA)

--- a/tests/test_kvt.nim
+++ b/tests/test_kvt.nim
@@ -14,6 +14,7 @@ import
   unittest2,
   results,
   eth/common,
+  eth/rlp,
   ../execution_chain/db/core_db,
   ../execution_chain/db/core_db/memory_only,
   ../execution_chain/db/storage_types,
@@ -262,6 +263,19 @@ suite "Kvt block hash cache":
 
     db.kvt.delBe(blockNumberToHashKey(BlockNumber(2)).toOpenArray).expect("del")
     check db.baseTxFrame().getBlockHash(BlockNumber(2)).expect("hash") == hashB
+
+    db.close()
+
+  test "A read miss fills the cache from the backend":
+    let batch = db.kvt.putBegFn().expect("batch")
+    db.kvt.putKvpFn(
+      batch, blockNumberToHashKey(BlockNumber(7)).toOpenArray, rlp.encode(hashA))
+    db.kvt.putEndFn(batch).expect("putEndFn")
+
+    check db.baseTxFrame().getBlockHash(BlockNumber(7)).expect("hash") == hashA
+
+    db.kvt.delBe(blockNumberToHashKey(BlockNumber(7)).toOpenArray).expect("del")
+    check db.baseTxFrame().getBlockHash(BlockNumber(7)).expect("hash") == hashA
 
     db.close()
 

--- a/tests/test_kvt.nim
+++ b/tests/test_kvt.nim
@@ -206,7 +206,7 @@ suite "Kvt block hash cache":
     hashB = hash32"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
   setup:
-    let db = newCoreDbRef DefaultDbMemory
+    let db = newCoreDbRef(DefaultDbMemory, enableCaches = true)
 
   test "Persisted block hashes are served from the cache":
     let base = db.baseTxFrame()
@@ -238,7 +238,7 @@ suite "Kvt block hash cache":
 
     db.close()
 
-  test "Persisting a new block hash invalidates the cache":
+  test "Persisting a new block hash updates the cache in place":
     let base = db.baseTxFrame()
     base.addBlockNumberToHashLookup(BlockNumber(1), hashA)
     db.persist(base)
@@ -250,6 +250,7 @@ suite "Kvt block hash cache":
     fork.checkpoint(BlockNumber(1))
     db.persist(fork)
 
+    db.kvt.delBe(blockNumberToHashKey(BlockNumber(1)).toOpenArray).expect("del")
     check db.baseTxFrame().getBlockHash(BlockNumber(1)).expect("hash") == hashB
 
     db.close()

--- a/tests/test_kvt.nim
+++ b/tests/test_kvt.nim
@@ -13,6 +13,10 @@
 import
   unittest2,
   results,
+  eth/common,
+  ../execution_chain/db/core_db,
+  ../execution_chain/db/core_db/memory_only,
+  ../execution_chain/db/storage_types,
   ../execution_chain/db/kvt,
   ../execution_chain/db/kvt/[kvt_init/memory_only, kvt_tx_frame, kvt_utils]
 
@@ -193,5 +197,75 @@ suite "Kvt TxFrame":
         values[0] == Opt.some(@[byte 0, 1, 4])
         values[1] == Opt.some(@[byte 0, 1, 6])
         values[2] == Opt.none(seq[byte])
+
+    db.close()
+
+suite "Kvt block hash cache":
+  const
+    hashA = hash32"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    hashB = hash32"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+  setup:
+    let db = newCoreDbRef DefaultDbMemory
+
+  test "Persisted block hashes are served from the cache":
+    let base = db.baseTxFrame()
+    base.addBlockNumberToHashLookup(BlockNumber(1), hashA)
+    db.persist(base)
+
+    check:
+      db.baseTxFrame().getBlockHash(BlockNumber(1)).expect("hash") == hashA
+      db.baseTxFrame().getBlockHash(BlockNumber(1)).expect("hash") == hashA
+
+    db.kvt.delBe(blockNumberToHashKey(BlockNumber(1)).toOpenArray).expect("del")
+    check db.baseTxFrame().getBlockHash(BlockNumber(1)).expect("hash") == hashA
+
+    db.close()
+
+  test "Frame writes take precedence over the cache":
+    let base = db.baseTxFrame()
+    base.addBlockNumberToHashLookup(BlockNumber(1), hashA)
+    db.persist(base)
+
+    check db.baseTxFrame().getBlockHash(BlockNumber(1)).expect("hash") == hashA
+
+    let fork = db.txFrameBegin()
+    fork.addBlockNumberToHashLookup(BlockNumber(1), hashB)
+
+    check:
+      fork.getBlockHash(BlockNumber(1)).expect("hash") == hashB
+      db.baseTxFrame().getBlockHash(BlockNumber(1)).expect("hash") == hashA
+
+    db.close()
+
+  test "Persisting a new block hash invalidates the cache":
+    let base = db.baseTxFrame()
+    base.addBlockNumberToHashLookup(BlockNumber(1), hashA)
+    db.persist(base)
+
+    check db.baseTxFrame().getBlockHash(BlockNumber(1)).expect("hash") == hashA
+
+    let fork = db.txFrameBegin()
+    fork.addBlockNumberToHashLookup(BlockNumber(1), hashB)
+    fork.checkpoint(BlockNumber(1))
+    db.persist(fork)
+
+    check db.baseTxFrame().getBlockHash(BlockNumber(1)).expect("hash") == hashB
+
+    db.close()
+
+  test "A deleted block hash is not resurrected by the cache":
+    let base = db.baseTxFrame()
+    base.addBlockNumberToHashLookup(BlockNumber(1), hashA)
+    db.persist(base)
+
+    check db.baseTxFrame().getBlockHash(BlockNumber(1)).expect("hash") == hashA
+
+    let deleting = db.txFrameBegin()
+    deleting.del(blockNumberToHashKey(BlockNumber(1)).toOpenArray).expect("del")
+    deleting.checkpoint(BlockNumber(1))
+    db.persist(deleting)
+
+    check db.baseTxFrame().getBlockHash(BlockNumber(1)).isErr()
 
     db.close()


### PR DESCRIPTION
This adds a block number to block hash cache to the kvt db instance. This is useful because the kvt backend currently has no caching (the rocksdb row cache is disabled) and so all block hash requests hit the database. Since these are small it makes sense to cache them. 

This cache gets used by the BLOCKHASH opcode, bal pruning and the getBlockHeader by block number and a few other places. Sized to `256 * 1024` entries so that the bal pruning will get hits when pruning headers outside the BAL retention period.

The other reason for having a cache here is to cover the parallel execution code path where we create a new ledger per transaction which each have empty block hashes caches. With this we still hit block hashes in memory when parallel execution is enabled.

