### PR TITLE
Ledger: differentiate accountExists and accountAlive

### DIFF
--- a/execution_chain/db/ledger.nim
+++ b/execution_chain/db/ledger.nim
@@ -700,6 +700,12 @@ proc accountExists*(ledger: LedgerRef, address: Address): bool =
     return
   acc.exists()
 
+proc accountAlive*(ledger: LedgerRef, address: Address): bool =
+  let acc = ledger.getAccount(address, false)
+  if acc.isNil:
+    return
+  acc.exists() and not acc.isEmpty()
+
 proc isEmptyAccount*(ledger: LedgerRef, address: Address): bool =
   let acc = ledger.getAccount(address, false)
   doAssert not acc.isNil
@@ -1084,6 +1090,7 @@ proc getCode*(ledger: ReadOnlyLedger, address: Address): CodeBytesRef = getCode(
 proc getCodeSize*(ledger: ReadOnlyLedger, address: Address): int = getCodeSize(distinctBase ledger, address)
 proc contractCollision*(ledger: ReadOnlyLedger, address: Address): bool = contractCollision(distinctBase ledger, address)
 proc accountExists*(ledger: ReadOnlyLedger, address: Address): bool = accountExists(distinctBase ledger, address)
+proc accountAlive*(ledger: ReadOnlyLedger, address: Address): bool = accountAlive(distinctBase ledger, address)
 proc isDeadAccount*(ledger: ReadOnlyLedger, address: Address): bool = isDeadAccount(distinctBase ledger, address)
 proc isEmptyAccount*(ledger: ReadOnlyLedger, address: Address): bool = isEmptyAccount(distinctBase ledger, address)
 proc getCommittedStorage*(ledger: ReadOnlyLedger, address: Address, slot: UInt256): UInt256 = getCommittedStorage(distinctBase ledger, address, slot)

--- a/execution_chain/evm/computation.nim
+++ b/execution_chain/evm/computation.nim
@@ -87,14 +87,14 @@ proc getBlockHash*(c: Computation, number: BlockNumber): Hash32 =
     return default(Hash32)
   c.vmState.getAncestorHash(number)
 
-template accountExists*(c: Computation, address: Address): bool =
+template accountAlive*(c: Computation, address: Address): bool =
   if c.balTrackerEnabled:
     c.vmState.balTracker.trackAddressAccess(address)
 
   if c.fork >= FkSpurious:
     not c.vmState.readOnlyLedger.isDeadAccount(address)
   else:
-    c.vmState.readOnlyLedger.accountExists(address)
+    c.vmState.readOnlyLedger.accountAlive(address)
 
 template getStorage*(c: Computation, slot: UInt256): UInt256 =
   if c.balTrackerEnabled:

--- a/execution_chain/evm/computation.nim
+++ b/execution_chain/evm/computation.nim
@@ -87,6 +87,12 @@ proc getBlockHash*(c: Computation, number: BlockNumber): Hash32 =
     return default(Hash32)
   c.vmState.getAncestorHash(number)
 
+template accountExists*(c: Computation, address: Address): bool =
+  if c.fork >= FkSpurious:
+    not c.vmState.readOnlyLedger.isDeadAccount(address)
+  else:
+    c.vmState.readOnlyLedger.accountExists(address)
+
 template accountAlive*(c: Computation, address: Address): bool =
   if c.balTrackerEnabled:
     c.vmState.balTracker.trackAddressAccess(address)

--- a/execution_chain/evm/interpreter/gas_costs.nim
+++ b/execution_chain/evm/interpreter/gas_costs.nim
@@ -420,7 +420,7 @@ template gasCosts(fork: EVMFork, prefix, ResultGasCostsName: untyped) =
       return err(opErr(OutOfGas))
 
     # Cnew_account
-    if params.isNewAccount() and params.kind == Call:
+    if params.kind == Call and params.isNewAccount():
       when fork < FkSpurious:
         # Pre-EIP161 all account creation calls consumed 25000 gas.
         gasCost += static(GasInt(FeeSchedule[GasNewAccount]))

--- a/execution_chain/evm/interpreter/op_handlers/oph_call.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_call.nim
@@ -270,7 +270,7 @@ proc callOp(cpt: VmCpt): EvmResultVoid =
   ?cpt.callParams(p)
 
   let
-    isNewAccount = proc(): bool = not cpt.accountExists(p.contractAddress)
+    isNewAccount = proc(): bool = not cpt.accountAlive(p.contractAddress)
     params1 = GasParamsCall1(
       kind:            Call,
       nonZeroVal:      p.value.isZero.not,
@@ -369,7 +369,6 @@ proc callCodeOp(cpt: VmCpt): EvmResultVoid =
   ?cpt.callCodeParams(p)
 
   let
-    isNewAccount = proc(): bool = not cpt.accountExists(p.contractAddress)
     params1 = GasParamsCall1(
       kind:            CallCode,
       nonZeroVal:      p.value.isZero.not,
@@ -385,7 +384,6 @@ proc callCodeOp(cpt: VmCpt): EvmResultVoid =
         kind:            params1.kind,
         nonZeroVal:      params1.nonZeroVal,
         gasCost1:        gasCost1,
-        isNewAccount:    isNewAccount,
         gasLeft:         cpt.gasMeter.executionGasLeft,
         gasCallDelegate: cpt.gasCallDelegate(p.codeAddress, p.flags),
         contractGas:     p.gas))
@@ -446,7 +444,6 @@ proc delegateCallOp(cpt: VmCpt): EvmResultVoid =
   var p: LocalParams
   ? cpt.delegateCallParams(p)
   let
-    isNewAccount = proc(): bool = not cpt.accountExists(p.contractAddress)
     params1 = GasParamsCall1(
       kind:            DelegateCall,
       nonZeroVal:      p.value.isZero.not,
@@ -462,7 +459,6 @@ proc delegateCallOp(cpt: VmCpt): EvmResultVoid =
         kind:            params1.kind,
         nonZeroVal:      params1.nonZeroVal,
         gasCost1:        gasCost1,
-        isNewAccount:    isNewAccount,
         gasLeft:         cpt.gasMeter.executionGasLeft,
         gasCallDelegate: cpt.gasCallDelegate(p.codeAddress, p.flags),
         contractGas:     p.gas))
@@ -517,7 +513,6 @@ proc staticCallOp(cpt: VmCpt): EvmResultVoid =
   var p: LocalParams
   ?cpt.staticCallParams(p)
   let
-    isNewAccount = proc(): bool = not cpt.accountExists(p.contractAddress)
     params1 = GasParamsCall1(
       kind:            StaticCall,
       nonZeroVal:      p.value.isZero.not,
@@ -533,7 +528,6 @@ proc staticCallOp(cpt: VmCpt): EvmResultVoid =
         kind:            params1.kind,
         nonZeroVal:      params1.nonZeroVal,
         gasCost1:        gasCost1,
-        isNewAccount:    isNewAccount,
         gasLeft:         cpt.gasMeter.executionGasLeft,
         gasCallDelegate: cpt.gasCallDelegate(p.codeAddress, p.flags),
         contractGas:     p.gas))

--- a/execution_chain/evm/interpreter/op_handlers/oph_create.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_create.nim
@@ -77,7 +77,7 @@ proc execSubCreate(c: Computation; childMsg: Message;
     return ok()
 
   if c.fork >= FkAmsterdam:
-    newAccountCharged = not c.accountExists(child.msg.contractAddress)
+    newAccountCharged = not c.accountAlive(child.msg.contractAddress)
     if newAccountCharged:
       c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "Create op new account").isOkOr:
         child.dispose()

--- a/execution_chain/evm/interpreter/op_handlers/oph_sysops.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_sysops.nim
@@ -96,7 +96,7 @@ proc selfDestructEIP150Op(cpt: VmCpt): EvmResultVoid =
   ## selfDestructEip150 (auto generated comment)
   let
     beneficiary = ? cpt.stack.popAddress()
-    condition = not cpt.accountAlive(beneficiary)
+    condition = not cpt.accountExists(beneficiary)
     gasCost = cpt.gasCosts[SelfDestruct].sc_handler(condition)
 
   ? cpt.opcodeGasCost(SelfDestruct,

--- a/execution_chain/evm/interpreter/op_handlers/oph_sysops.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_sysops.nim
@@ -96,7 +96,7 @@ proc selfDestructEIP150Op(cpt: VmCpt): EvmResultVoid =
   ## selfDestructEip150 (auto generated comment)
   let
     beneficiary = ? cpt.stack.popAddress()
-    condition = not cpt.accountExists(beneficiary)
+    condition = not cpt.accountAlive(beneficiary)
     gasCost = cpt.gasCosts[SelfDestruct].sc_handler(condition)
 
   ? cpt.opcodeGasCost(SelfDestruct,
@@ -110,7 +110,7 @@ proc selfDestructEIP161Op(cpt: VmCpt): EvmResultVoid =
 
   let
     beneficiary = ? cpt.stack.popAddress()
-    isDead      = not cpt.accountExists(beneficiary)
+    isDead      = not cpt.accountAlive(beneficiary)
     balance     = cpt.getBalance(cpt.msg.contractAddress)
     condition   = isDead and not balance.isZero
     gasCost     = cpt.gasCosts[SelfDestruct].sc_handler(condition)
@@ -138,7 +138,7 @@ proc selfDestructEIP2929Op(cpt: VmCpt): EvmResultVoid =
     return EvmResultVoid.err(gasErr(OutOfGas))
 
   let
-    isDead = not cpt.accountExists(beneficiary)
+    isDead = not cpt.accountAlive(beneficiary)
     balance = cpt.getBalance(cpt.msg.contractAddress)
     condition = isDead and not balance.isZero
 
@@ -172,7 +172,7 @@ proc selfDestructEIP8037Op(cpt: VmCpt): EvmResultVoid =
     return EvmResultVoid.err(gasErr(OutOfGas))
 
   let
-    isNewAccount = not cpt.accountExists(beneficiary)
+    isNewAccount = not cpt.accountAlive(beneficiary)
     balance = cpt.getBalance(cpt.msg.contractAddress)
     condition = isNewAccount and not balance.isZero
 

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -257,7 +257,7 @@ proc prepareDispatch(params: CallParams, c: Computation): EvmResultVoid =
           ? c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "prepareDispatch create new account")
         CodeBytesRef.init(params.input)
       else:
-        if params.value.isZero.not and not ledger.accountExists(c.msg.contractAddress):
+        if params.value.isZero.not and not ledger.accountAlive(c.msg.contractAddress):
           ? c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "prepareDispatch call new account")
         assign(c.msg.data, params.input)
         getRecipientCode(vmState, c.msg)

--- a/tests/test_ledger.nim
+++ b/tests/test_ledger.nim
@@ -374,26 +374,31 @@ proc runLedgerBasicOperationsTests() =
         code {.used.} = hexToSeqByte("0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6")
         stateRoot {.used.} : Hash32
 
-    test "accountExists and isDeadAccount":
+    test "accountExists and isDeadAccount and accountAlive":
       check ledger.accountExists(address) == false
       check ledger.isDeadAccount(address) == true
+      check ledger.accountAlive(address) == false
 
       ledger.setBalance(address, 1000.u256)
 
       check ledger.accountExists(address) == true
       check ledger.isDeadAccount(address) == false
+      check ledger.accountAlive(address) == true
 
       ledger.setBalance(address, 0.u256)
       ledger.setNonce(address, 1)
       check ledger.isDeadAccount(address) == false
+      check ledger.accountAlive(address) == true
 
       ledger.setCode(address, code)
       ledger.setNonce(address, 0)
       check ledger.isDeadAccount(address) == false
+      check ledger.accountAlive(address) == true
 
       ledger.setCode(address, newSeq[byte]())
       check ledger.isDeadAccount(address) == true
       check ledger.accountExists(address) == true
+      check ledger.accountAlive(address) == false
 
     test "clone storage":
       # give access to private fields of AccountRef


### PR DESCRIPTION
Based on a report prepared by Stefan. In a network where the genesis contains *dead* account, Nimbus test it as account's leaf exists instead of alive. Geth, reth, and besu agree on the block. But nimbus reject it because of block gas used mismatch.

Post-EIP-161 the shape(dead account) is not constructible at runtime.

This bug will split Nimbus from EELS on any EEST EIP-7610 vector in this class. And any future network whose genesis carries such an account inherits a permanent fork.

This PR fix the bug in three places suggested by the report:
- in call_common.nim: top level transfer
- CALL opcode
- SELFDESTRUCT beneficiary

In addition to that, this PR also fix:
- the same issue in CREATE opcode 
- cleanup other CALL* opcode which is not using the `accountAlive` check
- selfdestruct from spurious dragon to osaka in addition to amsterdam

This is the report. It will expired after 60 days of publish.
https://panda-uploads-production.devops-539.workers.dev/panda/uploads/9cc1a0/nimbus-eth1-storage-only-account-liveness-20260827.html