### PR TITLE
Speed up jumpdest computation

### DIFF
--- a/execution_chain/evm/code_bytes.nim
+++ b/execution_chain/evm/code_bytes.nim
@@ -57,6 +57,48 @@ template invalidPosition(c: CodeBytesRef, pos: int): bool =
   let (bpos, bbit) = bitpos(pos)
   (c.invalidPositions[bpos] and bbit) > 0
 
+func isPushOpcode(b: byte): bool =
+  ## PUSH1..PUSH32 (0x60..0x7f) are exactly the bytes whose top three bits
+  ## are `0b011`.
+  (b and 0xe0'u8) == 0x60'u8
+
+func hasPushOpcode(word: uint64): bool =
+  ## Whether any of the eight bytes packed into `word` is a PUSH opcode.
+  ##
+  ## Applying the `isPushOpcode` mask-and-compare to all eight bytes at once
+  ## leaves a zero byte wherever a PUSH was, turning the question into "is any
+  ## byte zero". That is the usual SWAR test: `(v - 1) and not v` keeps the
+  ## high bit of a byte only when that byte was zero. Masking first leaves
+  ## every byte a multiple of 0x20, so only a zero byte can borrow into its
+  ## neighbour and the test yields no false positives.
+  const
+    topThreeBits = 0xe0e0e0e0e0e0e0e0'u64
+    pushBits = 0x6060606060606060'u64
+    lowBitOfEach = 0x0101010101010101'u64
+    highBitOfEach = 0x8080808080808080'u64
+  let v = (word and topThreeBits) xor pushBits
+  ((v - lowBitOfEach) and not v and highBitOfEach) != 0
+
+func skipToNextPush(bytes: openArray[byte], start: int): int =
+  ## Index of the first PUSH opcode at or after `start`, or `bytes.len` if
+  ## there is none.
+  ##
+  ## The scan below only has work to do at a PUSH: every other opcode is one
+  ## byte wide and marks nothing. So a run of non-PUSH bytes can be stepped
+  ## over eight at a time instead of one per loop iteration, which is what
+  ## makes large contracts padded with plain opcodes cheap to scan.
+  var i = start
+  while i + 8 <= bytes.len:
+    var word: uint64
+    copyMem(addr word, unsafeAddr bytes[i], 8)
+    if hasPushOpcode(word):
+      break # a PUSH lies in these eight bytes; the byte loop finds which
+    i += 8
+
+  while i < bytes.len and not isPushOpcode(bytes[i]):
+    i += 1
+  i
+
 func isValidOpcode*(c: CodeBytesRef, position: int): bool =
   if position >= len(c):
     return false
@@ -80,7 +122,9 @@ func isValidOpcode*(c: CodeBytesRef, position: int): bool =
           c.invalidPositions[bpos] = c.invalidPositions[bpos] or bbit
         i = rightBound
       else:
-        i += 1
+        # Nothing to mark for this byte, nor for any byte before the next
+        # PUSH, so step over the whole run in one go
+        i = skipToNextPush(c.bytes, i + 1)
     c.processed = i - 1
 
     not c.invalidPosition(position)


### PR DESCRIPTION
Speeds up the jump dest computation by skipping bytes having no push opcode one word at a time.

