### PR TITLE
Hash transactions once and move receipt logs

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -535,7 +535,8 @@ proc validateBlock(
     parentTxFrame=cast[uint](parentFrame),
     txFrame=cast[uint](txFrame)
 
-  c.processBlock(parent, txFrame, blk, blockAccessList, blkHash, finalized).isOkOr:
+  let txHashes = c.processBlock(
+      parent, txFrame, blk, blockAccessList, blkHash, finalized).valueOr:
     txFrame.dispose()
     return err(error)
 
@@ -546,8 +547,8 @@ proc validateBlock(
 
   let newBlock = c.appendBlock(parent, blk, blkHash, txFrame)
 
-  for i, tx in blk.transactions:
-    c.txRecords[computeRlpHash(tx)] = (blkHash, uint64(i))
+  for i, txHash in txHashes:
+    c.txRecords[txHash] = (blkHash, uint64(i))
 
   # Entering base auto forward mode while avoiding forkChoice
   # handled region(head - baseDistance)

--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -182,6 +182,9 @@ proc processBlock*(
   let txHashes = c.writeBaggage(
     blk, blockAccessList, blkHash, txFrame, vmState.receipts, vmState.blockAccessList)
 
+  vmState.receipts.setLen(0)
+  vmState.allLogs.setLen(0)
+
   # Cache for the next block - the ledger caches stay warm on linear import
   c.vmState = vmState
   c.vmStateBlockHash = blkHash

--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -28,11 +28,11 @@ proc writeBaggage*(
     txFrame: CoreDbTxRef,
     receipts: openArray[StoredReceipt],
     generatedBal: Opt[BlockAccessListRef],
-) =
+): seq[Hash32] =
   template header(): Header =
     blk.header
 
-  txFrame.persistTransactions(header.number, header.txRoot, blk.transactions)
+  result = txFrame.persistTransactions(header.number, header.txRoot, blk.transactions)
   txFrame.persistReceipts(header.receiptsRoot, receipts)
   discard txFrame.persistUncles(blk.uncles)
 
@@ -100,7 +100,8 @@ proc processBlock*(
     blockAccessList: Opt[BlockAccessListRef],
     blkHash: Hash32,
     finalized: bool,
-): Result[seq[StoredReceipt], string] =
+): Result[seq[Hash32], string] =
+  ## On success returns the block's transaction hashes, in transaction order.
   template header(): Header =
     blk.header
 
@@ -176,11 +177,12 @@ proc processBlock*(
   # because validateUncles still need it
   ?txFrame.persistHeader(blkHash, header, c.com.startOfHistory)
 
-  c.writeBaggage(blk, blockAccessList, blkHash, txFrame, vmState.receipts, vmState.blockAccessList)
+  let txHashes = c.writeBaggage(
+    blk, blockAccessList, blkHash, txFrame, vmState.receipts, vmState.blockAccessList)
 
   # Cache for the next block - the ledger caches stay warm on linear import
   c.vmState = vmState
   c.vmStateBlockHash = blkHash
   cached = true
 
-  ok(move(vmState.receipts))
+  ok(txHashes)

--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -32,7 +32,7 @@ proc writeBaggage*(
   template header(): Header =
     blk.header
 
-  let txHashes =
+  var txHashes =
     txFrame.persistTransactions(header.number, header.txRoot, blk.transactions)
   txFrame.persistReceipts(header.receiptsRoot, receipts)
   discard txFrame.persistUncles(blk.uncles)
@@ -54,7 +54,7 @@ proc writeBaggage*(
       generatedBal.get(),
     )
 
-  txHashes
+  move(txHashes)
 
 proc getVmState(
     c: ForkedChainRef,
@@ -179,7 +179,7 @@ proc processBlock*(
   # because validateUncles still need it
   ?txFrame.persistHeader(blkHash, header, c.com.startOfHistory)
 
-  let txHashes = c.writeBaggage(
+  var txHashes = c.writeBaggage(
     blk, blockAccessList, blkHash, txFrame, vmState.receipts, vmState.blockAccessList)
 
   vmState.receipts.setLen(0)
@@ -190,4 +190,4 @@ proc processBlock*(
   c.vmStateBlockHash = blkHash
   cached = true
 
-  ok(txHashes)
+  ok(move(txHashes))

--- a/execution_chain/core/chain/forked_chain/chain_private.nim
+++ b/execution_chain/core/chain/forked_chain/chain_private.nim
@@ -32,7 +32,8 @@ proc writeBaggage*(
   template header(): Header =
     blk.header
 
-  result = txFrame.persistTransactions(header.number, header.txRoot, blk.transactions)
+  let txHashes =
+    txFrame.persistTransactions(header.number, header.txRoot, blk.transactions)
   txFrame.persistReceipts(header.receiptsRoot, receipts)
   discard txFrame.persistUncles(blk.uncles)
 
@@ -52,6 +53,8 @@ proc writeBaggage*(
       blkHash,
       generatedBal.get(),
     )
+
+  txHashes
 
 proc getVmState(
     c: ForkedChainRef,
@@ -101,7 +104,6 @@ proc processBlock*(
     blkHash: Hash32,
     finalized: bool,
 ): Result[seq[Hash32], string] =
-  ## On success returns the block's transaction hashes, in transaction order.
   template header(): Header =
     blk.header
 

--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -214,7 +214,8 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
     ?txFrame.persistHeaderAndSetHead(blockHash, header, com.startOfHistory)
 
   if PersistTransactions in p.flags:
-    txFrame.persistTransactions(header.number, header.txRoot, blk.transactions)
+    txFrame.persistTransactions(
+      header.number, header.txRoot, blk.transactions, collectTxHashes = false)
 
   if PersistReceipts in p.flags:
     txFrame.persistReceipts(header.receiptsRoot, vmState.receipts)

--- a/execution_chain/core/chain/persist_blocks.nim
+++ b/execution_chain/core/chain/persist_blocks.nim
@@ -215,7 +215,7 @@ proc persistBlock*(p: var Persister, blk: Block): Result[void, string] =
 
   if PersistTransactions in p.flags:
     txFrame.persistTransactions(
-      header.number, header.txRoot, blk.transactions, collectTxHashes = false)
+      header.number, header.txRoot, blk.transactions)
 
   if PersistReceipts in p.flags:
     txFrame.persistReceipts(header.receiptsRoot, vmState.receipts)

--- a/execution_chain/core/executor/executor_helpers.nim
+++ b/execution_chain/core/executor/executor_helpers.nim
@@ -50,20 +50,18 @@ proc makeReceipt*(
     vmState: BaseVMState; txType: TxType, callResult: var LogResult): StoredReceipt =
   ## Builds the receipt for `callResult`, moving its log entries into the
   ## receipt and leaving `callResult.logEntries` empty.
-  var rec: StoredReceipt
   if vmState.com.isByzantiumOrLater(vmState.blockNumber, vmState.blockCtx.timestamp):
-    rec.isHash = false
-    rec.status = vmState.status
+    result.isHash = false
+    result.status = vmState.status
   else:
-    rec.isHash = true
-    rec.hash   = vmState.ledger.getStateRoot()
+    result.isHash = true
+    result.hash   = vmState.ledger.getStateRoot()
     # we set the status for the t8n output consistency
-    rec.status = vmState.status
+    result.status = vmState.status
 
-  rec.receiptType = txType
-  rec.cumulativeGasUsed = vmState.cumulativeGasUsed
-  swap(rec.logs, callResult.logEntries)
-  rec
+  result.receiptType = txType
+  result.cumulativeGasUsed = vmState.cumulativeGasUsed
+  result.logs = move(callResult.logEntries)
 
 # ------------------------------------------------------------------------------
 # End

--- a/execution_chain/core/executor/executor_helpers.nim
+++ b/execution_chain/core/executor/executor_helpers.nim
@@ -48,6 +48,8 @@ func createBloom*(receipts: openArray[StoredReceipt]): Bloom =
 
 proc makeReceipt*(
     vmState: BaseVMState; txType: TxType, callResult: var LogResult): StoredReceipt =
+  ## Builds the receipt for `callResult`, moving its log entries into the
+  ## receipt and leaving `callResult.logEntries` empty.
   var rec: StoredReceipt
   if vmState.com.isByzantiumOrLater(vmState.blockNumber, vmState.blockCtx.timestamp):
     rec.isHash = false

--- a/execution_chain/core/executor/executor_helpers.nim
+++ b/execution_chain/core/executor/executor_helpers.nim
@@ -12,7 +12,6 @@
 
 import
   eth/bloom,
-  stew/assign2,
   ../../db/ledger,
   ../../evm/state,
   ../../evm/types,
@@ -48,7 +47,8 @@ func createBloom*(receipts: openArray[StoredReceipt]): Bloom =
   bloom.value.to(Bloom)
 
 proc makeReceipt*(
-    vmState: BaseVMState; txType: TxType, callResult: LogResult): StoredReceipt =
+    vmState: BaseVMState; txType: TxType, callResult: var LogResult): StoredReceipt =
+  ## Note: `callResult.logEntries` is moved into the receipt, leaving it empty
   var rec: StoredReceipt
   if vmState.com.isByzantiumOrLater(vmState.blockNumber, vmState.blockCtx.timestamp):
     rec.isHash = false
@@ -61,7 +61,7 @@ proc makeReceipt*(
 
   rec.receiptType = txType
   rec.cumulativeGasUsed = vmState.cumulativeGasUsed
-  assign(rec.logs, callResult.logEntries)
+  swap(rec.logs, callResult.logEntries)
   rec
 
 # ------------------------------------------------------------------------------

--- a/execution_chain/core/executor/executor_helpers.nim
+++ b/execution_chain/core/executor/executor_helpers.nim
@@ -48,7 +48,6 @@ func createBloom*(receipts: openArray[StoredReceipt]): Bloom =
 
 proc makeReceipt*(
     vmState: BaseVMState; txType: TxType, callResult: var LogResult): StoredReceipt =
-  ## Note: `callResult.logEntries` is moved into the receipt, leaving it empty
   var rec: StoredReceipt
   if vmState.com.isByzantiumOrLater(vmState.blockNumber, vmState.blockCtx.timestamp):
     rec.isHash = false

--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -71,7 +71,7 @@ proc processTransactions*(
   vmState.blockExecutionGasUsed = 0
   vmState.blockStateGasUsed = 0
   vmState.blobGasUsed = 0'u64
-  vmState.allLogs = @[]
+  vmState.allLogs.setLen(0)
 
   when compileOption("threads"):
     if vmState.com.balParallelExecutionEnabled(header.timestamp, blockAccessList):

--- a/execution_chain/core/executor/process_block.nim
+++ b/execution_chain/core/executor/process_block.nim
@@ -85,7 +85,7 @@ proc processTransactions*(
     if vmState.balTrackerEnabled:
       vmState.balTracker.setBlockAccessIndex(txIndex + 1)
 
-    let rc = vmState.processTransaction(tx, sender)
+    var rc = vmState.processTransaction(tx, sender)
     if rc.isErr:
       return err("Error processing tx with index " & $(txIndex) & ":" & rc.error)
     if skipReceipts:

--- a/execution_chain/core/executor/process_block_parallel.nim
+++ b/execution_chain/core/executor/process_block_parallel.nim
@@ -504,8 +504,9 @@ proc processTransactionsParallel*(
       if collectLogs:
         vmState.allLogs.add logs
     else:
+      var callResult = LogResult(logEntries: move(logs))
       vmState.receipts[i] =
-        vmState.makeReceipt(transactions[i].txType, LogResult(logEntries: move(logs)))
+        vmState.makeReceipt(transactions[i].txType, callResult)
       if collectLogs:
         vmState.allLogs.add vmState.receipts[i].logs
 

--- a/execution_chain/core/tx_pool/tx_packer.nim
+++ b/execution_chain/core/tx_pool/tx_packer.nim
@@ -215,7 +215,7 @@ proc vmExecGrabItem(pst: var TxPacker; item: TxItemRef, xp: TxPoolRef): bool =
     vmState.balTracker.setBlockAccessIndex(pst.packedTxs.len() + 1)
 
   # Find out what to do next: accepting this tx or trying the next account
-  let rc = processTransaction(vmState, item.tx, item.sender, rollbackReads = true)
+  var rc = processTransaction(vmState, item.tx, item.sender, rollbackReads = true)
   if rc.isErr:
     if vmState.classifyPackedNext():
       return ContinueWithNextAccount
@@ -229,7 +229,7 @@ proc vmExecGrabItem(pst: var TxPacker; item: TxItemRef, xp: TxPoolRef): bool =
     vmState.receipts.setLen(inx + receiptsExtensionSize)
 
   vmState.receipts[inx] = vmState.makeReceipt(item.tx.txType, rc.value)
-  vmState.allLogs.add rc.value.logEntries
+  vmState.allLogs.add vmState.receipts[inx].logs
 
   pst.packedTxs.add item
   pst.numBlobPerBlock += item.tx.versionedHashes.len

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -282,7 +282,7 @@ proc persistTransactions*(
     db.putMove(blockKey.toOpenArray, encodedTxKey).isOkOr:
       raiseAssert info & ": " & $$error
 
-  txHashes
+  move(txHashes)
 
 proc getTransactionByIndex*(
     db: CoreDbTxRef;

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -255,11 +255,14 @@ proc persistTransactions*(
     blockNumber: BlockNumber;
     txRoot: Hash32;
     transactions: openArray[Transaction];
+    collectTxHashes = true;
       ): seq[Hash32] {.discardable.} =
   const
     info = "persistTransactions()"
 
-  var txHashes = newSeqOfCap[Hash32](transactions.len)
+  var txHashes: seq[Hash32]
+  if collectTxHashes:
+    txHashes = newSeqOfCap[Hash32](transactions.len)
 
   for idx, tx in transactions:
     var encodedTx = rlp.encode(tx)
@@ -269,7 +272,8 @@ proc persistTransactions*(
       txKey = TransactionKey(blockNumber: blockNumber, index: idx.uint)
       key = hashIndexKey(txRoot, idx.uint16)
 
-    txHashes.add txHash
+    if collectTxHashes:
+      txHashes.add txHash
 
     db.putMove(key, encodedTx).isOkOr:
       raiseAssert info & ": " & $$error

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -255,13 +255,14 @@ proc persistTransactions*(
     blockNumber: BlockNumber;
     txRoot: Hash32;
     transactions: openArray[Transaction];
-      ) =
+      ): seq[Hash32] {.discardable.} =
   const
     info = "persistTransactions()"
 
   if transactions.len == 0:
     return
 
+  result = newSeqOfCap[Hash32](transactions.len)
   for idx, tx in transactions:
     var encodedTx = rlp.encode(tx)
     let
@@ -269,9 +270,12 @@ proc persistTransactions*(
       blockKey = transactionHashToBlockKey(txHash)
       txKey = TransactionKey(blockNumber: blockNumber, index: idx.uint)
       key = hashIndexKey(txRoot, idx.uint16)
+
+    result.add txHash
     db.putMove(key, encodedTx).isOkOr:
       warn info, idx, error=($$error)
       return
+
     var encodedTxKey = rlp.encode(txKey)
     db.putMove(blockKey.toOpenArray, encodedTxKey).isOkOr:
       trace info, blockKey, error=($$error)

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -255,14 +255,11 @@ proc persistTransactions*(
     blockNumber: BlockNumber;
     txRoot: Hash32;
     transactions: openArray[Transaction];
-    collectTxHashes = true;
       ): seq[Hash32] {.discardable.} =
   const
     info = "persistTransactions()"
 
-  var txHashes: seq[Hash32]
-  if collectTxHashes:
-    txHashes = newSeqOfCap[Hash32](transactions.len)
+  var txHashes = newSeqOfCap[Hash32](transactions.len)
 
   for idx, tx in transactions:
     var encodedTx = rlp.encode(tx)
@@ -272,8 +269,7 @@ proc persistTransactions*(
       txKey = TransactionKey(blockNumber: blockNumber, index: idx.uint)
       key = hashIndexKey(txRoot, idx.uint16)
 
-    if collectTxHashes:
-      txHashes.add txHash
+    txHashes.add txHash
 
     db.putMove(key, encodedTx).isOkOr:
       raiseAssert info & ": " & $$error

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -260,9 +260,9 @@ proc persistTransactions*(
     info = "persistTransactions()"
 
   if transactions.len == 0:
-    return
+    return @[]
 
-  result = newSeqOfCap[Hash32](transactions.len)
+  var txHashes = newSeqOfCap[Hash32](transactions.len)
   for idx, tx in transactions:
     var encodedTx = rlp.encode(tx)
     let
@@ -271,15 +271,17 @@ proc persistTransactions*(
       txKey = TransactionKey(blockNumber: blockNumber, index: idx.uint)
       key = hashIndexKey(txRoot, idx.uint16)
 
-    result.add txHash
+    txHashes.add txHash
     db.putMove(key, encodedTx).isOkOr:
       warn info, idx, error=($$error)
-      return
+      return txHashes
 
     var encodedTxKey = rlp.encode(txKey)
     db.putMove(blockKey.toOpenArray, encodedTxKey).isOkOr:
       trace info, blockKey, error=($$error)
-      return
+      return txHashes
+
+  txHashes
 
 proc getTransactionByIndex*(
     db: CoreDbTxRef;

--- a/execution_chain/db/core_db/core_apps.nim
+++ b/execution_chain/db/core_db/core_apps.nim
@@ -259,10 +259,8 @@ proc persistTransactions*(
   const
     info = "persistTransactions()"
 
-  if transactions.len == 0:
-    return @[]
-
   var txHashes = newSeqOfCap[Hash32](transactions.len)
+
   for idx, tx in transactions:
     var encodedTx = rlp.encode(tx)
     let
@@ -272,14 +270,13 @@ proc persistTransactions*(
       key = hashIndexKey(txRoot, idx.uint16)
 
     txHashes.add txHash
+
     db.putMove(key, encodedTx).isOkOr:
-      warn info, idx, error=($$error)
-      return txHashes
+      raiseAssert info & ": " & $$error
 
     var encodedTxKey = rlp.encode(txKey)
     db.putMove(blockKey.toOpenArray, encodedTxKey).isOkOr:
-      trace info, blockKey, error=($$error)
-      return txHashes
+      raiseAssert info & ": " & $$error
 
   txHashes
 

--- a/tools/t8n/transition.nim
+++ b/tools/t8n/transition.nim
@@ -288,7 +288,7 @@ proc exec(ctx: TransContext,
     if vmState.balTrackerEnabled:
       vmState.balTracker.setBlockAccessIndex(includedTx.len + 1)
 
-    let rc = vmState.processTransaction(tx, sender)
+    var rc = vmState.processTransaction(tx, sender)
 
     if conf.traceEnabled.isSome:
       ? closeTrace(vmState, closeStream)


### PR DESCRIPTION
Improve block import performance by:
- Hashing each transaction once in `persistTransactions` and then reusing these hashes later on.
- Avoid copying logs in the `makeReceipt` function.