### PR TITLE
stateless: build the guest natively + add in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           if [ '${{ matrix.os }}' != 'windows' ]; then
             EXTRA_TARGETS="stateless_guest_baremetal"
           fi
-          make ${DEFAULT_MAKE_FLAGS} tools build_fuzzers $EXTRA_TARGETS
+          make ${DEFAULT_MAKE_FLAGS} tools build_fuzzers stateless_guest_native $EXTRA_TARGETS
           # check_revision and test_import depend on nimbus_execution_client,
           # best to run them together to avoid double builds
           make ${DEFAULT_MAKE_FLAGS} nimbus_execution_client check_revision test_import

--- a/Makefile
+++ b/Makefile
@@ -422,14 +422,10 @@ stateless_guest_baremetal: | build deps
 
 # The guest as an ordinary host binary, with zkvm_io_stdio.c supplying read_input
 # and write_output over stdin/stdout in place of a zkVM runtime.
-#
-# gcc 14 errors on a pointer type that disagrees with the C prototype, earlier
-# versions only warn. Promote it so every gcc behaves like gcc 14. clang still
-# passes either way: nimbase.h ignores the diagnostic.
-STATELESS_GUEST_NATIVE_FLAGS := --passC:"-Werror=incompatible-pointer-types"
-
 stateless_guest_native: | build deps
-	$(ENV_SCRIPT) $(NIMC) c $(NIM_PARAMS) $(STATELESS_GUEST_FLAGS) $(STATELESS_GUEST_NATIVE_FLAGS) --compile:"execution_chain/stateless/zkvm_io_stdio.c" -o:build/$@ "execution_chain/stateless/stateless_guest.nim"
+	+ echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) $(NIMC) c $(NIM_PARAMS) $(STATELESS_GUEST_FLAGS) --compile:"execution_chain/stateless/zkvm_io_stdio.c" -o:build/$@ "execution_chain/stateless/stateless_guest.nim" && \
+		echo -e $(BUILD_END_MSG) "build/$@"
 
 # Two runs: the full suite with standard flags, then the guest specific test
 # with flags closer to the zkVM guest.

--- a/Makefile
+++ b/Makefile
@@ -422,8 +422,14 @@ stateless_guest_baremetal: | build deps
 
 # The guest as an ordinary host binary, with zkvm_io_stdio.c supplying read_input
 # and write_output over stdin/stdout in place of a zkVM runtime.
+#
+# gcc 14 errors on a pointer type that disagrees with the C prototype, earlier
+# versions only warn. Promote it so every gcc behaves like gcc 14. clang still
+# passes either way: nimbase.h ignores the diagnostic.
+STATELESS_GUEST_NATIVE_FLAGS := --passC:"-Werror=incompatible-pointer-types"
+
 stateless_guest_native: | build deps
-	$(ENV_SCRIPT) $(NIMC) c $(NIM_PARAMS) $(STATELESS_GUEST_FLAGS) --compile:"execution_chain/stateless/zkvm_io_stdio.c" -o:build/$@ "execution_chain/stateless/stateless_guest.nim"
+	$(ENV_SCRIPT) $(NIMC) c $(NIM_PARAMS) $(STATELESS_GUEST_FLAGS) $(STATELESS_GUEST_NATIVE_FLAGS) --compile:"execution_chain/stateless/zkvm_io_stdio.c" -o:build/$@ "execution_chain/stateless/stateless_guest.nim"
 
 # Two runs: the full suite with standard flags, then the guest specific test
 # with flags closer to the zkVM guest.

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ endif
 	evmstate \
 	evmstate_test \
 	stateless_guest_baremetal \
+	stateless_guest_native \
 	stateless_execution_test
 
 ifeq ($(NIM_PARAMS),)
@@ -418,6 +419,11 @@ STATELESS_GUEST_CPU ?= riscv64
 
 stateless_guest_baremetal: | build deps
 	$(ENV_SCRIPT) $(NIMC) c $(STATELESS_GUEST_FLAGS) --cpu:$(STATELESS_GUEST_CPU) --os:any --compileOnly --genScript "execution_chain/stateless/stateless_guest.nim"
+
+# The guest as an ordinary host binary, with zkvm_io_stdio.c supplying read_input
+# and write_output over stdin/stdout in place of a zkVM runtime.
+stateless_guest_native: | build deps
+	$(ENV_SCRIPT) $(NIMC) c $(NIM_PARAMS) $(STATELESS_GUEST_FLAGS) --compile:"execution_chain/stateless/zkvm_io_stdio.c" -o:build/$@ "execution_chain/stateless/stateless_guest.nim"
 
 # Two runs: the full suite with standard flags, then the guest specific test
 # with flags closer to the zkVM guest.

--- a/execution_chain/stateless/zkvm_io.nim
+++ b/execution_chain/stateless/zkvm_io.nim
@@ -36,23 +36,14 @@ when not defined(`any`) and not defined(standalone):
 else:
   {.passc: "-I\"" & zkvmIoDir & "\"".}
 
-# `buf_ptr` cannot be the matching `ptr ptr UncheckedArray[byte]`: the standard
-# declares it `const uint8_t**`, and C does not accept a `uint8_t**` here. Nim
-# cannot spell the const, and `void*` is the only pointer C converts freely, so
-# `pointer` it is. Downside: no type check on `buf_ptr`.
-#
-# Getting this wrong is only an error on newer gcc and is silent on clang, which
-# ignores the diagnostic in nimbase.h. Turn it into an error here instead, where
-# it applies to this file alone.
-{.emit: """/*TYPESECTION*/
-#pragma GCC diagnostic error "-Wincompatible-pointer-types"
-""".}
-{.localPassC: "-Werror=incompatible-pointer-types".}
-
+# `buf_ptr` cannot be matching `ptr ptr UncheckedArray[byte]`: the zkvm-standard
+# declares it `const uint8_t**`, not `uint8_t**`. Nim cannot provide the const,
+# and `void*` is the only pointer C converts freely, so `pointer` it is.
+# Downside is no type check on `buf_ptr`.
+# gcc 14 and later error on it. Older gcc and clang only warn, and Nim passes
+# -w to the C compiler default, so no reported warning or error.
 proc c_read_input(
-  # Temp. fix disabled
-  # buf_ptr: pointer, buf_size: ptr csize_t
-  buf_ptr: ptr ptr UncheckedArray[byte], buf_size: ptr csize_t
+  buf_ptr: pointer, buf_size: ptr csize_t
 ) {.importc: "read_input", header: "zkvm_io.h".}
 
 proc c_write_output(

--- a/execution_chain/stateless/zkvm_io.nim
+++ b/execution_chain/stateless/zkvm_io.nim
@@ -36,7 +36,22 @@ when not defined(`any`) and not defined(standalone):
 else:
   {.passc: "-I\"" & zkvmIoDir & "\"".}
 
+# `buf_ptr` cannot be the matching `ptr ptr UncheckedArray[byte]`: the standard
+# declares it `const uint8_t**`, and C does not accept a `uint8_t**` here. Nim
+# cannot spell the const, and `void*` is the only pointer C converts freely, so
+# `pointer` it is. Downside: no type check on `buf_ptr`.
+#
+# Getting this wrong is only an error on newer gcc and is silent on clang, which
+# ignores the diagnostic in nimbase.h. Turn it into an error here instead, where
+# it applies to this file alone.
+{.emit: """/*TYPESECTION*/
+#pragma GCC diagnostic error "-Wincompatible-pointer-types"
+""".}
+{.localPassC: "-Werror=incompatible-pointer-types".}
+
 proc c_read_input(
+  # Temp. fix disabled
+  # buf_ptr: pointer, buf_size: ptr csize_t
   buf_ptr: ptr ptr UncheckedArray[byte], buf_size: ptr csize_t
 ) {.importc: "read_input", header: "zkvm_io.h".}
 

--- a/execution_chain/stateless/zkvm_io_stdio.c
+++ b/execution_chain/stateless/zkvm_io_stdio.c
@@ -1,0 +1,102 @@
+/**
+ * Nimbus
+ * Copyright (c) 2026 Status Research & Development GmbH
+ * Licensed under either of
+ *   * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+ *   * MIT license ([LICENSE-MIT](LICENSE-MIT))
+ * at your option.
+ * This file may not be copied, modified, or distributed except according to
+ * those terms.
+ */
+
+/**
+ * stdio-backed implementation of the zkVM IO interface.
+ *
+ * This is a stand-in for the vendor-supplied static library described by
+ * zkvm-standards `standards/static-library-and-linker-script`: it provides the
+ * same two symbols, with the same semantics, backed by stdin/stdout instead of
+ * a zkVM. The `stateless_guest_native` make target links the guest against this
+ * so it can be driven as an ordinary binary over a pipe.
+ *
+ * Because the Nim side binds these symbols identically either way, the pipe
+ * test exercises the real FFI path rather than a parallel native code path.
+ *
+ * Semantics preserved from the standard:
+ *  - read_input is idempotent, and zero-copy: the whole input is slurped once
+ *    into an internal buffer and the same pointer is handed out every time.
+ *  - write_output appends: successive calls concatenate.
+ *  - Neither can fail, and neither can report an error. A real zkVM has the
+ *    input in memory and cannot hit the paths below, so rather than pass the
+ *    guest a short or empty buffer, this dies on stderr.
+ */
+
+#include "zkvm_io.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static uint8_t *g_input;
+static size_t g_input_size;
+static int g_input_loaded;
+
+static void die(const char *what) {
+    fprintf(stderr, "zkvm_io_stdio: %s\n", what);
+    exit(EXIT_FAILURE);
+}
+
+/* Read all of stdin into g_input. Called once, on the first read_input. */
+static void load_input(void) {
+    size_t cap = 1 << 16; /* one allocation for all but ~0.4% of EEST inputs */
+    size_t len = 0;
+    size_t n;
+    uint8_t *buf;
+
+    if (g_input_loaded) {
+        return;
+    }
+    g_input_loaded = 1;
+
+    buf = malloc(cap);
+    if (buf == NULL) {
+        die("out of memory reading stdin");
+    }
+
+    for (;;) {
+        if (len == cap) {
+            /* cap * 2 should not overflow: realloc fails well before SIZE_MAX/2 */
+            uint8_t *grown = realloc(buf, cap * 2);
+            if (grown == NULL) {
+                die("out of memory reading stdin");
+            }
+            buf = grown;
+            cap *= 2;
+        }
+        n = fread(buf + len, 1, cap - len, stdin);
+        len += n;
+        if (n == 0) {
+            /* cap - len was nonzero, so 0 bytes means EOF or a read error */
+            if (ferror(stdin)) {
+                die("error reading stdin");
+            }
+            break;
+        }
+    }
+
+    g_input = buf;
+    g_input_size = len;
+}
+
+void read_input(const uint8_t **buf_ptr, size_t *buf_size) {
+    load_input();
+    *buf_ptr = g_input;
+    *buf_size = g_input_size;
+}
+
+void write_output(const uint8_t *output, size_t size) {
+    if (size > 0 && fwrite(output, 1, size, stdout) != size) {
+        die("error writing stdout");
+    }
+    if (fflush(stdout) != 0) {
+        die("error flushing stdout");
+    }
+}


### PR DESCRIPTION
Add stateless_guest_native target, which builds the guest as an ordinary host binary with zkvm_io_stdio.c standing in for the vendor static library + add this build to CI.

This version can and has been tested by feeding it test fixture data and comparing its output.