### PR TITLE
stateless: split JSON witness tests into a separate test module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,9 @@ endif
 	t8n \
 	t8n_test \
 	evmstate \
-	evmstate_test
+	evmstate_test \
+	stateless_guest_baremetal \
+	stateless_execution_test
 
 ifeq ($(NIM_PARAMS),)
 # "variables.mk" was not included, so we update the submodules.
@@ -402,9 +404,12 @@ nimbus_verified_proxy_wasm_debug: | build deps
 stateless_guest_baremetal: | build deps
 	$(ENV_SCRIPT) $(NIMC) c --hints:off --cpu:riscv64 --os:any --mm:arc -d:useMalloc -d:chronicles_enabled:off -d:keccakCacheEnabled:false -d:senderCacheEnabled:false -u:metrics --threads:off --stackTrace:off -d:disable_libbacktrace --compileOnly --genScript "execution_chain/stateless/stateless_guest.nim"
 
+# Two runs: the full suite with standard flags, then the guest specific test
+# with flags closer to the zkVM guest.
+# TODO: add `--threads:off` here, but this causes still a mismatched stateroot
 stateless_execution_test: | build deps
 	$(ENV_SCRIPT) $(NIMC) c -r $(NIM_PARAMS) -d:chronicles_log_level=ERROR -o:build/$@ "tests/test_stateless/test_stateless_execution.nim"
-	$(ENV_SCRIPT) $(NIMC) c -r $(NIM_PARAMS) --mm:arc -d:useMalloc -d:chronicles_log_level=ERROR -o:build/$@ "tests/test_stateless/test_stateless_execution.nim"
+	$(ENV_SCRIPT) $(NIMC) c -r $(NIM_PARAMS) --mm:arc -d:useMalloc -d:chronicles_enabled:off -d:keccakCacheEnabled:false -d:senderCacheEnabled:false -u:metrics --stackTrace:off -d:disable_libbacktrace -o:build/$@_guest "tests/test_stateless/test_stateless_execution_guest.nim"
 
 # EEST standalone targets - binary to run individual test vector files
 eest_engine: | build deps

--- a/tests/test_stateless.nim
+++ b/tests/test_stateless.nim
@@ -14,4 +14,5 @@ import
   ./test_stateless/[
     test_stateless_witness_types, test_stateless_witness_generation,
     test_stateless_witness_verification, test_stateless_execution,
+    test_stateless_execution_guest,
   ]

--- a/tests/test_stateless/test_stateless_execution.nim
+++ b/tests/test_stateless/test_stateless_execution.nim
@@ -83,35 +83,3 @@ procSuite "Stateless Execution Tests":
       var partial = witness
       partial.state.asSeq.delete(dropIdx)
       check statelessProcessBlock(partial, com, blk).isErr()
-
-  asyncTest "Stateless process block json files - mainnet block 100":
-    let
-      witnessJsonFile = sourcePath / "mainnet_100_witness.json"
-      blkJsonFile = sourcePath / "mainnet_100_block.json"
-    check statelessProcessBlockJsonFiles(witnessJsonFile, com, blkJsonFile).isOk()
-
-    let com2 = CommonRef.new(
-      db = nil,
-      config = chainConfigForNetwork(networkId),
-      networkId = networkId,
-      initializeDb = false
-    )
-    check statelessProcessBlockJsonFiles(witnessJsonFile, com2, blkJsonFile).isOk()
-    discard era0
-    discard fc
-
-  asyncTest "Stateless process block json files - mainnet block 73141":
-    let
-      witnessJsonFile = sourcePath / "mainnet_73141_witness.json"
-      blkJsonFile = sourcePath / "mainnet_73141_block.json"
-    check statelessProcessBlockJsonFiles(witnessJsonFile, com, blkJsonFile).isOk()
-
-    let com2 = CommonRef.new(
-      db = nil,
-      config = chainConfigForNetwork(networkId),
-      networkId = networkId,
-      initializeDb = false
-    )
-    check statelessProcessBlockJsonFiles(witnessJsonFile, com2, blkJsonFile).isOk()
-    discard era0
-    discard fc

--- a/tests/test_stateless/test_stateless_execution_guest.nim
+++ b/tests/test_stateless/test_stateless_execution_guest.nim
@@ -1,0 +1,48 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+#    http://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+#    http://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+import
+  std/[os, strutils],
+  unittest2,
+  ../../execution_chain/common,
+  ../../execution_chain/db/core_db/memory_only,
+  ../../execution_chain/stateless/[stateless_execution, stateless_execution_helpers]
+
+const
+  sourcePath = currentSourcePath.rsplit({DirSep, AltSep}, 1)[0]
+  networkId = MainNet
+
+proc nodeCommonRef(): CommonRef =
+  # As a node running `statelessWitnessValidation` passes it.
+  CommonRef.new(AristoDbMemory.newCoreDbRef(), statelessProvider = true)
+
+proc guestCommonRef(): CommonRef =
+  # As the zkVM guest uses it: no database at all.
+  CommonRef.new(
+    db = nil,
+    config = chainConfigForNetwork(networkId),
+    networkId = networkId,
+    initializeDb = false,
+  )
+
+suite "Stateless Execution Tests - Guest Only":
+  test "Stateless process block json files - mainnet block 100":
+    let
+      witnessJsonFile = sourcePath / "mainnet_100_witness.json"
+      blkJsonFile = sourcePath / "mainnet_100_block.json"
+    check statelessProcessBlockJsonFiles(witnessJsonFile, nodeCommonRef(), blkJsonFile).isOk()
+    check statelessProcessBlockJsonFiles(witnessJsonFile, guestCommonRef(), blkJsonFile).isOk()
+
+  test "Stateless process block json files - mainnet block 73141":
+    let
+      witnessJsonFile = sourcePath / "mainnet_73141_witness.json"
+      blkJsonFile = sourcePath / "mainnet_73141_block.json"
+    check statelessProcessBlockJsonFiles(witnessJsonFile, nodeCommonRef(), blkJsonFile).isOk()
+    check statelessProcessBlockJsonFiles(witnessJsonFile, guestCommonRef(), blkJsonFile).isOk()


### PR DESCRIPTION
This test imports (almost) only what the zkVM guest does, so it can be build with flags closer to eventual zkvm guest program.