### PR TITLE
Update nim-rocksdb to v11.1.2.0

### DIFF
--- a/nix/rocksdb/default.nix
+++ b/nix/rocksdb/default.nix
@@ -7,6 +7,7 @@ let
   inherit (pkgs) stdenv lib writeScriptBin callPackage;
 
   version = callPackage ./version.nix { };
+  liburing = callPackage ./liburing.nix { };
 in stdenv.mkDerivation rec {
   pname = "rocksdb";
   inherit version;
@@ -20,6 +21,9 @@ in stdenv.mkDerivation rec {
   in with pkgs; [
     which perl fakeHostname
   ];
+
+  # Required for RocksDB to detect io_uring, which nim-rocksdb expects on Linux.
+  buildInputs = lib.optionals stdenv.isLinux [ liburing ];
 
   makeFlags = [
     # Compression libraries required for nimbus-eth1.
@@ -46,9 +50,19 @@ in stdenv.mkDerivation rec {
     cp -v ${lz4}  ${lz4.name}
   '';
 
-  # Nimbus build requires compression libs too.
+  # Match the check done by nim-rocksdb's build_static_deps.sh script.
+  postBuild = lib.optionalString stdenv.isLinux ''
+    if ! grep -q ROCKSDB_IOURING_PRESENT make_config.mk; then
+      echo "io_uring support was not detected by the RocksDB build."
+      exit 1
+    fi
+  '';
+
+  # Nimbus build requires compression and io_uring libs too.
   postInstall = ''
     cp -v liblz4.a libzstd.a $out/lib
+  '' + lib.optionalString stdenv.isLinux ''
+    cp -v ${liburing}/lib/liburing.a $out/lib
   '';
 
   meta = with lib; {

--- a/nix/rocksdb/liburing.nix
+++ b/nix/rocksdb/liburing.nix
@@ -1,0 +1,47 @@
+{
+  stdenv,
+  lib,
+  callPackage,
+  fetchurl,
+}:
+
+let
+  tools = callPackage ../tools.nix {};
+  source = ../../vendor/nim-rocksdb/scripts/build_static_deps.sh;
+
+  version = tools.findKeyValue "^LIBURING_VERSION=([0-9.]+)$" source;
+in stdenv.mkDerivation {
+  pname = "liburing";
+  inherit version;
+
+  src = fetchurl {
+    name = "liburing-${version}.tar.gz";
+    url = "https://github.com/axboe/liburing/archive/refs/tags/liburing-${version}.tar.gz";
+    hash = "sha256-X4CWQQiYHGrZecc18LSHfV9JkUwqBi+OiCgvJr9h3gw=";
+  };
+
+  enableParallelBuilding = true;
+
+  # Upstream configure is hand written and rejects the flags Nix passes.
+  configurePhase = ''
+    ./configure --prefix=$out
+  '';
+
+  # Only the static library is needed by nim-rocksdb.
+  buildPhase = ''
+    make -j$NIX_BUILD_CORES -C src liburing.a
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib $out/include
+    cp -v src/liburing.a $out/lib/
+    cp -rv src/include/* $out/include/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/axboe/liburing";
+    description = "Userspace library for the Linux io_uring API";
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
This updates RocksDb to v11.1.2.

The nim-rocksdb wrapper also has the following changes added:
- On linux we now link RocksDb with liburing. This should provide some performance improvements for the multiGet function under certain conditions.
- A new high performance multiGet function: https://github.com/status-im/nim-rocksdb/pull/113
- Added more configuration options: https://github.com/status-im/nim-rocksdb/pull/111
- memtableBatchLookupOptimization now defaults to true when constructing column family options. This provides performance improvements for multiGet when using skipList column families (such as the kvt column family). 
