### PR TITLE
rpc: support the "pending" block tag

### DIFF
--- a/execution_chain/core/tx_pool.nim
+++ b/execution_chain/core/tx_pool.nim
@@ -115,6 +115,7 @@ export
   addTx,
   getItem,
   getNonce,
+  getPendingNonce,
   contains,
   removeTx,
   removeExpiredTxs,
@@ -126,6 +127,7 @@ export
 # addTx(xp: TxPoolRef, tx: Transaction): Result[void, TxError]
 # getItem(xp: TxPoolRef, id: Hash32): Result[TxItemRef, TxError]
 # getNonce(xp: TxPoolRef; account: Address): AccountNonce
+# getPendingNonce(xp: TxPoolRef; account: Address): AccountNonce
 # contains(xp: TxPoolRef, id: Hash32): bool
 # removeTx(xp: TxPoolRef, id: Hash32)
 # removeExpiredTxs(xp: TxPoolRef, lifeTime: Duration)

--- a/execution_chain/core/tx_pool/tx_desc.nim
+++ b/execution_chain/core/tx_pool/tx_desc.nim
@@ -197,6 +197,19 @@ func excessBlobGas(xp: TxPoolRef): GasInt =
 proc getNonce*(xp: TxPoolRef; account: Address): AccountNonce =
   xp.vmState.ledger.getNonce(account)
 
+proc getPendingNonce*(xp: TxPoolRef; account: Address): AccountNonce =
+  ## Next nonce `account` can use once its pooled transactions are mined: the
+  ## head-state nonce advanced over the gap-free run of pooled transactions.
+  ## This is what `eth_getTransactionCount(account, "pending")` returns on
+  ## other clients.
+  var nonce = xp.getNonce(account)
+  let sn = xp.senderTab.getOrDefault(account)
+  if sn.isNil:
+    return nonce
+  while sn.list.eq(nonce).isOk:
+    inc nonce
+  nonce
+
 proc classifyValid(xp: TxPoolRef; tx: Transaction, sender: Address): bool =
   if tx.txType == TxEip4844:
     let

--- a/execution_chain/rpc/rpc_utils.nim
+++ b/execution_chain/rpc/rpc_utils.nim
@@ -454,7 +454,9 @@ proc headerFromTag*(chain: ForkedChainRef, blockTag: BlockTag): Result[Header, s
   of bidAlias:
     let tag = blockTag.alias.toLowerAscii
     case tag
-    of "latest":
+    of "latest", "pending":
+      # No pending block is assembled outside of payload building, so resolve
+      # "pending" to the head like erigon does instead of rejecting it.
       ok(chain.latestHeader)
     of "finalized":
       ok(chain.finalizedHeader)
@@ -475,7 +477,7 @@ proc blockFromTag*(chain: ForkedChainRef, blockTag: BlockTag, noHash: bool = fal
   of bidAlias:
     let tag = blockTag.alias.toLowerAscii
     case tag
-    of "latest":
+    of "latest", "pending":
       ok(chain.latestBlock)
     of "finalized":
       ok(chain.finalizedBlock)

--- a/execution_chain/rpc/server_api.nim
+++ b/execution_chain/rpc/server_api.nim
@@ -11,7 +11,7 @@
 
 import
   chronicles,
-  std/sequtils,
+  std/[sequtils, strutils],
   stint,
   web3/[conversions, eth_api_types],
   eth/common/[base, transaction_utils],
@@ -225,6 +225,11 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
       data: Address, blockTag: BlockTag
     ): Quantity {.raises: [ValueError].} =
       ## Returns the number of transactions ak.s. nonce sent from an address.
+      ## With the "pending" tag the sender's gap-free pooled transactions are
+      ## counted as well.
+      if blockTag.kind == bidAlias and blockTag.alias.toLowerAscii == "pending":
+        return Quantity(api.txPool.getPendingNonce(data))
+
       let
         txFrame = api.frameFromTag(blockTag).valueOr:
           raise newException(ValueError, error)
@@ -620,7 +625,6 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
       ##
       ## quantityTag: a block number, or the string "earliest", "latest" or "pending", as in the default block parameter.
       ## quantity: the transaction index position.
-      ## NOTE : "pending" blockTag is not supported.
       let index = uint64(quantity)
       let blk = api.blockFromTag(quantityTag, noHash = true).valueOr:
         return nil

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -473,6 +473,24 @@ proc rpcMain*() =
       let res = await client.eth_getTransactionCount(signer, blockId(1'u64))
       check res == w3Qty(2'u64)
 
+    test "eth_getTransactionCount pending":
+      let
+        acc = env.am[].getAccount(signer).tryGet()
+        head = await client.eth_getTransactionCount(signer, blockId("latest"))
+        pendingEmpty = await client.eth_getTransactionCount(signer, blockId("pending"))
+
+      # Nothing pooled for the signer: "pending" is the head-state nonce.
+      check pendingEmpty == head
+
+      let tx = env.makeTx(acc.privateKey, zeroAddress, 1.u256, 30_000_000_000'u64)
+      check tx.nonce == AccountNonce(head)
+      doAssert env.txPool.addTx(tx).isOk
+
+      let pending = await client.eth_getTransactionCount(signer, blockId("pending"))
+      check pending == w3Qty(uint64(head) + 1)
+
+      env.txPool.removeTx(tx.computeRlpHash)
+
     test "eth_getBlockTransactionCountByHash":
       let res = await client.eth_getBlockTransactionCountByHash(env.blockHash)
       check res == w3Qty(2'u64)


### PR DESCRIPTION
## Problem

Any RPC taking a block tag rejects `"pending"`:

```
$ eth_getTransactionCount(addr, "pending")
→ -32000 "`eth_getTransactionCount` raised an exception", data: "Unsupported block tag pending"
```

go-ethereum's `ethclient.PendingNonceAt` always asks for `"pending"`, so tooling built on it (e.g. [buildoor](https://github.com/ethpandaops/buildoor), which crash-looped at startup on every `buildoor-*-nimbusel` node of glamsterdam-devnet-8) cannot fetch a nonce from nimbus at all. `ethers`/`web3.js` default some calls to `"pending"` as well.

## Changes

- `TxPoolRef.getPendingNonce`: head-state nonce advanced over the sender's gap-free run of pooled transactions — the next usable nonce, which is what `eth_getTransactionCount(addr, "pending")` returns on geth & co.
- `eth_getTransactionCount` short-circuits `"pending"` to that.
- `headerFromTag` / `blockFromTag`: `"pending"` resolves to the head like `"latest"`. No pending block is assembled outside of payload building, so this mirrors erigon rather than erroring. (Also drops the now-stale "pending not supported" note on `eth_getTransactionByBlockNumberAndIndex`.)

## Tests

`tests/test_rpc.nim`: new `eth_getTransactionCount pending` case — equals `latest` with an empty pool, and `latest + 1` after pooling the signer's next tx (the tx is removed again so later cases are unaffected).

```
[Summary] 55 tests run (1.06s): 55 OK, 0 FAILED, 0 SKIPPED
```

Companion buildoor-side fallback: ethpandaops/buildoor#179.