### PR TITLE
eest_engine_test validate against errorCode

### DIFF
--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -40,73 +40,123 @@ func validateVersionedHashed(payload: ExecutionPayload,
       return false
   true
 
-template validateVersion(com, timestamp, payloadVersion, apiVersion) =
+template validateVersion(com, timestamp, payloadVersion, apiVersion, payload) =
   if apiVersion == Version.V5:
     if not com.isAmsterdamOrLater(timestamp):
       raise unsupportedFork("newPayloadV5 expect payload timestamp fall within Amsterdam")
-    if payloadVersion != Version.V4:
-      raise invalidParams("newPayload" & $apiVersion &
-      " expect ExecutionPayloadV4" &
-      " but got ExecutionPayload" & $payloadVersion)
 
   elif apiVersion == Version.V4:
     if not com.isPragueOrLater(timestamp):
-      raise unsupportedFork("newPayloadV4 expect payload timestamp fall within Prague")
-    if payloadVersion != Version.V3:
-      raise invalidParams("newPayload" & $apiVersion &
-      " expect ExecutionPayloadV3" &
-      " but got ExecutionPayload" & $payloadVersion)
+      raise unsupportedFork("newPayloadV4 expect payload timestamp fall within Prague or Osaka")
 
   elif apiVersion == Version.V3:
     if not com.isCancunOrLater(timestamp):
       raise unsupportedFork("newPayloadV3 expect payload timestamp fall within Cancun")
-    if payloadVersion != Version.V3:
-      raise invalidParams("newPayload" & $apiVersion &
-      " expect ExecutionPayloadV3" &
-      " but got ExecutionPayload" & $payloadVersion)
 
   if com.isAmsterdamOrLater(timestamp):
-    if payloadVersion != Version.V4:
-      raise invalidParams("if timestamp is Amsterdam or later, " &
-        "payload must be ExecutionPayloadV4, got ExecutionPayload" & $payloadVersion)
+    # TODO: probably blockAccessList field should be a string instead of Opt[string]
+    if payload.blockAccessList.isNone or payload.blockAccessList.value.len == 0:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing blockAccessList")
+
+    if payload.slotNumber.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing slotNumber")
+
+    if payload.excessBlobGas.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing excessBlobGas")
+
+    if payload.blobGasUsed.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing blobGasUsed")
+
+    if payload.withdrawals.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing withdrawals")
 
   elif com.isPragueOrLater(timestamp):
-    if payloadVersion != Version.V3:
-      raise invalidParams("if timestamp is Prague or later, " &
-        "payload must be ExecutionPayloadV3, got ExecutionPayload" & $payloadVersion)
+    if payload.excessBlobGas.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing excessBlobGas")
+
+    if payload.blobGasUsed.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing blobGasUsed")
+
+    if payload.withdrawals.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing withdrawals")
 
   elif com.isCancunOrLater(timestamp):
-    if payloadVersion != Version.V3:
-      raise invalidParams("if timestamp is Cancun or later, " &
-        "payload must be ExecutionPayloadV3, got ExecutionPayload" & $payloadVersion)
+    if payload.excessBlobGas.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing excessBlobGas")
+
+    if payload.blobGasUsed.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing blobGasUsed")
+
+    if payload.withdrawals.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing withdrawals")
 
   elif com.isShanghaiOrLater(timestamp):
-    if payloadVersion != Version.V2:
-      raise invalidParams("if timestamp is Shanghai or later, " &
-        "payload must be ExecutionPayloadV2, got ExecutionPayload" & $payloadVersion)
+    if payload.withdrawals.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": payload missing withdrawals")
 
   elif payloadVersion != Version.V1:
     raise invalidParams("if timestamp is earlier than Shanghai, " &
       "payload must be ExecutionPayloadV1, got ExecutionPayload" & $payloadVersion)
 
-template validatePayload(apiVersion, payloadVersion, payload) =
-  if payloadVersion >= Version.V2:
+  if payload.withdrawals.isSome:
+    if not com.isShanghaiOrLater(EthTime payload.timestamp):
+      raise invalidParams("newPayload" & $apiVersion &
+        ": withdrawals appear before Shanghai")
+
+  if payload.blobGasUsed.isSome:
+    if not com.isCancunOrLater(EthTime payload.timestamp):
+      raise invalidParams("newPayload" & $apiVersion &
+        ": blobGasUsed appear before Cancun")
+
+  if payload.excessBlobGas.isSome:
+    if not com.isCancunOrLater(EthTime payload.timestamp):
+      raise invalidParams("newPayload" & $apiVersion &
+        ": excessBlobGas appear before Cancun")
+
+  # TODO: probably blockAccessList field should be a string instead of Opt[string]
+  if payload.blockAccessList.isSome and payload.blockAccessList.value.len > 0:
+    if not com.isAmsterdamOrLater(EthTime payload.timestamp):
+      raise invalidParams("newPayload" & $apiVersion &
+        ": blockAccessList appear before Amsterdam")
+
+  if payload.slotNumber.isSome:
+    if not com.isAmsterdamOrLater(EthTime payload.timestamp):
+      raise invalidParams("newPayload" & $apiVersion &
+        ": slotNumber appear before Amsterdam")
+
+template validatePayload(apiVersion, payload) =
+  if apiVersion >= Version.V2:
     if payload.withdrawals.isNone:
       raise invalidParams("newPayload" & $apiVersion &
-        "withdrawals is expected from execution payload")
+        ": withdrawals is expected from execution payload")
 
-  if apiVersion >= Version.V3 or payloadVersion >= Version.V3:
+  if apiVersion >= Version.V3:
     if payload.blobGasUsed.isNone:
       raise invalidParams("newPayload" & $apiVersion &
-        "blobGasUsed is expected from execution payload")
+        ": blobGasUsed is expected from execution payload")
     if payload.excessBlobGas.isNone:
       raise invalidParams("newPayload" & $apiVersion &
-        "excessBlobGas is expected from execution payload")
+        ": excessBlobGas is expected from execution payload")
 
-  if apiVersion >= Version.V5 or payloadVersion >= Version.V4:
+  if apiVersion >= Version.V5:
     if payload.blockAccessList.isNone:
       raise invalidParams("newPayload" & $apiVersion &
-        "blockAccessList is expected from execution payload")
+        ": blockAccessList is expected from execution payload")
+    if payload.slotNumber.isNone:
+      raise invalidParams("newPayload" & $apiVersion &
+        ": slotNumber is expected from execution payload")
 
 # https://github.com/ethereum/execution-apis/blob/40088597b8b4f48c45184da002e27ffc3c37641f/src/engine/prague.md#request
 func validateExecutionRequest(
@@ -116,16 +166,16 @@ func validateExecutionRequest(
   for request in requests:
     if request.len == 0:
       raise invalidParams("newPayload" & $apiVersion &
-        ": " & "Execution request data must not be empty")
+        ": Execution request data must not be empty")
 
     let requestType = request[0]
     if requestType.int <= previousRequestType:
       raise invalidParams("newPayload" & $apiVersion &
-        ": " & "Execution requests are not in strictly ascending order")
+        ": Execution requests are not in strictly ascending order")
 
     if request.len == 1:
       raise invalidParams("newPayload" & $apiVersion &
-        ": " & "Empty data for request type " & $requestType)
+        ": Empty data for request type " & $requestType)
 
     if apiVersion >= Version.V5:
       if requestType notin [
@@ -134,18 +184,18 @@ func validateExecutionRequest(
         CONSOLIDATION_REQUEST_TYPE,
         BUILDER_DEPOSIT_REQUEST_TYPE,
         BUILDER_EXIT_REQUEST_TYPE]:
-        return Opt.some(invalidStatus(Opt.none(Hash32),
+        return Opt.some(invalidStatus(
           "newPayload" & $apiVersion & ": Invalid execution request type" & $requestType))
     else:
       if requestType notin [
         DEPOSIT_REQUEST_TYPE,
         WITHDRAWAL_REQUEST_TYPE,
         CONSOLIDATION_REQUEST_TYPE]:
-        return Opt.some(invalidStatus(Opt.none(Hash32),
+        return Opt.some(invalidStatus(
           "newPayload" & $apiVersion & ": Invalid execution request type" & $requestType))
 
     previousRequestType = requestType.int
-  err()
+  Opt.none(PayloadStatusV1)
 
 proc newPayload*(ben: BeaconEngineRef,
                  apiVersion: Version,
@@ -162,7 +212,8 @@ proc newPayload*(ben: BeaconEngineRef,
 
   if apiVersion >= Version.V3:
     if beaconRoot.isNone:
-      raise invalidParams("newPayloadV3 expect beaconRoot but got none")
+      raise invalidParams("newPayloadV" & $apiVersion &
+        ": expect beaconRoot but got none")
 
   if apiVersion >= Version.V4:
     if executionRequests.isNone:
@@ -179,8 +230,8 @@ proc newPayload*(ben: BeaconEngineRef,
     timestamp = ethTime payload.timestamp
     version = payload.version
 
-  validatePayload(apiVersion, version, payload)
-  validateVersion(com, timestamp, version, apiVersion)
+  validatePayload(apiVersion, payload)
+  validateVersion(com, timestamp, version, apiVersion, payload)
 
   let
     requestsHash = calcRequestsHash(executionRequests)
@@ -190,24 +241,27 @@ proc newPayload*(ben: BeaconEngineRef,
       except RlpError as e:
         warn "Failed to decode payload",
           error = e.msg
-        return invalidStatus(Opt.none(Hash32),
-          "Failed to decode block in payload: " & e.msg)
+        return invalidStatus("newPayload" & $apiVersion &
+          ": Failed to decode block in payload: " & e.msg)
     blockAccessList =
       try:
         blockAccessList(payload)
       except RlpError as e:
         warn "Failed to decode payload",
           error = e.msg
-        raise invalidParams("Failed to decode BAL in payload: " & e.msg)
-
-  template header: Header = blk.header
+        raise invalidParams("newPayload" & $apiVersion &
+          ": Failed to decode BAL in payload: " & e.msg)
 
   if apiVersion >= Version.V3:
     if versionedHashes.isNone:
       raise invalidParams("newPayload" & $apiVersion &
-        " expect blobVersionedHashes but got none")
+        ": expect blobVersionedHashes but got none")
+
     if not validateVersionedHashed(payload, versionedHashes.value):
-      return invalidStatus(Opt.none(Hash32), "invalid blob versionedHashes")
+      return invalidStatus("newPayload" & $apiVersion &
+        ": invalid blob versionedHashes")
+
+  template header: Header = blk.header
 
   let blockHash = payload.blockHash
   header.validateBlockHash(blockHash, version).isOkOr:
@@ -221,9 +275,10 @@ proc newPayload*(ben: BeaconEngineRef,
     return validStatus(blockHash)
 
   # If this block was rejected previously, keep rejecting it
-  let res = ben.checkInvalidAncestor(blockHash, blockHash)
-  if res.isSome:
-    return res.value
+  block:
+    let res = ben.checkInvalidAncestor(blockHash, blockHash)
+    if res.isSome:
+      return res.value
 
   # If the parent is missing, we - in theory - could trigger a sync, but that
   # would also entail a reorg. That is problematic if multiple sibling blocks
@@ -271,18 +326,19 @@ proc newPayload*(ben: BeaconEngineRef,
   trace "Importing block without sethead",
     hash = blockHash, number = header.number
 
-  let vres = await chain.queueImportBlock(blk, blockAccessList)
-  if vres.isErr:
-    warn "Error importing block",
-      number = header.number,
-      hash = blockHash.short,
-      parent = header.parentHash.short,
-      error = vres.error.msg
-    ben.setInvalidAncestor(header, blockHash)
-    let
-      txFrame = chain.latestTxFrame()
-      blockHash = latestValidHash(txFrame, parent, ttd)
-    return invalidStatus(blockHash, vres.error.msg)
+  block:
+    let res = await chain.queueImportBlock(blk, blockAccessList)
+    if res.isErr:
+      warn "Error importing block",
+        number = header.number,
+        hash = blockHash.short,
+        parent = header.parentHash.short,
+        error = res.error.msg
+      ben.setInvalidAncestor(header, blockHash)
+      let
+        txFrame = chain.latestTxFrame()
+        blockHash = latestValidHash(txFrame, parent, ttd)
+      return invalidStatus(blockHash, res.error.msg)
 
   ben.txPool.removeNewBlockTxs(blk, Opt.some(blockHash))
 

--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -54,7 +54,7 @@ template validateVersion(com, timestamp, payloadVersion, apiVersion, payload) =
       raise unsupportedFork("newPayloadV3 expect payload timestamp fall within Cancun")
 
   if com.isAmsterdamOrLater(timestamp):
-    # TODO: probably blockAccessList field should be a string instead of Opt[string]
+    # TODO: probably blockAccessList field should be a seq[byte] instead of Opt[seq[byte]]
     if payload.blockAccessList.isNone or payload.blockAccessList.value.len == 0:
       raise invalidParams("newPayload" & $apiVersion &
         ": payload missing blockAccessList")
@@ -125,7 +125,7 @@ template validateVersion(com, timestamp, payloadVersion, apiVersion, payload) =
       raise invalidParams("newPayload" & $apiVersion &
         ": excessBlobGas appear before Cancun")
 
-  # TODO: probably blockAccessList field should be a string instead of Opt[string]
+  # TODO: probably blockAccessList field should be a seq[byte] instead of Opt[seq[byte]]
   if payload.blockAccessList.isSome and payload.blockAccessList.value.len > 0:
     if not com.isAmsterdamOrLater(EthTime payload.timestamp):
       raise invalidParams("newPayload" & $apiVersion &

--- a/execution_chain/beacon/api_handler/api_utils.nim
+++ b/execution_chain/beacon/api_handler/api_utils.nim
@@ -118,6 +118,9 @@ func invalidStatus*(
 func invalidStatus*(validHash: common.Hash32, msg: string): PayloadStatusV1 =
   invalidStatus(Opt.some(validHash), msg)
 
+func invalidStatus*(msg: string): PayloadStatusV1 =
+  invalidStatus(Opt.none(Hash32), msg)
+  
 func invalidStatus*(validHash = default(common.Hash32)): PayloadStatusV1 =
   PayloadStatusV1(
     status: PayloadExecutionStatus.invalid,

--- a/execution_chain/beacon/payload_conv.nim
+++ b/execution_chain/beacon/payload_conv.nim
@@ -35,7 +35,7 @@ func wdRoot(list: openArray[WithdrawalV1]): Hash32 =
 
 func wdRoot(x: Opt[seq[WithdrawalV1]]): Opt[Hash32] =
   if x.isNone: Opt.none(Hash32)
-  else: Opt.some(wdRoot x.get)
+  else: Opt.some(wdRoot x.value)
 
 func txRoot(list: openArray[Web3Tx]): Hash32 =
   orderedTrieRoot(list)
@@ -44,7 +44,7 @@ func balHash(bal: Opt[seq[byte]]): Opt[Hash32] =
   if bal.isNone():
     Opt.none(Hash32)
   else:
-    Opt.some(keccak256(bal.get))
+    Opt.some(keccak256(bal.value))
 
 # ------------------------------------------------------------------------------
 # Public functions
@@ -71,25 +71,6 @@ func executionPayload*(blk: Block, bal: Opt[BlockAccessListRef]): ExecutionPaylo
     excessBlobGas: w3Qty blk.header.excessBlobGas,
     blockAccessList: w3BlockAccessList bal,
     slotNumber   : w3Qty blk.header.slotNumber,
-  )
-
-func executionPayloadV1V2*(blk: Block): ExecutionPayloadV1OrV2 =
-  ExecutionPayloadV1OrV2(
-    parentHash   : blk.header.parentHash,
-    feeRecipient : blk.header.coinbase,
-    stateRoot    : blk.header.stateRoot,
-    receiptsRoot : blk.header.receiptsRoot,
-    logsBloom    : blk.header.logsBloom,
-    prevRandao   : blk.header.prevRandao,
-    blockNumber  : w3Qty blk.header.number,
-    gasLimit     : w3Qty blk.header.gasLimit,
-    gasUsed      : w3Qty blk.header.gasUsed,
-    timestamp    : w3Qty blk.header.timestamp,
-    extraData    : w3ExtraData blk.header.extraData,
-    baseFeePerGas: blk.header.baseFeePerGas.get(0.u256),
-    blockHash    : blk.header.computeRlpHash,
-    transactions : w3Txs blk.txs,
-    withdrawals  : w3Withdrawals blk.withdrawals,
   )
 
 func blockHeader*(p: ExecutionPayload,
@@ -120,15 +101,6 @@ func blockHeader*(p: ExecutionPayload,
     requestsHash   : requestsHash,
     blockAccessListHash: balHash p.blockAccessList,
     slotNumber     : u64(p.slotNumber),
-  )
-
-func blockBody*(
-  p: ExecutionPayload
-): BlockBody {.gcsafe, raises: [RlpError].} =
-  BlockBody(
-    uncles      : @[],
-    transactions: ethTxs p.transactions,
-    withdrawals : ethWithdrawals p.withdrawals,
   )
 
 template blockAccessList*(

--- a/execution_chain/beacon/web3_eth_conv.nim
+++ b/execution_chain/beacon/web3_eth_conv.nim
@@ -101,10 +101,10 @@ func ethBlockAccessList*(
 
 func ethBlockAccessList*(
     bal: Opt[seq[byte]]): Opt[BlockAccessListRef] {.gcsafe, raises: [RlpError].} =
-  if bal.isNone():
+  if bal.isNone() or bal.value.len == 0:
     Opt.none(BlockAccessListRef)
   else:
-    Opt.some(ethBlockAccessList(bal.get))
+    Opt.some(ethBlockAccessList(bal.value))
 
 # ------------------------------------------------------------------------------
 # Eth types to Web3 types

--- a/tests/eest/eest_engine.nim
+++ b/tests/eest/eest_engine.nim
@@ -86,32 +86,36 @@ proc runTest(env: TestEnv, unit: EngineUnitEnv): Result[void, string] =
     return err("Client is not initialized")
 
   for enp in unit.engineNewPayloads:
-
-    var status = env.sendNewPayload(enp.newPayloadVersion.uint64, enp.params).valueOr:
-      if enp.validationError.isSome():
-        continue
+    let res = env.sendNewPayload(enp.newPayloadVersion.uint64, enp.params)
+    if res.isErr:
+      if enp.errorCode.isSome:
+        if enp.errorCode.value in res.error:
+          continue
+        else:
+          return err("newPayload produce error code " & res.error &
+            ", expect " & enp.errorCode.value)
       else:
-        return err(error)
+        return err("Unexpected newPayload error: " & res.error)
+    else:
+      if enp.errorCode.isSome:
+        return err("newPayload failed to produce error code " & enp.errorCode.value &
+          ", got: " & $res.value)
 
-    discard status
-    when false:
-      # Skip validation error check, use `unit.lastblockhash` to
-      # determine if the test is pass.
-      if status.validationError.isSome:
-        return err(status.validationError.value)
+    let status = res.value
+    if status.validationError.isSome:
+      if enp.validationError.isNone:
+        return err("Expect no validation error, but got " & status.validationError.value)
+    else:
+      if enp.validationError.isSome:
+        return err("Expect validation error: " & enp.validationError.value & ", but got none")
 
     let y = env.sendFCU(enp.forkchoiceUpdatedVersion.uint64, enp.params).valueOr:
       return err(error)
 
+    # Test pass if the last block hash equal
     discard y
-    when false:
-      # ditto
-      status = y.payloadStatus
-      if status.validationError.isSome:
-        return err(status.validationError.value)
 
   let header = env.chain.latestHeader()
-
   if unit.lastblockhash != header.computeRlpHash:
     return err("last block hash mismatch")
 

--- a/tests/eest/eest_parser.nim
+++ b/tests/eest/eest_parser.nim
@@ -74,6 +74,7 @@ type
     newPayloadVersion*: Numero
     forkchoiceUpdatedVersion*: Numero
     validationError*: Opt[string]
+    errorCode*: Opt[string]
 
   EnvConfig* = object
     network*: string


### PR DESCRIPTION
This PR add more validation to the engine_newPayload returned error code or payload status. And fix the newPayload error handling implementation too.

Because of too relaxed validation before this PR, many of hive test cases are failing with consume-engine simulator.