### PR TITLE
Update nim-rocksdb to v11.8.1.0

### DIFF
--- a/execution_chain/db/core_db/backend/aristo_rocksdb.nim
+++ b/execution_chain/db/core_db/backend/aristo_rocksdb.nim
@@ -137,6 +137,7 @@ proc toCfOpts*(opts: DbOptions, cache: CacheRef, bulk: bool): ColFamilyOptionsRe
   # simple tests around mainnet block 14M.
   # TODO evaluate zstd dictionary compression
   # https://github.com/facebook/rocksdb/wiki/Dictionary-Compression
+  cfOpts.compression = noCompression
   cfOpts.bottommostCompression = Compression.zstdCompression
 
   # With the default options, we end up with 512MB at the base level - a


### PR DESCRIPTION
Updates nim-rocksdb to v11.8.1.0, see here: https://github.com/status-im/nim-rocksdb/pull/115

RocksDB v11.8.1 now includes get async and multiGet async functions but unfortunately these are not yet included in the c API so we can't easily use these new features just yet.