### PR TITLE
Add block proof for Gloas and later

### DIFF
--- a/execution_chain/history/block_proofs/block_proof_common.nim
+++ b/execution_chain/history/block_proofs/block_proof_common.nim
@@ -13,24 +13,54 @@ from beacon_chain/spec/datatypes/capella import ExecutionPayload
 from beacon_chain/spec/datatypes/deneb import ExecutionPayload
 
 const
-  # TODO:
-  # This proof only works up until Fulu fork.
-  # For gloas+ the execution payload is no longer part of the BeaconBlockBody and thus
-  # an additional proof type is required.
+  # Bellatrix up to and including Fulu hold the execution payload in the
+  # BeaconBlockBody, so the block hash is proven straight from the payload.
   EXECUTION_BLOCK_HASH_GINDEX* = get_generalized_index(
     capella.BeaconBlock, "body", "execution_payload", "block_hash"
   )
   EXECUTION_BLOCK_HASH_GINDEX_DENEB* =
     get_generalized_index(deneb.BeaconBlock, "body", "execution_payload", "block_hash")
 
+  # Gloas (ePBS) moved the execution payload out of the BeaconBlockBody and into
+  # a separate ExecutionPayloadEnvelope revealed by the builder. All that is
+  # left in the block is the `SignedExecutionPayloadBid`, and its `block_hash`
+  # is merely a commitment to a payload that may never be revealed: it becomes
+  # canonical only once a later block confirms it.
+  #
+  # That confirmation is the `parent_block_hash` of the bid in such a later
+  # block: it is asserted to be equal to `state.latest_block_hash`, which only
+  # ever takes the block hash of a payload that was actually revealed and
+  # processed. Proving it therefore proves that the execution block was
+  # confirmed, which proving `block_hash` does not.
+  # https://github.com/ethereum/consensus-specs/blob/v1.7.0-beta.0/specs/gloas/beacon-chain.md#execution-payload-bid
+  #
+  # This is also what the light client protocol does, see
+  # https://github.com/ethereum/consensus-specs/blob/v1.7.0-beta.0/specs/gloas/light-client/full-node.md#modified-block_to_light_client_header
+  #
+  # As a consequence, from Gloas onwards a proof for an execution block is built
+  # from the beacon block that *follows* the one its payload was committed in.
+  EXECUTION_PARENT_BLOCK_HASH_GINDEX_GLOAS* = get_generalized_index(
+    gloas.BeaconBlock, "body", "signed_execution_payload_bid", "message",
+    "parent_block_hash",
+  )
+
 static:
   doAssert EXECUTION_BLOCK_HASH_GINDEX == 3228.GeneralizedIndex
   doAssert EXECUTION_BLOCK_HASH_GINDEX_DENEB == 6444.GeneralizedIndex
+  doAssert EXECUTION_PARENT_BLOCK_HASH_GINDEX_GLOAS == 25384.GeneralizedIndex
+  # Heze blocks are proven with the Gloas gindex, so its layout must not differ
+  doAssert EXECUTION_PARENT_BLOCK_HASH_GINDEX_GLOAS ==
+    get_generalized_index(
+      heze.BeaconBlock, "body", "signed_execution_payload_bid", "message",
+      "parent_block_hash",
+    )
 
 type
   ExecutionBlockProof* = array[log2trunc(EXECUTION_BLOCK_HASH_GINDEX), Digest]
   ExecutionBlockProofDeneb* =
     array[log2trunc(EXECUTION_BLOCK_HASH_GINDEX_DENEB), Digest]
+  ExecutionBlockProofGloas* =
+    array[log2trunc(EXECUTION_PARENT_BLOCK_HASH_GINDEX_GLOAS), Digest]
 
 func getBlockRootsIndex*(slot: Slot): uint64 =
   slot mod SLOTS_PER_HISTORICAL_ROOT
@@ -60,6 +90,19 @@ func buildProof*(
 
   ok(proof)
 
+# Builds proof to be able to verify that the EL block hash confirmed by this
+# CL BeaconBlock, i.e. the block hash of its parent execution block, is part of
+# the BeaconBlock for given root.
+func buildProof*(
+    beaconBlock:
+      gloas.TrustedBeaconBlock | gloas.BeaconBlock | heze.TrustedBeaconBlock |
+      heze.BeaconBlock
+): Result[ExecutionBlockProofGloas, string] =
+  var proof: ExecutionBlockProofGloas
+  ?beaconBlock.build_proof(EXECUTION_PARENT_BLOCK_HASH_GINDEX_GLOAS, proof)
+
+  ok(proof)
+
 func verifyProof*(
     blockHash: Digest, proof: ExecutionBlockProof, blockRoot: Digest
 ): bool =
@@ -72,4 +115,11 @@ func verifyProof*(
 ): bool =
   verify_merkle_multiproof(
     @[blockHash], proof, @[EXECUTION_BLOCK_HASH_GINDEX_DENEB], blockRoot
+  )
+
+func verifyProof*(
+    blockHash: Digest, proof: ExecutionBlockProofGloas, blockRoot: Digest
+): bool =
+  verify_merkle_multiproof(
+    @[blockHash], proof, @[EXECUTION_PARENT_BLOCK_HASH_GINDEX_GLOAS], blockRoot
   )

--- a/execution_chain/history/block_proofs/block_proof_historical_summaries.nim
+++ b/execution_chain/history/block_proofs/block_proof_historical_summaries.nim
@@ -17,6 +17,9 @@
 # ExecutionPayload in the BeaconBlock to proving that this BeaconBlock is rooted
 # in the historical_summaries.
 #
+# From Gloas onwards the chain starts at the parent block hash in the payload
+# bid instead, see `block_proof_common.nim`.
+#
 # The historical_summaries accumulator is updated for every period since Capella.
 # It can thus be used for block proofs for blocks after the Capella fork.
 #
@@ -70,6 +73,15 @@ type
     beaconBlockProof*: BeaconBlockProofHistoricalSummaries
     beaconBlockRoot*: Digest
     executionBlockProof*: ExecutionBlockProofDeneb
+    slot*: Slot
+
+  BlockProofHistoricalSummariesGloas* = object
+    # Note: `slot` and `beaconBlockRoot` are those of the BeaconBlock that
+    # confirms the execution block, not of the one it was committed in.
+    # Total size (13 + 1 + 14) * 32 bytes + 8 bytes = 904 bytes
+    beaconBlockProof*: BeaconBlockProofHistoricalSummaries
+    beaconBlockRoot*: Digest
+    executionBlockProof*: ExecutionBlockProofGloas
     slot*: Slot
 
   HistoricalSummaries* = HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT]
@@ -143,6 +155,26 @@ func buildProof*(
     )
   )
 
+func buildProof*(
+    blockRoots: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest],
+    beaconBlock:
+      gloas.TrustedBeaconBlock | gloas.BeaconBlock | heze.TrustedBeaconBlock |
+      heze.BeaconBlock,
+): Result[BlockProofHistoricalSummariesGloas, string] =
+  let
+    blockRootIndex = getBlockRootsIndex(beaconBlock)
+    executionBlockProof = ?beaconBlock.buildProof()
+    beaconBlockProof = ?blockRoots.buildProof(blockRootIndex)
+
+  ok(
+    BlockProofHistoricalSummariesGloas(
+      beaconBlockRoot: hash_tree_root(beaconBlock),
+      beaconBlockProof: beaconBlockProof,
+      executionBlockProof: executionBlockProof,
+      slot: beaconBlock.slot,
+    )
+  )
+
 func verifyProof*(
     blockHeaderRoot: Digest,
     proof: BeaconBlockProofHistoricalSummaries,
@@ -155,7 +187,9 @@ func verifyProof*(
 
 func verifyProof*(
     historical_summaries: HistoricalSummaries,
-    proof: BlockProofHistoricalSummaries | BlockProofHistoricalSummariesDeneb,
+    proof:
+      BlockProofHistoricalSummaries | BlockProofHistoricalSummariesDeneb |
+      BlockProofHistoricalSummariesGloas,
     blockHash: Digest,
     cfg: RuntimeConfig,
 ): bool =

--- a/execution_chain/history/e2store_formats/ere.nim
+++ b/execution_chain/history/e2store_formats/ere.nim
@@ -218,6 +218,7 @@ const
   ProofTypeHistoricalRoots* = 0x01'u64
   ProofTypeHistoricalSummaries* = 0x02'u64
   ProofTypeHistoricalSummariesDeneb* = 0x03'u64
+  ProofTypeHistoricalSummariesGloas* = 0x04'u64
 
 func init*(_: type Proof, proof: HistoricalHashesAccumulatorProof): Proof =
   Proof(proofType: ProofTypeHistoricalHashesAccumulator, proofData: SSZ.encode(proof))
@@ -230,6 +231,9 @@ func init*(_: type Proof, proof: BlockProofHistoricalSummaries): Proof =
 
 func init*(_: type Proof, proof: BlockProofHistoricalSummariesDeneb): Proof =
   Proof(proofType: ProofTypeHistoricalSummariesDeneb, proofData: SSZ.encode(proof))
+
+func init*(_: type Proof, proof: BlockProofHistoricalSummariesGloas): Proof =
+  Proof(proofType: ProofTypeHistoricalSummariesGloas, proofData: SSZ.encode(proof))
 
 proc init*(
     T: type EreGroup,
@@ -655,6 +659,13 @@ proc verifyProof(
       decodedProof, Digest(data: header.computeRlpHash().data), cfg
     ):
       return err("Invalid BlockProofHistoricalSummariesDeneb: verification failed")
+  elif proof.proofType == ProofTypeHistoricalSummariesGloas:
+    let decodedProof = decodeSsz(proof.proofData, BlockProofHistoricalSummariesGloas).valueOr:
+      return err("Invalid BlockProofHistoricalSummariesGloas: $error")
+    if not v.historicalSummaries.verifyProof(
+      decodedProof, Digest(data: header.computeRlpHash().data), cfg
+    ):
+      return err("Invalid BlockProofHistoricalSummariesGloas: verification failed")
   else:
     return err("Invalid proof type")
 

--- a/portal/tools/eth_data_exporter/cl_data_exporter.nim
+++ b/portal/tools/eth_data_exporter/cl_data_exporter.nim
@@ -487,7 +487,10 @@ proc exportBlockProof*(
     cfg = networkData.metadata.cfg
     slot = Slot(slotNumber)
 
-  if slot.epoch() >= cfg.DENEB_FORK_EPOCH:
+  if slot.epoch() >= cfg.GLOAS_FORK_EPOCH:
+    error "Block proofs for Gloas and later are not supported by this tool", slotNumber
+    quit QuitFailure
+  elif slot.epoch() >= cfg.DENEB_FORK_EPOCH:
     let (proof, blockNumber, blockHash) =
       getBlockProofDeneb(dataDir, eraDir, slotNumber, network)
 

--- a/tests/blockproofs/all_blockproofs_tests.nim
+++ b/tests/blockproofs/all_blockproofs_tests.nim
@@ -14,4 +14,5 @@ import
   ./test_block_proof_historical_roots_vectors,
   ./test_block_proof_historical_summaries,
   ./test_block_proof_historical_summaries_deneb,
+  ./test_block_proof_historical_summaries_gloas,
   ./test_block_proof_historical_summaries_vectors

--- a/tests/blockproofs/test_block_proof_historical_summaries_gloas.nim
+++ b/tests/blockproofs/test_block_proof_historical_summaries_gloas.nim
@@ -1,0 +1,146 @@
+# Nimbus
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+{.push raises: [].}
+
+import
+  unittest2,
+  beacon_chain/spec/forks,
+  ../../execution_chain/history/block_proofs/block_proof_historical_summaries
+
+# Test suite for the chain of proofs BlockProofHistoricalSummariesGloas:
+# -> BeaconBlockProofHistoricalSummaries
+# -> ExecutionBlockProofGloas
+#
+# From Gloas onwards the proof is built from the block that confirms the
+# payload rather than the one that commits to it, see `block_proof_common.nim`.
+#
+# Note: unlike the pre-Gloas suites these blocks are not produced by a state
+# transition, as only the shape of the block matters for the proofs. The
+# block_roots and the historical summary that anchors them are built here.
+
+suite "History Block Proofs - Historical Summaries - Gloas":
+  setup:
+    let
+      cfg = block:
+        var res = defaultRuntimeConfig
+        res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
+        res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
+        res.CAPELLA_FORK_EPOCH = GENESIS_EPOCH
+        res.DENEB_FORK_EPOCH = GENESIS_EPOCH
+        res.ELECTRA_FORK_EPOCH = GENESIS_EPOCH
+        res.FULU_FORK_EPOCH = GENESIS_EPOCH
+        res.GLOAS_FORK_EPOCH = GENESIS_EPOCH
+        res
+
+      # The execution block that is proven: confirmed by the block that builds
+      # on it, and thus the `parent_block_hash` of that block's bid.
+      confirmedBlockHash = Digest.fromHex(
+        "0x1111111111111111111111111111111111111111111111111111111111111111"
+      )
+      # The payload that same block commits to. It may never be revealed, so it
+      # must not be provable.
+      committedBlockHash = Digest.fromHex(
+        "0x2222222222222222222222222222222222222222222222222222222222222222"
+      )
+
+    const slotsToTest =
+      [1'u64, 2, 3, SLOTS_PER_HISTORICAL_ROOT div 2, SLOTS_PER_HISTORICAL_ROOT - 1]
+
+    proc confirmingBlock(slot: uint64): gloas.BeaconBlock =
+      ## Block that confirms `confirmedBlockHash` while committing to a payload
+      ## of its own.
+      var blck = default(gloas.BeaconBlock)
+      blck.slot = Slot(slot)
+      blck.body.signed_execution_payload_bid.message.parent_block_hash =
+        confirmedBlockHash
+      blck.body.signed_execution_payload_bid.message.block_hash = committedBlockHash
+      blck
+
+    proc historicalSummariesAt(
+        blockRoots: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest], era: int
+    ): HistoricalSummaries =
+      ## Summaries in which `blockRoots` is the summary of `era`, with
+      ## placeholders for the eras before it.
+      var summaries: HistoricalSummaries
+      for _ in 0 ..< era:
+        discard summaries.add(HistoricalSummary())
+      discard
+        summaries.add(HistoricalSummary(block_summary_root: hash_tree_root(blockRoots)))
+      summaries
+
+    proc historicalSummaries(
+        blockRoots: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+    ): HistoricalSummaries =
+      historicalSummariesAt(blockRoots, 0)
+
+  test "BlockProofHistoricalSummariesGloas for Execution BlockHeader":
+    for slot in slotsToTest:
+      let beaconBlock = confirmingBlock(slot)
+
+      var blockRoots: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+      blockRoots[slot] = hash_tree_root(beaconBlock)
+
+      let
+        summaries = historicalSummaries(blockRoots)
+        proof = buildProof(blockRoots, beaconBlock).expect("valid proof")
+
+      check:
+        proof.slot == Slot(slot)
+        proof.beaconBlockRoot == hash_tree_root(beaconBlock)
+        verifyProof(summaries, proof, confirmedBlockHash, cfg)
+
+  test "BlockProofHistoricalSummariesGloas - committed payload is not provable":
+    # A payload that a block commits to is not canonical until a later block
+    # confirms it, so the block hash in the bid must not verify.
+    let beaconBlock = confirmingBlock(1)
+
+    var blockRoots: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+    blockRoots[1] = hash_tree_root(beaconBlock)
+
+    let
+      summaries = historicalSummaries(blockRoots)
+      proof = buildProof(blockRoots, beaconBlock).expect("valid proof")
+
+    check:
+      not verifyProof(summaries, proof, committedBlockHash, cfg)
+      not verifyProof(summaries, proof, default(Digest), cfg)
+
+  test "BlockProofHistoricalSummariesGloas - confirming block in the next era":
+    # A payload committed to at the end of an era is confirmed by a block of the
+    # next era, so the proof anchors in the summary of that next era.
+    const confirmingSlot = uint64(SLOTS_PER_HISTORICAL_ROOT) # first slot of era 1
+    let beaconBlock = confirmingBlock(confirmingSlot)
+
+    var blockRoots: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+    blockRoots[0] = hash_tree_root(beaconBlock)
+
+    let
+      summaries = historicalSummariesAt(blockRoots, 1)
+      proof = buildProof(blockRoots, beaconBlock).expect("valid proof")
+
+    check:
+      proof.slot == Slot(confirmingSlot)
+      verifyProof(summaries, proof, confirmedBlockHash, cfg)
+      # Summaries that do not reach the era of the confirming block
+      not verifyProof(
+        historicalSummariesAt(blockRoots, 0), proof, confirmedBlockHash, cfg
+      )
+
+  test "BlockProofHistoricalSummariesGloas - block not in block_roots":
+    let beaconBlock = confirmingBlock(1)
+
+    var blockRoots: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+    blockRoots[2] = hash_tree_root(beaconBlock) # wrong slot
+
+    let
+      summaries = historicalSummaries(blockRoots)
+      proof = buildProof(blockRoots, beaconBlock).expect("valid proof")
+
+    check not verifyProof(summaries, proof, confirmedBlockHash, cfg)

--- a/tools/nimbus_history_exporter/beacon_proof_builder.nim
+++ b/tools/nimbus_history_exporter/beacon_proof_builder.nim
@@ -151,8 +151,61 @@ proc init*(
     )
   )
 
-proc buildProof*(b: BeaconProofBuilder, timestamp: uint64): Result[Proof, string] =
-  ## Build a post-merge block proof for the EL block with the given timestamp.
+proc gloasProof(
+    b: BeaconProofBuilder, slot: Slot, blockHash: Eth2Digest
+): Result[Proof, string] =
+  ## Build the proof for the execution block with `blockHash`, whose payload was
+  ## committed to at `slot`. It is built from the first beacon block after
+  ## `slot`, as that is the block that confirms the payload.
+  # Nothing bounds the number of consecutive empty slots, but a gap of a full
+  # era means the chain is not producing blocks at all, so rather than scanning
+  # on indefinitely, give up there.
+  for confirmingSlot in (slot + 1) .. (slot + SLOTS_PER_HISTORICAL_ROOT):
+    var bytes: seq[byte]
+    ?b.db.getBlockSSZ(b.historicalRoots, b.historicalSummaries, confirmingSlot, bytes)
+
+    if bytes.len() == 0: # Empty slot
+      continue
+
+    let blck =
+      try:
+        readSszForkedSignedBeaconBlock(b.cfg, bytes)
+      except SerializationError as exc:
+        return err(
+          "Cannot deserialize beacon block at slot " & $confirmingSlot & ": " & exc.msg
+        )
+
+    # The confirming block can be in the era after the one committing the payload
+    ?b.ensureStateLoaded(confirmingSlot.uint64 div SLOTS_PER_HISTORICAL_ROOT)
+
+    withBlck(blck):
+      when consensusFork >= ConsensusFork.Gloas:
+        let bid = forkyBlck.message.body.signed_execution_payload_bid.message
+        if bid.parent_block_hash != blockHash:
+          # The payload was never revealed, so it never became canonical
+          return err(
+            "Beacon block at slot " & $confirmingSlot &
+              " does not confirm execution block " & $blockHash
+          )
+
+        let proof = ?block_proof_historical_summaries.buildProof(
+          b.cachedState.block_roots.data, forkyBlck.message
+        )
+
+        return ok(Proof.init(proof))
+      else:
+        return err("Beacon block at slot " & $confirmingSlot & " is pre-Gloas")
+
+  err(
+    "No beacon block found after slot " & $slot &
+      ", the era files may not reach far enough yet"
+  )
+
+proc buildProof*(
+    b: BeaconProofBuilder, timestamp: uint64, blockHash: Eth2Digest
+): Result[Proof, string] =
+  ## Build a post-merge block proof for the EL block with the given timestamp
+  ## and block hash.
   ## Returns a Proof with the proof type set and SSZ-encoded proof data.
   let (afterGenesis, tsSlot) = b.clock.toSlot(times.fromUnix(timestamp.int64))
 
@@ -215,5 +268,4 @@ proc buildProof*(b: BeaconProofBuilder, timestamp: uint64): Result[Proof, string
   of ConsensusFork.Fulu:
     ok(summariesProof(fulu.TrustedSignedBeaconBlock))
   of ConsensusFork.Gloas, ConsensusFork.Heze:
-    # Gloas removed the execution payload from the BeaconBlockBody
-    err("Gloas fork and later not yet supported for proof building")
+    b.gloasProof(slot, blockHash)

--- a/tools/nimbus_history_exporter/ere_export.nim
+++ b/tools/nimbus_history_exporter/ere_export.nim
@@ -253,7 +253,12 @@ proc exportEreFile(
               "--era-dir required for post-merge proof building (block " & $blockNumber &
                 ")"
             )
-          ?group.update(e2, blockNumber, ?builder.buildProof(header.timestamp.uint64))
+          # The block hash is only needed from Gloas onwards, where the proof is
+          # built from the beacon block that confirms this execution block
+          let proof = ?builder.buildProof(
+            header.timestamp.uint64, Digest(data: header.computeRlpHash().data)
+          )
+          ?group.update(e2, blockNumber, proof)
 
     # Step 5: total difficulty, only in pre-merge and merge eras
     # https://github.com/eth-clients/e2store-format-specs/blob/ca2523a6420d64336000f5607c0b59df1a08c83b/formats/ere.md#merge-transition


### PR DESCRIPTION
The execution payload is no longer part of the BeaconBlockBody, so prove the parent_block_hash of the payload bid instead, which is built from the beacon block that follows the one committing the payload.

fixes https://github.com/status-im/nimbus-eth1/issues/4109
