### PR TITLE
Keep the discport query when parsing bootstrap enodes

### DIFF
--- a/execution_chain/networking/bootnodes.nim
+++ b/execution_chain/networking/bootnodes.nim
@@ -35,8 +35,8 @@ func removeCommentAndSpaces(line: string, start = 0): string =
     if c.int > alphabet.decode.high:
       pos = i
       break
-    if c in {':', '/', '@', '.'}:
-      # URI chars
+    if c in {':', '/', '@', '.', '?', '='}:
+      # URI chars, including the `?discport=` query of a discovery-only enode
       continue
     if alphabet.decode[c.int] == -1:
       pos = i

--- a/tests/networking/test_bootnodes.nim
+++ b/tests/networking/test_bootnodes.nim
@@ -37,8 +37,8 @@ suite "Bootnodes":
 
   test "one malformed entry does not drop the rest of the list":
     let bn = [
-      # discovery-only, TCP port 0 -> "enode: incorrect TCP port"
-      "enode://a9ab68c77cb408e200cd1249202ee8f8d32a948fbdcc8c7b55e0afd7e7238b55e4d0b521f26f8020866e8af4b631825b599e6c5726d3b7573f20da488e0dd596@159.223.116.60:0?discport=9010",
+      # TCP port 0 without a discport -> "enode: incorrect TCP port"
+      "enode://a9ab68c77cb408e200cd1249202ee8f8d32a948fbdcc8c7b55e0afd7e7238b55e4d0b521f26f8020866e8af4b631825b599e6c5726d3b7573f20da488e0dd596@159.223.116.60:0",
       "enode://2c82017536b1b74b62aa2a81769f4a1213ac9edd3a1df43af5fd008f3305e92bfd9351db9881c9c09de2afc79d3f7f6c271cf2f7231f9021926c0674dc02035c@159.223.116.60:30303?discport=30303",
       "enode://c34353f4d5fcc777863c511a09b3b57f1a9df066578b3432fa1e58d8b0a5d35ca0456b9cd1c38bc9cf30ac9bfecf8b13f0712aae1f1ae5537df8794b622f8ad1@157.230.233.160:30303?discport=30303",
       "enode://fec6d370e61500d2b314a064fd371dbddde6ddcc5b864218dc8af597817e0c09d39dfb3ca29a109266ec9a5e77258f7820685f3a920b550aeedd4783786ee3a1@147.182.209.19:30303?discport=30303",
@@ -60,3 +60,10 @@ suite "Bootnodes":
     var boot: BootstrapNodes
     check parseBootstrapNodes(bn, boot).isOk
     check boot.enodes.len == 2
+
+  test "discovery-only enode keeps its discport and trailing comment":
+    var boot: BootstrapNodes
+    check parseBootstrapNodes(["enode://a9ab68c77cb408e200cd1249202ee8f8d32a948fbdcc8c7b55e0afd7e7238b55e4d0b521f26f8020866e8af4b631825b599e6c5726d3b7573f20da488e0dd596@159.223.116.60:0?discport=9010 # nodeops-bootnode"], boot).isOk
+    check boot.enodes.len == 1
+    check boot.enodes[0].address.tcpPort == Port(0)
+    check boot.enodes[0].address.udpPort == Port(9010)


### PR DESCRIPTION
I am on the Ethereum Foundation's Node Infrastructure team (NodeOps). We run the bootnodes
that ship in this repository as the "EF" entries for mainnet, Sepolia and Hoodi. We are
replacing that fleet, and we would like the new records in a release before the Glamsterdam
client releases.

### What changes

- Add five new EF bootnodes per network. Every node serves all three networks.
- Remove the legacy EF entries. The new set is a replacement, not an addition.
- Third-party bootnodes and DNS discovery roots are untouched.

### The new fleet

Five bootnodes, each serving mainnet, Sepolia and Hoodi. They are geographically distributed,
multi-cloud, and dual stack (IPv4 + IPv6). Each node runs discv4 and discv5 on the EL port and
discv5 on the CL port, and the fleet spreads across several discovery implementations so one
implementation bug cannot take the whole set down.

### About the records

- The ENRs are generic bootnode records: no `eth2` field, no `tcp`, sequence number 1. Clients
  dial configured bootnodes regardless of fork, and a static list cannot be re-signed every
  fork, so we do not include fork data on purpose.
- Where an EL list accepts ENRs, we list the ENR. It covers discv4 and discv5 and carries the
  IPv6 endpoint. Enodes appear only where a list needs them, in the discovery-only form
  `enode://<pubkey>@<ip>:0?discport=<port>` (no RLPx listener).
- The records are derived from the node keys and are byte-identical across all the client
  PRs. The canonical copies are the eth-clients PRs (`metadata/bootstrap_nodes.yaml` and
  `metadata/enodes.yaml` for mainnet, sepolia and hoodi).

### Verification

- Each node answers discv4 and discv5 pings from the public internet on the advertised ports.
- The relevant tests in this repository pass with the new lists (details below).
- The legacy nodes stay online until client releases with the new records are widely deployed.
  We will announce the shutdown separately.

### Contact

Chase Wright, EF Node Infrastructure. Discord `MysticRyuujin` (ETH R&D and STEEL servers), or
chase.wright@ethereum.org.

### This repository

**Files:** `execution_chain/networking/bootnodes.nim`, `tests/networking/test_bootnodes.nim`.

**Semantics:** this PR carries no records. The compile-time bootnode loader strips trailing
comments by walking the line until a character outside the base64url alphabet and `:/@.`, so a
discovery-only enode `enode://<pub>@<ip>:0?discport=<port>` was cut at `?` and then rejected
(nim-eth accepts TCP port 0 with a discport since #864). The stripper now also keeps `?` and
`=`. The test that used such an enode as its malformed example now uses a bare `:0`, and a new
test checks that the discport survives with a trailing comment. The new eth-clients bootnodes
use this form, so this fix should land before the vendored metadata is bumped.

**Tests:** `tests/networking/test_bootnodes.nim` (4 tests) with the project toolchain.
