### PR TITLE
Refactor CallParams and TxContext

### DIFF
--- a/execution_chain/evm/computation.nim
+++ b/execution_chain/evm/computation.nim
@@ -69,10 +69,13 @@ template getGasPrice*(c: Computation): GasInt =
   c.vmState.txCtx.gasPrice
 
 template getVersionedHash*(c: Computation, index: int): VersionedHash =
-  c.vmState.txCtx.versionedHashes[index]
+  c.vmState.txCtx.tx.versionedHashes[index]
 
 template getVersionedHashesLen*(c: Computation): int =
-  c.vmState.txCtx.versionedHashes.len
+  if c.vmState.txCtx.tx.isNil:
+    0
+  else:
+    c.vmState.txCtx.tx.versionedHashes.len
 
 template getBlobBaseFee*(c: Computation): UInt256 =
   c.vmState.txCtx.blobBaseFee

--- a/execution_chain/evm/types.nim
+++ b/execution_chain/evm/types.nim
@@ -38,10 +38,10 @@ type
     slotNumber*       : uint64
 
   TxContext* = object
-    origin*         : Address
-    gasPrice*       : GasInt
-    versionedHashes*: seq[VersionedHash]
-    blobBaseFee*    : UInt256
+    origin*     : Address
+    gasPrice*   : GasInt
+    blobBaseFee*: UInt256
+    tx*         : ptr Transaction
 
   BaseVMState* = ref object of RootObj
     com*              : CommonRef

--- a/execution_chain/rpc/params.nim
+++ b/execution_chain/rpc/params.nim
@@ -25,13 +25,20 @@ const
 func sender*(args: TransactionArgs): Address =
   args.source.get(ZeroAddr)
 
-func destination*(args: TransactionArgs): Address =
-  args.to.get(ZeroAddr)
+func txType(n: TransactionArgs): TxType =
+  if n.authorizationList.isSome:
+    return TxEip7702
+  if n.blobVersionedHashes.isSome:
+    return TxEip4844
+  if n.gasPrice.isNone:
+    return TxEip1559
+  if n.accessList.isSome:
+    return TxEip2930
+  TxLegacy
 
-proc toCallParams*(vmState: BaseVMState,
-                   args: TransactionArgs,
-                   globalGasCap: GasInt,
-                   header: Header): EvmResult[CallParams] =
+proc toTransaction*(vmState: BaseVMState,
+                    args: TransactionArgs,
+                    globalGasCap: GasInt): EvmResult[Transaction] =
 
   # Reject invalid combinations of pre- and post-1559 fee styles
   if args.gasPrice.isSome and
@@ -52,50 +59,27 @@ proc toCallParams*(vmState: BaseVMState,
       cap = globalGasCap,
       gasLimit = globalGasCap
 
-  var gasPrice = GasInt args.gasPrice.get(0.Quantity)
-  if header.baseFeePerGas.isSome:
-    # A basefee is provided, necessitating EIP-1559-type execution
-    let
-        feeNormTx = Transaction(
-          txType:
-            if args.maxFeePerGas.isSome or args.maxPriorityFeePerGas.isSome:
-              TxEip1559
-            else:
-              TxLegacy,
-          gasPrice: GasInt args.gasPrice.get(0.Quantity),
-          maxPriorityFeePerGas: GasInt args.maxPriorityFeePerGas.get(0.Quantity),
-          maxFeePerGas: GasInt args.maxFeePerGas.get(0.Quantity),
-        )
-        maxPriorityFee = feeNormTx.maxPriorityFeePerGasNorm
-        maxFee = feeNormTx.maxFeePerGasNorm
-
-    # Backfill the legacy gasPrice for EVM execution, unless we're all zeroes
-    if maxPriorityFee > 0 or maxFee > 0:
-      let baseFee = header.baseFeePerGas.value.truncate(GasInt)
-      let priorityFee = min(maxPriorityFee, maxFee - baseFee)
-      gasPrice = priorityFee + baseFee
-
   template versionedHashes(args: TransactionArgs): seq[VersionedHash] =
     if args.blobVersionedHashes.isSome:
       args.blobVersionedHashes.get
     else:
       @[]
 
-  var res = CallParams(
-    vmState:         vmState,
-    sender:          args.sender,
-    to:              args.destination,
-    isCreate:        args.to.isNone,
-    gasLimit:        gasLimit,
-    gasPrice:        gasPrice,
-    value:           args.value.get(0.u256),
-    input:           args.payload(),
-    accessList:      args.accessList.get(@[]),
-    versionedHashes: args.versionedHashes,
-    authorizationList: args.authorizationList.get(@[]),
-  )
-
-  res.intrinsic = res.intrinsicGas(vmState.hardFork, header.gasLimit, res.sender)
-  ok(move(res))
+  ok(Transaction(
+    txType:               txType(args),
+    chainId:              args.chainId.get(0.u256),
+    nonce:                args.nonce.get(0.Quantity).AccountNonce,
+    gasPrice:             args.gasPrice.get(0.Quantity).GasInt,
+    maxPriorityFeePerGas: args.maxPriorityFeePerGas.get(0.Quantity).GasInt,
+    maxFeePerGas:         args.maxFeePerGas.get(0.Quantity).GasInt,
+    gasLimit:             gasLimit,
+    to:                   args.to,
+    value:                args.value.get(0.u256),
+    payload:              args.payload(),
+    accessList:           args.accessList.get(@[]),
+    maxFeePerBlobGas:     args.maxFeePerBlobGas.get(0.u256),
+    versionedHashes:      args.versionedHashes,
+    authorizationList:    args.authorizationList.get(@[]),
+  ))
 
 {.pop.}

--- a/execution_chain/rpc/params.nim
+++ b/execution_chain/rpc/params.nim
@@ -30,7 +30,7 @@ func txType(n: TransactionArgs): TxType =
     return TxEip7702
   if n.blobVersionedHashes.isSome:
     return TxEip4844
-  if n.gasPrice.isNone:
+  if n.maxFeePerGas.isSome or n.maxPriorityFeePerGas.isSome:
     return TxEip1559
   if n.accessList.isSome:
     return TxEip2930
@@ -38,7 +38,8 @@ func txType(n: TransactionArgs): TxType =
 
 proc toTransaction*(vmState: BaseVMState,
                     args: TransactionArgs,
-                    globalGasCap: GasInt): EvmResult[Transaction] =
+                    globalGasCap: GasInt,
+                    header: Header): EvmResult[Transaction] =
 
   # Reject invalid combinations of pre- and post-1559 fee styles
   if args.gasPrice.isSome and

--- a/execution_chain/transaction/call_common.nim
+++ b/execution_chain/transaction/call_common.nim
@@ -37,7 +37,10 @@ type
 
 proc initialAccessListEIP2929(params: CallParams) =
   # EIP2929 initial access list.
-  let vmState = params.vmState
+  let
+    vmState = params.vmState
+    tx = params.tx
+
   if vmState.fork < FkBerlin:
     return
 
@@ -53,7 +56,7 @@ proc initialAccessListEIP2929(params: CallParams) =
       ledger.accessList(c)
 
     # EIP2930 optional access list.
-    for account in params.accessList:
+    for account in tx.accessList:
       ledger.accessList(account.address)
       for key in account.storageKeys:
         ledger.accessList(account.address, key.to(UInt256))
@@ -63,9 +66,9 @@ proc setupComputation(params: CallParams, keepStack: bool, vmState: BaseVMState,
     var
       code = if params.isCreate:
               msg.contractAddress = generateContractAddress(vmState, params.sender)
-              CodeBytesRef.init(params.input)
+              CodeBytesRef.init(params.tx.payload)
             else:
-              assign(msg.data, params.input)
+              assign(msg.data, params.tx.payload)
               getRecipientCode(vmState, msg)
 
     if MsgFlags.Delegated in msg.flags:
@@ -85,10 +88,10 @@ proc setupEVM(params: CallParams, keepStack: bool): Computation =
     vmState = params.vmState
     fork = vmState.hardFork
   vmState.txCtx = TxContext(
-    origin         : params.sender,
-    gasPrice       : params.gasPrice,
-    versionedHashes: params.versionedHashes,
-    blobBaseFee    : getBlobBaseFee(vmState.blockCtx.excessBlobGas, vmState.com, fork),
+    origin     : params.sender,
+    gasPrice   : params.gasPrice,
+    blobBaseFee: getBlobBaseFee(vmState.blockCtx.excessBlobGas, vmState.com, fork),
+    tx         : params.tx,
   )
 
   # reset global gasRefunded counter each time
@@ -100,8 +103,9 @@ proc setupEVM(params: CallParams, keepStack: bool): Computation =
     # Note that this is only a short term fix. In the longer term we need to
     # implement validation on all fields in the Message before executing in the EVM.
     # TODO: Implement full validation on all fields. See related issue: https://github.com/status-im/nimbus-eth1/issues/1524
-    evmGas = if params.gasLimit < params.intrinsic.execution: 0.GasInt
-             else: params.gasLimit - params.intrinsic.execution
+    tx = params.tx
+    evmGas = if tx.gasLimit < params.intrinsic.execution: 0.GasInt
+             else: tx.gasLimit - params.intrinsic.execution
     executionGasBudget = TX_GAS_LIMIT - params.intrinsic.execution
 
   var
@@ -116,24 +120,25 @@ proc setupEVM(params: CallParams, keepStack: bool): Computation =
     executionRefund = setDelegation(params)
 
   let
+    destination = tx[].destination
     msg = Message(
       kind:              if params.isCreate: CallKind.Create
                          else: CallKind.Call,
       gas:               executionGas,
       stateGasReservoir: stateGasReservoir,
-      contractAddress:   params.to,
-      codeAddress:       params.to,
-      delegateTo:        params.to,
+      contractAddress:   destination,
+      codeAddress:       destination,
+      delegateTo:        destination,
       sender:            params.sender,
-      value:             params.value,
+      value:             tx.value,
     )
     computation = setupComputation(params, keepStack, vmState, msg)
 
   if computation.isSuccess:
     computation.addRefund(executionRefund)
-    vmState.captureStart(computation, params.sender, params.to,
-                         params.isCreate, params.input,
-                         params.gasLimit, params.value)
+    vmState.captureStart(computation, params.sender, destination,
+                         params.isCreate, tx.payload,
+                         tx.gasLimit, tx.value)
   computation
 
 # FIXME-awkwardFactoring: the factoring out of the pre and
@@ -145,6 +150,7 @@ proc prepareToRunComputation(params: CallParams) =
   let
     vmState = params.vmState
     fork = vmState.hardFork
+    tx = params.tx
 
   vmState.mutateLedger:
     if not params.isCreate:
@@ -153,10 +159,10 @@ proc prepareToRunComputation(params: CallParams) =
       ledger.incNonce(params.sender)
 
     # Charge for gas.
-    var gasFee = params.gasLimit.u256 * params.gasPrice.u256
+    var gasFee = tx.gasLimit.u256 * params.gasPrice.u256
     if fork >= Cancun:
       # EIP-4844
-      gasFee += calcDataFee(params.versionedHashes.len,
+      gasFee += calcDataFee(tx.versionedHashes.len,
         vmState.blockCtx.excessBlobGas, vmState.com, fork)
 
     if vmState.balTrackerEnabled:
@@ -167,6 +173,7 @@ proc calculateAndPossiblyRefundGas(c: Computation, params: CallParams): GasUsed 
   let
     vmState = c.vmState
     fork = c.vmState.fork
+    tx = params.tx
     # EIP-3529: Reduction in refunds
     MaxRefundQuotient = if fork >= FkLondon: 5.GasInt
                         else: 2.GasInt
@@ -176,7 +183,7 @@ proc calculateAndPossiblyRefundGas(c: Computation, params: CallParams): GasUsed 
 
   # Calculated gas used, taking into account refund rules.
   let
-    gasUsedBeforeRefund = params.gasLimit - c.gasMeter.executionGasLeft - c.gasMeter.stateGasLeft
+    gasUsedBeforeRefund = tx.gasLimit - c.gasMeter.executionGasLeft - c.gasMeter.stateGasLeft
     gasRefund = min(gasUsedBeforeRefund div MaxRefundQuotient, c.getGasRefund())
     gasUsedAfterRefund = gasUsedBeforeRefund - gasRefund
 
@@ -193,7 +200,7 @@ proc calculateAndPossiblyRefundGas(c: Computation, params: CallParams): GasUsed 
       blockExecutionGasUsed = max(gasUsedBeforeRefund - blockStateGasUsed, params.intrinsic.floorDataGas)
 
   # Refund for unused gas.
-  let txGasLeft = params.gasLimit - txGasUsed
+  let txGasLeft = tx.gasLimit - txGasUsed
   if txGasLeft > 0:
     let gasRefundAmount = txGasLeft.u256 * params.gasPrice.u256
     if vmState.balTrackerEnabled:
@@ -246,6 +253,7 @@ proc prepareDispatch(params: CallParams, c: Computation): EvmResultVoid =
   let
     vmState = c.vmState
     ledger = vmState.ledger
+    tx = params.tx
 
   if vmState.balTrackerEnabled:
     vmState.balTracker.trackAddressAccess(c.msg.contractAddress)
@@ -255,11 +263,11 @@ proc prepareDispatch(params: CallParams, c: Computation): EvmResultVoid =
       if params.isCreate:
         if ledger.originalAccountEmpty(c.msg.contractAddress):
           ? c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "prepareDispatch create new account")
-        CodeBytesRef.init(params.input)
+        CodeBytesRef.init(tx.payload)
       else:
-        if params.value.isZero.not and not ledger.isAccountAlive(c.msg.contractAddress):
+        if tx.value.isZero.not and not ledger.isAccountAlive(c.msg.contractAddress):
           ? c.gasMeter.chargeStateGas(CREATE_ACCOUNT_STATE_GAS, "prepareDispatch call new account")
-        assign(c.msg.data, params.input)
+        assign(c.msg.data, tx.payload)
         getRecipientCode(vmState, c.msg)
 
   if MsgFlags.Delegated in c.msg.flags:

--- a/execution_chain/transaction/call_evm.nim
+++ b/execution_chain/transaction/call_evm.nim
@@ -10,7 +10,6 @@
 
 import
   eth/common/eth_types_rlp,
-  stew/assign2,
   ../evm/[types, state],
   ../transaction,
   ./call_common,
@@ -20,30 +19,22 @@ import
 export
   call_common
 
-proc callParamsForTx(tx: Transaction, sender: Address,
-                     vmState: BaseVMState, baseFee: GasInt,
-                     intrinsic: IntrinsicGas): CallParams =
+proc callParams*(tx: Transaction,
+                 sender: Address,
+                 vmState: BaseVMState,
+                 intrinsic: IntrinsicGas): CallParams =
   # Is there a nice idiom for this kind of thing? Should I
   # just be writing this as a bunch of assignment statements?
-  result = CallParams(
-    vmState:      vmState,
-    gasPrice:     tx.effectiveGasPrice(baseFee),
-    gasLimit:     tx.gasLimit,
-    sender:       sender,
-    to:           tx.destination,
-    isCreate:     tx.contractCreation,
-    value:        tx.value,
-    input:        tx.payload,
-    intrinsic:    intrinsic
+  let
+    baseFee = vmState.blockCtx.baseFeePerGas
+  CallParams(
+    vmState:   vmState,
+    gasPrice:  tx.effectiveGasPrice(baseFee),
+    sender:    sender,
+    isCreate:  tx.contractCreation,
+    tx:        tx.addr,
+    intrinsic: intrinsic
   )
-  if tx.txType > TxLegacy:
-    assign(result.accessList, tx.accessList)
-
-  if tx.txType == TxEip4844:
-    assign(result.versionedHashes, tx.versionedHashes)
-
-  if tx.txType == TxEip7702:
-    assign(result.authorizationList, tx.authorizationList)
 
 proc txCallEvm*(tx: Transaction,
                 sender: Address,
@@ -51,8 +42,7 @@ proc txCallEvm*(tx: Transaction,
                 intrinsic: IntrinsicGas,
                 discardResult: static bool = false): auto =
   let
-    baseFee = vmState.blockCtx.baseFeePerGas
-    call = callParamsForTx(tx, sender, vmState, baseFee, intrinsic)
+    call = callParams(tx, sender, vmState, intrinsic)
   when discardResult:
     discard runComputation(call, VoidResult)
   else:
@@ -62,6 +52,5 @@ proc testCallEvm*(tx: Transaction,
                   sender: Address,
                   vmState: BaseVMState): DebugCallResult =
   let
-    baseFee = vmState.blockCtx.baseFeePerGas
-    call = callParamsForTx(tx, sender, vmState, baseFee, IntrinsicGas())
+    call = callParams(tx, sender, vmState, IntrinsicGas())
   runComputation(call, DebugCallResult)

--- a/execution_chain/transaction/call_evm_rpc.nim
+++ b/execution_chain/transaction/call_evm_rpc.nim
@@ -17,6 +17,7 @@ import
   ../evm/evm_errors,
   ../rpc/params,
   ./call_common,
+  ./call_evm,
   web3/eth_api_types,
   ../common/common
 
@@ -47,7 +48,10 @@ proc rpcCallEvm*(
   defer:
     vmState.dispose()
 
-  let params = ?toCallParams(vmState, args, globalGasCap, header)
+  let
+    tx = ? toTransaction(vmState, args, globalGasCap)
+    intrinsic = tx.intrinsicGas(vmState.hardFork, header.gasLimit, args.sender)
+    params = tx.callParams(args.sender, vmState, intrinsic)
 
   ok(runComputation(params, CallResult))
 
@@ -56,18 +60,21 @@ proc rpcCallEvm*(
 ): EvmResult[CallResult] =
   # TODO: globalGasCap should configurable by user
   let
-    params = ?toCallParams(vmState, args, globalGasCap, header)
+    tx = ? toTransaction(vmState, args, globalGasCap)
+    intrinsic = tx.intrinsicGas(vmState.hardFork, header.gasLimit, args.sender)
+    params = tx.callParams(args.sender, vmState, intrinsic)
   ok(runComputation(params, CallResult))
 
 proc rpcEstimateGas*(
     args: TransactionArgs, header: Header, vmState: BaseVMState, gasCap: GasInt
 ): Result[GasInt, (EvmErrorObj, OutputResult)] =
   # Binary search the gas requirement, as it may be higher than the amount used
-  let fork = vmState.fork
-  var params = toCallParams(vmState, args, gasCap, header).valueOr:
-    return err((evmErr(EvmInvalidParam), OutputResult()))
-
   let
+    fork = vmState.fork
+    tx = toTransaction(vmState, args, gasCap).valueOr:
+      return err((evmErr(EvmInvalidParam), OutputResult()))
+    intrinsic = tx.intrinsicGas(vmState.hardFork, header.gasLimit, args.sender)
+    params = tx.callParams(args.sender, vmState, intrinsic)
     txBaseCost = if fork >= FkAmsterdam: TX_BASE_COST_2780.GasInt
                  else: TX_BASE_COST.GasInt
 
@@ -118,7 +125,6 @@ proc rpcEstimateGas*(
     hi = gasCap
 
   let
-    intrinsic = intrinsicGas(params, vmState.hardFork, vmState.blockCtx.gasLimit, args.sender)
     minGasLimit = max(intrinsic.execution, intrinsic.floorDataGas)
 
   # Create a helper to check if a gas allowance results in an executable transaction
@@ -127,7 +133,7 @@ proc rpcEstimateGas*(
       # Special case, raise gas limit
       return err(OutputResult())
 
-    params.gasLimit = gasLimit
+    params.tx.gasLimit = gasLimit
     # TODO: bail out on consensus error similar to validateTransaction
     # Each trial must run against pristine state; a successful run (e.g. a
     # CREATE2 deploy) otherwise commits into the shared ledger and leaks into
@@ -142,8 +148,8 @@ proc rpcEstimateGas*(
       ok(res)
 
   # Short circuit estimation check: plain value transfer (no data, to has no code)
-  if not params.isCreate and params.input.len == 0 and
-      vmState.readOnlyLedger.getCodeSize(params.to) == 0:
+  if not params.isCreate and tx.payload.len == 0 and
+      vmState.readOnlyLedger.getCodeSize(tx.destination) == 0:
     if executable(txBaseCost).isOk:
       return ok(txBaseCost)
 

--- a/execution_chain/transaction/call_evm_rpc.nim
+++ b/execution_chain/transaction/call_evm_rpc.nim
@@ -49,7 +49,7 @@ proc rpcCallEvm*(
     vmState.dispose()
 
   let
-    tx = ? toTransaction(vmState, args, globalGasCap)
+    tx = ? toTransaction(vmState, args, globalGasCap, header)
     intrinsic = tx.intrinsicGas(vmState.hardFork, header.gasLimit, args.sender)
     params = tx.callParams(args.sender, vmState, intrinsic)
 
@@ -60,7 +60,7 @@ proc rpcCallEvm*(
 ): EvmResult[CallResult] =
   # TODO: globalGasCap should configurable by user
   let
-    tx = ? toTransaction(vmState, args, globalGasCap)
+    tx = ? toTransaction(vmState, args, globalGasCap, header)
     intrinsic = tx.intrinsicGas(vmState.hardFork, header.gasLimit, args.sender)
     params = tx.callParams(args.sender, vmState, intrinsic)
   ok(runComputation(params, CallResult))
@@ -71,7 +71,7 @@ proc rpcEstimateGas*(
   # Binary search the gas requirement, as it may be higher than the amount used
   let
     fork = vmState.fork
-    tx = toTransaction(vmState, args, gasCap).valueOr:
+    tx = toTransaction(vmState, args, gasCap, header).valueOr:
       return err((evmErr(EvmInvalidParam), OutputResult()))
     intrinsic = tx.intrinsicGas(vmState.hardFork, header.gasLimit, args.sender)
     params = tx.callParams(args.sender, vmState, intrinsic)

--- a/execution_chain/transaction/call_types.nim
+++ b/execution_chain/transaction/call_types.nim
@@ -25,29 +25,23 @@ export types
 type
   # Standard call parameters.
   CallParams* = object
-    vmState*:      BaseVMState          # Chain, database, state, block, fork.
-    gasPrice*:     GasInt               # Gas price for this call.
-    gasLimit*:     GasInt               # Maximum gas available for this call.
-    sender*:       addresses.Address    # Sender account.
-    to*:           addresses.Address    # Recipient (ignored when `isCreate`).
-    isCreate*:     bool                 # True if this is a contract creation.
-    value*:        UInt256              # Value sent from sender to recipient.
-    input*:        seq[byte]            # Input data.
-    accessList*:   AccessList           # EIP-2930 (Berlin) tx access list.
-    versionedHashes*: seq[VersionedHash]   # EIP-4844 (Cancun) blob versioned hashes
-    authorizationList*: seq[Authorization] # EIP-7702 (Prague) authorization list
-    intrinsic*:    IntrinsicGas
+    vmState*:   BaseVMState             # Chain, database, state, block, fork.
+    gasPrice*:  GasInt                  # Gas price for this tx.
+    sender*:    addresses.Address       # Sender account.
+    isCreate*:  bool                    # True if this is a contract creation.
+    tx*:        ptr Transaction
+    intrinsic*: IntrinsicGas
 
   # Standard call result.
   CallResult* = object of RootObj
     error*:           string            # Something if the call failed.
-    gasUsed*:         GasInt            # Gas used by the call.
+    gasUsed*:         GasInt            # Gas used by the tx.
     contractAddress*: addresses.Address # Created account (when `isCreate`).
     output*:          seq[byte]         # Output data.
 
   DebugCallResult* = object of CallResult
-    stack*:           seq[UInt256]      # EVM stack on return (for test only).
-    memory*:          EvmMemory         # EVM memory on return (for test only).
+    stack*:      seq[UInt256]           # EVM stack on return (for test only).
+    memory*:     EvmMemory              # EVM memory on return (for test only).
     logEntries*: seq[Log]
 
   LogResult* = object
@@ -67,17 +61,8 @@ type
     execution*: GasInt
     floorDataGas*: GasInt
 
-template isCreate(tx: Transaction): bool =
-  tx.contractCreation
-
-template input(tx: Transaction): auto =
-  tx.payload
-
 func isError*(cr: CallResult): bool =
   cr.error.len > 0
-
-func selfTransfer(call: CallParams, sender: Address): bool =
-  call.to == sender
 
 func selfTransfer(tx: Transaction, sender: Address): bool =
   tx.to.isSome and tx.to.value == sender
@@ -87,7 +72,7 @@ const
   TOTAL_COST_FLOOR_PER_TOKEN_EIP7976 = 16
   TX_VALUE_COST = 6000
 
-func intrinsicGas*(call: CallParams | Transaction, hardFork: HardFork, gasLimit: GasInt, sender: Address): IntrinsicGas =
+func intrinsicGas*(tx: Transaction, hardFork: HardFork, gasLimit: GasInt, sender: Address): IntrinsicGas =
   # Compute the baseline gas cost for this transaction.  This is the amount
   # of gas needed to send this transaction (but that is not actually used
   # for computation).
@@ -103,17 +88,17 @@ func intrinsicGas*(call: CallParams | Transaction, hardFork: HardFork, gasLimit:
     recipientExecutionGas = 0
 
   # EIP-2 (Homestead) extra intrinsic gas for contract creations.
-  if call.isCreate:
+  if tx.contractCreation:
     if hardFork >= Amsterdam:
       recipientExecutionGas += gasFees[fork][GasTXCreate]
     else:
       executionGas += gasFees[fork][GasTXCreate]
     if hardFork >= Shanghai:
-      executionGas += (gasFees[fork][GasInitcodeWord] * call.input.len.wordCount)
-  elif not call.selfTransfer(sender):
+      executionGas += (gasFees[fork][GasInitcodeWord] * tx.payload.len.wordCount)
+  elif not tx.selfTransfer(sender):
     if hardFork >= Amsterdam:
       recipientExecutionGas += COLD_ACCOUNT_ACCESS_8038
-      if call.value.isZero.not:
+      if tx.value.isZero.not:
         recipientExecutionGas += TX_VALUE_COST
 
   # Input data cost, reduced in EIP-2028 (Istanbul).
@@ -122,7 +107,7 @@ func intrinsicGas*(call: CallParams | Transaction, hardFork: HardFork, gasLimit:
     gasNonZero = gasFees[fork][GasTXDataNonZero]
     byteZeroToken = if hardFork >= Amsterdam: 4 else: 1
 
-  for b in call.input:
+  for b in tx.payload:
     if b == 0:
       executionGas += gasZero
       tokens += byteZeroToken
@@ -133,13 +118,13 @@ func intrinsicGas*(call: CallParams | Transaction, hardFork: HardFork, gasLimit:
   # EIP-2930 (Berlin) intrinsic gas for transaction access list.
   if hardFork >= Berlin:
     if hardFork >= Amsterdam:
-      for account in call.accessList:
+      for account in tx.accessList:
         executionGas += ACCESS_LIST_ADDRESS_COST_8038
         executionGas += account.storageKeys.len * ACCESS_LIST_STORAGE_KEY_COST_8038
         # Total byte count of addresses(20 bytes each) and storage keys (32 bytes each) in the access list.
         accessListBytes += 20 + account.storageKeys.len * 32
     else:
-      for account in call.accessList:
+      for account in tx.accessList:
         executionGas += ACCESS_LIST_ADDRESS_COST_2930
         executionGas += account.storageKeys.len * ACCESS_LIST_STORAGE_KEY_COST_2930
         # Total byte count of addresses(20 bytes each) and storage keys (32 bytes each) in the access list.
@@ -149,14 +134,14 @@ func intrinsicGas*(call: CallParams | Transaction, hardFork: HardFork, gasLimit:
     if hardFork >= Amsterdam:
       executionGas += recipientExecutionGas
       floorDataGas += recipientExecutionGas
-      executionGas += EXECUTION_PER_AUTH_BASE_COST * call.authorizationList.len
+      executionGas += EXECUTION_PER_AUTH_BASE_COST * tx.authorizationList.len
       # EIP-7981: Increase Access List Cost
       let floorTokensInAccessList = accessListBytes * 4
       tokens += floorTokensInAccessList
       executionGas += TOTAL_COST_FLOOR_PER_TOKEN_EIP7976 * floorTokensInAccessList
       floorDataGas += tokens * TOTAL_COST_FLOOR_PER_TOKEN_EIP7976
     else:
-      executionGas += call.authorizationList.len * PER_EMPTY_ACCOUNT_COST
+      executionGas += tx.authorizationList.len * PER_EMPTY_ACCOUNT_COST
       floorDataGas += tokens * TOTAL_COST_FLOOR_PER_TOKEN_EIP7623
 
   IntrinsicGas(

--- a/execution_chain/transaction/eoa_delegation.nim
+++ b/execution_chain/transaction/eoa_delegation.nim
@@ -52,16 +52,17 @@ proc validateAuthorization(auth: Authorization, vmState: BaseVMState): Opt[addre
 
   Opt.some(authority)
 
-proc setDelegation*(call: CallParams): int64 =
+proc setDelegation*(params: CallParams): int64 =
   var
     executionRefund = 0'i64
 
   let
-    vmState = call.vmState
+    vmState = params.vmState
     ledger = vmState.ledger
+    tx = params.tx
 
   # EIP-7702
-  for auth in call.authorizationList:
+  for auth in tx.authorizationList:
     let authority = auth.validateAuthorization(vmState).valueOr:
       continue
 
@@ -83,22 +84,23 @@ proc setDelegation*(call: CallParams): int64 =
 
   executionRefund
 
-proc setDelegation*(call: CallParams, c: Computation): EvmResultVoid =
+proc setDelegation*(params: CallParams, c: Computation): EvmResultVoid =
   var
     writtenAccounts: HashSet[addresses.Address]
     delegationSetFor: HashSet[addresses.Address]
 
-  writtenAccounts.incl call.sender
-
-  if call.value.isZero.not:
-    writtenAccounts.incl call.to
+  writtenAccounts.incl params.sender
 
   let
-    vmState = call.vmState
+    vmState = params.vmState
     ledger = vmState.ledger
+    tx = params.tx
+
+  if tx.value.isZero.not:
+    writtenAccounts.incl tx[].destination
 
   # Authorities a delegation was set for earlier in this transaction.
-  for auth in call.authorizationList:
+  for auth in tx.authorizationList:
     let authority = auth.validateAuthorization(vmState).valueOr:
       continue
 

--- a/tools/evmstate/helpers.nim
+++ b/tools/evmstate/helpers.nim
@@ -53,7 +53,7 @@ func txType(n: Txo): TxType =
     return TxEip7702
   if n.blobVersionedHashes.isSome:
     return TxEip4844
-  if n.gasPrice.isNone:
+  if n.maxPriorityFeePerGas.isSome or n.maxFeePerGas.isSome:
     return TxEip1559
   if n.accessLists.isSome:
     return TxEip2930


### PR DESCRIPTION
Upcoming EIP-8141 Frame Transaction requires almost all Transaction fields are inspectable by EVM. With current approach it means fields are copied twice. Once to CallParams, and once to TxContext. With this PR, only the pointer of the transaction is copied around without the need to copy the fields. This new approach also eliminating future changes to CallParams and TxContext if the Transaction gets additional fields.

Tradeoff made here is less copies and allocations but more indirections.