### PR TITLE
EVM system call now using SysCallParams

### DIFF
--- a/execution_chain/core/executor/process_transaction.nim
+++ b/execution_chain/core/executor/process_transaction.nim
@@ -196,7 +196,7 @@ proc processBeaconBlockRoot*(vmState: BaseVMState, beaconRoot: Hash32) =
   ## If EIP-4788 is enabled, we need to invoke the beaconroot storage
   ## contract with the new root.
   let
-    call = CallParams(
+    call = SysCallParams(
       vmState  : vmState,
       sender   : SYSTEM_ADDRESS,
       gasLimit : 30_000_000.GasInt,
@@ -211,7 +211,7 @@ proc processParentBlockHash*(vmState: BaseVMState, prevHash: Hash32) =
   ## processParentBlockHash stores the parent block hash in the
   ## history storage contract as per EIP-2935.
   let
-    call = CallParams(
+    call = SysCallParams(
       vmState  : vmState,
       sender   : SYSTEM_ADDRESS,
       gasLimit : 30_000_000.GasInt,
@@ -226,7 +226,7 @@ proc processDequeueWithdrawalRequests*(vmState: BaseVMState): Result[seq[byte], 
   ## processDequeueWithdrawalRequests applies the EIP-7002 system call
   ## to the withdrawal requests contract.
   let
-    call = CallParams(
+    call = SysCallParams(
       vmState  : vmState,
       sender   : SYSTEM_ADDRESS,
       gasLimit : 30_000_000.GasInt,
@@ -242,7 +242,7 @@ proc processDequeueConsolidationRequests*(vmState: BaseVMState): Result[seq[byte
   ## processDequeueConsolidationRequests applies the EIP-7251 system call
   ## to the consolidation requests contract.
   let
-    call = CallParams(
+    call = SysCallParams(
       vmState  : vmState,
       sender   : SYSTEM_ADDRESS,
       gasLimit : 30_000_000.GasInt,
@@ -258,7 +258,7 @@ proc processBuilderDepositRequests*(vmState: BaseVMState): Result[seq[byte], str
   ## processBuilderDepositRequests applies the EIP-8282 system call
   ## to the builder deposit requests contract.
   let
-    call = CallParams(
+    call = SysCallParams(
       vmState  : vmState,
       sender   : SYSTEM_ADDRESS,
       gasLimit : 30_000_000.GasInt,
@@ -274,7 +274,7 @@ proc processBuilderExitRequests*(vmState: BaseVMState): Result[seq[byte], string
   ## processBuilderExitRequests applies the EIP-8282 system call
   ## to the builder exit requests contract.
   let
-    call = CallParams(
+    call = SysCallParams(
       vmState  : vmState,
       sender   : SYSTEM_ADDRESS,
       gasLimit : 30_000_000.GasInt,

--- a/execution_chain/transaction/system_call.nim
+++ b/execution_chain/transaction/system_call.nim
@@ -12,13 +12,22 @@
 import
   ../evm/[types, state, computation, interpreter_dispatch, code_stream],
   ../db/ledger,
-  ../core/eip8037,
-  ./call_types
+  ../core/eip8037
+
+from ./call_types import OutputResult
 
 export
-  call_types
+  OutputResult
 
-proc setupComputation(params: CallParams): Computation =
+type
+  SysCallParams* = object
+    vmState*:  BaseVMState          # Chain, database, state, block, fork.
+    gasLimit*: GasInt               # Maximum gas available for this call.
+    sender*:   addresses.Address    # Sender account.
+    to*:       addresses.Address    # Recipient.
+    input*:    seq[byte]            # Input data.
+
+proc setupComputation(params: SysCallParams): Computation =
   let
     vmState = params.vmState
     stateGasReservoir = if vmState.fork >= FkAmsterdam: SYSTEM_STATE_GAS_RESERVOIR.GasInt
@@ -30,7 +39,6 @@ proc setupComputation(params: CallParams): Computation =
       contractAddress:   params.to,
       codeAddress:       params.to,
       sender:            params.sender,
-      value:             params.value,
       data:              params.input,
     )
     code = vmState.ledger.getCode(msg.codeAddress)
@@ -44,8 +52,8 @@ proc setupComputation(params: CallParams): Computation =
   # EVM called for a new transaction
   vmState.gasRefunded = 0
   vmState.captureStart(computation, params.sender, params.to,
-                       params.isCreate, params.input,
-                       params.gasLimit, params.value)
+                       false, params.input,
+                       params.gasLimit, 0.u256)
   computation
 
 func sysCallGasUsed(c: Computation): GasInt =
@@ -86,7 +94,7 @@ proc preExecComputation(c: Computation) =
         c.setError("No code found for builder deposit or exit requests contract")
         return
 
-proc systemCall*(params: CallParams, T: type): T =
+proc systemCall*(params: SysCallParams, T: type): T =
   let
     ledger = params.vmState.ledger
     c = setupComputation(params)


### PR DESCRIPTION
Nimbus-EL already have an almost clean separation of EVM system call from regular EVM call. With this PR, they now have their own set of parameters object.

With the EIP-8141 coming, regular EVM call will undergo significant changes. If system call still using regular CallParams, it is a waste of fields not used by system call. The incompatibility also grows larger.