### PR TITLE
KVT put and receipt root optimization

### DIFF
--- a/execution_chain/core/chain/forked_chain/chain_serialize.nim
+++ b/execution_chain/core/chain/forked_chain/chain_serialize.nim
@@ -199,10 +199,12 @@ proc serialize*(fc: ForkedChainRef, txFrame: CoreDbTxRef): Result[void, CoreDbEr
     b.index = uint i
     inc i
 
-  ?txFrame.put(FcStateKey.toOpenArray, rlp.encode(fc))
+  var encodedState = rlp.encode(fc)
+  ?txFrame.putMove(FcStateKey.toOpenArray, encodedState)
 
   for b in fc.hashToBlock.values:
-    ?txFrame.put(blockIndexKey(b.index), rlp.encode(b))
+    var encodedBlock = rlp.encode(b)
+    ?txFrame.putMove(blockIndexKey(b.index), encodedBlock)
     # Persist the per-block txFrame delta (Aristo + KVT) so deserialize can
     # restore the in-memory frame without re-executing the block.  The base
     # block shares its frame with the on-disk base and needs no blob.

--- a/execution_chain/core/chain/header_chain_cache.nim
+++ b/execution_chain/core/chain/header_chain_cache.nim
@@ -170,7 +170,8 @@ func decodePayload(data: seq[byte]; T: type): T =
 # ------------------------------------------------------------------------------
 
 proc putInfo(db: KvtTxRef; state: HccDbInfo) =
-  db.put(HccDbInfoKey.toOpenArray, encodePayload(state)).isOkOr:
+  var data = encodePayload(state)
+  db.putMove(HccDbInfoKey.toOpenArray, data).isOkOr:
     raiseAssert MsgPfx & "put(info) failed: " & $error
 
 proc getInfo(db: KvtTxRef): Opt[HccDbInfo] =
@@ -191,8 +192,8 @@ proc delInfo(db: KvtTxRef) =
 proc putHeader(db: KvtTxRef; h: Header) =
   ## Store the argument `header` indexed by block number, and the hash lookup
   ## of the parent header.
-  let data = encodePayload(h)
-  db.put(beaconHeaderKey(h.number).toOpenArray, data).isOkOr:
+  var data = encodePayload(h)
+  db.putMove(beaconHeaderKey(h.number).toOpenArray, data).isOkOr:
     raiseAssert MsgPfx & "put(header) failed: " & $error
 
   let parNumData = (h.number-1).toBytesBE

--- a/execution_chain/db/core_db/base.nim
+++ b/execution_chain/db/core_db/base.nim
@@ -230,6 +230,18 @@ proc put*(
 
   ok()
 
+proc put*(
+    kvt: CoreDbTxRef;
+    key: openArray[byte];
+    val: sink seq[byte];
+      ): CoreDbRc[void] =
+  ## Variant of `put()` that takes over ownership of `val` instead of
+  ## copying it - the caller must not use `val` after this call
+  kvt.kTx.put(key, val).isOkOr:
+    return err(error.toError(""))
+
+  ok()
+
 proc hasKeyRc*(kvt: CoreDbTxRef; key: openArray[byte]): CoreDbRc[bool] =
   ## For the argument `key` return `true` if `get()` returned a value on
   ## that argument, `false` if it returned `GetNotFound`, and an error

--- a/execution_chain/db/core_db/base.nim
+++ b/execution_chain/db/core_db/base.nim
@@ -233,7 +233,7 @@ proc put*(
 proc put*(
     kvt: CoreDbTxRef;
     key: openArray[byte];
-    val: sink seq[byte];
+    val: var seq[byte];
       ): CoreDbRc[void] =
   ## Variant of `put()` that takes over ownership of `val` instead of
   ## copying it - the caller must not use `val` after this call

--- a/execution_chain/db/core_db/base.nim
+++ b/execution_chain/db/core_db/base.nim
@@ -230,14 +230,14 @@ proc put*(
 
   ok()
 
-proc put*(
+proc putMove*(
     kvt: CoreDbTxRef;
     key: openArray[byte];
     val: var seq[byte];
       ): CoreDbRc[void] =
   ## Variant of `put()` that takes over ownership of `val` instead of
   ## copying it - the caller must not use `val` after this call
-  kvt.kTx.put(key, val).isOkOr:
+  kvt.kTx.putMove(key, val).isOkOr:
     return err(error.toError(""))
 
   ok()

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -246,7 +246,8 @@ proc addBlockNumberToHashLookup*(
   # TODO: Once we remove the kvt frame layers, this function should
   # write to the kvt block hashes cache.
   let blockNumberKey = blockNumberToHashKey(blockNumber)
-  db.put(blockNumberKey.toOpenArray, rlp.encode(blockHash)).isOkOr:
+  var encodedHash = rlp.encode(blockHash)
+  db.putMove(blockNumberKey.toOpenArray, encodedHash).isOkOr:
     warn "addBlockNumberToHashLookup", blockNumberKey, error=($$error)
 
 proc persistTransactions*(
@@ -271,7 +272,8 @@ proc persistTransactions*(
     db.putMove(key, encodedTx).isOkOr:
       warn info, idx, error=($$error)
       return
-    db.put(blockKey.toOpenArray, rlp.encode(txKey)).isOkOr:
+    var encodedTxKey = rlp.encode(txKey)
+    db.putMove(blockKey.toOpenArray, encodedTxKey).isOkOr:
       trace info, blockKey, error=($$error)
       return
 
@@ -318,10 +320,10 @@ proc persistWithdrawals*(
   if withdrawals.len == 0:
     return
 
-  db.put(withdrawalsKey(withdrawalsRoot).toOpenArray,
-    rlp.encode(withdrawals)).isOkOr:
-      warn info, error=($$error)
-      return
+  var encodedWds = rlp.encode(withdrawals)
+  db.putMove(withdrawalsKey(withdrawalsRoot).toOpenArray, encodedWds).isOkOr:
+    warn info, error=($$error)
+    return
 
   when false:
     # Ol withdrawals format
@@ -371,7 +373,8 @@ proc getTransactions*(
 
 proc persistBlockAccessList*(
     db: CoreDbTxRef, blockHash: Hash32, bal: BlockAccessListRef) =
-  db.put(blockHashToBlockAccessListKey(blockHash).toOpenArray, bal[].encode())
+  var encodedBal = bal[].encode()
+  db.putMove(blockHashToBlockAccessListKey(blockHash).toOpenArray, encodedBal)
     .expect("persistBlockAccessList should succeed")
 
 proc getBlockAccessList*(
@@ -519,7 +522,8 @@ proc setHead*(
     blockHash: Hash32;
       ): Result[void, string] =
   let canonicalHeadHash = canonicalHeadHashKey()
-  db.put(canonicalHeadHash.toOpenArray, rlp.encode(blockHash)).isOkOr:
+  var encodedHash = rlp.encode(blockHash)
+  db.putMove(canonicalHeadHash.toOpenArray, encodedHash).isOkOr:
     return err($$error)
   ok()
 
@@ -528,10 +532,12 @@ proc setHead*(
     header: Header;
     headerHash: Hash32;
       ): Result[void, string] =
-  db.put(genericHashKey(headerHash).toOpenArray, rlp.encode(header)).isOkOr:
+  var encodedHeader = rlp.encode(header)
+  db.putMove(genericHashKey(headerHash).toOpenArray, encodedHeader).isOkOr:
     return err($$error)
   let canonicalHeadHash = canonicalHeadHashKey()
-  db.put(canonicalHeadHash.toOpenArray, rlp.encode(headerHash)).isOkOr:
+  var encodedHash = rlp.encode(headerHash)
+  db.putMove(canonicalHeadHash.toOpenArray, encodedHash).isOkOr:
     return err($$error)
   ok()
 
@@ -546,7 +552,8 @@ proc persistReceipts*(
 
   for idx, rec in receipts:
     let key = hashIndexKey(receiptsRoot, idx.uint16)
-    db.put(key, rlp.encode(rec)).isOkOr:
+    var encodedRec = rlp.encode(rec)
+    db.putMove(key, encodedRec).isOkOr:
       warn info, idx, error=($$error)
 
 proc getReceipts*(
@@ -585,7 +592,8 @@ proc persistScore(
     info = "persistScore"
   let
     scoreKey = blockHashToScoreKey(blockHash)
-  db.put(scoreKey.toOpenArray, rlp.encode(score)).isOkOr:
+  var encodedScore = rlp.encode(score)
+  db.putMove(scoreKey.toOpenArray, encodedScore).isOkOr:
     return err(info & ": " & $$error)
   ok()
 
@@ -603,7 +611,8 @@ proc persistHeader*(
   if not isStartOfHistory and not db.headerExists(header.parentHash):
     return err(info & ": parent header missing number " & $header.number)
 
-  db.put(genericHashKey(blockHash).toOpenArray, rlp.encode(header)).isOkOr:
+  var encodedHeader = rlp.encode(header)
+  db.putMove(genericHashKey(blockHash).toOpenArray, encodedHeader).isOkOr:
     return err(info & ": " & $$error)
 
   let
@@ -657,9 +666,9 @@ proc persistHeaderAndSetHead*(
 proc persistUncles*(db: CoreDbTxRef, uncles: openArray[Header]): Hash32 =
   ## Persists the list of uncles to the database.
   ## Returns the uncles hash.
-  let enc = rlp.encode(uncles)
+  var enc = rlp.encode(uncles)
   result = keccak256(enc)
-  db.put(genericHashKey(result).toOpenArray, enc).isOkOr:
+  db.putMove(genericHashKey(result).toOpenArray, enc).isOkOr:
     warn "persistUncles()", unclesHash=result, error=($$error)
     return EMPTY_ROOT_HASH
 
@@ -668,7 +677,8 @@ proc persistWitness*(
     blockHash: Hash32;
     witness: Witness;
       ): Result[void, string] =
-  db.put(blockHashToWitnessKey(blockHash).toOpenArray, witness.encode()).isOkOr:
+  var encodedWitness = witness.encode()
+  db.putMove(blockHashToWitnessKey(blockHash).toOpenArray, encodedWitness).isOkOr:
     return err("persistWitness: " & $$error)
   ok()
 

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -268,7 +268,7 @@ proc persistTransactions*(
       blockKey = transactionHashToBlockKey(txHash)
       txKey = TransactionKey(blockNumber: blockNumber, index: idx.uint)
       key = hashIndexKey(txRoot, idx.uint16)
-    db.put(key, encodedTx).isOkOr:
+    db.putMove(key, encodedTx).isOkOr:
       warn info, idx, error=($$error)
       return
     db.put(blockKey.toOpenArray, rlp.encode(txKey)).isOkOr:

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -268,7 +268,7 @@ proc persistTransactions*(
       blockKey = transactionHashToBlockKey(txHash)
       txKey = TransactionKey(blockNumber: blockNumber, index: idx.uint)
       key = hashIndexKey(txRoot, idx.uint16)
-    db.put(key, move encodedTx).isOkOr:
+    db.put(key, encodedTx).isOkOr:
       warn info, idx, error=($$error)
       return
     db.put(blockKey.toOpenArray, rlp.encode(txKey)).isOkOr:

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -262,13 +262,13 @@ proc persistTransactions*(
     return
 
   for idx, tx in transactions:
+    var encodedTx = rlp.encode(tx)
     let
-      encodedTx = rlp.encode(tx)
       txHash = keccak256(encodedTx)
       blockKey = transactionHashToBlockKey(txHash)
       txKey = TransactionKey(blockNumber: blockNumber, index: idx.uint)
       key = hashIndexKey(txRoot, idx.uint16)
-    db.put(key, encodedTx).isOkOr:
+    db.put(key, move encodedTx).isOkOr:
       warn info, idx, error=($$error)
       return
     db.put(blockKey.toOpenArray, rlp.encode(txKey)).isOkOr:

--- a/execution_chain/db/kvt/kvt_layers.nim
+++ b/execution_chain/db/kvt/kvt_layers.nim
@@ -54,7 +54,7 @@ func layersGet*(db: KvtTxRef; key: openArray[byte]|seq[byte]): Opt[seq[byte]] =
 # Public functions: put function
 # ------------------------------------------------------------------------------
 
-func layersPut*(db: KvtTxRef; key: openArray[byte]; data: var seq[byte]) =
+func layersPutMove*(db: KvtTxRef; key: openArray[byte]; data: var seq[byte]) =
   ## Store a (potentally empty) value on the top layer, taking over the
   ## contents of `data` which is left empty
   swap(db.sTab.mgetOrPut(@key, EmptyBlob), data)
@@ -63,7 +63,7 @@ func layersPut*(db: KvtTxRef; key: openArray[byte]; data: var seq[byte]) =
 func layersPut*(db: KvtTxRef; key: openArray[byte]; data: openArray[byte]) =
   ## Store a (potentally empty) value on the top layer
   var data = @data
-  db.layersPut(key, data)
+  db.layersPutMove(key, data)
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/execution_chain/db/kvt/kvt_layers.nim
+++ b/execution_chain/db/kvt/kvt_layers.nim
@@ -58,6 +58,7 @@ func layersPut*(db: KvtTxRef; key: openArray[byte]; data: var seq[byte]) =
   ## Store a (potentally empty) value on the top layer, taking over the
   ## contents of `data` which is left empty
   swap(db.sTab.mgetOrPut(@key, EmptyBlob), data)
+  data.setLen(0)
 
 func layersPut*(db: KvtTxRef; key: openArray[byte]; data: openArray[byte]) =
   ## Store a (potentally empty) value on the top layer

--- a/execution_chain/db/kvt/kvt_layers.nim
+++ b/execution_chain/db/kvt/kvt_layers.nim
@@ -54,14 +54,15 @@ func layersGet*(db: KvtTxRef; key: openArray[byte]|seq[byte]): Opt[seq[byte]] =
 # Public functions: put function
 # ------------------------------------------------------------------------------
 
+func layersPut*(db: KvtTxRef; key: openArray[byte]; data: var seq[byte]) =
+  ## Store a (potentally empty) value on the top layer, taking over the
+  ## contents of `data` which is left empty
+  swap(db.sTab.mgetOrPut(@key, EmptyBlob), data)
+
 func layersPut*(db: KvtTxRef; key: openArray[byte]; data: openArray[byte]) =
   ## Store a (potentally empty) value on the top layer
-  db.sTab[@key] = @data
-
-func layersPut*(db: KvtTxRef; key: openArray[byte]; data: sink seq[byte]) =
-  ## Store `data` on the top layer taking over ownership - the caller must not
-  ## use `data` after this call
-  swap(db.sTab.mgetOrPut(@key, EmptyBlob), data)
+  var data = @data
+  db.layersPut(key, data)
 
 # ------------------------------------------------------------------------------
 # Public functions

--- a/execution_chain/db/kvt/kvt_layers.nim
+++ b/execution_chain/db/kvt/kvt_layers.nim
@@ -58,6 +58,11 @@ func layersPut*(db: KvtTxRef; key: openArray[byte]; data: openArray[byte]) =
   ## Store a (potentally empty) value on the top layer
   db.sTab[@key] = @data
 
+func layersPut*(db: KvtTxRef; key: openArray[byte]; data: sink seq[byte]) =
+  ## Store `data` on the top layer taking over ownership - the caller must not
+  ## use `data` after this call
+  swap(db.sTab.mgetOrPut(@key, EmptyBlob), data)
+
 # ------------------------------------------------------------------------------
 # Public functions
 # ------------------------------------------------------------------------------

--- a/execution_chain/db/kvt/kvt_utils.nim
+++ b/execution_chain/db/kvt/kvt_utils.nim
@@ -81,6 +81,21 @@ proc put*(
   db.layersPut(key, data)
   ok()
 
+proc put*(
+    db: KvtTxRef;                     # Database
+    key: openArray[byte];             # Key of database record to store
+    data: sink seq[byte];             # Value, ownership taken over
+      ): Result[void,KvtError] =
+  ## Variant of `put()` that takes over ownership of `data` instead of
+  ## copying it - the caller must not use `data` after this call.
+  if key.len == 0:
+    return err(KeyInvalid)
+  if data.len == 0:
+    return err(DataInvalid)
+
+  db.layersPut(key, data)
+  ok()
+
 
 proc del*(
     db: KvtTxRef;                     # Database

--- a/execution_chain/db/kvt/kvt_utils.nim
+++ b/execution_chain/db/kvt/kvt_utils.nim
@@ -66,7 +66,7 @@ proc delRangeBe*(
 
 # ------------
 
-proc put*(
+proc putMove*(
     db: KvtTxRef;                     # Database
     key: openArray[byte];             # Key of database record to store
     data: var seq[byte];              # Value of database record to store
@@ -79,7 +79,7 @@ proc put*(
   if data.len == 0:
     return err(DataInvalid)
 
-  db.layersPut(key, data)
+  db.layersPutMove(key, data)
   ok()
 
 proc put*(
@@ -87,9 +87,9 @@ proc put*(
     key: openArray[byte];             # Key of database record to store
     data: openArray[byte];            # Value of database record to store
       ): Result[void,KvtError] =
-  ## Variant of `put()` copying `data` into the top layer cache.
+  ## Variant of `putMove()` copying `data` into the top layer cache.
   var data = @data
-  db.put(key, data)
+  db.putMove(key, data)
 
 
 proc del*(

--- a/execution_chain/db/kvt/kvt_utils.nim
+++ b/execution_chain/db/kvt/kvt_utils.nim
@@ -69,10 +69,11 @@ proc delRangeBe*(
 proc put*(
     db: KvtTxRef;                     # Database
     key: openArray[byte];             # Key of database record to store
-    data: openArray[byte];            # Value of database record to store
+    data: var seq[byte];              # Value of database record to store
       ): Result[void,KvtError] =
   ## For the argument `key` associated the argument `data` as value (which
-  ## will be marked in the top layer cache.)
+  ## will be marked in the top layer cache.) The contents of `data` are taken
+  ## over, leaving it empty.
   if key.len == 0:
     return err(KeyInvalid)
   if data.len == 0:
@@ -84,17 +85,11 @@ proc put*(
 proc put*(
     db: KvtTxRef;                     # Database
     key: openArray[byte];             # Key of database record to store
-    data: sink seq[byte];             # Value, ownership taken over
+    data: openArray[byte];            # Value of database record to store
       ): Result[void,KvtError] =
-  ## Variant of `put()` that takes over ownership of `data` instead of
-  ## copying it - the caller must not use `data` after this call.
-  if key.len == 0:
-    return err(KeyInvalid)
-  if data.len == 0:
-    return err(DataInvalid)
-
-  db.layersPut(key, data)
-  ok()
+  ## Variant of `put()` copying `data` into the top layer cache.
+  var data = @data
+  db.put(key, data)
 
 
 proc del*(

--- a/execution_chain/db/tx_frame_db.nim
+++ b/execution_chain/db/tx_frame_db.nim
@@ -33,7 +33,7 @@
 ##    - `blobifyTxFrame(src.aTx)` walks `sTab`, `kMap`, `accLeaves`, `stoLeaves` and produces the Aristo blob.
 ##    - `blobifyKvtTxFrame(src.kTx)` walks `sTab` and produces the KVT blob.
 ##    - The two blobs are length-prefixed and concatenated.
-##    - The result is written to KVT via `target.put(txFrameKey(blockHash), combinedBlob)`.
+##    - The result is written to KVT via `target.putMove(txFrameKey(blockHash), combinedBlob)`.
 ## 3. On the next `persist` call the entry is flushed to RocksDB alongside the block's trie changes.
 ##
 ## Deserialization Process (startup restore)
@@ -94,7 +94,7 @@ proc storeTxFrame*(
   blob.add kvtBlob.len.uint32.toBytesBE
   blob.add kvtBlob
 
-  target.put(txFrameKey(blockHash).toOpenArray, blob)
+  target.putMove(txFrameKey(blockHash).toOpenArray, blob)
 
 proc loadTxFrameAsChild*(
     srcBase: CoreDbTxRef;

--- a/execution_chain/utils/utils.nim
+++ b/execution_chain/utils/utils.nim
@@ -12,7 +12,7 @@
 
 import
   std/math,
-  eth/[common/eth_types_rlp, trie/ordered_trie],
+  eth/[bloom, common/eth_types_rlp, trie/ordered_trie],
   stew/byteutils,
   stew/assign2,
   nimcrypto/sha2,
@@ -33,9 +33,30 @@ template calcTxRoot*(transactions: openArray[Transaction]): Root =
 template calcWithdrawalsRoot*(withdrawals: openArray[Withdrawal]): Root =
   orderedTrieRoot(withdrawals)
 
-template calcReceiptsRoot*(receipts: openArray[StoredReceipt]): Root =
-  let recs = receipts.to(seq[Receipt])
-  orderedTrieRoot(recs)
+type NetworkFormatReceipt = distinct StoredReceipt
+  ## Encodes as the network `Receipt` wire format (bloom included) while
+  ## borrowing the stored receipt's logs instead of copying them
+
+proc append(w: var RlpWriter, rec: NetworkFormatReceipt) =
+  template r(): StoredReceipt = StoredReceipt(rec)
+  if r.receiptType in {Eip2930Receipt, Eip1559Receipt, Eip4844Receipt, Eip7702Receipt}:
+    w.appendDetached(r.receiptType.uint8)
+  w.startList(4)
+  if r.isHash:
+    w.append(r.hash)
+  else:
+    w.append(r.status.uint8)
+  w.append(r.cumulativeGasUsed)
+  var bloom: bloom.BloomFilter
+  for log in r.logs:
+    bloom.incl log.address
+    for topic in log.topics:
+      bloom.incl topic
+  w.append(bloom.value.to(Bloom))
+  w.append(r.logs)
+
+func calcReceiptsRoot*(receipts: seq[StoredReceipt]): Root =
+  orderedTrieRoot(cast[seq[NetworkFormatReceipt]](receipts))
 
 template calcReceiptsRoot*(receipts: openArray[Receipt]): Root =
   orderedTrieRoot(receipts)

--- a/execution_chain/utils/utils.nim
+++ b/execution_chain/utils/utils.nim
@@ -61,8 +61,12 @@ proc append(w: var RlpWriter, rec: NetworkFormatReceipt) =
 
   w.append(r.logs)
 
-func calcReceiptsRoot*(receipts: seq[StoredReceipt]): Root =
-  orderedTrieRoot(cast[seq[NetworkFormatReceipt]](receipts))
+func calcReceiptsRoot*(receipts: openArray[StoredReceipt]): Root =
+  if receipts.len == 0:
+    return EMPTY_ROOT_HASH
+  orderedTrieRoot(
+    cast[ptr UncheckedArray[NetworkFormatReceipt]](addr receipts[0])
+      .toOpenArray(0, receipts.high))
 
 template calcReceiptsRoot*(receipts: openArray[Receipt]): Root =
   orderedTrieRoot(receipts)

--- a/execution_chain/utils/utils.nim
+++ b/execution_chain/utils/utils.nim
@@ -48,13 +48,17 @@ proc append(w: var RlpWriter, rec: NetworkFormatReceipt) =
     w.append(r.status.uint8)
   w.append(r.cumulativeGasUsed)
 
-  var bloom: bloom.BloomFilter
-  for log in r.logs:
-    bloom.incl log.address
-    for topic in log.topics:
-      bloom.incl topic
-  w.append(bloom.value.to(Bloom))
-  
+  when w is RlpLengthTracker:
+    # The length pass only needs the encoded size, identical for any bloom
+    w.append(default(Bloom))
+  else:
+    var bloom: bloom.BloomFilter
+    for log in r.logs:
+      bloom.incl log.address
+      for topic in log.topics:
+        bloom.incl topic
+    w.append(bloom.value.to(Bloom))
+
   w.append(r.logs)
 
 func calcReceiptsRoot*(receipts: seq[StoredReceipt]): Root =

--- a/execution_chain/utils/utils.nim
+++ b/execution_chain/utils/utils.nim
@@ -47,12 +47,14 @@ proc append(w: var RlpWriter, rec: NetworkFormatReceipt) =
   else:
     w.append(r.status.uint8)
   w.append(r.cumulativeGasUsed)
+
   var bloom: bloom.BloomFilter
   for log in r.logs:
     bloom.incl log.address
     for topic in log.topics:
       bloom.incl topic
   w.append(bloom.value.to(Bloom))
+  
   w.append(r.logs)
 
 func calcReceiptsRoot*(receipts: seq[StoredReceipt]): Root =


### PR DESCRIPTION
This adds a variant of the kvt put API that moves instead of copying the value. 

Also a custom receipt rlp encoding function is used to avoid copying logs while building the receipts root.