### PR TITLE
evmstate parse and validate receipt

### DIFF
--- a/execution_chain/utils/debug.nim
+++ b/execution_chain/utils/debug.nim
@@ -174,3 +174,34 @@ proc debugSum*(body: BlockBody): string =
   result.add "num uncles : " & $body.uncles.len & "\n"
   result.add "num wd     : " & numwd          & "\n"
   result.add "sumHash    : " & $sumHash(body) & "\n"
+
+proc debug*(logs: openArray[Log]): string =
+  if logs.len == 0:
+    return "zero length"
+
+  if logs.len > 0:
+    result.add "\n"
+
+  for x in logs:
+    result.add "  - address: " & $x.address & "\n"
+    result.add "  - topics : " & $x.topics & "\n"
+    result.add "  - data   : " & x.data.toHex & "\n"
+
+proc debug*(rec: Receipt): string =
+  result.add "Receipt\n"
+  result.add "receiptType      : " & $rec.receiptType & "\n"
+  result.add "isHash           : " & $rec.isHash & "\n"
+  result.add "status           : " & $rec.status & "\n"
+  result.add "hash             : " & $rec.hash & "\n"
+  result.add "cumulativeGasUsed: " & $rec.cumulativeGasUsed & "\n"
+  result.add "logsBloom        : " & $rec.logsBloom.toHex & "\n"
+  result.add "logs             : " & debug(rec.logs) & "\n"
+
+proc debug*(rec: StoredReceipt): string =
+  result.add "StoredReceipt\n"
+  result.add "receiptType      : " & $rec.receiptType & "\n"
+  result.add "isHash           : " & $rec.isHash & "\n"
+  result.add "status           : " & $rec.status & "\n"
+  result.add "hash             : " & $rec.hash & "\n"
+  result.add "cumulativeGasUsed: " & $rec.cumulativeGasUsed & "\n"
+  result.add "logs             : " & debug(rec.logs) & "\n"

--- a/tools/common/parsers.nim
+++ b/tools/common/parsers.nim
@@ -19,6 +19,7 @@ import
   eth/common/eth_types_rlp,
   eth/common/keys,
   eth/common/blocks,
+  eth/bloom,
   ../../execution_chain/transaction,
   ../../execution_chain/common/chain_config
 
@@ -31,6 +32,7 @@ createJsonFlavor Fixture,
 
 AccessPair.useDefaultSerializationIn Fixture
 Authorization.useDefaultSerializationIn Fixture
+Log.useDefaultSerializationIn Fixture
 
 template wrapValueError(body: untyped) =
   try:
@@ -84,6 +86,11 @@ proc readValue*(r: var JsonReader[Fixture], val: var UInt256)
        {.raises: [IOError, JsonReaderError].} =
   wrapValueError:
     val = parseHexOrInt[UInt256](r.parseString())
+
+proc readValue*(r: var JsonReader[Fixture], val: var bloom.BloomFilter)
+       {.raises: [IOError, JsonReaderError].} =
+  wrapValueError:
+    val.value = StUint[2048].fromHex(r.parseString())
 
 proc readValue*(r: var JsonReader[Fixture], val: var (uint8 | uint64))
        {.raises: [IOError, JsonReaderError].} =

--- a/tools/evmstate/evmstate.nim
+++ b/tools/evmstate/evmstate.nim
@@ -23,6 +23,7 @@ import
   ../../execution_chain/db/ledger,
   ../../execution_chain/transaction,
   ../../execution_chain/core/executor,
+  ../../execution_chain/core/executor/executor_helpers,
   ../../execution_chain/common/common,
   ../../execution_chain/evm/tracer/json_tracer,
   ../../execution_chain/utils/state_dump,
@@ -90,6 +91,71 @@ proc verifyResult(ctx: var StateContext,
       $ctx.expectedLogs
     return
 
+proc verifyReceipt(ctx: var StateContext,
+                   generatedReceipt: StoredReceipt,
+                   rec: TxoReceipt,
+                   tx: Transaction,
+                   txBytes: openArray[byte]) =
+  let
+    generatedHash = generatedReceipt.to(Receipt).computeRlpHash()
+    expectedHash = keccak256(rec.rlp)
+
+  if generatedHash != expectedHash:
+    ctx.error = "generated receipt hash mismatch: got " &
+      ($generatedHash).toLowerAscii &
+      ", want " &
+      $expectedHash
+    return
+
+  let
+    decodedTx = try: rlp.decode(txBytes, Transaction)
+                except RlpError as exc:
+                  ctx.error = "verifyReceipt: " & exc.msg
+                  return
+    decodedTxHash = decodedTx.computeRlpHash()
+
+  if decodedTxHash != rec.transactionHash:
+    ctx.error = "receipt tx hash mismatch: got " &
+      ($decodedTxHash).toLowerAscii &
+      ", want " &
+      $rec.transactionHash
+    return
+
+  let
+    txHash = tx.computeRlpHash()
+
+  if txHash != rec.transactionHash:
+    ctx.error = "receipt tx hash mismatch: got " &
+      ($txHash).toLowerAscii &
+      ", want " &
+      $rec.transactionHash
+    return
+
+  let
+    receipt = rec.parseReceipt()
+    receiptHash = receipt.computeRlpHash()
+
+  if receiptHash != expectedHash:
+    ctx.error = "parsed receipt hash mismatch: got " &
+      ($receiptHash).toLowerAscii &
+      ", want " &
+      $expectedHash
+    return
+
+  let
+    decodedReceipt = try: rlp.decode(rec.rlp, Receipt)
+                     except RlpError as exc:
+                       ctx.error = "verifyReceipt: " & exc.msg
+                       return
+    decodedHash = decodedReceipt.computeRlpHash()
+
+  if decodedHash != expectedHash:
+    ctx.error = "decoded receipt hash mismatch: got " &
+      ($decodedHash).toLowerAscii &
+      ", want " &
+      $expectedHash
+    return
+
 proc writeResultToStdout(stateRes: seq[StateResult]): Result[void, string] =
   var n = newJArray()
   for res in stateRes:
@@ -123,7 +189,11 @@ proc writeRootHashToStderr(stateRoot: Hash32): Result[void, string] =
   except IOError as exc:
     err(exc.msg)
 
-proc runExecution(ctx: var StateContext, conf: StateConf, pre: GenesisAlloc): Result[StateResult, string] =
+proc runExecution(ctx: var StateContext,
+                  conf: StateConf,
+                  pre: GenesisAlloc,
+                  receipt: Opt[TxoReceipt],
+                  txBytes: openArray[byte]): Result[StateResult, string] =
   let
     com     = CommonRef.new(newCoreDbRef DefaultDbMemory, ctx.chainConfig)
     stream  = newFileStream(stderr)
@@ -159,11 +229,14 @@ proc runExecution(ctx: var StateContext, conf: StateConf, pre: GenesisAlloc): Re
       fork : ctx.forkStr
     ))
 
-  let callResult = vmState.processTransaction(ctx.tx, sender).valueOr(LogResult())
+  var callResult = vmState.processTransaction(ctx.tx, sender).valueOr(LogResult())
   coinbaseStateClearing(vmState, ctx.header.coinbase)
 
   let stateRoot = vmState.readOnlyLedger.getStateRoot()
   ctx.verifyResult(vmState, stateRoot, callResult)
+  if receipt.isSome and ctx.error.len == 0:
+    let generatedReceipt = vmState.makeReceipt(ctx.tx.txType, callResult)
+    ctx.verifyReceipt(generatedReceipt, receipt.value, ctx.tx, txBytes)
 
   let res = StateResult(
     name : ctx.name,
@@ -195,7 +268,7 @@ proc toTracerFlags(conf: StateConf): set[TracerFlags] =
 proc parseTx(ctx: var StateContext, txo: Txo, subTest: SubTest): Result[void, string] =
   try:
     if txo.secretKey.isSome:
-      ctx.tx = ? parseTx(txo, subTest.indexes, ctx.chainConfig.eip155Block.isSome)
+      ctx.tx = ? parseTx(txo, subTest.indexes)
       return ok()
 
     if subTest.txbytes.len > 0:
@@ -203,8 +276,6 @@ proc parseTx(ctx: var StateContext, txo: Txo, subTest: SubTest): Result[void, st
       return ok()
 
     return err("Unsupported fixture format")
-  #except KeyError as exc:
-  #  return err(exc.msg)
   except RlpError as exc:
     return err(exc.msg)
 
@@ -223,7 +294,7 @@ proc runSubTest(ctx: var StateContext,
   if subTest.state.isNil.not:
     ctx.postState  = subTest.state
   ? ctx.parseTx(unit.txo, subTest)
-  ctx.runExecution(conf, unit.pre)
+  ctx.runExecution(conf, unit.pre, subTest.receipt, subTest.txbytes)
 
 proc executeTest(resList: var seq[StateResult], unit: StateUnit, conf: StateConf): Result[void, string] =
   var

--- a/tools/evmstate/helpers.nim
+++ b/tools/evmstate/helpers.nim
@@ -11,7 +11,7 @@
 {.push raises: [].}
 
 import
-  eth/common/[base, keys, headers, transactions],
+  eth/common/[base, keys, headers, transactions, receipts],
   stew/byteutils,
   json_serialization,
   ../../execution_chain/transaction,
@@ -47,12 +47,6 @@ template defaultZero(res, n: untyped, i: int) =
     res = n.value[i]
   else:
     res = default(typeof(res))
-
-template defaultTo(res, x, n: untyped) =
-  if n.isSome:
-    res = n.value
-  else:
-    res = x
 
 func txType(n: Txo): TxType =
   if n.authorizationList.isSome:
@@ -93,7 +87,7 @@ func parseParentHeader*(n: StateEnv): Result[Header, string] =
   optional(res.blobGasUsed, n.parentBlobGasUsed)
   ok(move(res))
 
-func parseTx*(n: Txo, index: Index, eip155: bool): Result[Transaction, string] =
+func parseTx*(n: Txo, index: Index): Result[Transaction, string] =
   var tx = Transaction(
     txType  : txType(n)
   )
@@ -101,7 +95,7 @@ func parseTx*(n: Txo, index: Index, eip155: bool): Result[Transaction, string] =
   required(tx.gasLimit, n.gasLimit, index.gas)
   required(tx.value, n.value, index.value)
   required(tx.payload, n.data, index.data)
-  defaultTo(tx.chainId, 1.u256, n.chainId)
+  defaultZero(tx.chainId, n.chainId)
   defaultZero(tx.gasPrice, n.gasPrice)
   defaultZero(tx.maxFeePerGas, n.maxFeePerGas)
   defaultZero(tx.accessList, n.accessLists, index.data)
@@ -118,7 +112,27 @@ func parseTx*(n: Txo, index: Index, eip155: bool): Result[Transaction, string] =
 
   let secretKey = n.secretKey.valueOr:
     return err("missing secretKey field")
-  ok(signTransaction(tx, secretKey, eip155))
+  ok(signTransaction(tx, secretKey, n.chainId.isSome))
+
+func parseReceipt*(rec: TxoReceipt): Receipt =
+  if rec.postState.isSome:
+    Receipt(
+      receiptType      : ReceiptType(rec.`type`),
+      isHash           : true,
+      hash             : rec.postState.value,
+      cumulativeGasUsed: rec.cumulativeGasUsed,
+      logsBloom        : rec.bloom.value.to(Bloom),
+      logs             : rec.logs,
+    )
+  else:
+    Receipt(
+      receiptType      : ReceiptType(rec.`type`),
+      isHash           : false,
+      status           : rec.status.get,
+      cumulativeGasUsed: rec.cumulativeGasUsed,
+      logsBloom        : rec.bloom.value.to(Bloom),
+      logs             : rec.logs,
+    )
 
 proc setupLedger*(wantedState: GenesisAlloc, ledger: LedgerRef) =
   for address, account in wantedState:

--- a/tools/evmstate/parser.nim
+++ b/tools/evmstate/parser.nim
@@ -12,7 +12,8 @@
 
 import
   std/[strutils, tables],
-  eth/common/[base, keys, headers, transactions],
+  eth/common/[base, keys, headers, transactions, receipts],
+  eth/bloom,
   stint,
   json_serialization,
   json_serialization/pkg/results,
@@ -58,6 +59,16 @@ type
     authorizationList*   : Opt[seq[Authorization]]
     secretKey*           : Opt[PrivateKey]
 
+  TxoReceipt* = object
+    transactionHash*  : Hash32
+    `type`*           : uint8
+    cumulativeGasUsed*: GasInt
+    bloom*            : BloomFilter
+    logs*             : seq[Log]
+    status*           : Opt[bool]
+    postState*        : Opt[Hash32]
+    rlp*              : seq[byte]
+
   Index* = object
     data* : int
     gas*  : int
@@ -69,6 +80,7 @@ type
     txbytes*: seq[byte]
     indexes*: Index
     state*  : JsonNode
+    receipt*: Opt[TxoReceipt]
 
   SubTests* = ref object
     subs*: seq[SubTest]
@@ -87,6 +99,7 @@ Fixture.automaticSerialization(int, true)
 
 StateEnv.useDefaultReaderIn Fixture
 Txo.useDefaultReaderIn Fixture
+TxoReceipt.useDefaultReaderIn Fixture
 SubTest.useDefaultReaderIn Fixture
 Index.useDefaultReaderIn Fixture
 

--- a/tools/evmstate/testdata/00001742-mixed-2.json
+++ b/tools/evmstate/testdata/00001742-mixed-2.json
@@ -19,6 +19,7 @@
       }
     },
     "transaction": {
+      "chainId": "0x1",
       "maxFeePerGas": "0x10",
       "maxPriorityFeePerGas": "0x10",
       "nonce": "0x0",


### PR DESCRIPTION
Receipt has been added to the EEST test fixtures for quite some time now. But we have not validate the parser, receipt maker, and receipt encoder/decoder in evmstate test.

Upcoming EIP-8141 made significant changes to the Transaction and Receipt. This PR will bridge the gap and we will have more thorough test coverage for both Transaction and Receipt.