### PR TITLE
stateless: build the ZisK guest against ziskos v1.1.0-alpha

### DIFF
--- a/.github/workflows/stateless_guest.yml
+++ b/.github/workflows/stateless_guest.yml
@@ -60,7 +60,7 @@ jobs:
     # silent change in what CI proved.
     env:
       XPACK_GCC_VERSION: 15.2.0-1
-      ZISK_REF: v1.0.0-alpha
+      ZISK_REF: v1.1.0-alpha
 
     defaults:
       run:


### PR DESCRIPTION
Matches the version the zkevm-benchmark-workload harness runs the guest under, and fixes a memory corruption that made some fixtures fail.