### PR TITLE
nix: add --falback to handle unavailable substituters

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: '${{ matrix.system }} / ${{ matrix.test }}'
+    name: '${{ matrix.system }} / ${{ matrix.nixpkg }}'
     timeout-minutes: 25
     runs-on: ${{ matrix.runs_on }}
     strategy:
@@ -38,7 +38,7 @@ jobs:
 
       - name: 'Run Nix build for ${{ matrix.nixpkg }}'
         shell: bash
-        run: nix build -L '.?submodules=1#${{ matrix.nixpkg }}'
+        run: nix build --fallback -L '.?submodules=1#${{ matrix.nixpkg }}'
 
       - name: 'Run NixOS service check for ${{ matrix.nixpkg }}'
         if: ${{ matrix.nixpkg == 'execution-client' }}


### PR DESCRIPTION
This should build instead of failing if cache is unavailable.