### PR TITLE
fix pruned db rpc fetch request

### DIFF
--- a/execution_chain/core/chain/forked_chain.nim
+++ b/execution_chain/core/chain/forked_chain.nim
@@ -1047,8 +1047,8 @@ func memoryTxHashesForBlock*(c: ForkedChainRef, blockHash: Hash32): Opt[seq[Hash
     )
   Opt.some(cachedTxHashes.mapIt(it[0]))
 
-proc latestBlock*(c: ForkedChainRef): Block =
-  c.latest.txFrame.getEthBlock(c.latest.hash).expect("latestBlock exists")
+proc latestBlock*(c: ForkedChainRef): Result[Block, string] =
+  c.latest.txFrame.getEthBlock(c.latest.hash)
 
 proc getBadBlocks*(c: ForkedChainRef): seq[(Block, Opt[BlockAccessListRef])] =
   var blks: seq[(Block, Opt[BlockAccessListRef])]
@@ -1081,17 +1081,17 @@ func safeHeader*(c: ForkedChainRef): Header =
 
   c.base.header
 
-proc finalizedBlock*(c: ForkedChainRef): Block =
+proc finalizedBlock*(c: ForkedChainRef): Result[Block, string] =
   c.hashToBlock.withValue(c.latestFinalized.hash, loc):
-    return loc[].txFrame.getEthBlock(loc[].hash).expect("finalizedBlock exists")
+    return loc[].txFrame.getEthBlock(loc[].hash)
 
-  c.baseTxFrame.getEthBlock(c.base.hash).expect("base finalizedBlock exists")
+  c.baseTxFrame.getEthBlock(c.base.hash)
 
-proc safeBlock*(c: ForkedChainRef): Block =
+proc safeBlock*(c: ForkedChainRef): Result[Block, string] =
   c.hashToBlock.withValue(c.fcuSafe.hash, loc):
-    return loc[].txFrame.getEthBlock(loc[].hash).expect("safeBlock exists")
+    return loc[].txFrame.getEthBlock(loc[].hash)
 
-  c.baseTxFrame.getEthBlock(c.base.hash).expect("base safeBlock exists")
+  c.baseTxFrame.getEthBlock(c.base.hash)
 
 proc headerByHash*(c: ForkedChainRef, blockHash: Hash32): Result[Header, string] =
   c.hashToBlock.withValue(blockHash, loc):

--- a/execution_chain/rpc/rpc_utils.nim
+++ b/execution_chain/rpc/rpc_utils.nim
@@ -50,9 +50,10 @@ proc invalidParams*(msg: string): ref ApplicationError =
     msg: msg,
   )
 
-proc calculateMedianGasPrice*(chain: ForkedChainRef): GasInt =
+proc calculateMedianGasPrice*(chain: ForkedChainRef): Result[GasInt, string] =
   const minGasPrice = 30_000_000_000.GasInt
-  var prices = chain.latestBlock.transactions.mapIt(it.gasPrice)
+  let blk = ?chain.latestBlock
+  var prices = blk.transactions.mapIt(it.gasPrice)
 
   # TODO: This should properly incorporate the base fee in the block data,
   # and recommend a gas fee that likely gets the block to confirm.
@@ -61,20 +62,20 @@ proc calculateMedianGasPrice*(chain: ForkedChainRef): GasInt =
   # sane minimum for compatibility to unblock testing.
   # Note: When this is fixed, update `tests/graphql/queries.toml` and
   # re-enable the "query.gasPrice" test case (remove `skip = true`).
-  result = max(median(prices), minGasPrice)
+  ok(max(median(prices), minGasPrice))
 
-proc calculateMedianMaxPriorityFeePerGas*(chain: ForkedChainRef): GasInt =
-  let blk = chain.latestBlock
+proc calculateMedianMaxPriorityFeePerGas*(chain: ForkedChainRef): Result[GasInt, string] =
+  let blk = ?chain.latestBlock
   var prices = blk.transactions
     .mapIt(it.effectiveGasTip(blk.header.baseFeePerGas))
     .filterIt(it > 0.GasInt)
 
-  median(prices)
+  ok(median(prices))
 
 proc unsignedTx*(tx: TransactionArgs,
                  chain: ForkedChainRef,
                  defaultNonce: AccountNonce,
-                 chainId: ChainId): Transaction =
+                 chainId: ChainId): Result[Transaction, string] =
   var res: Transaction
 
   if tx.to.isSome:
@@ -88,7 +89,7 @@ proc unsignedTx*(tx: TransactionArgs,
   if tx.gasPrice.isSome:
     res.gasPrice = tx.gasPrice.get.GasInt
   else:
-    res.gasPrice = calculateMedianGasPrice(chain)
+    res.gasPrice = ?calculateMedianGasPrice(chain)
 
   if tx.value.isSome:
     res.value = tx.value.get
@@ -103,7 +104,7 @@ proc unsignedTx*(tx: TransactionArgs,
   res.payload = tx.payload
   res.chainId = chainId
 
-  return res
+  ok(res)
 
 proc populateTransactionObject*(tx: Transaction,
                                 optionalHash: Opt[Hash32] = Opt.none(Hash32),
@@ -478,11 +479,11 @@ proc blockFromTag*(chain: ForkedChainRef, blockTag: BlockTag, noHash: bool = fal
     let tag = blockTag.alias.toLowerAscii
     case tag
     of "latest", "pending":
-      ok(chain.latestBlock)
+      chain.latestBlock
     of "finalized":
-      ok(chain.finalizedBlock)
+      chain.finalizedBlock
     of "safe":
-      ok(chain.safeBlock)
+      chain.safeBlock
     # wait till pruner pr is merged for tail semantics to be available, which is the appropriate way to resolve this tag
     of "earliest":
       chain.blockByNumber(base.BlockNumber(0))

--- a/execution_chain/rpc/server_api.nim
+++ b/execution_chain/rpc/server_api.nim
@@ -428,9 +428,11 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
           )
       Quantity(gasUsed)
 
-    proc eth_gasPrice(): Quantity =
+    proc eth_gasPrice(): Quantity {.raises: [ValueError].} =
       ## Returns an integer of the current gas price in wei.
-      w3Qty(calculateMedianGasPrice(api.chain).uint64)
+      let gasPrice = calculateMedianGasPrice(api.chain).valueOr:
+        raise newException(ValueError, error)
+      w3Qty(gasPrice.uint64)
 
     proc eth_accounts(): seq[Address] =
       ## Returns a list of addresses owned by client.
@@ -511,7 +513,8 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
         txFrame = api.frameFromTag(blockId("latest")).valueOr:
           raise newException(ValueError, "Latest Block not found")
         accRec = txFrame.fetchAccount(address.computeAccPath).valueOr(emptyDbAccount)
-        tx = unsignedTx(data, api.chain, accRec.nonce + 1, api.com.chainId)
+        tx = unsignedTx(data, api.chain, accRec.nonce + 1, api.com.chainId).valueOr:
+          raise newException(ValueError, error)
         eip155 = api.com.isEIP155(api.chain.latestNumber)
         signedTx = signTransaction(tx, acc.privateKey, eip155)
       return rlp.encode(signedTx)
@@ -534,7 +537,8 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
           raise newException(ValueError, "Latest Block not found")
         accRec = txFrame.fetchAccount(address.computeAccPath).valueOr(emptyDbAccount)
 
-        tx = unsignedTx(data, api.chain, accRec.nonce + 1, api.com.chainId)
+        tx = unsignedTx(data, api.chain, accRec.nonce + 1, api.com.chainId).valueOr:
+          raise newException(ValueError, error)
         eip155 = api.com.isEIP155(api.chain.latestNumber)
         signedTx = signTransaction(tx, acc.privateKey, eip155)
         blobsBundle =
@@ -802,8 +806,10 @@ proc setupServerAPI*(api: ServerAPIRef, server: RpcServer, am: ref AccountsManag
       api.oracle.feeHistory(blockCount.uint64, newestBlock, rewardPercentiles.get(@[])).valueOr:
         raise newException(ValueError, error)
 
-    proc eth_maxPriorityFeePerGas(): Quantity =
-      w3Qty(calculateMedianMaxPriorityFeePerGas(api.chain).uint64)
+    proc eth_maxPriorityFeePerGas(): Quantity {.raises: [ValueError].} =
+      let maxPriorityFee = calculateMedianMaxPriorityFeePerGas(api.chain).valueOr:
+        raise newException(ValueError, error)
+      w3Qty(maxPriorityFee.uint64)
 
     proc eth_getStorageValues(request: StorageValuesRequest, blockTag: BlockTag): StorageValuesResponse {.raises: [ValueError].} =
       let

--- a/tests/test_forked_chain.nim
+++ b/tests/test_forked_chain.nim
@@ -30,7 +30,10 @@ import
   ../execution_chain/db/core_db/memory_only,
   ../execution_chain/history/db/ere_db,
   ../execution_chain/db/fcu_db,
+  ../execution_chain/rpc/rpc_utils,
   ./test_forked_chain/chain_debug
+
+from web3/eth_api_types import blockId
 
 const
   genesisFile = "tests/customgenesis/cancun123.json"
@@ -877,6 +880,43 @@ suite "ForkedChainRef tests":
     checkImportBlock(fc, blk2)
     checkForkChoice(fc, blk2, blk2)
     check chain.validate info & " (2)"
+
+  test "latestBlock returns err when the block body is not in the db":
+    # An `Era1`/`Era` import stores headers and state but no transaction bodies,
+    # see `persistBlocks()` without `PersistTransactions`. Loading such a block
+    # as `base`/`latest` must surface an error, not take the node down.
+    const info = "latestBlock without body"
+    let
+      com = env.newCom()
+      chain = ForkedChainRef.init(com, baseDistance = 0, persistBatchSize = 1)
+    checkImportBlock(chain, blk1)
+    checkForkChoice(chain, blk1, blk1)
+    check chain.validate info & " (1)"
+
+    # Write a header that claims transactions but store none of them, and make
+    # it the saved state block -- exactly what an `Era` import leaves behind.
+    var header = blk1.header
+    header.number = 2
+    header.parentHash = blk1.blockHash
+    header.timestamp = blk1.header.timestamp + 1
+    header.transactionsRoot =
+      hash32"0x38abf3ae5e933b7856447028d7fe8928f1a51b57fa657079203d31a217b81e9b"
+
+    let
+      txFrame = com.db.baseTxFrame()
+      headerHash = header.computeBlockHash
+    check txFrame.persistHeaderAndSetHead(headerHash, header).isOk
+    txFrame.checkpoint(header.number, skipSnapshot = true)
+    com.db.persist(txFrame)
+
+    let fc = ForkedChainRef.init(env.newCom(com.db),
+      baseDistance = 0, persistBatchSize = 1)
+    check fc.latestNumber == 2
+    check fc.latestHash == headerHash
+
+    # Before the fix these raised a `ResultDefect`, killing the process.
+    check fc.latestBlock.isErr
+    check fc.blockFromTag(blockId("latest")).isErr
 
   test "newBase move forward, greater than persistBatchSize":
     const info = "newBase move forward, greater than persistBatchSize"

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -449,7 +449,8 @@ proc rpcMain*() =
 
     test "eth_maxPriorityFeePerGas":
       let res = await client.eth_maxPriorityFeePerGas()
-      check res == w3Qty(calculateMedianMaxPriorityFeePerGas(env.chain).uint64)
+      check res == w3Qty(calculateMedianMaxPriorityFeePerGas(env.chain)
+        .expect("body present in test db").uint64)
 
     test "eth_accounts":
       let res = await client.eth_accounts()


### PR DESCRIPTION
Issue triggered only when using a db which has just imported blocks with the `import` command. The `import` command imports the blocks and builds the state, but doesn't store the block bodies.
So when a node is started on this db, an rpc request to these pruned blocks creates a crash reported by #4696 