### PR TITLE
Update glamsterdam devnet fixtures to v8.1.4 

### DIFF
--- a/execution_chain/evm/interpreter/gas_meter.nim
+++ b/execution_chain/evm/interpreter/gas_meter.nim
@@ -112,3 +112,14 @@ func frameStateGasUsed*(gasMeter: var GasMeter, stateGasReservoir: GasInt): int6
   int64(stateGasReservoir) -
     int64(gasMeter.stateGasLeft) +
     int64(gasMeter.stateGasSpilled)
+
+func repayStateGasSpill*(gasMeter: var GasMeter) =
+  # Repay outstanding [spill] from the reservoir after a child merges.
+  let
+    repayment = min(gasMeter.stateGasLeft, gasMeter.stateGasSpilled)
+
+  gasMeter.executionGasLeft = gasMeter.executionGasLeft + repayment
+  gasMeter.stateGasLeft -= repayment
+  gasMeter.stateGasSpilled -= repayment
+  # The claim and the credit cannot both survive a repayment.
+  doAssert gasMeter.stateGasLeft == 0 or gasMeter.stateGasSpilled == 0

--- a/execution_chain/evm/interpreter/op_handlers/oph_call.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_call.nim
@@ -241,6 +241,7 @@ proc execSubCall(c: Computation; childMsg: Message; code: CodeBytesRef;
         c.gasMeter.returnStateGas(child.gasMeter.stateGasLeft)
         c.gasMeter.appendStateGasUsed(child.gasMeter.stateGasUsed)
         c.gasMeter.stateGasSpilled += child.gasMeter.stateGasSpilled
+        c.gasMeter.repayStateGasSpill()
       c.merge(child)
       c.stack.lsTop(1)
     else:

--- a/execution_chain/evm/interpreter/op_handlers/oph_create.nim
+++ b/execution_chain/evm/interpreter/op_handlers/oph_create.nim
@@ -50,6 +50,7 @@ proc postExecutionCreate(c: Computation, child: Computation, newAccountCharged: 
       c.gasMeter.returnStateGas(child.gasMeter.stateGasLeft)
       c.gasMeter.appendStateGasUsed(child.gasMeter.stateGasUsed)
       c.gasMeter.stateGasSpilled += child.gasMeter.stateGasSpilled
+      c.gasMeter.repayStateGasSpill()
     c.merge(child)
     c.stack.lsTop child.msg.contractAddress
   else:

--- a/scripts/eest_ci_cache.sh
+++ b/scripts/eest_ci_cache.sh
@@ -22,7 +22,7 @@ EEST_MAINNET_URL="https://github.com/ethereum/execution-specs/releases/download/
 
 # --- Devnet Release ---
 EEST_DEVNET_NAME="tests-glamsterdam-devnet"
-EEST_DEVNET_VERSION="v8.1.3"
+EEST_DEVNET_VERSION="v8.1.4"
 EEST_DEVNET_DIR="${FIXTURES_DIR}/eest_devnet"
 EEST_DEVNET_ARCHIVE="fixtures_glamsterdam-devnet.tar.gz"
 EEST_DEVNET_URL="https://github.com/ethereum/execution-specs/releases/download/${EEST_DEVNET_NAME}%40${EEST_DEVNET_VERSION}/${EEST_DEVNET_ARCHIVE}"

--- a/tests/eest/eest_evmstate.nim
+++ b/tests/eest/eest_evmstate.nim
@@ -23,7 +23,7 @@ proc runTest(filePath: string): Result[seq[StateResult], string] =
     postState    : true,
     dumpEnabled  : true,
     enableError  : false,
-    sanitizeEnv  : true,
+    sanitizeEnv  : false,
   )
 
   evmstate.prepareAndRun(filePath, conf, seq[StateResult])


### PR DESCRIPTION
This PR also contains spec changes update:
- repay spilled state gas from the reservoir when a child merges.

eest_evmstate_test changes:
- `sanitizeEnv` flag turned off. Sanitation issue with glamsterdam-devnet-tests@v8.1.3's `env` fields have been fixed in 8.1.4 release.