### PR TITLE
newPayloadV5: undecodable BAL is an invalid payload, not invalid params

### DIFF
--- a/execution_chain/beacon/api_handler/api_newpayload.nim
+++ b/execution_chain/beacon/api_handler/api_newpayload.nim
@@ -249,7 +249,7 @@ proc newPayload*(ben: BeaconEngineRef,
       except RlpError as e:
         warn "Failed to decode payload",
           error = e.msg
-        raise invalidParams("newPayload" & $apiVersion &
+        return invalidStatus("newPayload" & $apiVersion &
           ": Failed to decode BAL in payload: " & e.msg)
 
   if apiVersion >= Version.V3:

--- a/tests/test_engine_api.nim
+++ b/tests/test_engine_api.nim
@@ -477,6 +477,50 @@ proc newPayloadInvalidRLP(env: TestEnv): Result[void, string] =
 
   ok()
 
+proc newPayloadV5UndecodableBAL(env: TestEnv): Result[void, string] =
+  let
+    client = env.client
+    header = ? client.latestHeader()
+    update = ForkchoiceStateV1(
+      headBlockHash: header.computeBlockHash
+    )
+    time = getTime().toUnix
+    attr = PayloadAttributes(
+      timestamp:             w3Qty(time + 1),
+      prevRandao:            default(Bytes32),
+      suggestedFeeRecipient: default(Address),
+      withdrawals:           Opt.some(newSeq[WithdrawalV1]()),
+      parentBeaconBlockRoot: Opt.some(default(Hash32)),
+      slotNumber:            Opt.some(w3Qty(9'u64)),
+      targetGasLimit:        Opt.some(w3Qty(60_000_000'u64)),
+    )
+
+  let
+    fcuRes = ? client.forkchoiceUpdated(Version.V4, update, Opt.some(attr))
+    bundle = ? client.getPayload(Version.V6, fcuRes.payloadId.get)
+
+  var payload = bundle.executionPayload
+  payload.blockAccessList = Opt.some(@[0xde'u8, 0xad'u8, 0xbe'u8, 0xef'u8])
+
+  # An undecodable blockAccessList is an invalid block, not an invalid request,
+  # so it is reported as an invalid payload status.
+  let res = client.newPayloadV5(
+    payload,
+    Opt.some(newSeq[Hash32]()),
+    Opt.some(default(Hash32)),
+    bundle.executionRequests)
+
+  if res.isErr:
+    return err("res should not error on undecodable BAL: " & res.error)
+
+  if res.get.status != PayloadExecutionStatus.invalid:
+    return err("res.status should be equal to PayloadExecutionStatus.invalid")
+
+  if res.get.latestValidHash.isSome:
+    return err("latestValidHash should be none for an undecodable BAL")
+
+  ok()
+
 proc newPayloadV4InvalidRequestType(env: TestEnv): Result[void, string] =
   const
     paramsFile = "tests/engine_api/newPayloadV4_invalid_requests_type.json"
@@ -609,6 +653,11 @@ const testList = [
     name: "newPayload undecodable RLP payload",
     fork: Prague,
     testProc: newPayloadInvalidRLP
+  ),
+  TestSpec(
+    name: "newPayloadV5 undecodable block access list",
+    fork: Amsterdam,
+    testProc: newPayloadV5UndecodableBAL
   ),
   TestSpec(
     name: "PayloadAttributesV4 preserve withdrawals",


### PR DESCRIPTION
Fix return value for undecodable BAL.
Related specs pr:
https://github.com/ethereum/execution-apis/pull/869