### PR TITLE
Verify the genesis block of PoS only networks against the genesis data

### DIFF
--- a/execution_chain/history/e2store_formats/ere.nim
+++ b/execution_chain/history/e2store_formats/ere.nim
@@ -624,6 +624,8 @@ type HeaderVerifier* = object
   historicalHashes*: Opt[FinishedHistoricalHashesAccumulator]
   historicalRoots*: HistoricalRoots
   historicalSummaries*: HistoricalSummaries
+  # Only needed for PoS only networks
+  genesisBlockHash*: Opt[Hash32]
 
 proc verifyProof(
     proof: Proof, header: headers.Header, v: HeaderVerifier, cfg: RuntimeConfig
@@ -697,7 +699,17 @@ proc verify*(
       if header.receiptsRoot != calcReceiptsRoot(receipts):
         return err("Invalid receipts root: blocknumber " & $blockNumber)
 
-    if not f.blockIdx.noProofs:
+    if blockNumber == 0 and f.mergeBlockNumber == 0:
+      # The genesis block of a PoS only network predates the beacon chain: the
+      # beacon chain holds it only in its genesis state and never in a beacon
+      # block, so it cannot be proven like the other blocks. It is verified
+      # against the genesis block of the network instead.
+      let genesisBlockHash = v.genesisBlockHash.valueOr:
+        return err("No genesis block hash to verify the genesis block with")
+
+      if header.computeRlpHash() != genesisBlockHash:
+        return err("Invalid genesis block: does not match the network genesis block")
+    elif not f.blockIdx.noProofs:
       let proof = ?getProof(f, blockNumber)
       ?verifyProof(proof, header, v, cfg)
 

--- a/tools/nimbus_history_exporter/beacon_proof_builder.nim
+++ b/tools/nimbus_history_exporter/beacon_proof_builder.nim
@@ -209,7 +209,7 @@ proc buildProof*(
   ## Returns a Proof with the proof type set and SSZ-encoded proof data.
   let (afterGenesis, tsSlot) = b.clock.toSlot(times.fromUnix(timestamp.int64))
 
-  # On PoS-only networks (e.g. hoodi), GENESIS_DELAY > 0 means the EL
+  # On PoS only networks (e.g. hoodi), GENESIS_DELAY > 0 means the EL
   # genesis block's timestamp predates the CL genesis time. The genesis beacon
   # block at slot 0 holds the genesis EL payload, so we use slot 0.
   let slot =

--- a/tools/nimbus_history_exporter/era1_export.nim
+++ b/tools/nimbus_history_exporter/era1_export.nim
@@ -96,8 +96,7 @@ proc exportEra1*(config: HistoryExportConf) =
     networkName = config.network
 
   if mergeBlockNumber == 0:
-    fatal "exportEra1 is not supported for post-merge-only networks",
-      network = networkName
+    fatal "exportEra1 is not supported for PoS only networks", network = networkName
     quit(QuitFailure)
 
   let

--- a/tools/nimbus_history_exporter/ere_export.nim
+++ b/tools/nimbus_history_exporter/ere_export.nim
@@ -19,7 +19,7 @@ import
   ../../execution_chain/history/block_proofs/block_proof_historical_hashes_accumulator,
   ../../execution_chain/history/block_proofs/block_proof_historical_roots,
   ../../execution_chain/history/block_proofs/block_proof_historical_summaries,
-  ../../execution_chain/common/[hardforks, chain_config],
+  ../../execution_chain/common/[hardforks, chain_config, genesis],
   ../../execution_chain/db/core_db,
   ../../execution_chain/db/core_db/persistent,
   ../../execution_chain/db/opts,
@@ -353,7 +353,7 @@ proc exportEreFromEra1*(config: HistoryExportConf) =
     networkName = config.network
 
   if mergeBlockNumber == 0:
-    fatal "exportEreFromEra1 is not supported for post-merge-only networks",
+    fatal "exportEreFromEra1 is not supported for PoS only networks",
       network = networkName
     quit(QuitFailure)
 
@@ -423,18 +423,27 @@ proc buildHeaderVerifier(
         defaultDataDir("", network) / "era"
     (historicalRoots, historicalSummaries) =
       ?loadHistoricalDataFromEraDir(networkMetadata.cfg, eraDirPath)
-    # Post-merge-only networks (e.g. hoodi) have no pre-merge history, so there
-    # is no baked-in accumulator to load.
+    isPosOnly = mergeBlockNumber(nid) == 0
+    # PoS only networks (e.g. hoodi) have no pre-merge history, so there is no
+    # baked-in accumulator to load.
     historicalHashes =
-      if mergeBlockNumber(nid) == 0:
+      if isPosOnly:
         Opt.none(FinishedHistoricalHashesAccumulator)
       else:
         Opt.some(loadAccumulator(network))
+    # Their genesis block cannot be proven, so it gets verified against the
+    # genesis block of the network itself.
+    genesisHash =
+      if isPosOnly:
+        Opt.some(genesisBlockHash(networkParams(nid)))
+      else:
+        Opt.none(Hash32)
   ok(
     HeaderVerifier(
       historicalHashes: historicalHashes,
       historicalRoots: historicalRoots,
       historicalSummaries: historicalSummaries,
+      genesisBlockHash: genesisHash,
     )
   )
 


### PR DESCRIPTION
Their genesis block predates the beacon chain, so its execution payload is never part of a beacon block, which makes it impossible to create a proof of the same type as for the other blocks.

Thus we skip regular proof verification and instead verify it against the genesis block itself.

Other option would be to create another proof type specifically for block 0 on PoS only networks. But that seems overkill as the block can already be verified/created with genesis data.