### PR TITLE
aristo: fix wrong state root when building with --threads:off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,10 +408,9 @@ stateless_guest_baremetal: | build deps
 
 # Two runs: the full suite with standard flags, then the guest specific test
 # with flags closer to the zkVM guest.
-# TODO: add `--threads:off` here, but this causes still a mismatched stateroot
 stateless_execution_test: | build deps
 	$(ENV_SCRIPT) $(NIMC) c -r $(NIM_PARAMS) -d:chronicles_log_level=ERROR -o:build/$@ "tests/test_stateless/test_stateless_execution.nim"
-	$(ENV_SCRIPT) $(NIMC) c -r $(NIM_PARAMS) --mm:arc -d:useMalloc -d:chronicles_enabled:off -d:keccakCacheEnabled:false -d:senderCacheEnabled:false -u:metrics --stackTrace:off -d:disable_libbacktrace -o:build/$@_guest "tests/test_stateless/test_stateless_execution_guest.nim"
+	$(ENV_SCRIPT) $(NIMC) c -r $(NIM_PARAMS) --mm:arc -d:useMalloc -d:chronicles_enabled:off -d:keccakCacheEnabled:false -d:senderCacheEnabled:false -u:metrics --threads:off --stackTrace:off -d:disable_libbacktrace -o:build/$@_guest "tests/test_stateless/test_stateless_execution_guest.nim"
 
 # EEST standalone targets - binary to run individual test vector files
 eest_engine: | build deps

--- a/execution_chain/db/aristo/aristo_compute.nim
+++ b/execution_chain/db/aristo/aristo_compute.nim
@@ -14,12 +14,12 @@ import
   std/[atomics, strformat],
   chronicles,
   results,
-  eth/common/hashes_rlp,
+  eth/common/[base_rlp, hashes_rlp],
   ./[aristo_desc, aristo_get, aristo_layers, aristo_blobify, aristo_serialise],
   ./aristo_desc/desc_backend,
   ../../concurrency/[queue, shared_types]
 
-export aristo_desc, chronicles, hashes_rlp, shared_types
+export aristo_desc, chronicles, base_rlp, hashes_rlp, shared_types
 
 type
   WriteBatch* = object


### PR DESCRIPTION
computeKey is generic, so the RLP `append` encoder used for an account its balance (UInt256) gets bound in the scope of whichever caller instantiates it first. That caller had no base_rlp in scope, and thus the default UInt256 encoder was used instead. Import and export base_rlp from aristo_compute to fix this, and enable --threads:off in the stateless_execution_test guest run to get it properly tested.