### PR TITLE
Top frame address collision must restore state gas to entry

### DIFF
--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -308,6 +308,7 @@ proc preExecComputation(c: Computation, params: CallParams) =
         return
 
     if not c.accountDeployable():
+      c.refillFrameStateGas()
       return
 
     return


### PR DESCRIPTION
This case is not covered by glamsterdam-devnet-8 test fixtures. But it is covered in focil@v0.2.0 test fixtures.