### PR TITLE
Remove unused isNewAccount from callCodeOp/delegateCallOp/staticCallOp

### DIFF
--- a/execution_chain/evm/interpreter/gas_costs.nim
+++ b/execution_chain/evm/interpreter/gas_costs.nim
@@ -420,7 +420,7 @@ template gasCosts(fork: EVMFork, prefix, ResultGasCostsName: untyped) =
       return err(opErr(OutOfGas))
 
     # Cnew_account
-    if params.isNewAccount() and params.kind == Call:
+    if params.kind == Call and params.isNewAccount():
       when fork < FkSpurious:
         # Pre-EIP161 all account creation calls consumed 25000 gas.
         gasCost += static(GasInt(FeeSchedule[GasNewAccount]))

--- a/execution_chain/evm/interpreter/op_handlers/oph_call.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_call.nim
@@ -369,7 +369,6 @@ proc callCodeOp(cpt: VmCpt): EvmResultVoid =
   ?cpt.callCodeParams(p)
 
   let
-    isNewAccount = proc(): bool = not cpt.accountExists(p.contractAddress)
     params1 = GasParamsCall1(
       kind:            CallCode,
       nonZeroVal:      p.value.isZero.not,
@@ -385,7 +384,6 @@ proc callCodeOp(cpt: VmCpt): EvmResultVoid =
         kind:            params1.kind,
         nonZeroVal:      params1.nonZeroVal,
         gasCost1:        gasCost1,
-        isNewAccount:    isNewAccount,
         gasLeft:         cpt.gasMeter.executionGasLeft,
         gasCallDelegate: cpt.gasCallDelegate(p.codeAddress, p.flags),
         contractGas:     p.gas))
@@ -446,7 +444,6 @@ proc delegateCallOp(cpt: VmCpt): EvmResultVoid =
   var p: LocalParams
   ? cpt.delegateCallParams(p)
   let
-    isNewAccount = proc(): bool = not cpt.accountExists(p.contractAddress)
     params1 = GasParamsCall1(
       kind:            DelegateCall,
       nonZeroVal:      p.value.isZero.not,
@@ -462,7 +459,6 @@ proc delegateCallOp(cpt: VmCpt): EvmResultVoid =
         kind:            params1.kind,
         nonZeroVal:      params1.nonZeroVal,
         gasCost1:        gasCost1,
-        isNewAccount:    isNewAccount,
         gasLeft:         cpt.gasMeter.executionGasLeft,
         gasCallDelegate: cpt.gasCallDelegate(p.codeAddress, p.flags),
         contractGas:     p.gas))
@@ -517,7 +513,6 @@ proc staticCallOp(cpt: VmCpt): EvmResultVoid =
   var p: LocalParams
   ?cpt.staticCallParams(p)
   let
-    isNewAccount = proc(): bool = not cpt.accountExists(p.contractAddress)
     params1 = GasParamsCall1(
       kind:            StaticCall,
       nonZeroVal:      p.value.isZero.not,
@@ -533,7 +528,6 @@ proc staticCallOp(cpt: VmCpt): EvmResultVoid =
         kind:            params1.kind,
         nonZeroVal:      params1.nonZeroVal,
         gasCost1:        gasCost1,
-        isNewAccount:    isNewAccount,
         gasLeft:         cpt.gasMeter.executionGasLeft,
         gasCallDelegate: cpt.gasCallDelegate(p.codeAddress, p.flags),
         contractGas:     p.gas))


### PR DESCRIPTION
`isNewAccount` only used by by `callOp` and never by the other three. So remove it from the three of them.